### PR TITLE
hotfix/progress-bar-schemas

### DIFF
--- a/frontend/src/app/views/schemas/schemas.component.css
+++ b/frontend/src/app/views/schemas/schemas.component.css
@@ -286,6 +286,11 @@ a {
     top: 10px;
 }
 
+.toolbar-btn.add mat-icon {
+    font-size: 30px;
+    left: 10px;
+    top: 7px;
+}
 
 .schemas-table .mat-column-tags {
     max-width: 175px;

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -265,3 +265,12 @@
     <div *ngIf="!isSystem && !isConfirmed" class="not-exist">
         Before starting work you need to get DID <a [routerLink]="['/profile']">here</a>
     </div>
+
+    <div *ngIf="loading && !taskId" class="loading">
+        <mat-spinner></mat-spinner>
+    </div>
+    <div *ngIf="loading && taskId" class="loading">
+        <async-progress class="loading-progress" [taskId]="taskId" [expected]="expectedTaskMessages"
+            (error)="onAsyncError($event)" (completed)="onAsyncCompleted()"></async-progress>
+    </div>
+</div>


### PR DESCRIPTION
# **Description**:

As described in issue #2046, the progress bar of all the steps involved when performing schema operations such as Create and Import have disappeared after merging with the following [PR](https://github.com/hashgraph/guardian/commit/66bef4877fe97ed05593a25ec8cd6880080a8e06#diff-34fafbe6087488af8b4%5B%E2%80%A6%5De4603cb716a01cfc0f85L268).

This PR intends to bring these progress bars.



# **Fixes**:

The pieces of code under `/frontend/src/app/views/schemas` that were mistakenly deleted have been restored.
