### PR TITLE
fix: trust-chain api get broken

### DIFF
--- a/api-gateway/src/helpers/guardians.ts
+++ b/api-gateway/src/helpers/guardians.ts
@@ -101,7 +101,7 @@ export class Guardians extends ServiceRequestsBase {
      * @returns {IChainItem[]} - trust chain
      */
     public async getChain(id: string): Promise<IChainItem[]> {
-        return await this.request(MessageAPI.GET_CHAIN, id);
+        return await this.request(MessageAPI.GET_CHAIN, { id });
     }
 
     /**

--- a/guardian-service/src/api/trust-chain.service.ts
+++ b/guardian-service/src/api/trust-chain.service.ts
@@ -214,7 +214,7 @@ export const trustChainAPI = async function (
      */
     ApiResponse(channel, MessageAPI.GET_CHAIN, async (msg) => {
         try {
-            const hash = msg;
+            const hash = msg.id;
             const chain: IChainItem[] = [];
             let root: VcDocument | VpDocument;
 


### PR DESCRIPTION
Signed-off-by: Truong Nguyen <samuraitruong@hotmail.com>

**Description**:
 trust-chain get API was broken since introduce NATs due to the params as string instead of object. Similar to delete schema api issue before

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
