### PR TITLE
feat: running NATS as cluster

### DIFF
--- a/common/src/mq/index.ts
+++ b/common/src/mq/index.ts
@@ -81,12 +81,16 @@ export class MessageBrokerChannel {
      * @returns 
      */
     public static async connect(connectionName: string) {
-        assert(process.env.MQ_ADDRESS, 'Missing MQ_ADDRESS environment variable');
-        return connect({
-            servers: [process.env.MQ_ADDRESS],
+        const mqServer = process.env.MQ_ADDRESS;
+        assert(mqServer, 'Missing MQ_ADDRESS environment variable');
+        console.log("Connecting to MQ: %s", mqServer);
+        const cn = await connect({
+            servers: [mqServer],
             name: connectionName,
             reconnectDelayHandler: () => 2000,
             maxReconnectAttempts: -1 // reconnect forever
         });
+        console.log('Servers: %s', cn.getServer());
+        return cn;
     };
 }

--- a/config/nats.conf
+++ b/config/nats.conf
@@ -1,0 +1,3 @@
+debug = true
+trace = true
+max_payload=10240000

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,22 +10,28 @@ services:
     message-broker:
         container_name: message-broker
         image: nats
+        volumes:
+            - ./config/:/etc/nats
         expose:
             - 4222
         ports:
             - '8222:8222'
             - '4222:4222'
             - '6222:6222'
-        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222 --debug'
+        command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222 --debug'
     message-broker-1:
         container_name: message-broker-1
         image: nats
-        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
+        volumes:
+            - ./config/:/etc/nats
+        command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
         depends_on: [ "message-broker" ]
     message-broker-2:
         container_name: message-broker-2
         image: nats
-        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
+        volumes:
+            - ./config/:/etc/nats
+        command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
         depends_on: [ "message-broker" ]
 
     dev-tools:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,6 +8,7 @@ services:
         ports:
             - 27017:27017
     message-broker:
+        container_name: message-broker
         image: nats
         expose:
             - 4222
@@ -15,7 +16,18 @@ services:
             - '8222:8222'
             - '4222:4222'
             - '6222:6222'
-        command: '--http_port 8222'
+        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222 --debug'
+    message-broker-1:
+        container_name: message-broker-1
+        image: nats
+        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
+        depends_on: [ "message-broker" ]
+    message-broker-2:
+        container_name: message-broker-2
+        image: nats
+        command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222 --debug'
+        depends_on: [ "message-broker" ]
+
     dev-tools:
         build: .
         image: guardian-development
@@ -166,6 +178,7 @@ services:
             - dev-tools
         volumes:
             - ./:/app
+            - guardian_frontend:/app/frontend/node_modules/.cache
         environment:
             - NG_PERSISTENT_BUILD_CACHE=1
             - CI=local
@@ -190,3 +203,4 @@ volumes:
         # volume-ui-service:
         # volume-mrv-sender:
         #  volume-message-broker:
+    guardian_frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,19 @@ services:
       - 4222
     ports:
       - '8222:8222'
-    command: '--http_port 8222'
+      - '4222:4222'
+      - '6222:6222'
+    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222'
+  message-broker-1:
+    container_name: message-broker-1
+    image: nats
+    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
+    depends_on: [ "message-broker" ]
+  message-broker-2:
+    container_name: message-broker-2
+    image: nats
+    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
+    depends_on: [ "message-broker" ]
 
   logger-service:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,20 +17,27 @@ services:
     image: nats
     expose:
       - 4222
+    volumes:
+      - ./config/:/etc/nats
     ports:
       - '8222:8222'
       - '4222:4222'
       - '6222:6222'
-    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222'
+    command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --http_port 8222'
   message-broker-1:
     container_name: message-broker-1
     image: nats
-    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
+    volumes:
+      - ./config/:/etc/nats
+
+    command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
     depends_on: [ "message-broker" ]
   message-broker-2:
     container_name: message-broker-2
+    volumes:
+      - ./config/:/etc/nats
     image: nats
-    command: '--cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
+    command: '-c /etc/nats/nats.conf --cluster_name message-broker --cluster nats://0.0.0.0:6222 --routes=nats://message-broker:6222'
     depends_on: [ "message-broker" ]
 
   logger-service:

--- a/docs/getting-started/getting-started/installation.md
+++ b/docs/getting-started/getting-started/installation.md
@@ -254,3 +254,6 @@ npm run test
 | MRV\_SENDER    | [http://localhost:3005/](http://localhost:3005/) |
 | TOPIC\_VIEWER  | [http://localhost:3006/](http://localhost:3006/) |
 | API\_DOCS      | [http://localhost:3001/](http://localhost:3001/) |
+
+#### Nats server configuration
+Nats server has limit 1MB for payload by default, If you run production which requires bigger payload please refer to (https://docs.nats.io/running-a-nats-service/configuration)[https://docs.nats.io/running-a-nats-service/configuration] to  change max_payload property. You can also enable other features that suiteable for your production environment.


### PR DESCRIPTION
**Description**:
For production ready we need to run NATs as cluster instead of single container.  In the real production environment we will use k8s or other orchestration tool to make sure production environment is stable.  this PR just make the local development and the default docker compose to run NATS as cluster so at least we have the 

**Related issue(s)**:
#574 
#899
Fixes #
NA
**Notes for reviewer**:
NA
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
