### PR TITLE
docs: add instruction for launch cache container in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you want to manually build every component with debug information, then build
 * [NodeJS V20](https://nodejs.org)
 * [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
 * [Nats 1.12.2](https://nats.io/)
+* [Redict 7.3.0](https://redict.io/)
 
 ### Build and start each component
 


### PR DESCRIPTION
**Description**:

Instruction for launch cache container
