### PR TITLE
fix: add queue to support horizontal scale

### DIFF
--- a/common/src/mq/message-broker-channel.ts
+++ b/common/src/mq/message-broker-channel.ts
@@ -22,7 +22,7 @@ export class MessageBrokerChannel {
     public async response<TData, TResponse>(eventType: string, handleFunc: (data: TData) => Promise<IMessageResponse<TResponse>>) {
         const target = this.getTarget(eventType);
         console.log('MQ subscribed: %s', target);
-        const sub = this.channel.subscribe(target);
+        const sub = this.channel.subscribe(target, { queue: process.env.SERVICE_CHANNEL });
         const fn = async (sub: Subscription) => {
             for await (const m of sub) {
                 let responseMessage: IMessageResponse<TResponse>;


### PR DESCRIPTION
**Description**:
In production environment, to guarantee the HA system we run each service  with at least 2 instances(pod, nodes). Nats has design `Node Groups` to avoid the message being processed by multiple subscribers. 

Please refer to document here : 
https://github.com/nats-io/nats.js#queue-groups


**Related issue(s)**:

Fixes #


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
