### PR TITLE
fix: nats and websocket fixes

### DIFF
--- a/api-gateway/src/helpers/task-manager.ts
+++ b/api-gateway/src/helpers/task-manager.ts
@@ -99,7 +99,7 @@ export class TaskManager {
             const { taskId, statuses, result, error, info } = msg;
             if (taskId) {
                 if (info) {
-                    this.addInfo(taskId, info, statuses);
+                    this.addInfo(taskId, info, []);
                 } else if (statuses) {
                     this.addStatuses(taskId, statuses);
                 }


### PR DESCRIPTION
Updated ZipCodec to reserve header space when checking payload size; removed unused zlib/gzip code. In TaskManager, changed addInfo to always pass an empty statuses array.