### PR TITLE
Feature/environemnt hcp newenv

### DIFF
--- a/docs/environments/Dynamic secret in KMS according to environment.md
+++ b/docs/environments/Dynamic secret in KMS according to environment.md
@@ -49,7 +49,7 @@ About the steps provided at docs/secrets manager/guardian-vault.md
 The execution of the steps described allow the easy execution of every single services in the same node by his own by the means of PM2. 
 In this case the only environment files used are the ones present in each of the guardian services at \<service\>/configs/.env.\<GUARDIAN_ENV\>.\<service_name\>  (this execution need to mind the common environment variables configuring them manually for each of the service).
 
-When executing by the means of an orchestrator (as docker compose) the environment files used are the Ecosystem environment starting by the ones at path guardian/configs/.env.\<GUARDIAN_ENV\>.guardian.system (containing the common variables) with the integration of single service level variables as usual. 
+When executing by the means of an orchestrator (as docker compose) the environment files used are the Ecosystem environment starting by the ones at path guardian/configs/.env.\<GUARDIAN_ENV\>.guardian.system (containing the common variables) continuing with the integration of single service level variables as usual. 
 
 In this latter case the steps described for [hashicorp](https://github.com/hashgraph/guardian/blob/main/docs/secrets%20manager/guardian-vault.md#hashicorp-vault) are changed as follows:
 
@@ -79,6 +79,8 @@ In this latter case the steps described for [hashicorp](https://github.com/hashg
 
     if not present the variables are inserted only in the 4 services: auth-service, guardian-ervice, policy-service, and worker-service. Their value are populated in the guardian/\<service\>/configs/.env.\<GUARDIAN_ENV\>.\<SERVICE NAME\> files by the script basing on the previously defined GUARDIAN_ENV variable.
 
+    The same script create a set of files in folder guardian/vault/hashicorp/configs/vault/secrets/tokens/<service_name>/.env.secrets this files are kept to allow configuration of other environment
+
 - **Step 8** start Guardian as usual
 
 For Hashicorpp Vault the secret multienvironment naming convetion defined in the Vault by the execution of the script is going to be:
@@ -89,6 +91,16 @@ The script executed at stop 7 produce two kind of policies to manage the case wh
 
 	Policy1: <HEDERA_NET> / <PATH_TO_SECRET>                                       
 	Policy2: <GUARDIAN_ENV> / <HEDERA_NET> / <PATH_TO_SECRET>
+
+- **Adding other new environment :**
+After the first execution of the 8 steps every of the services is configured as Application with the Role needed to access the secrets following the policies configured. 
+To add other environment you need to create new secrets in the Vault per every of the environemt and configure the two variables in every of the right environmet in the guardian/<service_name>/configs/.env.<service_name>.<GUARDIAN_ENV>.
+
+        VAULT_APPROLE_ROLE_ID= 
+        VAULT_APPROLE_SECRET_ID=
+
+    To execute this actions automatically configure the GUARDIAN_ENV variable at folder guardian/vault/hashicorp/.env with the new environment name and run the provided script: guardian/vault/hashicorp/scripts/vault/vault_new_env.sh. The script configure the environemnt file of every of the four service and push the new secrets to the vault server.
+    Now you can stop and start the guardian application: configure the new ecosystem environment per all its files and restart the application.
 
 ## AWS Secret Manager
 

--- a/vault/hashicorp/scripts/consul/consul_backup.sh
+++ b/vault/hashicorp/scripts/consul/consul_backup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+BASE_DIR=$PWD/vault/hashicorp
+BACKUP_DIR=$BASE_DIR/backup/
+VAULT_ROOT_TOKEN_PATH=$BASE_DIR/vault/.root
+
+CONSUL_ADDR=http://localhost:8500
+
+# Executes a vault read command using curl
+# $1: URI vault path to be executed
+# $2: name of the snapshot file
+read() {
+  URL=$CONSUL_ADDR/$1
+  OUTPUT=$BACKUP_DIR/$2
+
+  curl $URL --output $OUTPUT
+}
+
+
+# Execute the complete snapshot for the consul server
+execute_backup() {
+
+  # create a backup dir /vault/hashicorp/backup
+  mkdir $BACKUP_DIR
+  # backup root acces file
+  cp $VAULT_ROOT_TOKEN_PATH $BACKUP_DIR/.root
+  # copy TLS material
+  cp -r $CERT_REPOSITORY_DIR $BACKUP_DIR
+
+  # execute read from server and backup in secret-backup.snap
+  read v1/snapshot secret-backup.snap
+}
+
+echo "execute backup"
+execute_backup


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**: #2403
Automatic adding multienv on hashicorp vault

Fixes 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This PR goes in the same line as #2263: Dynamic environment managing secrets.

Add: vault/hashicorp/scripts/vault/vault_new_env.sh to provide the automatic push in the hashicorp vault and the 
Update: vault/hashicorp/scripts/vault/vault_init.sh to insert in the vault/hashicorp vault the secret token to r/w per each service
Update the: docs/environments/Dynamic secret in KMS according to environment.md to provide information about this own changes
overmore introduce a vault/hashicorp/scripts/consul/consul_backup.sh to let hashicorp Vault to be backup (the means it is the Vault back end: consul)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
