### PR TITLE
Worker-service now operates on the network specified by guardian-service

### DIFF
--- a/guardian-service/src/hedera-modules/environment.ts
+++ b/guardian-service/src/hedera-modules/environment.ts
@@ -13,13 +13,21 @@ export class Environment {
      */
     public static readonly HEDERA_MAINNET_TOPIC_API: string = 'https://mainnet-public.mirrornode.hedera.com/api/v1/topics/';
     /**
-     * Testnar message API
+     * Testnet message API
      */
     public static readonly HEDERA_TESTNET_MESSAGE_API: string = 'https://testnet.mirrornode.hedera.com/api/v1/topics/messages';
     /**
      * Testnet topic API
      */
     public static readonly HEDERA_TESTNET_TOPIC_API: string = 'https://testnet.mirrornode.hedera.com/api/v1/topics/';
+    /**
+     * Previewnet message API
+     */
+    public static readonly HEDERA_PREVIEW_MESSAGE_API: string = 'https://Previewnet.mirrornode.hedera.com/api/v1/topics/messages';
+    /**
+     * Previewnet topic API
+     */
+    public static readonly HEDERA_PREVIEW_TOPIC_API: string = 'https://Previewnet.mirrornode.hedera.com/api/v1/topics/';
     /**
      * Localnode message API
      */
@@ -72,6 +80,12 @@ export class Environment {
                 Environment._topicsApi = Environment.HEDERA_TESTNET_TOPIC_API;
                 break;
 
+            case 'previewnet':
+                Environment._network = 'previewnet';
+                Environment._messagesApi = Environment.HEDERA_PREVIEW_MESSAGE_API;
+                Environment._topicsApi = Environment.HEDERA_PREVIEW_TOPIC_API;
+                break;
+
             case 'localnode':
                 Environment._network = 'localnode';
                 Environment._messagesApi = Environment.HEDERA_LOCALNODE_MESSAGE_API;
@@ -79,7 +93,7 @@ export class Environment {
                 break;
 
             default:
-                throw new Error(`Unknown network: ${Environment._network}`)
+                throw new Error(`Unknown network: ${network}`)
         }
 
         if (mirrornode) {
@@ -114,6 +128,9 @@ export class Environment {
 
             case 'testnet':
                 return Client.forTestnet();
+
+            case 'previewnet':
+                return Client.forPreviewnet();
 
             case 'localnode':
                 const node = {} as any;

--- a/guardian-service/src/helpers/workers.ts
+++ b/guardian-service/src/helpers/workers.ts
@@ -2,6 +2,7 @@ import { Singleton } from '@helpers/decorators/singleton';
 import { GenerateUUIDv4, IActiveTask, ITask, IWorkerRequest, WorkerEvents } from '@guardian/interfaces';
 import { ServiceRequestsBase } from '@helpers/service-requests-base';
 import { MessageResponse } from '@guardian/common';
+import { Environment } from '@hedera-modules';
 
 /**
  * Workers helper
@@ -37,6 +38,7 @@ export class Workers extends ServiceRequestsBase {
      * @param priority
      */
     public addNonRetryableTask(task: ITask, priority: number): Promise<any> {
+        if(!task.data.network) task.data.network = Environment.network;
         return this.addTask(task, priority, false);
     }
 
@@ -47,6 +49,7 @@ export class Workers extends ServiceRequestsBase {
      * @param attempts
      */
     public addRetryableTask(task: ITask, priority: number, attempts: number = 0): Promise<any> {
+        if(!task.data.network) task.data.network = Environment.network;
         return this.addTask(task, priority, true, attempts);
     }
 

--- a/worker-service/src/api/helpers/environment.ts
+++ b/worker-service/src/api/helpers/environment.ts
@@ -17,7 +17,7 @@ export class Environment {
      */
     public static readonly HEDERA_MAINNET_ACCOUNT_API: string = 'https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/';
     /**
-     * Testnar message API
+     * Testnet message API
      */
     public static readonly HEDERA_TESTNET_MESSAGE_API: string = 'https://testnet.mirrornode.hedera.com/api/v1/topics/messages';
     /**
@@ -28,6 +28,18 @@ export class Environment {
      * Testnet account API
      */
     public static readonly HEDERA_TESTNET_ACCOUNT_API: string = 'https://testnet.mirrornode.hedera.com/api/v1/accounts/';
+    /**
+     * Preview message API
+     */
+    public static readonly HEDERA_PREVIEW_MESSAGE_API: string = 'https://preview.mirrornode.hedera.com/api/v1/topics/messages';
+    /**
+     * Preview topic API
+     */
+    public static readonly HEDERA_PREVIEW_TOPIC_API: string = 'https://preview.mirrornode.hedera.com/api/v1/topics/';
+    /**
+     * Preview account API
+     */
+    public static readonly HEDERA_PREVIEW_ACCOUNT_API: string = 'https://preview.mirrornode.hedera.com/api/v1/accounts/';
     /**
      * Localnode message API
      */
@@ -75,7 +87,7 @@ export class Environment {
      * @param network
      * @param mirrornode
      */
-    public static setNetwork(network: string, mirrornode?: string) {
+    public static setNetwork(network: string, mirrornode?: string) {        
         switch (network) {
             case 'mainnet':
                 Environment._network = 'mainnet';
@@ -91,6 +103,13 @@ export class Environment {
                 Environment._accountsApi = Environment.HEDERA_TESTNET_ACCOUNT_API;
                 break;
 
+            case 'previewnet':
+                Environment._network = 'previewnet';
+                Environment._messagesApi = Environment.HEDERA_TESTNET_MESSAGE_API;
+                Environment._topicsApi = Environment.HEDERA_TESTNET_TOPIC_API;
+                Environment._accountsApi = Environment.HEDERA_TESTNET_ACCOUNT_API;
+                break;
+
             case 'localnode':
                 Environment._network = 'localnode';
                 Environment._messagesApi = Environment.HEDERA_LOCALNODE_MESSAGE_API;
@@ -99,7 +118,7 @@ export class Environment {
                 break;
 
             default:
-                throw new Error(`Unknown network: ${Environment._network}`)
+                throw new Error(`Unknown network: ${network}`)
         }
 
         if (mirrornode) {
@@ -136,6 +155,9 @@ export class Environment {
 
             case 'testnet':
                 return Client.forTestnet();
+
+            case 'previewnet':
+                return Client.forPreviewnet();
 
             case 'localnode':
                 const node = {} as any;
@@ -178,3 +200,4 @@ export class Environment {
         return Environment._accountsApi;
     }
 }
+

--- a/worker-service/src/api/helpers/hedera-sdk-helper.ts
+++ b/worker-service/src/api/helpers/hedera-sdk-helper.ts
@@ -73,6 +73,15 @@ export interface ITransactionLoggerData {
 }
 
 /**
+ * Network options
+ */
+export class NetworkOptions {
+    public network: string = 'testnet';
+    public localNodeAddress: string = '';
+    public localNodeProtocol: string = '';
+}
+
+/**
  * Contains methods to simplify work with hashgraph sdk
  */
 export class HederaSDKHelper {
@@ -114,9 +123,13 @@ export class HederaSDKHelper {
     constructor(
         operatorId: string | AccountId | null,
         operatorKey: string | PrivateKey | null,
-        dryRun: string = null
+        dryRun: string = null,
+        networkOptions: NetworkOptions
     ) {
-        this.dryRun = dryRun || null;
+        Environment.setNetwork(networkOptions.network);
+        Environment.setLocalNodeAddress(networkOptions.localNodeAddress);
+        Environment.setLocalNodeProtocol(networkOptions.localNodeProtocol);
+        this.dryRun = dryRun || null;        
         this.client = Environment.createClient();
         if (operatorId && operatorKey) {
             this.client.setOperator(operatorId, operatorKey);

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -7,8 +7,7 @@ import {
     WorkerEvents,
     WorkerTaskType
 } from '@guardian/interfaces';
-import { HederaSDKHelper } from './helpers/hedera-sdk-helper';
-import { Environment } from './helpers/environment';
+import { HederaSDKHelper, NetworkOptions } from './helpers/hedera-sdk-helper';
 import { IpfsClient } from './ipfs-client';
 import Blob from 'cross-blob';
 import { AccountId, ContractFunctionParameters, PrivateKey, TokenId } from '@hashgraph/sdk';
@@ -183,8 +182,12 @@ export class Worker {
     private async processTask(task: ITask): Promise<ITaskResult> {
         const result: ITaskResult = {
             id: this.currentTaskId
+        }        
+        const networkOptions: NetworkOptions = {
+            network: task.data.network,
+            localNodeAddress: task.data.localNodeAddress,
+            localNodeProtocol: task.data.localNodeProtocol
         }
-
         try {
             switch (task.type) {
                 case WorkerTaskType.ADD_FILE: {
@@ -244,11 +247,8 @@ export class Worker {
                 }
 
                 case WorkerTaskType.SEND_HEDERA: {
-                    Environment.setNetwork(task.data.network);
-                    Environment.setLocalNodeAddress(task.data.localNodeAddress);
-                    Environment.setLocalNodeProtocol(task.data.localNodeProtocol);
                     const { operatorId, operatorKey, dryRun } = task.data.clientOptions;
-                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun, networkOptions);
                     const { topicId, buffer, submitKey, memo } = task.data;
                     result.data = await client.submitMessage(topicId, buffer, submitKey, memo);
                     break;
@@ -256,7 +256,7 @@ export class Worker {
 
                 case WorkerTaskType.GENERATE_DEMO_KEY: {
                     const { operatorId, operatorKey, initialBalance } = task.data;
-                    const client = new HederaSDKHelper(operatorId, operatorKey);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, null, networkOptions);
                     const treasury = await client.newAccount(initialBalance);
                     result.data = {
                         id: treasury.id.toString(),
@@ -267,7 +267,7 @@ export class Worker {
 
                 case WorkerTaskType.GET_USER_BALANCE: {
                     const { hederaAccountId, hederaAccountKey } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, null, networkOptions);
                     result.data = await client.balance(hederaAccountId);
 
                     break;
@@ -275,7 +275,7 @@ export class Worker {
 
                 case WorkerTaskType.GET_ACCOUNT_INFO: {
                     const { userID, userKey, hederaAccountId } = task.data;
-                    const client = new HederaSDKHelper(userID, userKey);
+                    const client = new HederaSDKHelper(userID, userKey, null, networkOptions);
                     result.data = await client.accountInfo(hederaAccountId);
 
                     break;
@@ -295,7 +295,7 @@ export class Worker {
                         tokenSymbol,
                         tokenType
                     } = task.data;
-                    const client = new HederaSDKHelper(operatorId, operatorKey);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, null, networkOptions);
                     const nft = tokenType === 'non-fungible';
                     const _decimals = nft ? 0 : decimals;
                     const _initialSupply = nft ? 0 : initialSupply;
@@ -358,7 +358,7 @@ export class Worker {
                     if (changes.wipeKey) {
                         changes.wipeKey = PrivateKey.generate();
                     }
-                    const client = new HederaSDKHelper(operatorId, operatorKey);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, null, networkOptions);
                     const status = await client.updateToken(
                         TokenId.fromString(tokenId),
                         HederaUtils.parsPrivateKey(adminKey, true, 'Admin Key'),
@@ -383,7 +383,7 @@ export class Worker {
                         adminKey,
                     } = task.data;
 
-                    const client = new HederaSDKHelper(operatorId, operatorKey);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, null, networkOptions);
                     result.data = await client.deleteToken(
                         TokenId.fromString(tokenId),
                         HederaUtils.parsPrivateKey(adminKey, true, 'Admin Key')
@@ -394,7 +394,7 @@ export class Worker {
 
                 case WorkerTaskType.ASSOCIATE_TOKEN: {
                     const { userID, userKey, associate, tokenId, dryRun } = task.data;
-                    const client = new HederaSDKHelper(userID, userKey, dryRun);
+                    const client = new HederaSDKHelper(userID, userKey, dryRun, networkOptions);
                     if (associate) {
                         result.data = await client.associate(tokenId, userID, userKey);
                     } else {
@@ -414,7 +414,7 @@ export class Worker {
                         grant,
                         dryRun
                     } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
 
                     if (grant) {
                         result.data = await client.grantKyc(tokenId, userHederaAccountId, kycKey);
@@ -435,7 +435,7 @@ export class Worker {
                         freeze,
                         dryRun
                     } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     if (freeze) {
                         result.data = await client.freeze(tokenId, userHederaAccountId, freezeKey);
                     } else {
@@ -447,7 +447,7 @@ export class Worker {
 
                 case WorkerTaskType.MINT_NFT: {
                     const { hederaAccountId, hederaAccountKey, dryRun, tokenId, supplyKey, metaData, transactionMemo } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     let data: Uint8Array[];
                     if (Array.isArray(metaData)) {
                         data = new Array<Uint8Array>(metaData.length);
@@ -473,14 +473,14 @@ export class Worker {
                         element,
                         transactionMemo
                     } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     result.data = await client.transferNFT(tokenId, targetAccount, treasuryId, treasuryKey, element, transactionMemo);
                     break;
                 }
 
                 case WorkerTaskType.MINT_FT: {
                     const { hederaAccountId, hederaAccountKey, dryRun, tokenId, supplyKey, tokenValue, transactionMemo } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     result.data = await client.mint(tokenId, supplyKey, tokenValue, transactionMemo);
                     break;
                 }
@@ -497,7 +497,7 @@ export class Worker {
                         tokenValue,
                         transactionMemo
                     } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     result.data = await client.transfer(tokenId, targetAccount, treasuryId, treasuryKey, tokenValue, transactionMemo);
                     break;
                 }
@@ -513,7 +513,7 @@ export class Worker {
                         wipeKey,
                         uuid
                     } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     if (token.tokenType === 'non-fungible') {
                         result.error = 'unsupported operation';
                     } else {
@@ -525,7 +525,7 @@ export class Worker {
 
                 case WorkerTaskType.NEW_TOPIC: {
                     const { hederaAccountId, hederaAccountKey, dryRun, topicMemo, keys } = task.data;
-                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun);
+                    const client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
                     let adminKey: any = null;
                     let submitKey: any = null;
                     if (keys) {
@@ -555,7 +555,7 @@ export class Worker {
                         dryRun,
                         timeStamp
                     } = task.data;
-                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun, networkOptions);
                     result.data = await client.getTopicMessage(timeStamp);
 
                     break;
@@ -568,7 +568,7 @@ export class Worker {
                         dryRun,
                         topic
                     } = task.data;
-                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, dryRun, networkOptions);
                     result.data = await client.getTopicMessages(topic);
 
                     break;
@@ -590,7 +590,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.createContract(
                         bytecodeFileId,
@@ -608,7 +610,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.contractCall(
                         contractId, 'addUser',
@@ -630,7 +634,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.contractCall(
                         contractId, 'addPair',
@@ -652,7 +658,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = AccountId.fromSolidityAddress(
                         (
@@ -674,7 +682,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = (await client.contractQuery(
                         contractId, 'checkStatus',
@@ -695,7 +705,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.contractCall(
                         contractId, 'retire',
@@ -719,7 +731,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.contractCall(
                         contractId, 'cancelUserRequest',
@@ -741,7 +755,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     const contractQueryResult = await client.contractQuery(
                         contractId, 'getPair',
@@ -772,7 +788,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     result.data = await client.contractCall(
                         contractId, 'addUserRequest',
@@ -799,7 +817,9 @@ export class Worker {
                     } = task.data;
                     const client = new HederaSDKHelper(
                         hederaAccountId,
-                        hederaAccountKey
+                        hederaAccountKey,
+                        null,
+                        networkOptions
                     );
                     const contractQueryResult = await client.contractQuery(
                         contractId, 'getUserRequest',
@@ -822,7 +842,7 @@ export class Worker {
                         operatorKey,
                         tokenId,
                     } = task.data;
-                    const client = new HederaSDKHelper(operatorId, operatorKey);
+                    const client = new HederaSDKHelper(operatorId, operatorKey, null, networkOptions);
                     const nfts = (await client.getSerialsNFT(tokenId)) || [];
                     const serials = {};
                     nfts.forEach(item => {

--- a/worker-service/tests/network-tests/hedera-sdk-helper.test.js
+++ b/worker-service/tests/network-tests/hedera-sdk-helper.test.js
@@ -23,11 +23,12 @@ describe('Hedera SDK Helper', function () {
     const initialBalance = 5;
     const OPERATOR_ID = process.env.OPERATOR_ID;
     const OPERATOR_KEY = process.env.OPERATOR_KEY;
+    const HEDERA_NET = process.env.HEDERA_NET;
 
     this.timeout(60 * transactionTimeout);
 
     before(async function () {
-        sdk = new HederaSDKHelper(OPERATOR_ID, OPERATOR_KEY);
+        sdk = new HederaSDKHelper(OPERATOR_ID, OPERATOR_KEY, null, { network: HEDERA_NET });
     });
 
     it('Test SDK newAccount', async function () {


### PR DESCRIPTION
**Description**:
Following the request in #1607, this PR modifies:

* The worker service, to let the client decide what network the operations should be sent to
* The guardian-service to always specify the network it intended to use

This PR also fixes minor issues.

**Related issue(s)**:

Respond to #1607

**Notes for reviewer**:
Regardless of the initial request about the Previewnet, the worker service seems to expose some potential issues, in particular:
* The worker service currently uses global variables for the network settings; this can lead to problems in case of multiple tasks executed in parallel
* Private keys are exchanged in the message payload
* In some cases, the network is decided by the client; in other cases, no. The client (guardian service) should be in charge of defining the network rather than the worker. This way, multiple worker can run on the same queue, serving request from multiple networks at the same time. The worker can declare support for a subset of networks and reject the task if the request is for an unsupported network.

This PR fixes some of the above while trying to support multiple networks, but we should discuss the overall approach.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
