### PR TITLE
fix: subscribed event type fixed

### DIFF
--- a/application-events/src/connections/pub-subs/NatsPubSubAdapter.ts
+++ b/application-events/src/connections/pub-subs/NatsPubSubAdapter.ts
@@ -16,7 +16,7 @@ export default class NatsPubSubAdapter implements PubSub {
     return this.natsServer.publish(subject, JSON.stringify(event))
   }
 
-  async subscribe (subject: string, cb: (payload: JSON) => void) {
+  async subscribe (subject: string, cb: (payload: any) => void) {
     await this.initServer()
     return this.natsServer.subscribe(subject, (data: any) => {
       console.log(`Received message on "${subject}" subject:`, data)

--- a/application-events/src/routes/events.ts
+++ b/application-events/src/routes/events.ts
@@ -18,8 +18,13 @@ eventRoutes.get('/api/events/subscribe', async (req: Request, res: Response) => 
     for (const subject of externalMessageEvents) {
       await natsPubSubAdapter.subscribe(subject, (data: any) => {
         if (data) {
-          console.log('data.received.stringify', JSON.stringify(data))
-          res.write(`${JSON.stringify({subject, payload: data})},\n`);
+          try {
+            console.log('data.received.stringify', JSON.stringify(data));
+            res.write(`${JSON.stringify({subject, payload: data})},\n`);
+          } catch (e: any) {
+            console.log(e);
+            res.write(`${JSON.stringify({subject, payload: {}})},\n`);
+          }
         }
       });
     }

--- a/application-events/src/services/ApplicationMetricService.ts
+++ b/application-events/src/services/ApplicationMetricService.ts
@@ -44,7 +44,7 @@ export default class ApplicationMetricService {
     };
     for (const webhook of webhooks) {
       try {
-        const { data } = await axios.post(webhook, payload, { headers })
+        const { data } = await axios.post(webhook, payload, { headers });
         console.log('Webhook response:', JSON.stringify(data));
       } catch (e: any) {
         console.error('Webhook response:', e.message);
@@ -56,10 +56,13 @@ export default class ApplicationMetricService {
     const subscriptions: any[] = [];
 
     for (const subject of externalMessageEvents) {
-      console.log('Subject:', subject);
       const sub = this.pubSub.subscribe(subject, (data: any) => {
-        console.log(`Received message on "${subject}" subject:`, JSON.stringify(data));
-        this.sendEvents(subject, data);
+        try {
+          console.log(`Received message on "${subject}" subject:`, JSON.stringify(data));
+          this.sendEvents(subject, data);
+        } catch (e: any) {
+          console.error('Error:', e.stack, data);
+        }
       });
       subscriptions.push(sub);
     }


### PR DESCRIPTION
**Description**:
In the previous version, we typed the event received as JSON, but it was causing issues because we were considering the attribute value as a JSON. Now we changed it to `any` to avoid any constraints.


- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
