### PR TITLE
ci: Updates self hosted runner group and adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,49 @@
+###################################
+##### Global Protection Rule ######
+###################################
+# NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
+*                                               @developer-advocates
+
+############################
+#####  Project Files  ######
+############################
+
+/src/**                                         @developer-advocates
+/__tests__/**                                   @developer-advocates
+
+
+#########################
+#####  Core Files  ######
+#########################
+
+# NOTE: Must be placed last to ensure enforcement over all other rules
+
+# Protection Rules for Github Configuration Files and Actions Workflows
+/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
+
+# NodeJS project files
+package.json                                    @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+package-lock.json                               @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+jest.config.mjs                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+
+# Codacy Tool Configurations
+/config/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+.remarkrc                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+
+# Semantic Release Configuration
+.releaserc                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers
+
+# Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
+/CODEOWNERS                                     @hashgraph/release-engineering-managers
+
+# Protect the repository root files
+/README.md                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/LICENSE                                      @hashgraph/release-engineering-managers
+
+# CodeCov configuration
+**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/devops-ci-committers
+
+# Git Ignore definitions
+**/.gitignore                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,14 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @developer-advocates
+*                                               @hashgraph/developer-advocates
 
 ############################
 #####  Project Files  ######
 ############################
 
-/src/**                                         @developer-advocates
-/__tests__/**                                   @developer-advocates
+/src/**                                         @hashgraph/developer-advocates
+/__tests__/**                                   @hashgraph/developer-advocates
 
 
 #########################
@@ -23,13 +23,13 @@
 /.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
 
 # NodeJS project files
-package.json                                    @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
-package-lock.json                               @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
-jest.config.mjs                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+package.json                                    @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates
+package-lock.json                               @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates
+jest.config.mjs                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
-.remarkrc                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @developer-advocates
+/config/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates
+.remarkrc                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/developer-advocates
 
 # Semantic Release Configuration
 .releaserc                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers

--- a/.github/workflows/add-documentation-to-repo.yaml
+++ b/.github/workflows/add-documentation-to-repo.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   runService:
     name: Run Service
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: guardian-linux-medium
     strategy:
       matrix:
         node-version: [ 20.x ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   buildAndTest:
     name: Build and Test (Manual - Main)
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: guardian-linux-medium
     strategy:
       matrix:
         node-version: [ 20.10.0 ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   docker:
     name: Publish to Docker
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: guardian-linux-medium
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
**Description**:

Update the self-hosted runner to use the guardian runner group label Adds a standard CODEOWNERS file

**Related issue(s)**:

Fixes #4031 


