### PR TITLE
Updated worker-service to use replicas + updated external dependencies + minor fixes

### DIFF
--- a/ai-service/.gitignore
+++ b/ai-service/.gitignore
@@ -1,2 +1,3 @@
-./faiss-vector/.
-./data/
+/faiss-vector
+/data
+

--- a/configs/.env..guardian.system
+++ b/configs/.env..guardian.system
@@ -61,12 +61,13 @@ MAX_PRIORITY="20"
 TASK_TIMEOUT="300"
 REFRESH_INTERVAL="60"
 
-IPFS_TIMEOUT="720"
-IPFS_PROVIDER="web3storage" # 'filebase', 'web3storage' or 'local'
-IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}'
-IPFS_STORAGE_KEY="..."
-IPFS_STORAGE_PROOF="..."
-IPFS_NODE_ADDRESS="http://ipfs-node:5001"
+IPFS_TIMEOUT="720" # seconds
+IPFS_PROVIDER="web3storage" # valid options: 'filebase', 'web3storage', 'local'
+IPFS_STORAGE_KEY="..." # only valid for web3storage provider; ignored in other cases
+IPFS_STORAGE_PROOF="..." # only valid for web3storage provider; ignored in other cases
+IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}' # use this for public providers (filebase, web3storage, etc.)
+#IPFS_PUBLIC_GATEWAY='http://ipfs-node:8080/ipfs/${cid}' # use this for local provider
+IPFS_NODE_ADDRESS="http://ipfs-node:5001" # only valid for local provider; ignored in other cases
 
 #BATCH_NFT_MINT_SIZE=10
 # FE/DEMO

--- a/configs/.env.develop.guardian.system
+++ b/configs/.env.develop.guardian.system
@@ -62,12 +62,13 @@ MAX_PRIORITY="20"
 TASK_TIMEOUT="300"
 REFRESH_INTERVAL="60"
 
-IPFS_TIMEOUT="720"
-IPFS_PROVIDER="web3storage" # 'web3storage' or 'local'
-IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}'
-IPFS_STORAGE_KEY="..."
-IPFS_STORAGE_PROOF="..."
-IPFS_NODE_ADDRESS="http://ipfs-node:5001"
+IPFS_TIMEOUT="720" # seconds
+IPFS_PROVIDER="web3storage" # valid options: 'filebase', 'web3storage', 'local'
+IPFS_STORAGE_KEY="..." # only valid for web3storage provider; ignored in other cases
+IPFS_STORAGE_PROOF="..." # only valid for web3storage provider; ignored in other cases
+IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}' # use this for public providers (filebase, web3storage, etc.)
+#IPFS_PUBLIC_GATEWAY='http://ipfs-node:8080/ipfs/${cid}' # use this for local provider
+IPFS_NODE_ADDRESS="http://ipfs-node:5001" # only valid for local provider; ignored in other cases
 
 #BATCH_NFT_MINT_SIZE=10
 # FE/DEMO

--- a/configs/.env.template.guardian.system
+++ b/configs/.env.template.guardian.system
@@ -78,12 +78,13 @@ MAX_PRIORITY="20"
 TASK_TIMEOUT="300"
 REFRESH_INTERVAL="60"
 
-IPFS_TIMEOUT="720"
-IPFS_PROVIDER="web3storage" # 'filebase', 'web3storage' or 'local'
-IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}'
-IPFS_STORAGE_KEY="..."
-IPFS_STORAGE_PROOF="..."
-IPFS_NODE_ADDRESS="http://ipfs-node:5001"
+IPFS_TIMEOUT="720" # seconds
+IPFS_PROVIDER="web3storage" # valid options: 'filebase', 'web3storage', 'local'
+IPFS_STORAGE_KEY="..." # only valid for web3storage provider; ignored in other cases
+IPFS_STORAGE_PROOF="..." # only valid for web3storage provider; ignored in other cases
+IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}' # use this for public providers (filebase, web3storage, etc.)
+#IPFS_PUBLIC_GATEWAY='http://ipfs-node:8080/ipfs/${cid}' # use this for local provider
+IPFS_NODE_ADDRESS="http://ipfs-node:5001" # only valid for local provider; ignored in other cases
 #BATCH_NFT_MINT_SIZE=10
 
 # FE/DEMO

--- a/docker-compose-analytics.yml
+++ b/docker-compose-analytics.yml
@@ -1,24 +1,23 @@
+  # https://docs.docker.com/compose/environment-variables/envvars-precedence/
+  # Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
+  # ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
+  # specific service variables defined by "environment" can override what is defined in the ecosystem file
 version: "3.8"
 services:
   mongo:
-    image: mongo:6.0.3
+    image: mongo:6.0.13
     command: "--setParameter allowDiskUseByDefault=true"
     restart: always
     expose:
       - 27017
 
   message-broker:
-    image: nats:2.9.8
+    image: nats:2.9.24
     expose:
       - 4222
     ports:
       - '8222:8222'
     command: '--http_port 8222'
-
-  # https://docs.docker.com/compose/environment-variables/envvars-precedence/
-  # Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-  # ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-  # specific service variables defined by "environment" can override what is defined in the ecosystem file
 
   logger-service:
     env_file:
@@ -54,7 +53,7 @@ services:
       - 6555
       - 5005
 
-  worker-service-1:
+  worker-service:
     env_file:
       - ./configs/.env.${GUARDIAN_ENV}.guardian.system
     build:
@@ -62,7 +61,6 @@ services:
       dockerfile: ./worker-service/Dockerfile
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL:"worker.1"
     depends_on:
       auth-service:
         condition: service_started
@@ -71,168 +69,8 @@ services:
     volumes:
       - ./worker-service/tls:/usr/local/worker-service/tls:ro
       - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-2:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.2"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-3:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.3"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-4:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.4"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-5:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.5"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-6:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.6"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-7:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.7"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-8:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.8"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-9:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.9"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-10:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.10"
-    depends_on:
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
+    deploy:
+      replicas: 10
 
   analytics-service:
     env_file:
@@ -242,8 +80,7 @@ services:
       dockerfile: ./analytics-service/Dockerfile
     depends_on:
       - message-broker
-      - worker-service-1
-      - worker-service-2
+      - worker-service
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
     expose:
@@ -252,13 +89,6 @@ services:
       - "3000:3020"
     volumes:
       - ./analytics-service/configs:/usr/local/analytics-service/configs:ro
-
-volumes:
-  mongo:
-  # volume-guardian-service:
-  # volume-ui-service:
-  # volume-mrv-sender:
-  #  volume-message-broker:
 
 networks:
   monitoring:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     mongo:
-        image: mongo:6.0.3
+        image: mongo:6.0.13
         command: "--setParameter allowDiskUseByDefault=true"
         restart: always
         expose:
@@ -9,7 +9,7 @@ services:
         ports:
             - 27017:27017
     ipfs-node:
-        image: ipfs/kubo:v0.22.0
+        image: ipfs/kubo:v0.26.0
         ports:
             - "5001:5001"
             - "4001:4001"
@@ -18,7 +18,7 @@ services:
             - ./runtime-data/ipfs/staging:/export:rw
             - ./runtime-data/ipfs/data:/data/ipfs:rw
     message-broker:
-        image: nats:2.9.8
+        image: nats:2.9.24
         expose:
             - 4222
         ports:
@@ -172,9 +172,4 @@ services:
             - front-end
         volumes:
             - ./web-proxy/configs/local.conf:/etc/nginx/conf.d/default.conf
-volumes:
-    mongo:
-    # volume-guardian-service:
-    # volume-ui-service:
-    # volume-mrv-sender:
-    #  volume-message-broker:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,39 @@
+# https://docs.docker.com/compose/environment-variables/envvars-precedence/
+# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
+# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
+# specific service variables defined by "environment" can override what is defined in the ecosystem file
 version: "3.8"
 services:
   mongo:
-    image: mongo:6.0.3
+    image: mongo:6.0.13
     command: "--setParameter allowDiskUseByDefault=true"
     restart: always
     expose:
       - 27017
 
   mongo-express:
-    image: mongo-express:1.0.0-alpha.4
+    image: mongo-express:1.0.2-20
     expose:
       - 8081
     environment:
       ME_CONFIG_MONGODB_SERVER: mongo
       ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_SITE_BASEURL: /mongo-admin
+      ME_CONFIG_SITE_BASEURL: /mongo-admin # default credentials: admin/pass
     depends_on:
       - mongo
 
   ipfs-node:
-    image: ipfs/kubo:v0.22.0
+    image: ipfs/kubo:v0.26.0
     ports:
       - "5001:5001"
       - "4001:4001"
       - "8080:8080"
     volumes:
-      - ./runtime-data/ipfs/staging:/export:rw
-      - ./runtime-data/ipfs/data:/data/ipfs:rw
+      - ipfs_data:/data/ipfs:rw
+      - ipfs_export:/export:rw
 
   message-broker:
-    image: nats:2.9.8
+    image: nats:2.9.24
     expose:
       - 4222
     ports:
@@ -37,7 +41,7 @@ services:
     command: '--http_port 8222'
 
   vault:
-    image: vault:1.12.2
+    image: hashicorp/vault:1.12.11
     expose:
       - 8200
     ports:
@@ -50,11 +54,6 @@ services:
     volumes:
       - ./file:/vault/file:rw
       - ./config:/vault/config:rw
-
-  # https://docs.docker.com/compose/environment-variables/envvars-precedence/
-  # Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-  # ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-  # specific service variables defined by "environment" can override what is defined in the ecosystem file
 
   notification-service:
     env_file:
@@ -84,7 +83,7 @@ services:
     volumes:
       - ./logger-service/configs:/usr/local/logger-service/configs:ro
 
-  worker-service-1:
+  worker-service:
     env_file:
       - ./configs/.env.${GUARDIAN_ENV}.guardian.system
     build:
@@ -97,32 +96,13 @@ services:
         condition: service_started
     environment:
       - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL:"worker.1"
     expose:
       - 6555
     volumes:
       - ./worker-service/tls:/usr/local/worker-service/tls:ro
       - ./worker-service/configs:/usr/local/worker-service/configs:ro
-
-  worker-service-2:
-    env_file:
-      - ./configs/.env.${GUARDIAN_ENV}.guardian.system
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    depends_on:
-      ipfs-node:
-        condition: service_healthy
-      auth-service:
-        condition: service_started
-    environment:
-      - GUARDIAN_ENV=${GUARDIAN_ENV}
-      - SERVICE_CHANNEL="worker.2"
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/worker-service/tls:ro
-      - ./worker-service/configs:/usr/local/worker-service/configs:ro
+    deploy:
+      replicas: 2
 
   auth-service:
     env_file:
@@ -207,7 +187,6 @@ services:
       - ./policy-service/tls:/usr/local/policy-service/tls:ro
       - ./policy-service/configs:/usr/local/policy-service/configs:ro
 
-
   guardian-service:
     env_file:
       - ./configs/.env.${GUARDIAN_ENV}.guardian.system
@@ -224,8 +203,7 @@ services:
       - message-broker
       - auth-service
       - logger-service
-      - worker-service-1
-      - worker-service-2
+      - worker-service
       - policy-service
       - ai-service
     environment:
@@ -248,7 +226,6 @@ services:
       - guardian-service
       - auth-service
       - logger-service
-
 
   mrv-sender:
     build:
@@ -285,7 +262,6 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.44.0
-    container_name: prometheus
     restart: unless-stopped
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
@@ -302,8 +278,7 @@ services:
       - monitoring
 
   grafana:
-    image: grafana/grafana:10.0.0
-    container_name: grafana
+    image: grafana/grafana:10.0.10
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
@@ -320,14 +295,10 @@ services:
       - monitoring
 
 volumes:
-  mongo:
-  prometheus_data: {}
-  grafana_data: {}
-  branding_data:
-  # volume-guardian-service:
-  # volume-ui-service:
-  # volume-mrv-sender:
-  #  volume-message-broker:
+  prometheus_data:
+  grafana_data:
+  ipfs_data:
+  ipfs_export:
 
 networks:
   monitoring:

--- a/worker-service/configs/.env.worker
+++ b/worker-service/configs/.env.worker
@@ -5,7 +5,7 @@ VAULT_APPROLE_ROLE_ID=
 VAULT_APPROLE_SECRET_ID=
 
 # Ecosystem Defined Variables
-SERVICE_CHANNEL="worker.1" # assigned at orkestrator level
+# SERVICE_CHANNEL="worker.1" # assigned at orchestrator level
 HEDERA_NET="testnet"
 PREUSED_HEDERA_NET="testnet"
 ACCESS_TOKEN_SECRET="youraccesstokensecret"

--- a/worker-service/configs/.env.worker.develop
+++ b/worker-service/configs/.env.worker.develop
@@ -5,7 +5,7 @@ VAULT_APPROLE_ROLE_ID=
 VAULT_APPROLE_SECRET_ID=
 
 # Ecosystem Defined Variables
-SERVICE_CHANNEL="worker.1" # assigned at orkestrator level
+# SERVICE_CHANNEL="worker.1" # assigned at orchestrator level
 HEDERA_NET="testnet"
 PREUSED_HEDERA_NET="testnet"
 ACCESS_TOKEN_SECRET="youraccesstokensecret"

--- a/worker-service/configs/.env.worker.template
+++ b/worker-service/configs/.env.worker.template
@@ -5,7 +5,7 @@ VAULT_APPROLE_ROLE_ID=
 VAULT_APPROLE_SECRET_ID=
 
 # Ecosystem Defined Variables
-SERVICE_CHANNEL="worker.1" # assigned at orkestrator level
+# SERVICE_CHANNEL="worker.1" # assigned at orchestrator level
 HEDERA_NET=""
 PREUSED_HEDERA_NET=""
 ACCESS_TOKEN_SECRET="youraccesstokensecret"

--- a/worker-service/src/app.ts
+++ b/worker-service/src/app.ts
@@ -1,7 +1,7 @@
 import { ApplicationState, LargePayloadContainer, Logger, MessageBrokerChannel, NotificationService, OldSecretManager, SecretManager, Users, ValidateConfiguration } from '@guardian/common';
 import { Worker } from './api/worker';
 import { HederaSDKHelper } from './api/helpers/hedera-sdk-helper';
-import { ApplicationStates } from '@guardian/interfaces';
+import { ApplicationStates, GenerateUUIDv4 } from '@guardian/interfaces';
 import * as process from 'process';
 import { Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
@@ -12,13 +12,13 @@ import { MicroserviceOptions, Transport } from '@nestjs/microservices';
         NotificationService,
     ]
 })
-class AppModule {}
+class AppModule { }
 
-const channelName = (process.env.SERVICE_CHANNEL || `worker.${Date.now()}`).toUpperCase();
+const channelName = (process.env.SERVICE_CHANNEL || `worker.${GenerateUUIDv4().substring(26)}`).toUpperCase();
 
 Promise.all([
     MessageBrokerChannel.connect('WORKERS_SERVICE'),
-    NestFactory.createMicroservice<MicroserviceOptions>(AppModule,{
+    NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
         transport: Transport.NATS,
         options: {
             name: channelName,
@@ -47,6 +47,11 @@ Promise.all([
             clearInterval(timer);
         }
 
+        if (process.env.IPFS_PROVIDER === 'local' && !process.env.IPFS_NODE_ADDRESS) {
+            logger.error('IPFS_NODE_ADDRESS must be set if IPFS_PROVIDER is `local`', [channelName, 'WORKER']);
+            return false
+        }
+
         let IPFS_STORAGE_KEY: string;
         let IPFS_STORAGE_PROOF: string;
         let IPFS_STORAGE_API_KEY: string;
@@ -57,7 +62,7 @@ Promise.all([
             if (!keyAndProof?.IPFS_STORAGE_API_KEY) {
                 IPFS_STORAGE_KEY = process.env.IPFS_STORAGE_KEY;
                 IPFS_STORAGE_PROOF = process.env.IPFS_STORAGE_PROOF;
-                await secretManager.setSecrets('apikey/ipfs', {IPFS_STORAGE_API_KEY: `${IPFS_STORAGE_KEY};${IPFS_STORAGE_PROOF}`});
+                await secretManager.setSecrets('apikey/ipfs', { IPFS_STORAGE_API_KEY: `${IPFS_STORAGE_KEY};${IPFS_STORAGE_PROOF}` });
             } else {
                 const [key, proof] = keyAndProof.IPFS_STORAGE_API_KEY.split(';')
                 IPFS_STORAGE_KEY = key;
@@ -69,7 +74,7 @@ Promise.all([
             const key = await secretManager.getSecrets('apikey/ipfs');
             if (!key?.IPFS_STORAGE_API_KEY) {
                 IPFS_STORAGE_API_KEY = process.env.IPFS_STORAGE_API_KEY;
-                await secretManager.setSecrets('apikey/ipfs', {IPFS_STORAGE_API_KEY});
+                await secretManager.setSecrets('apikey/ipfs', { IPFS_STORAGE_API_KEY });
             } else {
                 IPFS_STORAGE_API_KEY = key.IPFS_STORAGE_API_KEY;
             }
@@ -80,14 +85,8 @@ Promise.all([
         });
 
         await state.updateState(ApplicationStates.INITIALIZING);
-        const w = new Worker(IPFS_STORAGE_KEY, IPFS_STORAGE_PROOF, IPFS_STORAGE_API_KEY);
+        const w = new Worker(IPFS_STORAGE_KEY, IPFS_STORAGE_PROOF, IPFS_STORAGE_API_KEY, channelName);
         await w.setConnection(cn).init();
-
-        if (process.env.IPFS_PROVIDER === 'local') {
-            if (!process.env.IPFS_NODE_ADDRESS) {
-                return false
-            }
-        }
 
         return true;
     });


### PR DESCRIPTION
**Description**:
This PR modifies applies some improvements, in particular:

- Updated worker-service to use replicas. Now docker need to build the container only once, regardless of the number of workers, and the developer don't need to manually _cut&paste_ the configuration in the docker compose file. Plus, the worker service uses now a random UUID instead of Date() to set its ID.
- Updated IPFS container and volume configuration
- Updated other external dependencies (only fix releases)
- Fixed .gitignore for the ai-service

**Related issue(s)**:

Fixes #N/A

**Notes for reviewer**:

- I updated all the docker-compose files that seem to make sense. I'm not sure if the rest of the docker-compose files, but if you confirm they are used, and you like this PR, I can update those files also.
- About the ai-service, I suggest removing the static files in the `./data/generated-data` and `./faiss-vector` folders.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
