### PR TITLE
Update wallet.ts

### DIFF
--- a/common/src/helpers/wallet.ts
+++ b/common/src/helpers/wallet.ts
@@ -52,7 +52,6 @@ export const KEY_TYPE_KEY_ENTITY: Map<KeyType, KeyEntity> = new Map([
     [KeyType.TOKEN_KYC_KEY, KeyEntity.TOKEN],
     [KeyType.TOKEN_WIPE_KEY, KeyEntity.TOKEN],
     [KeyType.TOPIC_SUBMIT_KEY, KeyEntity.TOPIC],
-    [KeyType.TOKEN_WIPE_KEY, KeyEntity.TOPIC],
     [KeyType.DID_KEYS, KeyEntity.DID],
     [KeyType.KEY, KeyEntity.KEY],
 ]);


### PR DESCRIPTION
**Description**:
Token Wipe block retirement does not work as expected and triggers the following error from the worker-service:
Task error: 144e765a-e5c7-4aff-9b62-8d0172c3c60a, Wipe Key is not set

**Related issue(s)**:
https://github.com/hashgraph/guardian/issues/4989

Fixes #
Remove TOPIC Entity mapping for WIPE_KEY

**Checklist**
- [ ❌] Documented (Code comments, README, etc.)
- [ ✓ ] Integration testing
