### PR TITLE
feature/ux-in-selecting-standards: Replace username filter for standard registries with geography, update UX of Generate button

### DIFF
--- a/frontend/src/app/views/root-config/root-config.component.html
+++ b/frontend/src/app/views/root-config/root-config.component.html
@@ -110,7 +110,7 @@
                 </div>
             </div>
             <div *ngIf="!generated" class="list-button">
-                <button mat-raised-button type="button" id="generate-btn-mobile" (click)="randomKey()">Generate</button>
+                <button mat-raised-button type="button" class="generate-btn" (click)="randomKey()">Generate</button>
             </div>
             <div class="list-item" *ngIf="showForm && generated">
                 <app-schema-form [formGroup]="vcForm" [schema]="schema" [private-fields]="hideVC"
@@ -176,7 +176,7 @@
     <div *ngIf="!isConfirmed && isFailed" class="error-list">
         <p>An error occurred while creating the document.</p>
         <p>Please try again later.</p>
-        <button mat-raised-button type="button" color="primary" class="generate-btn" (click)="retry()">Retry</button>
+        <button mat-raised-button type="button" color="primary" (click)="retry()">Retry</button>
     </div>
 
     <div *ngIf="errorLoadSchema" class="error-schema">

--- a/frontend/src/app/views/root-config/root-config.component.scss
+++ b/frontend/src/app/views/root-config/root-config.component.scss
@@ -256,6 +256,10 @@
     background: none !important;
     color: var(--button-primary-color);
     box-shadow: none;
+
+    &:hover {
+        background: #f8f9fd !important;
+    }
 }
 
 @media (max-width: 810px) {

--- a/frontend/src/app/views/root-config/root-config.component.scss
+++ b/frontend/src/app/views/root-config/root-config.component.scss
@@ -251,6 +251,13 @@
     align-items: center;
 }
 
+.generate-btn {
+    border: 1px solid var(--button-primary-color);
+    background: none !important;
+    color: var(--button-primary-color);
+    box-shadow: none;
+}
+
 @media (max-width: 810px) {
 
     .list {
@@ -270,12 +277,6 @@
         width: 100% !important;
         position: static;
         margin: 0 !important;
-    }
-
-    #generate-btn-mobile {
-        border: 1px solid var(--button-primary-color);
-        background: none !important;
-        color: var(--button-primary-color);
     }
 
     .white-space {

--- a/frontend/src/app/views/user-profile/user-profile.component.html
+++ b/frontend/src/app/views/user-profile/user-profile.component.html
@@ -204,7 +204,7 @@
                             </mat-form-field>
     
                             <mat-form-field class="user-onboarding-wizard__control" appearance="outline">
-                                <input matInput placeholder="Username" formControlName="username">
+                                <input matInput placeholder="Geography" formControlName="geography">
                             </mat-form-field>
                         </div>
 

--- a/frontend/src/app/views/user-profile/user-profile.component.scss
+++ b/frontend/src/app/views/user-profile/user-profile.component.scss
@@ -280,6 +280,10 @@ a[disabled="true"] {
     background: none !important;
     color: var(--button-primary-color);
     box-shadow: none;
+
+    &:hover {
+        background: #f8f9fd !important;
+    }
 }
 
 .list-item {

--- a/frontend/src/app/views/user-profile/user-profile.component.scss
+++ b/frontend/src/app/views/user-profile/user-profile.component.scss
@@ -276,6 +276,10 @@ a[disabled="true"] {
 .generate-btn {
     margin-bottom: 20px;
     width: 100% !important;
+    border: 1px solid var(--button-primary-color);
+    background: none !important;
+    color: var(--button-primary-color);
+    box-shadow: none;
 }
 
 .list-item {
@@ -522,12 +526,6 @@ a[disabled="true"] {
         &__title {
             margin-bottom: 15px;
         }
-    }
-
-    .generate-btn {
-        border: 1px solid #2C78F6;
-        background: none !important;
-        color: #2C78F6;
     }
 
     .user-onboarding-wizard {

--- a/frontend/src/app/views/user-profile/user-profile.component.ts
+++ b/frontend/src/app/views/user-profile/user-profile.component.ts
@@ -62,7 +62,7 @@ export class UserProfileComponent implements OnInit {
 
     filtersForm = new FormGroup({
         policyName: new FormControl(''),
-        username: new FormControl(''),
+        geography: new FormControl(''),
     });
 
     displayedColumns: string[] = [
@@ -549,20 +549,20 @@ export class UserProfileComponent implements OnInit {
     }
 
     applyFilters(): void {
-        if (this.filters.policyName && this.filters.username) {
-            this.filterByPolicyNameAndUsername();
+        if (this.filters.policyName && this.filters.geography) {
+            this.filterByPolicyNameAndGeography();
             this.handleFiltering();
             return;
         }
 
         this.filters.policyName
             ? this.filterByPolicyName()
-            : this.filterByUsername();
+            : this.filterByGeography();
         this.handleFiltering();
     }
 
     clearFilters(): void {
-        this.filtersForm.reset({ policyName: '', username: '' });
+        this.filtersForm.reset({ policyName: '', geography: '' });
         this.filteredRegistries = [];
         this.noFilterResults = false;
         this.selectStandardRegistry('');
@@ -583,17 +583,17 @@ export class UserProfileComponent implements OnInit {
         );
     }
 
-    private filterByUsername(): void {
+    private filterByGeography(): void {
         this.filteredRegistries = this.standardRegistries.filter(
             (registry: IStandardRegistryResponse) =>
-                this.isRegistryNameEqualToFilter(registry)
+                this.isGeographyEqualToFilter(registry)
         );
     }
 
-    private filterByPolicyNameAndUsername(): void {
+    private filterByPolicyNameAndGeography(): void {
         this.filteredRegistries = this.standardRegistries.filter(
             (registry: IStandardRegistryResponse) =>
-                this.isRegistryNameEqualToFilter(registry) &&
+                this.isGeographyEqualToFilter(registry) &&
                 this.isRegistryContainPolicy(registry)
         );
     }
@@ -610,12 +610,12 @@ export class UserProfileComponent implements OnInit {
         );
     }
 
-    private isRegistryNameEqualToFilter(
+    private isGeographyEqualToFilter(
         registry: IStandardRegistryResponse
-    ): boolean {
-        return registry.username
-            .toLowerCase()
-            .includes(this.filters.username.toLowerCase());
+    ): boolean | undefined {
+        return registry.vcDocument.document?.credentialSubject[0]?.geography
+            ?.toLowerCase()
+            .includes(this.filters.geography.toLowerCase());
     }
 
     private handleFiltering(): void {
@@ -623,10 +623,10 @@ export class UserProfileComponent implements OnInit {
         this.selectStandardRegistry('');
     }
 
-    private get filters(): { policyName: string; username: string } {
+    private get filters(): { policyName: string; geography: string } {
         return {
             policyName: this.filtersForm.value?.policyName?.trim(),
-            username: this.filtersForm.value?.username?.trim(),
+            geography: this.filtersForm.value?.geography?.trim(),
         };
     }
 
@@ -651,7 +651,7 @@ export class UserProfileComponent implements OnInit {
     get isFilterButtonDisabled(): boolean {
         return (
             this.filters.policyName.length === 0 &&
-            this.filters.username.length === 0
+            this.filters.geography.length === 0
         );
     }
 }


### PR DESCRIPTION
**Description**:
These changes are based on the client's feedback from the latest sprint demo. List of updates:
- Replaced username filter for standard registries with geography;
- Update UX of Generate button so that it won't look like disabled for the user.
<img width="1200" alt="image" src="https://github.com/hashgraph/guardian/assets/131377033/1c0f7c5a-8e3f-4592-ac87-312167f6747a">
<img width="1200" alt="image" src="https://github.com/hashgraph/guardian/assets/131377033/94177f56-fda6-4b6c-9a47-8155231808e3">
<img width="1200" alt="image" src="https://github.com/hashgraph/guardian/assets/131377033/bb3de1d4-752a-4b23-afee-bd8ad79d40fa">
<img width="1200" alt="image" src="https://github.com/hashgraph/guardian/assets/131377033/ee5baba4-b681-4c98-9b83-f5c3e8036118">

**Related issue(s)**:
#2296 
#2295 