### PR TITLE
feat: Quick start settings and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Guardian is a modular open-source solution that includes best-in-class identity 
 
 ## Discovering Digital Environmental Assets assets on Hedera
 
-
 As identified in Hedera Improvement Proposal 19 (HIP-19), each entity on the Hedera network may contain a specific identifier in the memo field for discoverability. Guardian demonstrates this when every Hedera Consensus Service transaction is logged to a Hedera Consensus Service (HCS) Topic. Observing the Hedera Consensus Service Topic, you can discover newly minted tokens.
 
 In the memo field of each token mint transaction you will find a unique Hedera message timestamp. This message contains the url of the Verifiable Presentation (VP) associated with the token. The VP can serve as a starting point from which you can traverse the entire sequence of documents produced by Guardian policy workflow, which led to the creation of the token. This includes a digital Methodology (Policy) HCS Topic, an associated Registry HCS Topic for that Policy, and a Project HCS Topic.
@@ -18,6 +17,48 @@ In the memo field of each token mint transaction you will find a unique Hedera m
 Please see p.17 in the FAQ for more information. This is further defined in [Hedera Improvement Proposal 28 (HIP-28)](https://hips.hedera.com/hip/hip-28).
 
 ([back to top](#readme))
+
+## Quickstart
+
+This procedure is useful for demos, quick testing, and hackathons. It will only start the minimum required services for using the main Guardian features. It will not start features like the AI or MRV sender services, Prometheus integration, Grafana integration, etc.
+
+1. Ensure to have [Git](https://git-scm.com/downloads) and [Docker](https://www.docker.com/) installed on your machine.
+2. Clone this repository
+
+```bash
+git clone https://github.com/hashgraph/guardian.git
+cd guardian
+```
+
+3. Login or register on the [Hedera Developer Portal](https://portal.hedera.com/login).
+4. Generate an ED25519 key pair and account.
+5. Copy your AccountID (i.e, `0.0.123456...`) and the associated DER Encoded Private Key (i.e., `302e020100300506032b657004220420....`).
+6. Create a local `.env` file in the root directory of your project and update it with your AccountID and private key.
+
+```dotenv
+OPERATOR_ID=0.0.123456...
+OPERATOR_KEY=302e020100300506032b657004220420....
+```
+
+7. Start the environment with:
+
+```bash
+docker compose -f docker-compose-quickstart.yml up --pull=always -d
+```
+
+8. Navigate to <http://localhost:3000> in your web browser.
+
+9. If you want to stop the environment, preserving all the local data, use:
+
+```bash
+docker compose -f docker-compose-quickstart.yml stop
+```
+
+10. If you want to destroy the environment, loosing all the local data, use:
+
+```bash
+docker compose -f docker-compose-quickstart.yml down
+```
 
 ## Getting started
 
@@ -54,25 +95,28 @@ When building the reference implementation, you can [manually build every compon
 2. Create a Mainnet account and note the Account ID (`0.0.x`).  
 3. Export the ED25519 key pair  
    - *HashPack path*: Settings → Manage Accounts → Export Private Key (DER format).  
-4. Update your `.env`  
+4. Update your `.env`
+
    ```dotenv
    HEDERA_NET=mainnet
-   HEDERA_OPERATOR_ID=0.0.123456
-   HEDERA_OPERATOR_KEY=<Enter your Private Key Here>
+   OPERATOR_ID=0.0.123456...
+   OPERATOR_KEY=302e020100300506032b657004220420....
    ```
+
 ## 2.4. Preparing a Testnet Account & Keys
 
 1. Create a Testnet account via the [Hedera Developer Portal](https://portal.hedera.com/login).
 2. Record your Account ID (0.0.x).
 3. Download the ED25519 private key (ignore ECDSA)
-4. Select DER Encoded — do not choose HEX Encoded.
-5. Update your `.env`
+   - Select the DER Encoded Private Key — do not choose HEX Encoded.
+4. Update your `.env`
 
-```dotenv
-HEDERA_NET=testnet
-HEDERA_OPERATOR_ID=0.0.987654
-HEDERA_OPERATOR_KEY=<Enter your Private Key Here>
-```
+   ```dotenv
+   HEDERA_NET=testnet
+   OPERATOR_ID=0.0.123456...
+   OPERATOR_KEY=302e020100300506032b657004220420....
+   ```
+
 ## 2.5. Automatic installation
 
 ### Prerequisites for automatic installation

--- a/configs/.env.quickstart.guardian.system
+++ b/configs/.env.quickstart.guardian.system
@@ -1,0 +1,244 @@
+# ECOSYSTEM ENVIRONMENT VARIABLES AND FEATURES
+
+# OVERRIDE - default "false"
+# ---------------------------
+# OVERRIDE="false"
+
+# HEDERA_NET - MANDATORY
+# ------------------------
+HEDERA_NET="testnet"
+
+# PRE USED HEDERA_NET
+# ---------------------
+PREUSED_HEDERA_NET="testnet"
+
+# TESTNET
+#OPERATOR_ID=""
+#OPERATOR_KEY=""
+INITIALIZATION_TOPIC_ID="0.0.1960"
+SR_INITIAL_PASSWORD="..."
+
+# # LOCALNODE
+# LOCALNODE_ADDRESS="..."
+# LOCALNODE_PROTOCOL="http"
+# OPERATOR_ID="0.0.2"
+# OPERATOR_KEY="..."
+
+# # PREVIEWNET
+# OPERATOR_ID="..."
+# OPERATOR_KEY="..."
+# INITIALIZATION_TOPIC_ID="0.0.155110"
+
+SEND_KEYS_TO_VAULT="TRUE"
+RETIRE_CONTRACT_FILE_ID="0.0.6371646"
+WIPE_CONTRACT_FILE_ID="0.0.6371642"
+RETIRE_SINGLE_FILE_ID="0.0.6371651"
+RETIRE_DOUBLE_FILE_ID="0.0.6371652"
+MAX_HEDERA_TIMEOUT="600"
+
+# Mainnet
+# HEDERA_CUSTOM_NODES={"35.237.200.180:50211":"0.0.3"}
+# HEDERA_CUSTOM_NODES={"35.237.200.180:50211":"0.0.3","35.186.191.247:50211":"0.0.4","35.192.2.25:50211":"0.0.5","35.199.161.108:50211":"0.0.6","35.203.82.240:50211":"0.0.7","35.236.5.219:50211":"0.0.8","35.197.192.225:50211":"0.0.9","35.242.233.154:50211":"0.0.10","35.240.118.96:50211":"0.0.11","35.204.86.32:50211":"0.0.12","35.234.132.107:50211":"0.0.13","35.236.2.27:50211":"0.0.14","35.228.11.53:50211":"0.0.15","34.91.181.183:50211":"0.0.16","34.86.212.247:50211":"0.0.17","172.105.247.67:50211":"0.0.18","34.89.87.138:50211":"0.0.19","34.82.78.255:50211":"0.0.20","34.76.140.109:50211":"0.0.21","34.64.141.166:50211":"0.0.22","35.232.244.145:50211":"0.0.23","34.89.103.38:50211":"0.0.24","34.93.112.7:50211":"0.0.25","34.87.150.174:50211":"0.0.26","34.125.200.96:50211":"0.0.27","35.198.220.75:50211":"0.0.28","34.142.71.129:50211":"0.0.29","35.234.249.150:50211":"0.0.30","34.107.78.179:50211":"0.0.31"}
+# HEDERA_CUSTOM_MIRROR_NODES=["mainnet-public.mirrornode.hedera.com:443"]
+
+# Testnet
+# HEDERA_CUSTOM_NODES={"0.testnet.hedera.com:50211":"0.0.3"}
+# HEDERA_CUSTOM_NODES={"0.testnet.hedera.com:50211":"0.0.3", "1.testnet.hedera.com:50211":"0.0.4", "2.testnet.hedera.com:50211":"0.0.5", "3.testnet.hedera.com:50211":"0.0.6", "4.testnet.hedera.com:50211":"0.0.7", "5.testnet.hedera.com:50211":"0.0.8", "6.testnet.hedera.com:50211":"0.0.9"}
+# HEDERA_CUSTOM_MIRROR_NODES=["testnet.mirrornode.hedera.com:443"]
+
+
+# MAX_TRANSACTION_FEE="10"
+
+# ADDRESSING / SERVICES
+# ----------------------
+#
+# ALERT: The keys below are disposable quick-start keys, please don't use them in production environments
+#
+JWT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+MIICWgIBAAKBgHVHC+XXUHzBPaSvnVqrseJY/BXSinnurYDYY3lCD+WlRmCIvlfO
+DZvILtPXnpBVSOQ8JhjcoQNJQ2pdq9rkemSUGYQyv2JLTblNFXgEe9s/Cb0mCOFZ
+VfLmxXsLp51DlMBBNvX+7LkscvTh8+HI100ZrB/992jg5mJvrlT8qlJrAgMBAAEC
+gYAP7SoMeIURrBx29PJlkdOCbZsuS31KucMOMFSx7urBwQQhr/BJdE4czb6uPiXm
+a+6OMCzsS2oCTDy/gSEJhOWp+yAuDZsMmGTRvZhmIR92GP9a7fN88JZwhC6ruaGy
+cpEx4HCggEhXHt5Eq7lm2LWD/eYqwbPuAjLikHwwXzG8gQJBANDcTfibF8gve64D
+/tfnQoi2gc2rrzUZILjTk6lnGaLrEPVkN6kC4MkMzkD0UaB5kuzfenzW1+x0k+3A
+yNZ1sXsCQQCPvzD/i+S0F2QYgYvE+/B8o+NnmNOtoexzsT6z5qcsHwd/S97ezl0v
+lXPGN4WDBR0j4MMxUOXrjz01rnjWaTfRAkB1e3ZgYNz/vbXULGstBuhl/kMFbY0g
+UQIW9OwaXeQNwCvJ3JVyfCv06z8ZSlSf78K1ev9rOW47k1eiZM6T06ABAkBCpdDg
+C0qkvVupiRb25CEiiRI8zD0I+lSZZ4q8+qpz6IcfXFwfTesiztZ5BvEeSFa0ddfK
+m8meqDEnHJfmQa6hAkBQnmC8wBN9egodBR5VABnJsXHubeyvRUPIzcmXrarnlgQ8
+JhwKNaygjE0miFIOyj+bdaxZxk2xTD32fbOGrGBW
+-----END RSA PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgHVHC+XXUHzBPaSvnVqrseJY/BXS
+innurYDYY3lCD+WlRmCIvlfODZvILtPXnpBVSOQ8JhjcoQNJQ2pdq9rkemSUGYQy
+v2JLTblNFXgEe9s/Cb0mCOFZVfLmxXsLp51DlMBBNvX+7LkscvTh8+HI100ZrB/9
+92jg5mJvrlT8qlJrAgMBAAE=
+-----END PUBLIC KEY-----"
+MQ_ADDRESS="message-broker"
+MQ_MAX_PAYLOAD="1048576"
+
+MRV_ADDRESS="http://message-broker:3003/mrv"
+
+DB_HOST="mongo"
+
+MIN_PRIORITY="0"
+MAX_PRIORITY="20"
+TASK_TIMEOUT="300"
+REFRESH_INTERVAL="60"
+
+IPFS_TIMEOUT="720" # seconds
+IPFS_PROVIDER="local" # valid options: 'filebase', 'web3storage', 'local'
+IPFS_STORAGE_KEY="..." # only valid for web3storage provider; ignored in other cases
+IPFS_STORAGE_PROOF="..." # only valid for web3storage provider; ignored in other cases
+#IPFS_PUBLIC_GATEWAY='https://ipfs.io/ipfs/${cid}' # use this for public providers (filebase, web3storage, etc.)
+IPFS_PUBLIC_GATEWAY='http://ipfs-node:8080/ipfs/${cid}' # use this for local provider
+IPFS_NODE_ADDRESS="http://ipfs-node:5001" # only valid for local provider; ignored in other cases
+ANALYTICS_SERVICE="http://indexer-api-gateway:3021"
+#ANALYTICS_SERVICE_TOKEN="" # mandatory to be able to use the MGS indexer
+
+#BATCH_NFT_MINT_SIZE=10
+# FE/DEMO
+# --------------
+INITIAL_BALANCE="100"
+INITIAL_STANDARD_REGISTRY_BALANCE="100"
+
+# COMMONS
+# ----------
+MESSAGE_LANG="en-US"
+#LOG_LEVEL="2"
+TRANSACTION_LOG_LEVEL="1"
+MULTI_POLICY_SCHEDULER="0 0 * * *"
+#DOCUMENT_CACHE_FIELD_LIMIT=100
+
+# FEATURES
+# --------------
+BBS_SIGNATURES_MODE="WASM"
+# IMPORT_KEYS_FROM_DB=1
+# MQ_MESSAGE_CHUNK=5000000
+# RAW_REQUEST_LIMIT="1gb"
+# JSON_REQUEST_LIMIT="1mb"
+
+# Secret Manager Configs
+# -------------------------
+# Set SECRET_MANAGER as empty when not using any Secret Manager
+SECRET_MANAGER=""
+# Vault
+VAULT_API_VERSION=v1
+VAULT_ADDRESS=https://vault:8200
+VAULT_CA_CERT=tls/vault/client/ca.crt
+VAULT_CLIENT_CERT=tls/vault/client/tls.crt
+VAULT_CLIENT_KEY=tls/vault/client/tls.key
+# AWS
+AWS_REGION=eu-central-1
+
+# Azure Key Vault Configs
+AZURE_VAULT_NAME=guardianVault
+
+VAULT_PROVIDER="database"
+HASHICORP_TOKEN="Q5D>3nu+Z#TbN.@9PWHSyL"
+HASHICORP_ADDRESS="http://vault:8200"
+HASHICORP_NAMESPACE="admin"
+HASHICORP_ENCRIPTION_ALG="sha512"
+#HASHICORP_UNSEAL_KEY=""
+
+# ANALYTICS
+ANALYTICS_SCHEDULER="0 0 * * 1"
+
+MEECO_AUTH_PROVIDER_ACTIVE=0
+MEECO_BASE_URL=https://api-sandbox.svx.exchange
+MEECO_OAUTH_URL="https://login-sandbox.securevalueexchange.com/oauth2/token"
+MEECO_OAUTH_CLIENT_ID=571*********************e6a
+MEECO_OAUTH_SECRET_ID=ONO@*****************rnNxpNt
+MEECO_OAUTH_SCOPE=openid
+MEECO_OAUTH_GRANT_TYPE=client_credentials
+MEECO_ORGANIZATION_ID="09f7115e***********be032d6ca149"
+MEECO_PASSPHRASE=7MHHMTJQQ******************7TPBH2P71XKDH1ZPF
+MEECO_ISSUER_ORGANIZATION_ID="did:web:did-web.securevalue.exchange:343b08f3-***********-3f2d8a146a0d"
+MEECO_ISSUER_ORGANIZATION_NAME=
+MEECO_PRESENTATION_DEFINITION_ID="832e996c-**********-9d170fa381a8"
+
+ACCESS_TOKEN_UPDATE_INTERVAL=60000000
+REFRESH_TOKEN_UPDATE_INTERVAL=31536000000
+# pragma: allowlist nextline secret
+MIN_PASSWORD_LENGTH=8
+# pragma: allowlist nextline secret
+PASSWORD_COMPLEXITY="medium" # "easy", "medium", "hard"
+
+OPENAI_API_KEY=...
+
+#CACHE
+HOST_CACHE='cache'
+PORT_CACHE='6379'
+ENABLE_CACHE='true'
+
+#PINO_LOGGER
+TRANSPORTS="CONSOLE, MONGO"
+DB_LOGGER_NAME="logger_db"
+DB_LOGGER_HOST="mongo"
+DB_LOGGER_COLLECTION="log"
+LOG_FILE_PATH="./logs/app.log"
+LOG_LEVEL="info"
+SEQ_SERVER_URL="http://seq:5341"
+#SEQ_UI_URL="http://localhost:5341"
+#SEQ_API_KEY=""
+
+# MONGO_INIT
+MIN_POOL_SIZE="1"
+MAX_POOL_SIZE="5"
+MAX_IDLE_TIME_MS="30000"
+
+#REQUEST_DATA
+ALLOWED_PROTOCOLS="https"
+BLOCK_PRIVATE_IP="false"
+
+#Service secrets for auth between services
+# SERVICE_JWT_SECRET_KEY_ALL and SERVICE_JWT_PUBLIC_KEY_ALL are used for local development only
+# Recommended to create separate key pairs for each service
+
+#
+# ALERT: The keys below are disposable quick-start keys, please don't use them in production environments
+#
+SERVICE_JWT_PUBLIC_KEY_ALL="-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4sQqcaS5fKCTjcDqzu4l
+33bS1uKIdUeZykgqQNng2NOdriW5tTgkFFoT7XCxMIs6zR+vEaPMavrSasmHyQ0o
+flvpS7ZzwMY9jLcAB4giqxdHcvELkK4Wo9pgpZ15sCmhFqhrAegWyYVpeQ7pn8DS
+Lm5MBatsbe9PoPHjYBxFwFmQt+cq7JxuCvlMip09JqPwgKXBRl2oyyzbRk7LAliH
+vz+MUKucJfa162Xlx60hkb+jvVjl4JLbq+rav5Q3pHn5UblQwWV36pKoMhyffrT1
+wdx3hlZw6zKJeJUzPM4uy34XCd4yTrseGCEhNQHurVRX6tuM9O35653zURCLVs8k
+IwIDAQAB
+-----END PUBLIC KEY-----"
+SERVICE_JWT_SECRET_KEY_ALL="-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA4sQqcaS5fKCTjcDqzu4l33bS1uKIdUeZykgqQNng2NOdriW5
+tTgkFFoT7XCxMIs6zR+vEaPMavrSasmHyQ0oflvpS7ZzwMY9jLcAB4giqxdHcvEL
+kK4Wo9pgpZ15sCmhFqhrAegWyYVpeQ7pn8DSLm5MBatsbe9PoPHjYBxFwFmQt+cq
+7JxuCvlMip09JqPwgKXBRl2oyyzbRk7LAliHvz+MUKucJfa162Xlx60hkb+jvVjl
+4JLbq+rav5Q3pHn5UblQwWV36pKoMhyffrT1wdx3hlZw6zKJeJUzPM4uy34XCd4y
+TrseGCEhNQHurVRX6tuM9O35653zURCLVs8kIwIDAQABAoIBACPtLkhI77Yl/pqT
+uN/F7SwlOCwhQbtK97uLiV4y5qOTi0S+51glp9mtl8CjfP8S3+MFpQfnaoh8an/O
+o/ufYQ37489B/b7J6ZB0ocWPtOZkTsaQF+P5IM8e1vcGJvRY9BOR5TotGgcdYuNy
+EGNl+iavBM5VJV2Zb4UxLXPZptddTOkUSngghVL8gg+lRP/7Ij8zZLRdEyNqeIt1
+1oaXNFKp3Z1jDIXc0kYToZSv2H7yPDxPhsT6w4Gydm46Nek6Nazsv9vrJA07QrAr
+hkoDMh/TqeLuLyVZ7Koz1U/Mu12e5IjTO/vntZah4HeKrpyyivXQtKIWp8SJPcno
+qaBc02ECgYEA9uJvxZ9hMUn8BkBBKeSKtjoPsicP9n3a9ZRAn8dI7Gd/fVqbRVcl
+XSGgSqpYW5xJjpjVHm+z7joz9VeHlTWZFpOQWAywuArPtMtd6Nl6yrl7rlmdh+hu
+br6Qltnv5HkIAksEq6715UmmYMuPxitm5JVE3kPlR9zhDQ9LTQTCQbMCgYEA6yOS
+FZRdASYIUbPHe/CoUtllHq+eYdajFuKka8TLVlwC0bXRw+MG5UdezNZWP4Q5bNRX
+ICoL6YM4ggbqL+WLFhjoOyLxDtyZEBC3TjDQ1eu1b5YAFttwQAC+LnruYut30+hz
+FhFEoVznaCJcIwycqYsZhOFtDDf8k7sKagJ/+9ECgYBisMXpg/rAT0j13r2t13Qz
+wCYCG2dgK5NZ1De5J1rZVc469/tVzq5a+lQvRMUpaeJlpGadUh3lP1MB4kmKtfBK
+fBaZfAkwqPG63gjeSgGyBE+StLQqXhm3H2qBQwGInXE8KWzmjHwzeiuOShFhMHxj
+J+Bt0UpYXc2BAPojAaH9zQKBgQDDXgaej2rG7Yaz+5+fRtFUJPRzjo8V03QmK6FZ
+OWWJF2HwRBVJoHO2RJprrxpyI7Ziyfqp6sWC+1gUERK7QQlTDtbFa77GDlvOkVT8
+Tmr1kqZpVEQ2uZSGWRerHtC6t9IT62rTxv0y5TIPv5y2MmBoLf7B/VrRcCMXy6xX
+cEROQQKBgQCb1s+l3SDaD91IibXhVumNivlFI+Zns4MzPzewn0kVtx/I380F9UwD
+GZhouinEhzP7WB0hTPqQFvi7vy0xHTALCdNlcx13BdXBdsyHU4HMQDvM4rDP3XIS
+aEyGCs1wYwyQz/o6a6Y9q8/AbVmp9DGq11B84UjqwNnQLkEZllxFIA==
+-----END RSA PRIVATE KEY-----"
+# set QM_VERIFICATION to false to disable message verification and signing
+# QM_VERIFICATION=false
+
+#Integrations tokens
+KANOP_IO_AUTH_TOKEN="..."
+FIRMS_AUTH_TOKEN="..."
+GLOBAL_FOREST_WATCH_API_KEY="..."

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -1,0 +1,208 @@
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
+
+# YAML anchor that contains common configuration elements for our services
+x-service-template: &service-template
+    init: true
+    env_file:
+        - ./configs/.env.quickstart.guardian.system
+    environment:
+        - GUARDIAN_ENV=${GUARDIAN_ENV}
+
+services:
+    mongo:
+        image: mongo:6.0.25
+        #command: "--setParameter allowDiskUseByDefault=true"
+        # This command line options gets rid of mongodb messages in the logs, so you can see more clearly what's happening
+        command: "--setParameter allowDiskUseByDefault=true  --quiet --logpath /dev/null"
+        restart: always
+        expose:
+            - 27017
+
+    cache:
+        image: registry.redict.io/redict
+        platform: linux/amd64
+        restart: always
+        expose:
+            - 6379
+
+    ipfs-node:
+        image: ipfs/kubo:v0.36.0
+        ports:
+            - "5001:5001"
+            - "4001:4001"
+            - "8080:8080"
+        volumes:
+            - ipfs_data:/data/ipfs:rw
+            - ipfs_export:/export:rw
+
+    message-broker:
+        image: nats:2.9.25
+        expose:
+            - 4222
+        ports:
+            - "8222:8222"
+        command: "-c /etc/nats/nats.conf --http_port 8222"
+        volumes:
+            - ./configs/nats.conf:/etc/nats/nats.conf
+
+    notification-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            - message-broker
+        volumes:
+            - ./notification-service/configs:/usr/local/app/configs:ro
+
+    logger-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            - message-broker
+        expose:
+            - 6555
+        volumes:
+            - ./logger-service/configs:/usr/local/app/configs:ro
+
+    queue-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            - mongo
+            - message-broker
+            - logger-service
+        expose:
+            - 6555
+        volumes:
+            - ./queue-service/configs:/usr/local/app/configs:ro
+
+    topic-listener-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            - mongo
+            - message-broker
+            - queue-service
+        expose:
+            - 6555
+        volumes:
+            - ./topic-listener-service/configs:/usr/local/app/configs:ro
+
+    worker-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            queue-service:
+                condition: service_started
+            ipfs-node:
+                condition: service_healthy
+            auth-service:
+                condition: service_started
+        expose:
+            - 6555
+        volumes:
+            - ./worker-service/tls:/usr/local/app/tls:ro
+            - ./worker-service/configs:/usr/local/app/configs:ro
+        deploy:
+            replicas: 1
+        environment:
+            - OPERATOR_ID=${OPERATOR_ID}
+            - OPERATOR_KEY=${OPERATOR_KEY}
+
+    auth-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/auth-service-demo:${GUARDIAN_VERSION:-latest}
+        volumes:
+            - ./auth-service/tls:/usr/local/app/tls:ro
+            - ./auth-service/configs:/usr/local/app/configs:ro
+        depends_on:
+            - mongo
+            - message-broker
+            - logger-service
+        expose:
+            - 6555
+            - 5005
+
+    api-gateway:
+        <<: *service-template
+        image: gcr.io/hedera-registry/api-gateway-demo:${GUARDIAN_VERSION:-latest}
+        expose:
+            - 3002
+            - 6555
+        depends_on:
+            - mongo
+            - cache
+            - message-broker
+            - guardian-service
+            - auth-service
+            - logger-service
+        volumes:
+            - ./api-gateway/configs:/usr/local/app/configs:ro
+
+    policy-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
+        depends_on:
+            - mongo
+            - message-broker
+            - auth-service
+            - logger-service
+        expose:
+            - 50000-60000
+            - 5006
+        volumes:
+            - ./policy-service/tls:/usr/local/app/tls:ro
+            - ./policy-service/configs:/usr/local/app/configs:ro
+
+    guardian-service:
+        <<: *service-template
+        image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
+        volumes:
+            - ./guardian-service/tls:/usr/local/app/tls:ro
+            - ./guardian-service/configs:/usr/local/app/configs:ro
+        depends_on:
+            - mongo
+            - message-broker
+            - auth-service
+            - logger-service
+            - worker-service
+            - policy-service
+        expose:
+            - 6555
+            - 5007
+        environment:
+            - OPERATOR_ID=${OPERATOR_ID}
+            - OPERATOR_KEY=${OPERATOR_KEY}
+
+    topic-viewer:
+        image: gcr.io/hedera-registry/topic-viewer:${GUARDIAN_VERSION:-latest}
+        init: true
+        expose:
+            - 3006
+            - 5009
+
+    web-proxy:
+        image: gcr.io/hedera-registry/frontend-demo:${GUARDIAN_VERSION:-latest}
+        init: true
+        environment:
+            GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
+            GATEWAY_HOST: api-gateway
+            GATEWAY_PORT: 3002
+            MRV_SENDER_HOST: mrv-sender
+            MRV_SENDER_PORT: 3005
+            TOPIC_VIEWER_HOST: topic-viewer
+            TOPIC_VIEWER_PORT: 3006
+        ports:
+            - "3000:80"
+        depends_on:
+            - guardian-service
+            - auth-service
+            - api-gateway
+
+volumes:
+    ipfs_data:
+    ipfs_export:
+
+networks:
+    monitoring:
+        driver: bridge


### PR DESCRIPTION
**Description**:

This introduces a new Docker Compose file and documentation for a quick start guide on running a local Guardian instance. Users only need to configure their Hedera account ID and private key; the rest of the environment will be configured with predefined variables.

Only a minimum set of services required for the most common features will be started, excluding services like the AI or MRV sender, Prometheus and Grafana integration, etc.

**Related issue(s)**:

N/A

**Notes for reviewer**:

This PR does not update the GitBook-managed documentation. I had a negative experience doing that directly in the past, so I prefer to delegate the update to a second time after this PR is accepted.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
