### PR TITLE
feat: prometheus and grafana integration

### DIFF
--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -21,6 +21,8 @@
     "reflect-metadata": "^0.1.13",
     "ws": "^8.2.1",
     "yup": "^1.1.1"
+    "prometheus-api-metrics": "3.2.2",
+    "prom-client": "^14.1.1"
   },
   "description": "",
   "devDependencies": {

--- a/api-gateway/src/api/service/index.ts
+++ b/api-gateway/src/api/service/index.ts
@@ -13,3 +13,4 @@ export { analyticsAPI } from '@api/service/analytics';
 export { moduleAPI } from '@api/service/module';
 export { tagsAPI } from '@api/service/tags';
 export { themesAPI } from '@api/service/themes';
+export { metricsAPI } from '@api/service/metrics';

--- a/api-gateway/src/api/service/metrics.ts
+++ b/api-gateway/src/api/service/metrics.ts
@@ -1,0 +1,9 @@
+import { Request, Response, Router } from 'express';
+import client from 'prom-client';
+
+export const metricsAPI = Router();
+
+metricsAPI.get('/', async (req: Request, res: Response) => {
+    res.set('Content-Type', client.register.contentType);
+    return res.send(await client.register.metrics());
+});

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -14,7 +14,10 @@
     "jsonwebtoken": "^8.5.1",
     "module-alias": "^2.2.2",
     "node-vault": "^0.9.22",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "express": "^4.17.1",
+    "prometheus-api-metrics": "3.2.2",
+    "prom-client": "^14.1.1"
   },
   "description": "",
   "devDependencies": {

--- a/auth-service/src/app.ts
+++ b/auth-service/src/app.ts
@@ -18,6 +18,7 @@ import { ImportKeysFromDatabase } from '@helpers/import-keys-from-database';
 import process from 'process';
 import { SecretManager } from '@guardian/common/dist/secret-manager';
 import { OldSecretManager } from '@guardian/common/dist/secret-manager/old-style/old-secret-manager';
+import { startMetricsServer } from './utils/metrics';
 
 Promise.all([
     Migration({
@@ -74,6 +75,8 @@ Promise.all([
         console.error(error.message);
         process.exit(1);
     }
+
+    startMetricsServer();
 }, (reason) => {
     console.log(reason);
     process.exit(0);

--- a/auth-service/src/utils/metrics.ts
+++ b/auth-service/src/utils/metrics.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import client from 'prom-client';
+import guardianServicePrometheusMetrics from 'prometheus-api-metrics';
+
+const app = express();
+
+const PORT = process.env.METRICS_PORT || 5005;
+
+export const startMetricsServer = () => {
+  app.use(guardianServicePrometheusMetrics());
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', client.register.contentType);
+
+    return res.send(await client.register.metrics());
+  });
+
+  app.listen(PORT, () => {
+    console.log(`auth-service metrics server started at http://localhost:${PORT}`);
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,8 @@ services:
     build:
       context: .
       dockerfile: ./auth-service/Dockerfile
+    ports:
+      - '5005:5005'
     depends_on:
       - mongo
       - vault
@@ -124,6 +126,7 @@ services:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
     expose:
       - 6555
+      - 5005
 
   api-gateway:
     env_file:
@@ -149,6 +152,8 @@ services:
     build:
       context: .
       dockerfile: ./policy-service/Dockerfile
+    ports:
+      - "5006:5006"
     depends_on:
       - mongo
       - message-broker
@@ -158,6 +163,7 @@ services:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
     expose:
       - 50000-60000
+      - 5006
 
 
   guardian-service:
@@ -166,6 +172,8 @@ services:
     build:
       context: .
       dockerfile: ./guardian-service/Dockerfile
+    ports:
+      - "5007:5007"
     depends_on:
       - mongo
       - message-broker
@@ -178,6 +186,7 @@ services:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
     expose:
       - 6555
+      - 5007
 
   application-events:
     build:
@@ -200,7 +209,10 @@ services:
       context: .
       dockerfile: ./mrv-sender/Dockerfile
     expose:
-      - 3005
+      - 3003
+      - 5008
+    ports:
+      - "5008:5008"
 
   topic-viewer:
     build:
@@ -208,6 +220,9 @@ services:
       dockerfile: ./topic-viewer/Dockerfile
     expose:
       - 3006
+      - 5009
+    ports:
+      - "5009:5009"
 
   web-proxy:
     build:
@@ -222,9 +237,52 @@ services:
       - api-docs
       - mrv-sender
       - mongo-express
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring
+    
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/etc/grafana/dashboards
+    environment:
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_SERVER_HTTP_PORT=9080
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/prometheus-dashboard.json
+    ports:
+      - "9080:9080"
+    networks:
+      - monitoring
+      
 volumes:
   mongo:
+  prometheus_data: {}
+  grafana_data: {}
   # volume-guardian-service:
   # volume-ui-service:
   # volume-mrv-sender:
   #  volume-message-broker:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/grafana/dashboards/prometheus-dashboard.json
+++ b/grafana/dashboards/prometheus-dashboard.json
@@ -1,0 +1,2929 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "datasource",
+                    "uid": "grafana"
+                },
+                "enable": false,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "description": "Monitor metrics for node.js and express router status.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 12230,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#C4162A",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 70
+                            },
+                            {
+                                "color": "#299c46",
+                                "value": 90
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 6,
+                "x": 0,
+                "y": 0
+            },
+            "id": 51,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "(\n        (   \n                sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$target\",code=~\"^2..$\"})\n                + (\n                        sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$tolerated\",code=~\"^2..$\"})\n                        - sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$target\",code=~\"^2..$\"})\n                ) / 2\n        ) / sum(http_request_duration_seconds_count{instance=~\"$instance\",code=~\"^2..$\"})\n) * 100",
+                    "legendFormat": "score",
+                    "refId": "A"
+                }
+            ],
+            "title": "Apdex Score: target $target s, tolerated $tolerated s",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 100
+                            },
+                            {
+                                "color": "#C4162A",
+                                "value": 200
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 6,
+                "y": 0
+            },
+            "id": 57,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "sum(rate(http_request_duration_seconds_count{instance=~\"$instance\"}[$interval]))",
+                    "refId": "A"
+                }
+            ],
+            "title": "QPS",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "fixedColor": "rgb(31, 120, 193)",
+                        "mode": "fixed"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 4,
+                "x": 8,
+                "y": 0
+            },
+            "id": 53,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "sum(http_request_duration_seconds_count{instance=~\"$instance\"})",
+                    "instant": false,
+                    "refId": "A"
+                }
+            ],
+            "title": "Requests",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 5
+                            },
+                            {
+                                "color": "#C4162A",
+                                "value": 10
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 12,
+                "y": 0
+            },
+            "id": 63,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "(\n\tsum(\n\t\thttp_request_duration_seconds_count{instance=~\"$instance\",code=~\"^[45]..$\"} OR on() vector(0)\n\t) / \n\tsum(\n\t\thttp_request_duration_seconds_count{instance=~\"$instance\"}\n\t)\n)*100",
+                    "legendFormat": "error %",
+                    "refId": "A"
+                }
+            ],
+            "title": "Error",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 4,
+                "x": 14,
+                "y": 0
+            },
+            "id": 59,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "sum(http_response_size_bytes_sum{instance=~\"$instance\"}) + sum(http_request_size_bytes_sum{instance=~\"$instance\"})",
+                    "refId": "A"
+                }
+            ],
+            "title": "Transferred",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "fixedColor": "rgb(31, 120, 193)",
+                        "mode": "fixed"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 18,
+                "y": 0
+            },
+            "id": 70,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "sum(rate(http_response_size_bytes_sum{instance=~\"$instance\"}[$interval])) + sum(rate(http_request_size_bytes_sum{instance=~\"$instance\"}[$interval]))",
+                    "refId": "A"
+                }
+            ],
+            "title": "Transfer Rate",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "text": "N/A"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "#299c46",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 1
+                            },
+                            {
+                                "color": "#C4162A",
+                                "value": 2
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 3,
+                "x": 21,
+                "y": 0
+            },
+            "id": 61,
+            "links": [],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.3.6",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "sum(changes(process_start_time_seconds{instance=~\"$instance\"}[$restarts_interval]))",
+                    "refId": "A"
+                }
+            ],
+            "title": "Restarts in $restarts_interval",
+            "type": "stat"
+        },
+        {
+            "collapsed": true,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 2
+            },
+            "id": 87,
+            "panels": [
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 0,
+                        "y": 15
+                    },
+                    "id": 21,
+                    "legend": {
+                        "alignAsTable": false,
+                        "avg": false,
+                        "current": true,
+                        "max": false,
+                        "min": false,
+                        "rightSide": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "nodejs_eventloop_lag_seconds{instance=~\"$instance\"}",
+                            "hide": false,
+                            "instant": false,
+                            "legendFormat": "last",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "nodejs_eventloop_lag_p99_seconds{instance=~\"$instance\"}",
+                            "legendFormat": "p99",
+                            "refId": "B"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "nodejs_eventloop_lag_p50_seconds{instance=~\"$instance\"}",
+                            "legendFormat": "p50",
+                            "refId": "C"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Eventloop Latency",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 8,
+                        "y": 15
+                    },
+                    "id": 42,
+                    "legend": {
+                        "avg": true,
+                        "current": false,
+                        "max": true,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[$interval])",
+                            "legendFormat": "cpu",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Rate of CPU Time Spent",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 16,
+                        "y": 15
+                    },
+                    "id": 82,
+                    "legend": {
+                        "avg": false,
+                        "current": true,
+                        "max": true,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "process_virtual_memory_bytes{instance=~\"$instance\"}",
+                            "legendFormat": "virtual memory",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "process_heap_bytes{instance=~\"$instance\"}",
+                            "legendFormat": "heap memory",
+                            "refId": "B"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Process Memory",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "bytes",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 0,
+                        "y": 20
+                    },
+                    "id": 77,
+                    "legend": {
+                        "avg": false,
+                        "current": true,
+                        "max": true,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "expressjs_number_of_open_connections{instance=~\"$instance\"}",
+                            "legendFormat": "{{instance}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Number of Open Connections",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "decimals": 0,
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 8,
+                        "y": 20
+                    },
+                    "id": 79,
+                    "legend": {
+                        "avg": false,
+                        "current": true,
+                        "max": false,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "( process_open_fds{instance=~\"$instance\"} / process_max_fds{instance=~\"$instance\"})",
+                            "legendFormat": "{{instance}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Used File Descriptors",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "percentunit",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 8,
+                        "x": 16,
+                        "y": 20
+                    },
+                    "id": 66,
+                    "legend": {
+                        "avg": false,
+                        "current": true,
+                        "max": true,
+                        "min": false,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "nodejs_active_handles_total{instance=~\"$instance\"}",
+                            "legendFormat": "Active Handler",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "nodejs_active_requests_total{instance=~\"$instance\"}",
+                            "legendFormat": "Active Request",
+                            "refId": "B"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Active Handlers/Requests",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                }
+            ],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Node.js Process",
+            "type": "row"
+        },
+        {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 3
+            },
+            "id": 40,
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Node.js Garbage Collection",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 43,
+            "legend": {
+                "avg": true,
+                "current": false,
+                "max": true,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "rate(nodejs_gc_duration_seconds_sum{instance=~\"$instance\"}[$interval])",
+                    "legendFormat": "{{kind}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Rate of Garbage Collection Duration",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "legend": {
+                "avg": true,
+                "current": false,
+                "max": true,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "rate(nodejs_gc_duration_seconds_count{instance=~\"$instance\"}[$interval])",
+                    "legendFormat": "{{kind}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Rate of Garbage Collection",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 46,
+            "legend": {
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_gc_duration_seconds_sum{instance=~\"$instance\"}",
+                    "legendFormat": "{{kind}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Garbage Collection Duration",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "s",
+                    "label": "",
+                    "logBase": 2,
+                    "show": true
+                },
+                {
+                    "format": "s",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 45,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_gc_duration_seconds_count{instance=~\"$instance\"}",
+                    "legendFormat": "{{kind}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Garbage Collection Count",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "",
+                    "logBase": 2,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 34,
+            "legend": {
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_heap_size_total_bytes{instance=~\"$instance\"}",
+                    "legendFormat": "total",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_heap_size_used_bytes{instance=~\"$instance\"}",
+                    "legendFormat": "used",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+                    "legendFormat": "resident",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_external_memory_bytes{instance=~\"$instance\"}",
+                    "legendFormat": "external",
+                    "refId": "D"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Heap Memory Usage",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 14
+            },
+            "hiddenSeries": false,
+            "id": 36,
+            "legend": {
+                "avg": false,
+                "current": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.3.6",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "expr": "nodejs_heap_space_size_used_bytes{instance=~\"$instance\"}",
+                    "legendFormat": "{{space}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Heap Space Used",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "bytes",
+                    "logBase": 1,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+        },
+        {
+            "collapsed": true,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PC62BA7048C9E0167"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+            },
+            "id": 26,
+            "panels": [
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 12,
+                        "x": 0,
+                        "y": 5
+                    },
+                    "id": 73,
+                    "legend": {
+                        "avg": true,
+                        "current": true,
+                        "max": true,
+                        "min": true,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "links": [],
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pluginVersion": "6.3.2",
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "(\n        (   \n                sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$target\",code=~\"^2..$\"})\n                + (\n                        sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$tolerated\",code=~\"^2..$\"})\n                        - sum(http_request_duration_seconds_bucket{instance=~\"$instance\",le=\"$target\",code=~\"^2..$\"})\n                ) / 2\n        ) / sum(http_request_duration_seconds_count{instance=~\"$instance\",code=~\"^2..$\"})\n) * 100",
+                            "legendFormat": "score",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Apdex Score: target $target s, tolerated $tolerated s",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "description": "",
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 9,
+                        "w": 12,
+                        "x": 12,
+                        "y": 5
+                    },
+                    "id": 18,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": true,
+                        "hideEmpty": true,
+                        "hideZero": true,
+                        "max": true,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "connected",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{instance=~\"$instance\"}[$interval])) by (code,le))",
+                            "legendFormat": "{{code}}(95%)",
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "histogram_quantile(1, sum(rate(http_request_duration_seconds_bucket{instance=~\"$instance\"}[$interval])) by (code,le))",
+                            "legendFormat": "{{code}}(100%)",
+                            "refId": "E"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Response Latency",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "s",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 12,
+                        "x": 0,
+                        "y": 10
+                    },
+                    "id": 32,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": false,
+                        "max": true,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "sum(rate(http_request_duration_seconds_count{instance=~\"$instance\"}[$interval])) by (code)",
+                            "legendFormat": "{{code}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Requests Per Seconds",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 12,
+                        "w": 12,
+                        "x": 12,
+                        "y": 14
+                    },
+                    "id": 30,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": true,
+                        "max": false,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "sum(http_response_size_bytes_sum{instance=~\"$instance\"}) by (route)",
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Response Size",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "bytes",
+                            "logBase": 2,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 5,
+                        "w": 12,
+                        "x": 0,
+                        "y": 15
+                    },
+                    "id": 44,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": true,
+                        "max": false,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "sum(http_request_duration_seconds_count{instance=~\"$instance\"}) by (code)",
+                            "legendFormat": "{{code}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Code Count",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "gridPos": {
+                        "h": 6,
+                        "w": 12,
+                        "x": 0,
+                        "y": 20
+                    },
+                    "id": 64,
+                    "legend": {
+                        "alignAsTable": true,
+                        "avg": false,
+                        "current": true,
+                        "max": false,
+                        "min": false,
+                        "rightSide": true,
+                        "show": true,
+                        "sort": "current",
+                        "sortDesc": true,
+                        "total": false,
+                        "values": true
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "options": {
+                        "dataLinks": []
+                    },
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": true,
+                    "steppedLine": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "PC62BA7048C9E0167"
+                            },
+                            "expr": "sum(http_request_duration_seconds_count{instance=~\"$instance\"}) by (route)",
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "title": "Request Count",
+                    "tooltip": {
+                        "shared": true,
+                        "sort": 0,
+                        "value_type": "individual"
+                    },
+                    "type": "graph",
+                    "xaxis": {
+                        "mode": "time",
+                        "show": true,
+                        "values": []
+                    },
+                    "yaxes": [
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": true
+                        },
+                        {
+                            "format": "short",
+                            "logBase": 1,
+                            "show": false
+                        }
+                    ],
+                    "yaxis": {
+                        "align": false
+                    }
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 0,
+                        "y": 26
+                    },
+                    "id": 95,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "s"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, sum by (route)(http_request_duration_seconds_sum{instance=~\"$instance\"}))",
+                            "instant": true,
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Request Duration",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 4,
+                        "y": 26
+                    },
+                    "id": 89,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "s"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, sum by (route)(http_request_duration_seconds_sum{instance=~\"$instance\",code=~\"^[23]..$\"}))",
+                            "instant": true,
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Success Duration",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 8,
+                        "y": 26
+                    },
+                    "id": 93,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "s"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, sum by (route)(http_request_duration_seconds_sum{instance=~\"$instance\",code=~\"^[45]..$\"}))",
+                            "instant": true,
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Error Duration",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 12,
+                        "y": 26
+                    },
+                    "id": 96,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "short"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, sum by (route)(http_request_duration_seconds_count{instance=~\"$instance\"}))",
+                            "instant": true,
+                            "legendFormat": "{{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Request Count",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 16,
+                        "y": 26
+                    },
+                    "id": 91,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "short"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, http_request_duration_seconds_count{instance=~\"$instance\",code=~\"^[23]..$\"})",
+                            "instant": true,
+                            "legendFormat": "({{code}}) {{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Success Count",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                },
+                {
+                    "columns": [
+                        {
+                            "text": "Current",
+                            "value": "current"
+                        }
+                    ],
+                    "datasource": {
+                        "type": "datasource",
+                        "uid": "grafana"
+                    },
+                    "fontSize": "100%",
+                    "gridPos": {
+                        "h": 6,
+                        "w": 4,
+                        "x": 20,
+                        "y": 26
+                    },
+                    "id": 92,
+                    "options": {},
+                    "scroll": true,
+                    "showHeader": true,
+                    "sort": {
+                        "col": 1,
+                        "desc": true
+                    },
+                    "styles": [
+                        {
+                            "alias": "Time",
+                            "align": "auto",
+                            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                            "pattern": "Time",
+                            "type": "date"
+                        },
+                        {
+                            "alias": "",
+                            "align": "auto",
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "pattern": "/.*/",
+                            "thresholds": [],
+                            "type": "number",
+                            "unit": "short"
+                        }
+                    ],
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "datasource",
+                                "uid": "grafana"
+                            },
+                            "expr": "topk(5, http_request_duration_seconds_count{instance=~\"$instance\",code=~\"^[45]..$\"})",
+                            "instant": true,
+                            "legendFormat": "({{code}}) {{route}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 5 Error Count",
+                    "transform": "timeseries_aggregations",
+                    "type": "table-old"
+                }
+            ],
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PC62BA7048C9E0167"
+                    },
+                    "refId": "A"
+                }
+            ],
+            "title": "Express Route",
+            "type": "row"
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [
+        "node.js",
+        "express",
+        "prometheus"
+    ],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PC62BA7048C9E0167"
+                },
+                "definition": "label_values(nodejs_version_info, instance)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "instance",
+                "multi": true,
+                "name": "instance",
+                "options": [],
+                "query": {
+                    "query": "label_values(nodejs_version_info, instance)",
+                    "refId": "Guardian metrics-instance-Variable-Query"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                    "selected": false,
+                    "text": "1m",
+                    "value": "1m"
+                },
+                "hide": 0,
+                "name": "interval",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "1m",
+                        "value": "1m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "10m",
+                        "value": "10m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "30m",
+                        "value": "30m"
+                    },
+                    {
+                        "selected": false,
+                        "text": "1h",
+                        "value": "1h"
+                    },
+                    {
+                        "selected": false,
+                        "text": "6h",
+                        "value": "6h"
+                    },
+                    {
+                        "selected": false,
+                        "text": "12h",
+                        "value": "12h"
+                    },
+                    {
+                        "selected": false,
+                        "text": "1d",
+                        "value": "1d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "7d",
+                        "value": "7d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "14d",
+                        "value": "14d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "30d",
+                        "value": "30d"
+                    }
+                ],
+                "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+                "refresh": 2,
+                "skipUrlSync": false,
+                "type": "interval"
+            },
+            {
+                "current": {
+                    "tags": [],
+                    "text": "0.05",
+                    "value": "0.05"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "target",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "0.05",
+                        "value": "0.05"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.1",
+                        "value": "0.1"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.2",
+                        "value": "0.2"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.3",
+                        "value": "0.3"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.4",
+                        "value": "0.4"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.5",
+                        "value": "0.5"
+                    }
+                ],
+                "query": "0.05,0.1,0.2,0.3,0.4,0.5",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "current": {
+                    "tags": [],
+                    "text": "0.2",
+                    "value": "0.2"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "tolerated",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "0.1",
+                        "value": "0.1"
+                    },
+                    {
+                        "selected": true,
+                        "text": "0.2",
+                        "value": "0.2"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.3",
+                        "value": "0.3"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.4",
+                        "value": "0.4"
+                    },
+                    {
+                        "selected": false,
+                        "text": "0.5",
+                        "value": "0.5"
+                    }
+                ],
+                "query": "0.1,0.2,0.3,0.4,0.5",
+                "skipUrlSync": false,
+                "type": "custom"
+            },
+            {
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                    "selected": false,
+                    "text": "1d",
+                    "value": "1d"
+                },
+                "hide": 0,
+                "name": "restarts_interval",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "1d",
+                        "value": "1d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "7d",
+                        "value": "7d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "14d",
+                        "value": "14d"
+                    },
+                    {
+                        "selected": false,
+                        "text": "30d",
+                        "value": "30d"
+                    }
+                ],
+                "query": "1d,7d,14d,30d",
+                "refresh": 2,
+                "skipUrlSync": false,
+                "type": "interval"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Guardian Application Dashboard",
+    "uid": "3J_78b6Zz",
+    "version": 1,
+    "weekStart": ""
+}

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: Guardian metrics
+    type: prometheus
+    access: proxy
+    url: http://host.docker.internal:9090

--- a/guardian-service/package.json
+++ b/guardian-service/package.json
@@ -44,6 +44,8 @@
     "moment": "^2.29.2",
     "mongodb": "5.3.0",
     "reflect-metadata": "^0.1.13"
+    "prometheus-api-metrics": "3.2.2",
+    "prom-client": "^14.1.1"
   },
   "description": "",
   "devDependencies": {

--- a/guardian-service/src/app.ts
+++ b/guardian-service/src/app.ts
@@ -56,6 +56,7 @@ import { demoAPI } from '@api/demo.service';
 import { SecretManager } from '@guardian/common/dist/secret-manager';
 import { OldSecretManager } from '@guardian/common/dist/secret-manager/old-style/old-secret-manager';
 import { themeAPI } from '@api/theme.service';
+import { startMetricsServer } from './utils/metrics';
 
 export const obj = {};
 
@@ -291,6 +292,8 @@ Promise.all([
         }, 1000)
     });
     await validator.validate();
+
+    startMetricsServer();
 }, (reason) => {
     console.log(reason);
     process.exit(0);

--- a/guardian-service/src/utils/metrics.ts
+++ b/guardian-service/src/utils/metrics.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import client from 'prom-client';
+import guardianServicePrometheusMetrics from 'prometheus-api-metrics';
+
+const app = express();
+
+const PORT = process.env.METRICS_PORT || 5007;
+
+export const startMetricsServer = () => {
+  app.use(guardianServicePrometheusMetrics());
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', client.register.contentType);
+
+    return res.send(await client.register.metrics());
+  });
+
+  app.listen(PORT, () => {
+    console.log(`guardian-service metrics server started at http://localhost:${PORT}`);
+  });
+}

--- a/mrv-sender/package.json
+++ b/mrv-sender/package.json
@@ -12,6 +12,8 @@
     "axios": "^1.3.6",
     "express": "^4.17.3",
     "jose": "4.14.1"
+    "prometheus-api-metrics": "3.2.2",
+    "prom-client": "^14.1.1"
   },
   "description": "",
   "devDependencies": {

--- a/mrv-sender/src/index.ts
+++ b/mrv-sender/src/index.ts
@@ -5,6 +5,7 @@ import { DefaultDocumentLoader } from './document-loader/document-loader-default
 import { VCHelper } from './vc-helper';
 import path from 'path';
 import fs from 'fs';
+import { startMetricsServer } from './utils/metrics';
 
 enum GenerateMode {
     TEMPLATES = "TEMPLATES",
@@ -122,6 +123,7 @@ const PORT = process.env.PORT || 3005;
         res.status(200).json(document);
     });
 
+    startMetricsServer();
     app.listen(PORT, () => {
         console.log('Sender started at port', PORT);
     })

--- a/mrv-sender/src/utils/metrics.ts
+++ b/mrv-sender/src/utils/metrics.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import client from 'prom-client';
+import guardianServicePrometheusMetrics from 'prometheus-api-metrics';
+
+const app = express();
+
+const PORT = process.env.PORT || 5008;
+
+export const startMetricsServer = () => {
+  app.use(guardianServicePrometheusMetrics());
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', client.register.contentType);
+
+    return res.send(await client.register.metrics());
+  });
+
+  app.listen(PORT, () => {
+    console.log(`mrv-sender metrics server started at http://localhost:${PORT}`);
+  });
+}

--- a/policy-service/package.json
+++ b/policy-service/package.json
@@ -42,6 +42,8 @@
         "mathjs": "^10.1.0",
         "module-alias": "^2.2.2",
         "moment": "^2.29.2",
+        "prometheus-api-metrics": "3.2.2",
+        "prom-client": "^14.1.1"
         "mongodb": "5.3.0",
         "reflect-metadata": "^0.1.13"
     },

--- a/policy-service/src/app.ts
+++ b/policy-service/src/app.ts
@@ -5,6 +5,7 @@ import {
 } from '@guardian/common';
 import { ApplicationStates } from '@guardian/interfaces';
 import { PolicyContainer } from '@helpers/policy-container';
+import { startMetricsServer } from './utils/metrics';
 
 export const obj = {};
 
@@ -31,6 +32,8 @@ Promise.all([
     await new Logger().info('Policy service started', ['GUARDIAN_SERVICE']);
 
     await state.updateState(ApplicationStates.READY);
+
+    startMetricsServer();
 }, (reason) => {
     console.log(reason);
     process.exit(0);

--- a/policy-service/src/utils/metrics.ts
+++ b/policy-service/src/utils/metrics.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import client from 'prom-client';
+import guardianServicePrometheusMetrics from 'prometheus-api-metrics';
+
+const app = express();
+
+const PORT = process.env.METRICS_PORT || 5006;
+
+export const startMetricsServer = () => {
+  app.use(guardianServicePrometheusMetrics());
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', client.register.contentType);
+
+    return res.send(await client.register.metrics());
+  });
+
+  app.listen(PORT, () => {
+    console.log(`policy-service metrics server started at http://localhost:${PORT}`);
+  });
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,33 @@
+global:
+    scrape_interval: 15s
+scrape_configs:
+    - job_name: "api-gateway"
+      scrape_interval: 5s
+      metrics_path: /api/v1/metrics
+      static_configs:
+        - targets: ["host.docker.internal:3000"]
+        
+    - job_name: "guardian-service"
+      scrape_interval: 5s
+      static_configs:
+        - targets: ["host.docker.internal:5007"]
+    
+    - job_name: "auth-service"
+      scrape_interval: 5s
+      static_configs:
+        - targets: [ "host.docker.internal:5005" ]
+    
+    - job_name: "policy-service"
+      scrape_interval: 5s
+      static_configs:
+        - targets: [ "host.docker.internal:5006" ]
+    
+    - job_name: "topic-viewer"
+      scrape_interval: 5s
+      static_configs:
+        - targets: [ "host.docker.internal:5009" ]
+    
+    - job_name: "mrv-sender"
+      scrape_interval: 5s
+      static_configs:
+        - targets: [ "host.docker.internal:5008" ]

--- a/topic-viewer/package.json
+++ b/topic-viewer/package.json
@@ -1,7 +1,9 @@
 {
   "author": "Envision Blockchain Solutions <info@envisionblockchain.com>",
   "dependencies": {
-    "express": "^4.17.3"
+    "express": "^4.17.3",
+    "prometheus-api-metrics": "3.2.2",
+    "prom-client": "^14.1.1"
   },
   "description": "",
   "devDependencies": {

--- a/topic-viewer/src/index.ts
+++ b/topic-viewer/src/index.ts
@@ -1,10 +1,13 @@
 import express from 'express';
+import { startMetricsServer } from './utils/metrics';
 
 const PORT = process.env.PORT || 3006;
 (async () => {
     const app = express();
     app.use(express.static('public'));
     app.use(express.json());
+
+    startMetricsServer();
     app.listen(PORT, () => {
         console.log('Topic Viewer started at port', PORT);
     })

--- a/topic-viewer/src/utils/metrics.ts
+++ b/topic-viewer/src/utils/metrics.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import client from 'prom-client';
+import guardianServicePrometheusMetrics from 'prometheus-api-metrics';
+
+const app = express();
+
+const PORT = process.env.METRICS_PORT || 5009;
+
+export const startMetricsServer = () => {
+  app.use(guardianServicePrometheusMetrics());
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', client.register.contentType);
+
+    return res.send(await client.register.metrics());
+  });
+
+  app.listen(PORT, () => {
+    console.log(`topic-viewer metrics server started at http://localhost:${PORT}`);
+  });
+}


### PR DESCRIPTION
This PR aims to configure the Prometheus and Grafana application in the Guardian project.

Related issue: [https://github.com/hashgraph/guardian/issues/1770](https://github.com/hashgraph/guardian/issues/1770)

The modules below provide a server with a route `/metrics` to expose application metrics. 

These services are being scraped by Prometheus, which is running here **http://localhost:9090**.

- api-gateway
- guardian-service
- auth-service
- policy-service
- topic-viewer
- mrv-sender

A dashboard was created using the Grafana application to present these data. This dashboard can be accessed here -> **http://localhost:9080**.

Simple tests were written to check if the servers exposing the metrics are running.

![Screenshot 2023-02-23 at 15 25 43](https://user-images.githubusercontent.com/220753/220951740-45a57b4f-71f3-4c3f-ada9-1496c3e23535.png)
