### PR TITLE
feat: Capability to retire tokens by serial number #4988

### DIFF
--- a/common/src/helpers/workers.ts
+++ b/common/src/helpers/workers.ts
@@ -44,6 +44,7 @@ export const NON_RETRYABLE_HEDERA_ERRORS = [
     HederaResponseCode.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT,
     HederaResponseCode.TOKEN_HAS_NO_WIPE_KEY,
     HederaResponseCode.INVALID_WIPE_KEY,
+    HederaResponseCode.INVALID_NFT_ID,
 
     // Burn type errors
     HederaResponseCode.INVALID_TOKEN_BURN_AMOUNT,

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -18,6 +18,8 @@ services:
     restart: always
     expose:
       - 27017
+    volumes:
+      - mongo_data:/data/db
 
   mongo-express:
     image: mongo-express:1.0.2-20
@@ -36,6 +38,8 @@ services:
     restart: always
     expose:
       - 6379
+    volumes:
+      - redis_data:/data
 
 #  seq:
 #    image: datalust/seq
@@ -328,6 +332,8 @@ volumes:
   grafana_data:
   ipfs_data:
   ipfs_export:
+  mongo_data:
+  redis_data:
 #  seq_data:
 
 networks:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -18,8 +18,6 @@ services:
     restart: always
     expose:
       - 27017
-    volumes:
-      - mongo_data:/data/db
 
   mongo-express:
     image: mongo-express:1.0.2-20
@@ -38,8 +36,6 @@ services:
     restart: always
     expose:
       - 6379
-    volumes:
-      - redis_data:/data
 
 #  seq:
 #    image: datalust/seq
@@ -332,8 +328,6 @@ volumes:
   grafana_data:
   ipfs_data:
   ipfs_export:
-  mongo_data:
-  redis_data:
 #  seq_data:
 
 networks:

--- a/docs/guardian/standard-registry/policies/policy-creation/introduction/token-wipe-workflow-block.md
+++ b/docs/guardian/standard-registry/policies/policy-creation/introduction/token-wipe-workflow-block.md
@@ -1,5 +1,11 @@
 # wipeDocumentBlock
 
+### Description
+This block allows to wipe tokens. 
+* **Fungible (FT):** Wipes the amount computed by **Rule**.
+* **Non-Fungible (NFT):** Wipes one or more serial numbers defined by a flexible Serial Numbers Expression. If the block is configured with **fixed serial numbers** (e.g., 1,2-5,10), the wipe operation will always target that same serial range. This effectively makes the run **single-use for those serials**. To keep the policy **reusable across documents**, configure serial numbers to be derived from the selected document.
+
+
 ### Properties
 
 | Block Property   | Definition                                                                        | Example Input                             | Status |
@@ -12,10 +18,11 @@
 
 ### UI Properties
 
-| UI Property | Definition                                                                 |
-| ----------- | -------------------------------------------------------------------------- |
-| Token       | Select which token to wipe. The token must exist in the Guardian instance. |
-| Rule        | Enter any wiping calculations.                                             |
+| UI Property         | Definition                                                                                      | Examples                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Token       | Select which token to wipe. The token must exist in the Guardian instance. | specific token                        |
+| Rule        | **FT required.** Enter any FT wiping calculations.                                             | `field0`, `10` |
+| Serial Numbers        | **NFT required.** Enter serials and ranges for NFT wiping. Supports comma-separated and range formats.                                             | `field0,field1-field2,field3`, `1,2-5,10`        |
 
 ### Events
 

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
@@ -1,0 +1,104 @@
+<!-- UI Prop -->
+<table class="properties" [attr.readonly]="readonly" *ngIf="properties">
+    <tr class="propHeader">
+        <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
+            <i class="pi pi-caret-down"></i>
+        </td>
+        <td class="propHeaderCell cellName">Properties</td>
+        <td class="propHeaderCell"></td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Use Template</td>
+        <td class="propRowCell">
+            <input class="prop-input" type="checkbox" (change)="onUseTemplateChange()"
+                   [(ngModel)]="properties.useTemplate" [readonly]="readonly" (blur)="onSave()">
+        </td>
+    </tr>
+    <tr *ngIf="!properties.useTemplate" class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Token</td>
+        <td class="propRowCell">
+            <p-dropdown [(ngModel)]="properties.tokenId"
+                        [options]="tokens"
+                        [disabled]="readonly"
+                        (onChange)="onSave()"
+                        placeholder="Select Token"
+                        optionLabel="name"
+                        optionValue="value"
+                        [appendTo]="'body'"
+            >
+            </p-dropdown>
+        </td>
+    </tr>
+    <tr *ngIf="properties.useTemplate" class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Token Template</td>
+        <td class="propRowCell">
+            <p-dropdown [(ngModel)]="properties.template"
+                        [options]="tokenTemplate"
+                        [disabled]="readonly"
+                        (onChange)="onSave()"
+                        placeholder="Select Template"
+                        optionLabel="name"
+                        optionValue="value"
+                        [appendTo]="'body'"
+            >
+            </p-dropdown>
+        </td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Rule</td>
+        <td class="propRowCell">
+            <input class="prop-input" [(ngModel)]="properties.rule" [readonly]="readonly" (blur)="onSave()">
+        </td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Account Type</td>
+        <td class="propRowCell">
+            <p-dropdown [(ngModel)]="properties.accountType"
+                        [options]="accountTypeOptions"
+                        [disabled]="readonly"
+                        (onChange)="changeAccountType()"
+                        placeholder="Select Account Type"
+                        optionLabel="label"
+                        optionValue="value"
+                        [appendTo]="'body'"
+            >
+            </p-dropdown>
+        </td>
+    </tr>
+    <tr *ngIf="properties.accountType==='custom'" class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Account Id (Field)</td>
+        <td class="propRowCell">
+            <input class="prop-input" [(ngModel)]="properties.accountId" [readonly]="readonly" (blur)="onSave()">
+        </td>
+    </tr>
+    <tr *ngIf="properties.accountType==='custom-value'" class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Account Id (Value)</td>
+        <td class="propRowCell">
+            <input class="prop-input" [(ngModel)]="properties.accountIdValue" [readonly]="readonly" (blur)="onSave()">
+        </td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Memo</td>
+        <td class="propRowCell">
+            <span class="wipe-memo-prefix" pTooltip="VP message identifier">**********.*********</span>
+            <input class="prop-input" class="wipe-memo-input" [(ngModel)]="properties.memo" [readonly]="readonly"
+                   (blur)="onSave()">
+        </td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Serial Numbers</td>
+        <td class="propRowCell">
+            <input class="prop-input" [(ngModel)]="properties.serialNumbersExpression" [readonly]="readonly"
+                   (blur)="onSave()"  placeholder="Examples: 1,2-5,10  |  field0,field1-field5,field10">
+        </td>
+    </tr>
+</table>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.scss
@@ -1,0 +1,16 @@
+.wipe-memo-prefix {
+    margin-left: 5px;
+    margin-right: 10px;
+}
+
+.wipe-memo-prefix + .wipe-memo-input {
+    width: 191px;
+}
+
+::ng-deep p-dropdown span {
+    height: 34px
+}
+
+::ng-deep p-dropdownitem li {
+    height: 30px;
+}

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.ts
@@ -1,0 +1,76 @@
+import {Component, EventEmitter, Input, OnInit, Output, SimpleChanges, ViewEncapsulation} from '@angular/core';
+import {IModuleVariables, PolicyBlock, TokenTemplateVariables, TokenVariables} from '../../../../structures';
+
+/**
+ * Settings for block of 'wipeDocument' and 'wipeDocument' types.
+ */
+@Component({
+    selector: 'wipe-config',
+    templateUrl: './wipe-config.component.html',
+    styleUrls: ['./wipe-config.component.scss'],
+    encapsulation: ViewEncapsulation.Emulated
+})
+export class WipeConfigComponent implements OnInit {
+    @Input('block') currentBlock!: PolicyBlock;
+    @Input('readonly') readonly!: boolean;
+    @Output() onInit = new EventEmitter();
+
+    private moduleVariables!: IModuleVariables | null;
+    private item!: PolicyBlock;
+
+    propHidden: any = {
+        main: false,
+    };
+
+    properties!: any;
+    tokens!: TokenVariables[];
+    tokenTemplate!: TokenTemplateVariables[];
+
+    public accountTypeOptions = [
+        {label: 'Default', value: 'default'},
+        {label: 'Custom Account Field', value: 'custom'},
+        {label: 'Custom Account Value', value: 'custom-value'}
+    ];
+
+    constructor() {
+    }
+
+    ngOnInit(): void {
+        this.tokens = [];
+        this.tokenTemplate = [];
+        this.onInit.emit(this);
+        this.load(this.currentBlock);
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        this.load(this.currentBlock);
+    }
+
+    load(block: PolicyBlock) {
+        this.moduleVariables = block.moduleVariables;
+        this.item = block;
+        this.properties = block.properties;
+        this.properties.uiMetaData = this.properties.uiMetaData || {};
+
+        this.tokens = this.moduleVariables?.tokens || [];
+        this.tokenTemplate = this.moduleVariables?.tokenTemplates || [];
+    }
+
+    onHide(item: any, prop: any) {
+        item[prop] = !item[prop];
+    }
+
+    changeAccountType() {
+        delete this.properties.accountId;
+        delete this.properties.accountIdValue;
+    }
+
+    onUseTemplateChange() {
+        delete this.properties.tokenId;
+        delete this.properties.template;
+    }
+
+    onSave() {
+        this.item.changed = true;
+    }
+}

--- a/frontend/src/app/modules/policy-engine/policy-engine.module.ts
+++ b/frontend/src/app/modules/policy-engine/policy-engine.module.ts
@@ -158,6 +158,7 @@ import { IntegrationButtonBlockComponent } from './policy-viewer/blocks/integrat
 import { RestoreSavepointDialog } from './policy-viewer/dialogs/restore-savepoint-dialog/restore-savepoint-dialog.component';
 import { AddSavepointDialog } from "./policy-viewer/dialogs/add-savepoint-dialog/add-savepoint-dialog.component";
 import { OnLoadSavepointDialog } from "./policy-viewer/dialogs/on-load-savepoint-dialog/on-load-savepoint-dialog.component";
+import { WipeConfigComponent } from './policy-configuration/blocks/tokens/wipe-config/wipe-config.component';
 
 @NgModule({
     declarations: [
@@ -170,6 +171,7 @@ import { OnLoadSavepointDialog } from "./policy-viewer/dialogs/on-load-savepoint
         RequestConfigComponent,
         PolicyPropertiesComponent,
         MintConfigComponent,
+        WipeConfigComponent,
         SendConfigComponent,
         ExternalDataConfigComponent,
         AggregateConfigComponent,

--- a/frontend/src/app/modules/policy-engine/services/blocks-information.ts
+++ b/frontend/src/app/modules/policy-engine/services/blocks-information.ts
@@ -56,6 +56,7 @@ import { TransformationButtonBlockComponent } from '../policy-viewer/blocks/tran
 import { IntegrationButtonBlockComponent } from '../policy-viewer/blocks/integration-button-block/integration-button-block.component';
 import { HttpRequestUIAddonCode } from '../policy-viewer/code/http-request-ui-addon';
 import { TransformationUIAddonCode } from '../policy-viewer/code/transformation-ui-addon';
+import { WipeConfigComponent } from '../policy-configuration/blocks/tokens/wipe-config/wipe-config.component';
 
 const Container: IBlockSetting = {
     type: BlockType.Container,
@@ -663,7 +664,7 @@ const Wipe: IBlockSetting = {
     group: BlockGroup.Tokens,
     header: BlockHeaders.ServerBlocks,
     factory: null,
-    property: MintConfigComponent,
+    property: WipeConfigComponent,
     code: null,
 }
 

--- a/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
+++ b/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
@@ -39,8 +39,81 @@ export class RetirementBlock {
                 validator.addError('Option "rule" must be a string');
             }
 
-            if (ref.options.serialNumbersExpression && typeof ref.options.serialNumbersExpression !== 'string') {
+            if (
+                ref.options.serialNumbersExpression &&
+                typeof ref.options.serialNumbersExpression !== "string"
+            ) {
                 validator.addError('Option "serial numbers" must be a string');
+            } else if (
+                ref.options.serialNumbersExpression &&
+                typeof ref.options.serialNumbersExpression === "string"
+            ) {
+                const wipeTokens = ref.options.serialNumbersExpression
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                const numRe = /^\d+$/;
+
+                for (const tok of wipeTokens) {
+                    const firstDash = tok.indexOf("-");
+                    const lastDash = tok.lastIndexOf("-");
+
+                    if (/[^A-Za-z0-9-]/.test(tok)) {
+                        const bad = tok.match(/[^A-Za-z0-9-]/)![0];
+                        validator.addError(
+                            `Invalid serial number "${tok}": character "${bad}" is not allowed.  Use single input (e.g., "1" or "field0"), or range (e.g., "1-3 or field0-field1").`
+                        );
+                        continue;
+                    }
+
+                    if (numRe.test(tok)) {
+                        const v = parseInt(tok, 10);
+                        if (v < 1) {
+                            validator.addError(
+                                `Invalid serial number "${tok}": must be greater than or equal to 1.`
+                            );
+                            continue;
+                        }
+                    }
+
+                    if (firstDash === 0 || firstDash === tok.length - 1) {
+                        validator.addError(
+                            `Invalid serial number range "${tok}": both start and end are required (e.g., "1-3" or "field1-field5").`
+                        );
+                        continue;
+                    }
+
+                    if (firstDash > 0) {
+                        if (firstDash !== lastDash) {
+                            validator.addError(
+                                `Invalid serial number range "${tok}": only one '-' is allowed in a range.`
+                            );
+                            continue;
+                        }
+
+                        const left = tok.slice(0, firstDash).trim();
+                        const right = tok.slice(firstDash + 1).trim();
+
+                        const leftIsNum = numRe.test(left);
+                        const rightIsNum = numRe.test(right);
+
+                        if (leftIsNum && rightIsNum) {
+                            const l = parseInt(left, 10);
+                            const r = parseInt(right, 10);
+                            if (l < 1 || r < 1) {
+                                validator.addError(
+                                    `Invalid serial number range "${tok}": Serial numbers must be greater than or equal to 1`
+                                );
+                            }
+                            if (!(l < r)) {
+                                validator.addError(
+                                    `Invalid serial number range "${tok}": End serial number must be greater than start serial number.`
+                                );
+                            }
+                        }
+                        continue;
+                    }
+                }
             }
 
             const accountType = ['default', 'custom'];

--- a/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
+++ b/guardian-service/src/policy-engine/block-validators/blocks/retirement-block.ts
@@ -35,10 +35,12 @@ export class RetirementBlock {
                 }
             }
 
-            if (!ref.options.rule) {
-                validator.addError('Option "rule" is not set');
-            } else if (typeof ref.options.rule !== 'string') {
+            if (ref.options.rule && typeof ref.options.rule !== 'string') {
                 validator.addError('Option "rule" must be a string');
+            }
+
+            if (ref.options.serialNumbersExpression && typeof ref.options.serialNumbersExpression !== 'string') {
+                validator.addError('Option "serial numbers" must be a string');
             }
 
             const accountType = ['default', 'custom'];

--- a/guardian-service/system-schemas/system-schemas.json
+++ b/guardian-service/system-schemas/system-schemas.json
@@ -577,6 +577,13 @@
                     "description": "tokenId",
                     "type": "string",
                     "readOnly": false
+                },
+                "serialNumbers": {
+                    "$comment": "{\"term\": \"serialNumbers\", \"@id\": \"https://www.schema.org/text\"}",
+                    "title": "serialNumbers",
+                    "description": "serialNumbers",
+                    "type": "string",
+                    "readOnly": false
                 }
             },
             "required": [

--- a/policy-service/src/policy-engine/blocks/retirement-block.ts
+++ b/policy-service/src/policy-engine/blocks/retirement-block.ts
@@ -1,13 +1,13 @@
 import { ActionCallback, BasicBlock } from '../helpers/decorators/index.js';
 import { BlockActionError } from '../errors/index.js';
-import { DocumentCategoryType, DocumentSignature, LocationType, SchemaEntity, SchemaHelper } from '@guardian/interfaces';
+import { DocumentCategoryType, DocumentSignature, LocationType, SchemaEntity, SchemaHelper, TokenType } from '@guardian/interfaces';
 import { PolicyComponentsUtils } from '../policy-components-utils.js';
 import { CatchErrors } from '../helpers/decorators/catch-errors.js';
-import { Token as TokenCollection, VcHelper, VcDocumentDefinition as VcDocument, MessageServer, VCMessage, MessageAction, VPMessage, HederaDidDocument } from '@guardian/common';
+import { Token as TokenCollection, VcHelper, VcDocumentDefinition as VcDocument, MessageServer, VCMessage, MessageAction, VPMessage, HederaDidDocument} from '@guardian/common';
 import { PolicyUtils } from '../helpers/utils.js';
 import { AnyBlockType, IPolicyDocument, IPolicyEventState } from '../policy-engine.interface.js';
 import { IPolicyEvent, PolicyInputEventType, PolicyOutputEventType } from '../interfaces/index.js';
-import { ChildrenType, ControlType } from '../interfaces/block-about.js';
+import { ChildrenType, ControlType, PropertyType } from '../interfaces/block-about.js';
 import { PolicyUser, UserCredentials } from '../policy-user.js';
 import { ExternalDocuments, ExternalEvent, ExternalEventType } from '../interfaces/external-event.js';
 import { MintService } from '../mint/mint-service.js';
@@ -34,10 +34,11 @@ import { MintService } from '../mint/mint-service.js';
             PolicyOutputEventType.RefreshEvent,
             PolicyOutputEventType.ErrorEvent
         ],
-        defaultEvent: true
+        defaultEvent: true,
     },
     variables: [
         { path: 'options.tokenId', alias: 'token', type: 'Token' },
+        { path: 'options.serialNumbersExpression', alias: 'serialNumbersExpression', type: 'String' },
         { path: 'options.template', alias: 'template', type: 'TokenTemplate' }
     ]
 })
@@ -48,13 +49,15 @@ export class RetirementBlock {
      * @param token
      * @param data
      * @param ref
+     * @param serialNumbers
      * @private
      */
     private async createWipeVC(
         didDocument: HederaDidDocument,
         token: any,
         data: any,
-        ref: AnyBlockType
+        ref: AnyBlockType,
+        serialNumbers?: number[]
     ): Promise<VcDocument> {
         const vcHelper = new VcHelper();
         const policySchema = await PolicyUtils.loadSchemaByType(ref, SchemaEntity.WIPE_TOKEN);
@@ -63,7 +66,8 @@ export class RetirementBlock {
             ...SchemaHelper.getContext(policySchema),
             date: (new Date()).toISOString(),
             tokenId: token.tokenId,
-            amount: amount.toString()
+            amount: amount.toString(),
+            ...(serialNumbers && { serialNumbers: serialNumbers.join(',') })
         }
         const uuid = await ref.components.generateUUID();
         const wipeVC = await vcHelper.createVerifiableCredential(
@@ -119,9 +123,73 @@ export class RetirementBlock {
         const policyOwnerSignOptions = await policyOwner.loadSignOptions(ref, userId);
 
         const uuid: string = await ref.components.generateUUID();
-        const amount = PolicyUtils.aggregate(ref.options.rule, documents);
-        const [tokenValue, tokenAmount] = PolicyUtils.tokenAmount(token, amount);
-        const wipeVC = await this.createWipeVC(policyOwnerDidDocument, token, tokenAmount, ref);
+        
+        let serialNumbers: number[] = []
+        let tokenValue: number = 0;
+        let tokenAmount: string = '0';
+        if (token.tokenType === TokenType.NON_FUNGIBLE) {
+            const exprOpt = ref.options.serialNumbersExpression;
+            if (!exprOpt || !String(exprOpt).trim()) {
+                throw new Error('For NON_FUNGIBLE tokens, Serial numbers is required');
+            }
+            const wipeTokens = String(exprOpt).split(',').map(t => t.trim()).filter(Boolean);
+            const out = new Set<number>();
+
+            for (const tok of wipeTokens) {
+                const dash = tok.indexOf('-');
+                if (dash > 0) {
+                    const leftRaw  = tok.slice(0, dash).trim();
+                    const rightRaw = tok.slice(dash + 1).trim();
+
+                    const startRule = PolicyUtils.aggregate(String(leftRaw), documents);
+                    const endRule   = PolicyUtils.aggregate(String(rightRaw), documents);
+
+                    if (!Number.isInteger(startRule) || !Number.isInteger(endRule)) {
+                        throw new Error(`Serial numbers must be integers.`);
+                    }
+                    if (startRule < 1 || endRule < 1) {
+                        throw new Error('Serial numbers must be greater than or equal to 1');
+                    }
+                    if (startRule > endRule) {
+                        throw new Error(`End serial number must be greater than or equal to start serial number.`);
+                    }
+                    for (const n of PolicyUtils.aggregateSerialRange(startRule, endRule)) out.add(n);
+                } else {
+                    const valRule = PolicyUtils.aggregate(
+                        String(tok),
+                        documents
+                    );
+                    if (!Number.isInteger(valRule)) {
+                        throw new Error(
+                            `Serial numbers must be integers.`
+                        );
+                    }
+                    if (valRule < 1) {
+                        throw new Error(
+                            "Serial numbers must be greater than or equal to 1."
+                        );
+                    }
+                    out.add(valRule);
+                }
+            }
+            serialNumbers = Array.from(out).sort((a, b) => a - b);
+            if (serialNumbers.length === 0) {
+                throw new Error('No valid Serial Numbers found');
+            }
+        }
+        else if (token.tokenType === TokenType.FUNGIBLE) {
+            const ruleOpt =  ref.options.rule
+            const hasRule =
+                ruleOpt !== null && ruleOpt !== undefined &&
+                (typeof ruleOpt !== 'string' || ruleOpt.trim() !== '');
+             if (!hasRule) {
+                throw new Error('For FUNGIBLE tokens, Rule is required');
+            }
+            const amount = PolicyUtils.aggregate(ref.options.rule, documents);
+            [tokenValue, tokenAmount] = PolicyUtils.tokenAmount(token, amount);
+        }
+        
+        const wipeVC = await this.createWipeVC(policyOwnerDidDocument, token, tokenAmount, ref, serialNumbers);
         const vcs = [].concat(documents, wipeVC);
         const vp = await this.createVP(policyOwnerDidDocument, uuid, vcs);
 
@@ -184,7 +252,7 @@ export class RetirementBlock {
         vpDocument.relationships = relationships;
         await ref.databaseServer.saveVP(vpDocument);
 
-        await MintService.wipe(ref, token, tokenValue, policyOwnerHederaCred, targetAccountId, vpMessageResult.getId(), userId);
+        await MintService.wipe(ref, token, tokenValue, policyOwnerHederaCred, targetAccountId, vpMessageResult.getId(), userId, serialNumbers);
 
         return [vpDocument, tokenValue];
     }
@@ -226,11 +294,12 @@ export class RetirementBlock {
     @CatchErrors()
     async runAction(event: IPolicyEvent<IPolicyEventState>) {
         const ref = PolicyComponentsUtils.GetBlockRef(this);
+
         const docs = PolicyUtils.getArray<IPolicyDocument>(event.data.data);
         if (!docs.length && docs[0]) {
             throw new BlockActionError('Bad VC', ref.blockType, ref.uuid);
         }
-
+        
         const token = await this.getToken(ref, docs);
         if (!token) {
             throw new BlockActionError('Bad token id', ref.blockType, ref.uuid);

--- a/policy-service/src/policy-engine/helpers/utils.ts
+++ b/policy-service/src/policy-engine/helpers/utils.ts
@@ -147,6 +147,20 @@ export class PolicyUtils {
         return amount;
     }
 
+     /**
+     * Create Serial Numbers Array
+     * @param startRule
+     * @param endRule
+     */
+    public static aggregateSerialRange(startRule: number, endRule: number): number[] {
+        const from = Math.min(startRule, endRule);
+        const to = Math.max(startRule, endRule);
+        const len = to - from + 1;
+        const serialNumbers: number[]= Array.from({ length: len }, (_, i) => from + i);
+
+        return serialNumbers
+    }
+
     /**
      * Token amount
      * @param token

--- a/policy-service/src/policy-engine/mint/mint-service.ts
+++ b/policy-service/src/policy-engine/mint/mint-service.ts
@@ -575,6 +575,7 @@ export class MintService {
      * @param targetAccount
      * @param uuid
      * @param userId
+     * @param serialNumbers
      */
     public static async wipe(
         ref: AnyBlockType,
@@ -583,7 +584,8 @@ export class MintService {
         root: IHederaCredentials,
         targetAccount: string,
         uuid: string,
-        userId: string | null
+        userId: string | null,
+        serialNumbers?: number[]
     ): Promise<void> {
         const workers = new Workers();
         if (token.wipeContractId) {
@@ -612,7 +614,7 @@ export class MintService {
                             {
                                 type: ContractParamType.INT64,
                                 value: tokenValue,
-                            },
+                            }
                         ],
                         payload: { userId }
                     },
@@ -640,6 +642,7 @@ export class MintService {
                         targetAccount,
                         tokenValue,
                         uuid,
+                        serialNumbers,
                         payload: { userId }
                     },
                 },

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -754,6 +754,7 @@ export class Worker extends NatsService {
                         hederaAccountKey,
                         targetAccount,
                         tokenValue,
+                        serialNumbers,
                         dryRun,
                         token,
                         wipeKey,
@@ -761,13 +762,8 @@ export class Worker extends NatsService {
                         payload: {userId}
                     } = task.data;
                     client = new HederaSDKHelper(hederaAccountId, hederaAccountKey, dryRun, networkOptions);
-                    if (token.tokenType === 'non-fungible') {
-                        result.error = 'unsupported operation';
-                    } else {
-                        await client.wipe(token.tokenId, targetAccount, wipeKey, tokenValue, userId, uuid);
-                        result.data = {}
-                    }
-
+                    await client.wipe(token.tokenId, targetAccount, wipeKey, tokenValue, userId, token.tokenType, serialNumbers, uuid);
+                    result.data = {}
                     break;
                 }
 


### PR DESCRIPTION
### Issue Label
[https://github.com/hashgraph/guardian/issues/4988](https://github.com/hashgraph/guardian/issues/4988)

### Problem Description
The current implementation of Hedera Guardian does not support retiring NFTs by a specific set of serial numbers, even though the Hedera SDK natively supports this operation. 

In applications such as carbon credit management, it is often necessary to retire selected tokens (e.g., specific serial numbers) rather than the entire supply or a fixed count.

### Requirements
Enhance Guardian to support NFT retirement by specifying a list of serial numbers. The implementation should:
* Allow users or policy workflows to pass a custom array of serial numbers.
* Call the appropriate Hedera SDK function to retire those specific serial-numbered NFTs.

### Summary of Changes
By applying this enhancement:

* Users can select specific NFT serial numbers to retire.
* For NFT operations:

  * **Serial Numbers** field is required.
  * Guardian will generate an array of serial numbers and pass them to the Hedera SDK for the wipe operation.
* For FT operations:

  * **Rule** remains the required field.
  * No changes are introduced to the FT wipe process.

### Validation Rules
* The Serial Numbers field is required.
* The Serial Numbers expression may contain individual numbers or inclusive ranges (e.g., 1,2-5,10).
* If a range is used (e.g., 2-5), the end value must be greater than or equal to the start value.
* Rule is required for FT operations.

### NFT Wipe Flow
**_Schema-Driven Wipe Flow_**

Serial numbers can be dynamically provided via schema fields or policy formulas. This enables multiple wipe operations for the same token, with different sets of serial numbers, as needed. Can useful for workflows requiring repeated or conditional NFT retirement.

<img width="886" height="3337" alt="FireShot Capture 004 - Guardian -  3 93 78 104" src="https://github.com/user-attachments/assets/e60da834-0507-461b-9dfa-a22a3e0b866f" />
<img width="787" height="287" alt="image" src="https://github.com/user-attachments/assets/ac6aaa2e-e8dd-4d5a-ab40-2787fbaed59a" />


* Example usage
  * Mint NFTs via the Mint Block, with the amount provided by the schema.
  * Add a separate schema for wipe operations.

<img width="985" height="300" alt="image" src="https://github.com/user-attachments/assets/022829b5-d344-4ec1-b26d-e299624cd899" />

  * Retire serial numbers 1, 3, 4, 5, 8, 12, 13, 14, 15, (entered dynamically in schema).

<img width="1098" height="832" alt="image" src="https://github.com/user-attachments/assets/d17401f6-3608-4d80-b3b4-3377bc8e4f40" />
<img width="1912" height="1907" alt="image" src="https://github.com/user-attachments/assets/9429d05c-ec0e-4bc3-abb8-6f2feb7b51af" />


**_Single Wipe Flow (Per User, Per Token)_**

A constant value for Serial Numbers Expression (for example, 1,2-5,10) can be provided. This allows a one-time wipe of specific NFTs per user and per token throughout the policy lifecycle.

<img width="788" height="283" alt="image" src="https://github.com/user-attachments/assets/60349543-c9e6-4a7f-ba74-5b1c1d2f07b9" />

* Example usage
  * Mint 20 NFTs using the Mint Block.
  * (Minting amount must be ≥ highest serial number to be retired)
  * Retire serial numbers 10,12,13,14,18. 
  
<img width="1790" height="828" alt="image" src="https://github.com/user-attachments/assets/da926dd8-19e8-4c52-a80d-4114887957de" />
<img width="1912" height="1457" alt="image" src="https://github.com/user-attachments/assets/b85f85e3-3e5d-481e-aeae-e4eeb94c1f7f" />


Transaction History of Single NFT
<img width="1847" height="420" alt="image" src="https://github.com/user-attachments/assets/793ad878-e0c2-4425-a1e2-6765b02dd7f1" />


### FT Wipe Flow

No changes to the existing FT token wipe flow.

<img width="975" height="410" alt="image" src="https://github.com/user-attachments/assets/f60f4776-5c50-4a80-baf0-474a842c8479" />

* Example usage
  * Create an FT token using schema-driven Mint Block.
  * Use Wipe Block to retire 1 token (based on Rule).
  
  
<img width="975" height="385" alt="image" src="https://github.com/user-attachments/assets/3bd6b26f-3656-4e37-a1d6-68387e944a14" />
<img width="975" height="425" alt="image" src="https://github.com/user-attachments/assets/4ef2fe95-7002-494d-95c0-e19592dfdb0f" />
<img width="1896" height="643" alt="image" src="https://github.com/user-attachments/assets/385cf245-3bf0-4866-8984-9a65801fffed" />


