### PR TITLE
Fix icon alignment in schema-form component

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-form/schema-form.component.css
+++ b/frontend/src/app/modules/schema-engine/schema-form/schema-form.component.css
@@ -202,12 +202,14 @@ form {
 
 .invalid-field-label {
     color: red;
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 10px;
 }
 
 .invalid-arrow-circle {
-    position: absolute;
-    left: -35px;
     font-size: 30px;
+    margin-right: 10px;
 }
 
 .ipfs-url ::ng-deep .mat-form-field-infix {
@@ -265,14 +267,7 @@ form {
 
 @media (max-width: 810px) {
     .invalid-field-label {
-        position: relative;
-        left: 30px;
-        margin-bottom: 10px;
-        width: calc(90% - 30px);
-    }
-
-    .invalid-arrow-circle {
-        left: -31px;
+        align-items: center;
     }
 
     mat-form-field * {


### PR DESCRIPTION
**Description**:
This PR fixes an alignment of the icon inside the error message in schema-form component.

**Related issue(s)**:
#2545 