### PR TITLE
Added port map for API gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
     build:
       context: .
       dockerfile: ./api-gateway/Dockerfile
+    ports:
+      - "3002:3002"
     expose:
       - 3002
     depends_on:


### PR DESCRIPTION
When:
- running docker-compose, then
- starting frontend

I expected:
- all necessary services to run in docker, and
- frontend to be able to reach the backend

but, what I got:
- frontend couldn't reach port 3002

So I:
- added mapping "3002:3002" to the docker-compose file to allow the frontend to talk to the api gateway

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
