### PR TITLE
Show transaction id in the log

### DIFF
--- a/worker-service/src/api/helpers/transaction-logger.ts
+++ b/worker-service/src/api/helpers/transaction-logger.ts
@@ -51,6 +51,7 @@ export class TransactionLogger {
         if (!transaction) {
             return data;
         }
+        data += `txid: ${transaction.transactionId}; `;
         if (transactionName === 'TokenCreateTransaction') {
             const t = transaction as TokenCreateTransaction;
             data += 'payer sigs: 1; ';


### PR DESCRIPTION
**Description**:
This PR add the transaction id in the log file of the guardian-service in order to support during debugging operations.

Example of logged information with the PR applied, you can notice the`txid: 0.0.3988863@1680776708.817371192;` added to the second line:
```bash
2023-04-06 12:25:21 2023-04-06T10:25:21.788Z [TRANSACTION,CREATE,2023-04-06T10:25:21.788Z,_,TopicMessageSubmitTransaction,b1a6176a-0b2a-480b-9447-cb329de2223f,0.0.3988863,]: TopicMessageSubmitTransaction
2023-04-06 12:25:33 2023-04-06T10:25:33.151Z [TRANSACTION,COMPLETION,2023-04-06T10:25:33.150Z,11.362s,TopicMessageSubmitTransaction,b1a6176a-0b2a-480b-9447-cb329de2223f,0.0.3988863,txid: 0.0.3988863@1680776708.817371192; payer sigs: 1; total sigs: 1; message size: 431; memo size: 23; ]: TopicMessageSubmitTransaction
```
Current log without the PR:
```bash
2023-04-06 12:25:21 2023-04-06T10:25:21.788Z [TRANSACTION,CREATE,2023-04-06T10:25:21.788Z,_,TopicMessageSubmitTransaction,b1a6176a-0b2a-480b-9447-cb329de2223f,0.0.3988863,]: TopicMessageSubmitTransaction
2023-04-06 12:25:33 2023-04-06T10:25:33.151Z [TRANSACTION,COMPLETION,2023-04-06T10:25:33.150Z,11.362s,TopicMessageSubmitTransaction,b1a6176a-0b2a-480b-9447-cb329de2223f,0.0.3988863,payer sigs: 1; total sigs: 1; message size: 431; memo size: 23; ]: TopicMessageSubmitTransaction
```

**Related issue(s)**:

Fixes #1983

**Notes for reviewer**:
N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
