### PR TITLE
Fix: this prevents nginx to emergency shutdown if optional services are not started

### DIFF
--- a/web-proxy/configs/default.conf
+++ b/web-proxy/configs/default.conf
@@ -59,7 +59,9 @@ server {
     }
 
     location /mrv-sender/ {
-        proxy_pass http://mrv-sender:3005/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://mrv-sender:3005/;
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
@@ -68,7 +70,9 @@ server {
     }
 
     location /topic-viewer/ {
-        proxy_pass http://topic-viewer:3006/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://topic-viewer:3006/;
+        proxy_pass $target;        
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
@@ -86,7 +90,9 @@ server {
     }
 
     location /mongo-admin {
-        proxy_pass http://mongo-express:8081;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://mongo-express:8081;
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;

--- a/web-proxy/configs/demo.conf
+++ b/web-proxy/configs/demo.conf
@@ -59,7 +59,9 @@ server {
     }
 
     location /mrv-sender/ {
-        proxy_pass http://${MRV_SENDER_HOST}:${MRV_SENDER_PORT}/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://${MRV_SENDER_HOST}:${MRV_SENDER_PORT}/;
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
@@ -68,7 +70,9 @@ server {
     }
 
     location /topic-viewer/ {
-        proxy_pass http://${TOPIC_VIEWER_HOST}:${TOPIC_VIEWER_PORT}/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://${TOPIC_VIEWER_HOST}:${TOPIC_VIEWER_PORT}/;
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;

--- a/web-proxy/configs/local.conf
+++ b/web-proxy/configs/local.conf
@@ -59,7 +59,9 @@ server {
     }
 
     location /mrv-sender/ {
-        proxy_pass http://mrv-sender:3005/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://mrv-sender:3005/; 
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
@@ -68,7 +70,9 @@ server {
     }
 
     location /topic-viewer/ {
-        proxy_pass http://topic-viewer:3006/;
+        resolver 127.0.0.11 valid=600s;
+        set $target http://topic-viewer:3006/;
+        proxy_pass $target;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
**Description**:
This PR prevents nginx to emergency shutdown (`host "xxx" not found in upstream`) if an optional service like the mrv-sender, topic-viewer or mongodb-admin is not started (i.e., it's excluded from the docker-compose file);

**Related issue(s)**:

Fixes # N/A

**Notes for reviewer**:


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
