### PR TITLE
Application-events stopped to running temporarily

### DIFF
--- a/application-events/.env
+++ b/application-events/.env
@@ -1,3 +1,4 @@
 MQ_ADDRESS=localhost
 MONGODB_SERVER_URL=mongodb://mongo:27017
+SERVICE_CHANNEL="application-events"
 

--- a/application-events/.env.docker
+++ b/application-events/.env.docker
@@ -1,2 +1,3 @@
 MQ_ADDRESS="message-broker"
 MONGODB_SERVER_URL=mongodb://mongo:27017
+SERVICE_CHANNEL="application-events"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - auth-service
     environment:
       - SERVICE_CHANNEL=worker.2
-      - ENV=${GUARDIAN_ENV}
+      - ENV=${GUARDIAN_ENV}/message-broker-channel.js:265
       - DIRECT_MESSAGE_PORT=6555
     expose:
       - 6555
@@ -177,20 +177,20 @@ services:
     expose:
       - 6555
 
-  application-events:
-    build:
-      context: .
-      dockerfile: application-events/Dockerfile
-    expose:
-      - 3012
-    ports:
-      - "3012:3012"
-    depends_on:
-      - mongo
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
+#  application-events:
+#    build:
+#      context: .
+#      dockerfile: application-events/Dockerfile
+#    expose:
+#      - 3012
+#    ports:
+#      - "3012:3012"
+#    depends_on:
+#      - mongo
+#      - message-broker
+#      - guardian-service
+#      - auth-service
+#      - logger-service
 
   mrv-sender:
     build:


### PR DESCRIPTION
**Description**:

This is a small fix to avoid the `application-events` runs, once the way the architecture handles events and exposes them could hamper the guardian work and cause side effects, like TIMEOUTs.

For example, in the application-events, we also subscribe the _**externals-events.ipfs_added_file**_ which according to this documentation it is an event to be externalized: https://docs.hedera.com/guardian/guardian/standard-registry/external-events. But when you have two subscribers to the same event, one of them is picked up randomly to be executed, and sometimes the subscriber that only sends the event payload to the webhook (previously registered in the **application-events** module) is called without processing anything. 

The solution seems to be to create different publishing events indicating the purpose, like in the code below:

```
nc.publish('externals-events.ipfs_added_file', 'payload');
nc.publish('externals-events.ipfs_added_file.external, 'payload');
```

**_But even the proposal above needs to be tested._**