### PR TITLE
Update workers on docker-compose.yml

### DIFF
--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -50,8 +50,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     env_file:
       - ./worker-service/.env.docker
     environment:
@@ -65,8 +67,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     env_file:
       - ./worker-service/.env.docker
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL:"worker.1"
@@ -97,8 +99,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL="worker.2"

--- a/docker-composeRIL.yml
+++ b/docker-composeRIL.yml
@@ -79,8 +79,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL:"worker.1"
@@ -94,8 +96,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL="worker.2"

--- a/docker-compose_SSV.yml
+++ b/docker-compose_SSV.yml
@@ -96,8 +96,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL=${WORKER_1_SERVICE_CHANNEL}
@@ -109,8 +111,10 @@ services:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - ipfs-node
-      - auth-service
+      ipfs-node:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
       - SERVICE_CHANNEL=${WORKER_2_SERVICE_CHANNEL}


### PR DESCRIPTION
**Description**:

On cold start of docker compose, workers crash because ipfs is not ready yet. With this change the workers will wait til the ipfs sevice is READY based on the container health check.


**Related issue(s)**:

I haven't found any related open issue, but this behaviour is happening when using ipfs container.

**Steps to reproduce the issue**:

1. clone develop branch and configure the services to use containerized ipfs
2. docker compose up (after a while the workers will crash)
3. docker compose ls -a will show both workers are down
4. docker compose up will bring back the workers, and because now ipfs bootstrap is ready, they won't crash again

**After the fix**

After the fix, even on the first compose up, the workers don't crash