### PR TITLE
Improve Dockerfiles to prevent unnecessary npm install

### DIFF
--- a/guardian-service/Dockerfile
+++ b/guardian-service/Dockerfile
@@ -4,25 +4,25 @@ ENV PLATFORM="docker"
 
 WORKDIR /usr/vc-modules
 COPY ./vc-modules/package*.json ./
-COPY ./vc-modules/tsconfig.json ./
 RUN npm install
+COPY ./vc-modules/tsconfig.json ./
 ADD ./vc-modules/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/interfaces
 COPY ./interfaces/package*.json ./
-COPY ./interfaces/tsconfig.json ./
 RUN npm install
+COPY ./interfaces/tsconfig.json ./
 ADD ./interfaces/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/guardian-service
 COPY ./guardian-service/package*.json ./
+RUN npm install
 COPY ./guardian-service/tsconfig.json ./
 COPY ./guardian-service/config.json ./
 COPY ./guardian-service/.env.docker ./.env
 COPY ./guardian-service/system-schemes ./system-schemes/.
-RUN npm install
 ADD ./guardian-service/src ./src/.
 RUN npm run build
 

--- a/message-broker/Dockerfile
+++ b/message-broker/Dockerfile
@@ -4,8 +4,8 @@ ENV PLATFORM="docker"
 
 WORKDIR /usr/message-broker
 COPY ./message-broker/package*.json ./
-COPY ./message-broker/tsconfig.json ./
 RUN npm install
+COPY ./message-broker/tsconfig.json ./
 ADD ./message-broker/src ./src/.
 RUN npm run build
 

--- a/mrv-sender/Dockerfile
+++ b/mrv-sender/Dockerfile
@@ -4,22 +4,22 @@ ENV PLATFORM="docker"
 
 WORKDIR /usr/vc-modules
 COPY ./vc-modules/package*.json ./
-COPY ./vc-modules/tsconfig.json ./
 RUN npm install
+COPY ./vc-modules/tsconfig.json ./
 ADD ./vc-modules/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/interfaces
 COPY ./interfaces/package*.json ./
-COPY ./interfaces/tsconfig.json ./
 RUN npm install
+COPY ./interfaces/tsconfig.json ./
 ADD ./interfaces/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/mrv-sender
 COPY ./mrv-sender/package*.json ./
-COPY ./mrv-sender/tsconfig.json ./
 RUN npm install
+COPY ./mrv-sender/tsconfig.json ./
 ADD ./mrv-sender/src ./src/.
 ADD ./mrv-sender/public ./public/.
 RUN npm run build

--- a/ui-service/Dockerfile
+++ b/ui-service/Dockerfile
@@ -4,23 +4,23 @@ ENV PLATFORM="docker"
 
 WORKDIR /usr/vc-modules
 COPY ./vc-modules/package*.json ./
-COPY ./vc-modules/tsconfig.json ./
 RUN npm install
+COPY ./vc-modules/tsconfig.json ./
 ADD ./vc-modules/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/interfaces
 COPY ./interfaces/package*.json ./
-COPY ./interfaces/tsconfig.json ./
 RUN npm install
+COPY ./interfaces/tsconfig.json ./
 ADD ./interfaces/src ./src/.
 RUN npm run build
 
 WORKDIR /usr/frontend
 COPY ./frontend/package*.json ./
+RUN npm install
 COPY ./frontend/tsconfig.json ./
 COPY ./frontend/tsconfig.app.json ./
-RUN npm install
 COPY ./frontend/angular.json ./
 COPY ./frontend/index.html ./
 ADD ./frontend/src ./src/.
@@ -28,10 +28,10 @@ RUN npm run build:deploy
 
 WORKDIR /usr/ui-service
 COPY ./ui-service/package*.json ./
+RUN npm install
 COPY ./ui-service/tsconfig.json ./
 COPY ./ui-service/.env.docker ./.env
 ADD ./ui-service/api ./api/.
-RUN npm install
 ADD ./ui-service/src ./src/.
 RUN npm run build
 


### PR DESCRIPTION
**Description**:

Improve Dockerfiles to prevent unnecessary `npm install`, by moving `npm install` immediately below the `COPY ./package*.json ./`, so changes in `config.json` or `.env` do not require docker to run `npm install` again, which improve the development startup time.

**Related issue(s)**: N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
