### PR TITLE
chore: Update Dependabot configuration to improve usability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: weekly
     open-pull-requests-limit: 10
+    target-branch: "develop"
+
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 15
     target-branch: "develop"
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
**Description**:

- Updates interval on github-actions ecosystem to check for updates weekly instead of daily.
- Sets the target-branch for all updates to "develop" instead of "main"
- sets the versioning-strategy on the npm-ecosystem to increase-if-necessary which should reduce the number of updates that are triggered on the repository.

**Related Issue(s)**:

Fixes #4467

After this is merged I will cherry pick to main branch as well
