### PR TITLE
Fixes schema update documentation

### DIFF
--- a/docs/schema-creation-using-the-guardian-apis/updating-schema.md
+++ b/docs/schema-creation-using-the-guardian-apis/updating-schema.md
@@ -2,17 +2,13 @@
 
 ### UPDATING SCHEMA BASED ON SCHEMA ID
 
-{% swagger method="get" path="" baseUrl="/schemas/{schemaId}" summary="Updates the schema" %}
+{% swagger method="put" path="" baseUrl="/schemas" summary="Updates the schema" %}
 {% swagger-description %}
-Updates the schema with the provided schema ID. Only users with the Standard Registry role are allowed to make the request.
+Updates the schema matching the id in the request body. Only users with the Standard Registry role are allowed to make the request.
 {% endswagger-description %}
 
-{% swagger-parameter in="path" name="schemaID" type="String" required="true" %}
-Schema ID
-{% endswagger-parameter %}
-
 {% swagger-parameter in="body" type="schema" required="true" %}
-Object that contains a valid schema
+Object that contains a valid schema including the id of the schema that is to be update
 {% endswagger-parameter %}
 
 {% swagger-response status="200: OK" description="Succesful Operation" %}


### PR DESCRIPTION
The current docs are incorrect for the update schema endpoint.

- `GET` should be `PUT`
- The `id` of the schema to be updated should be defined in the JSON body of the schema object, not in the URL parameters.

```
{
    "id": "<SCHEMA_ID>",
    ...schema
}
```

**Checklist**
I've not been able to verify the following but the changes are so small that I assume there will be no issues:
- [ ] Test that the updated swagger template strings render correctly in the UI
