### PR TITLE
Using the new kubo 0.18 docker image;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tsconfig.tsbuildinfo
 !.yarn/versions
 .pnp.*
 node_modules
+runtime-data/
 
 # OSX related metadata removal and IDE nonsense
 .DS_store

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
         ports:
             - 27017:27017
     ipfs-node:
-        image: ipfs/kubo:v0.17.0
+        image: ipfs/kubo:v0.18.1
         ports:
             - "5001:5001"
             - "5002:5002"
@@ -17,6 +17,9 @@ services:
             - "4002:4002"
             - "8080:8080"
             - "8081:8081"
+        volumes:
+            - ./runtime-data/ipfs/staging:/export:rw
+            - ./runtime-data/ipfs/data:/data/ipfs:rw
     message-broker:
         image: nats:2.9.8
         expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - mongo
 
   ipfs-node:
-    image: ipfs/kubo:v0.17.0
+    image: ipfs/kubo:v0.18.1
     ports:
       - "5001:5001"
       - "5002:5002"
@@ -27,6 +27,9 @@ services:
       - "4002:4002"
       - "8080:8080"
       - "8081:8081"
+    volumes:
+      - ./runtime-data/ipfs/staging:/export:rw
+      - ./runtime-data/ipfs/data:/data/ipfs:rw
 
   api-docs:
     build:


### PR DESCRIPTION
**Description**:
Kubo 0.18 improved the resource management. Moving the default image to the latest version.

**Related issue(s)**:

Fixes #1812 

**Notes for reviewer**:
The use of volumes for the container is now mandatory.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
