### PR TITLE
chore: Add flow-pull-request-formatting.yaml

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "PR Formatting"
+on:
+  pull_request_target:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - edited
+      - converted_to_draft
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+      - locked
+      - unlocked
+      - synchronize
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  statuses: write
+
+jobs:
+  title-check:
+    name: Title Check
+    runs-on: guardian-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check PR Title
+        uses: step-security/conventional-pr-title-action@8a8989588c2547f23167c4c42f0fb2356479e81b # v3.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  assignee-check:
+    name: Assignee Check
+    runs-on: guardian-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check Assignee
+        if: ${{ github.event.pull_request.assignees == null || github.event.pull_request.assignees[0] == null }}
+        run: |
+          echo "Assignee is not set. Failing the workflow."
+          exit 1


### PR DESCRIPTION
**Description**:

Adds a new workflow - `flow-pull-request-formatting.yaml` which is used to validate that PR titles match conventional commit format and that there is an assignee on every PR targeting the default (main) branch and release branches.

See details on writing conventional-commit compliant PR titles [here](https://www.conventionalcommits.org/en/v1.0.0/)

**Related issue(s)**:

Fixes #5137 
