### PR TITLE
Hotfix/application events - subscribed events without JSON structure removed

### DIFF
--- a/application-events/.env
+++ b/application-events/.env
@@ -1,2 +1,3 @@
 MQ_ADDRESS=localhost
-MONGODB_SERVER_URL=mongodb://host.docker.internal:27017
+MONGODB_SERVER_URL=mongodb://mongo:27017
+

--- a/application-events/.env.docker
+++ b/application-events/.env.docker
@@ -1,2 +1,2 @@
 MQ_ADDRESS="message-broker"
-MONGODB_SERVER_URL=mongodb://host.docker.internal:27017
+MONGODB_SERVER_URL=mongodb://mongo:27017

--- a/application-events/package.json
+++ b/application-events/package.json
@@ -17,8 +17,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@guardian/common": "^2.11.0-prerelease",
-        "@guardian/interfaces": "^2.11.0-prerelease",
+        "@guardian/common": "^2.11.0",
+        "@guardian/interfaces": "^2.11.0",
         "@mikro-orm/core": "^5.6.12",
         "@mikro-orm/mongodb": "^5.6.12",
         "@mikro-orm/reflection": "^5.6.12",

--- a/application-events/src/connections/pub-subs/NatsPubSubAdapter.ts
+++ b/application-events/src/connections/pub-subs/NatsPubSubAdapter.ts
@@ -3,24 +3,23 @@ import { MessageBrokerChannel } from '@guardian/common';
 
 export default class NatsPubSubAdapter implements PubSub {
   private natsServer!: MessageBrokerChannel;
-
   async initServer () {
     if (!this.natsServer) {
-      const natsConnection = await MessageBrokerChannel.connect('application-events')
+      const natsConnection = await MessageBrokerChannel.connect('application-events');
       this.natsServer = new MessageBrokerChannel(natsConnection, 'application-events');
     }
   }
 
-  async publish (subject: string, event: JSON) {
-    await this.initServer()
-    return this.natsServer.publish(subject, JSON.stringify(event))
+  async publish<T> (subject: string, event: T) {
+    await this.initServer();
+    return this.natsServer.publish<T>(subject, event);
   }
 
-  async subscribe (subject: string, cb: (payload: JSON) => void) {
-    await this.initServer()
-    return this.natsServer.subscribe(subject, (data: any) => {
-      console.log(`Received message on "${subject}" subject:`, data)
-      cb(data)
+  async subscribe (subject: string, cb: (payload: unknown) => void) {
+    await this.initServer();
+    return this.natsServer.subscribe(subject, (data: unknown) => {
+      console.log(`Received message on "${subject}" subject:`, data);
+      cb(data);
     });
   }
 

--- a/application-events/src/connections/pub-subs/interfaces/PubSub.ts
+++ b/application-events/src/connections/pub-subs/interfaces/PubSub.ts
@@ -1,4 +1,4 @@
 export default interface PubSub {
-  publish (subject: string, event: JSON): void;
-  subscribe (subject: string, cb: (payload: JSON) => void): void;
+  publish<T> (subject: string, event: T): void;
+  subscribe (subject: string, cb: (payload: unknown) => void): void;
 }

--- a/application-events/src/services/ApplicationMetricService.ts
+++ b/application-events/src/services/ApplicationMetricService.ts
@@ -4,10 +4,7 @@ import WebhookService from './WebhookService';
 
 import {
   PolicyEvents,
-  AuthEvents,
   PolicyEngineEvents,
-  WalletEvents,
-  MessageAPI,
   ExternalMessageEvents
 } from '@guardian/interfaces';
 import WebhookStore from '../singletons/WebhookStore';
@@ -22,15 +19,14 @@ const avoidEvents = [
   'GET_BALANCE',
   'GENERATE_NEW_TOKEN',
   'GET_STATUS',
+  'get-setting-key',
+  'GET_MAP_API_KEY',
 ];
 
 export const externalMessageEvents = [
-  ...(Object.values(AuthEvents)),
   ...(Object.values(ExternalMessageEvents)),
   ...(Object.values(PolicyEvents)),
   ...(Object.values(PolicyEngineEvents)),
-  ...(Object.values(WalletEvents)),
-  ...(Object.values(MessageAPI)),
 ].filter((event) => !avoidEvents.includes(event));
 
 export default class ApplicationMetricService {

--- a/application-events/src/singletons/MongodbConnection.ts
+++ b/application-events/src/singletons/MongodbConnection.ts
@@ -10,7 +10,7 @@ export default class MongodbConnection {
 
   constructor () {
     this.connection = MikroORM.init({
-      clientUrl: process.env.MONGODB_SERVER_URL || 'mongodb://host.docker.internal:27017',
+      clientUrl: process.env.MONGODB_SERVER_URL || 'mongodb://mongo:27017',
       dbName: 'application_events',
       driver: MongoDriver,
       entities: [ Webhook ],

--- a/application-events/src/singletons/WebhookStore.ts
+++ b/application-events/src/singletons/WebhookStore.ts
@@ -4,7 +4,7 @@ export default class WebhookStore {
   private static instance: WebhookStore;
   private webhooks: { [eventName: string]: string[] } = {};
 
-  public async initEvents(webhooks: Webhook[]) {
+  public async initEvents (webhooks: Webhook[]) {
     for (const webhook of webhooks) {
       this.seedWebhookEvents(webhook);
     }
@@ -14,7 +14,7 @@ export default class WebhookStore {
    * Seed webhooks
    * @param webhook
    */
-  public seedWebhookEvents(webhook: Webhook) {
+  public seedWebhookEvents (webhook: Webhook) {
     if (webhook.events.length) {
       for (const event of webhook.events) {
         this.addWebhook(event, webhook.url);
@@ -26,7 +26,7 @@ export default class WebhookStore {
    * Unregister webhook for all events
    * @param webhook
    */
-  public removeWebhookEvents(webhook: Webhook) {
+  public removeWebhookEvents (webhook: Webhook) {
     if (this.webhooks.length) {
       for (const event of webhook.events) {
         const index = this.webhooks[event].indexOf(webhook.url)
@@ -40,7 +40,7 @@ export default class WebhookStore {
   /**
    * Get class instance
    */
-  public static getInstance(): WebhookStore {
+  public static getInstance (): WebhookStore {
     if (!WebhookStore.instance) {
       WebhookStore.instance = new WebhookStore();
     }
@@ -52,7 +52,7 @@ export default class WebhookStore {
    * @param eventName
    * @param url
    */
-  public addWebhook(eventName: string, url: string): void {
+  public addWebhook (eventName: string, url: string): void {
     if (!this.webhooks[eventName]) {
       this.webhooks[eventName] = [];
     }
@@ -65,7 +65,7 @@ export default class WebhookStore {
    * Get webhooks of an event
    * @param eventName
    */
-  public getWebhooks(eventName: string): string[] {
+  public getWebhooks (eventName: string): string[] {
     return this.webhooks[eventName] || [];
   }
 }


### PR DESCRIPTION
**Description**:

In the beginning, the application-events module was defined to subscribe to a huge amount of events. However, some events are not published as a valid JSON structure causing some unnecessary logs in the shared file `src/mq/message-broker-channel.ts` that was flooding the **application-events** module of error logs. Once we can handle this issue without impacting other modules, we decided to restrict the subscriptions for only specific

Like this message: `guardian-application-events-1  |  Unexpected token ^_ in JSON at position 0`

**Related issue(s)**:

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
