### PR TITLE
ci: replace action with step-security maintained version

### DIFF
--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -144,7 +144,7 @@ jobs:
                   popd
 
             - name: Publish API Test Results
-              uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+              uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
               if: always()
               with:
                   files: e2e-tests/cypress/test_results/**/*.xml

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -146,7 +146,7 @@ jobs:
                   npx cypress run --env "portApi=3002,operatorId=${{ secrets.CI_HEDERA_ACCOUNT }},operatorKey=${{ secrets.CI_HEDERA_PRIV_KEY }},grepTags=${{ inputs.tags }},grepFilterSpecs=true" --spec "cypress/e2e/api-tests/**/*.cy.js" --browser chrome         
                   popd
             - name: Publish API Test Results
-              uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+              uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
               if: always()
               with:
                   files: e2e-tests/cypress/test_results/**/*.xml

--- a/.github/workflows/api-schedule.yml
+++ b/.github/workflows/api-schedule.yml
@@ -145,7 +145,7 @@ jobs:
                   popd
 
             - name: Publish API Test Results
-              uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+              uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
               if: always()
               with:
                   files: e2e-tests/cypress/test_results/**/*.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
           OPERATOR_KEY: ${{ secrets.CI_HEDERA_PRIV_KEY }}
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         if: always()
         with:
           files: test_results/**/*.xml


### PR DESCRIPTION
**Description**:
Replaced EnricoMi/publish-unit-test-result-action with step-security maintained version

**Related issue(s)**:

Fixes #4807

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
