### PR TITLE
fix: add topicId filter for the tokens page [4784]

### DIFF
--- a/indexer-api-gateway/src/api/services/entities.ts
+++ b/indexer-api-gateway/src/api/services/entities.ts
@@ -685,6 +685,12 @@ export class EntityApi extends ApiClient {
         example: '0.0.1960',
         required: false,
     })
+    @ApiQuery({
+        name: 'topicId',
+        description: 'Topic identifier',
+        example: '0.0.1960',
+        required: false,
+    })
     @HttpCode(HttpStatus.OK)
     async getTokens(
         @Query('pageIndex') pageIndex?: number,
@@ -693,6 +699,7 @@ export class EntityApi extends ApiClient {
         @Query('orderDir') orderDir?: string,
         @Query('tokenId') tokenId?: string,
         @Query('treasury') treasury?: string,
+        @Query('topicId') topicId?: string,
     ) {
         return await this.send(IndexerMessageAPI.GET_TOKENS, {
             pageIndex,
@@ -701,6 +708,7 @@ export class EntityApi extends ApiClient {
             orderDir,
             tokenId,
             treasury,
+            topicId,
         });
     }
 

--- a/indexer-frontend/src/app/views/collections/tokens/tokens.component.ts
+++ b/indexer-frontend/src/app/views/collections/tokens/tokens.component.ts
@@ -160,6 +160,11 @@ export class TokensComponent extends BaseGridComponent {
         }))
         this.filters.push(new Filter({
             type: 'input',
+            field: 'topicId',
+            label: 'grid.topic_id'
+        }))
+        this.filters.push(new Filter({
+            type: 'input',
             field: 'treasury',
             label: 'grid.treasury'
         }))

--- a/indexer-frontend/src/app/views/details/topic-details/topic-details.component.ts
+++ b/indexer-frontend/src/app/views/details/topic-details/topic-details.component.ts
@@ -207,6 +207,14 @@ export class TopicDetailsComponent extends BaseDetailsComponent {
         });
     }
 
+    public override onOpenTokens() {
+        this.router.navigate(['/tokens'], {
+            queryParams: {
+                'topicId': this.id,
+            },
+        });
+    }
+
     public override onOpenRoles() {
         this.router.navigate(['/roles'], {
             queryParams: {

--- a/swagger-indexer.yaml
+++ b/swagger-indexer.yaml
@@ -886,6 +886,13 @@ paths:
           schema:
             example: 0.0.1960
             type: string
+        - name: topicId
+          required: false
+          in: query
+          description: Topic identifier
+          schema:
+            example: 0.0.1960
+            type: string
       responses:
         '200':
           description: Tokens


### PR DESCRIPTION
**Description**:
- **Backend** (`/entities/tokens` endpoint):
  - Added an optional `topicId` query parameter.
  - When `topicId` is provided, only tokens related to the specified topic are returned.
  - If `topicId` is not provided, the endpoint returns the full list of tokens.

- **Frontend**:
  - Introduced a new filter for `topicId` on the tokens page.
  - When navigating from `/topics/{topicId}?tab=activity` to the tokens page, the `topicId` is automatically included in the URL to display tokens related to that topic.

**Related issue(s)**:

Fixes https://github.com/hashgraph/guardian/issues/4784

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
![image](https://github.com/user-attachments/assets/902fd090-a7aa-472a-bd6c-3d89c5a1cce9)


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
