### PR TITLE
fix configuration for local development using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ If you want to manually build every component with debug information, then build
       docker-compose -f docker-compose-dev.yml up --build
 
      ```
+
+     Note: The first run will take a few minutes to install dependencies and compile code for each service.
+
   3. Access local development using http://localhost:3000 or http://localhost:4200
 
   ### Troubleshoot 

--- a/dev.js
+++ b/dev.js
@@ -14,7 +14,7 @@ const fs = require('fs');
         }
 
         if (!fs.existsSync(folder + '/dist/')) {
-            await execSync(`yarn build --cwd ${folder}`, { stdio: 'inherit', shell: true });
+            await execSync(`yarn --cwd ${folder} build`, { stdio: 'inherit', shell: true });
         }
 
         await new Promise((resolve) => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
         "typescript": "~4.3.2"
     },
     "license": "Apache-2.0",
-    "name": "guardian",
+    "name": "frontend",
     "private": true,
     "scripts": {
         "dev:docker": "ng serve --host 0.0.0.0 --disable-host-check --proxy-config ./proxy.docker.json",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,23 @@
   "name": "guardian",
   "private": true,
   "packageManager": "yarn@3.2.1",
-  "workspaces": [
-    "interfaces",
-    "common",
-    "api-docs",
-    "api-gateway",
-    "auth-service",
-    "guardian-service",
-    "ipfs-client",
-    "logger-service",
-    "mrv-sender"
-  ],
+  "workspaces": {
+    "packages": [
+      "interfaces",
+      "common",
+      "api-docs",
+      "api-gateway",
+      "auth-service",
+      "guardian-service",
+      "ipfs-client",
+      "logger-service",
+      "mrv-sender",
+      "topic-viewer",
+      "frontend"
+    ],
+    "nohoist": [
+      "**/frontend/**"
+    ]
+  },
   "version": "2.3.0"
 }


### PR DESCRIPTION
**Description**:

  
This PR fixes the configuration for running local development environment with docker.
* Fix syntax error in the 'yarn' command in `dev.js`;
* Rename frontend package name from 'guardian' to 'frontend' to avoid conflict with the parent project name;
* Add missing yarn workspaces (frontend and topic-viewer) in `package.json`
* Sets no 'nohoist' for the frontend workspace. This is required for the Angular CLI in frontend to work properly.


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
