### PR TITLE
feat: add Haid humanitarian aid methodology

### DIFF
--- a/Methodology Library/Hackathon/Haid/README.md
+++ b/Methodology Library/Hackathon/Haid/README.md
@@ -1,0 +1,92 @@
+Haid – Humanitarian Aid with Hedera
+Deployed App: https://haid.vercel.app
+
+Track: DLT for Operations
+
+Pitch Deck: View Deck
+
+Certificates: View Folder
+
+Overview
+Haid is a humanitarian aid distribution system powered by the Hedera Guardian network. It brings transparency, dignity, and efficiency to how food, medical supplies, and essentials reach displaced people and refugees.
+
+The platform connects NGOs, volunteers, donors, and recipients in one trusted ecosystem, using Hedera’s DIDs and immutable event logs to guarantee fairness and accountability.
+
+Problem Statement
+Millions of displaced people struggle to access aid because of broken systems: no formal identity, fraudulent claims, and chaotic manual processes. For NGOs and donors, it’s almost impossible to see where aid actually goes or verify how it’s used.
+
+This lack of transparency creates waste, slows down distribution, and erodes trust. Haid fixes this by putting identity, distribution, and accountability all on Hedera’s distributed ledger.
+
+Solution
+Each refugee receives a waterproof Haid Band embedded with an NFC chip that contains a unique Decentralized Identifier (DID) on Hedera Guardian. For the hackathon, this is represented by a QR code, used purely for demo purposes due to financial constraints.
+
+When a volunteer scans a band, the system instantly verifies the recipient’s identity and logs the distribution on Hedera. NGOs can then track events in real time, while donors and auditors can see exactly how aid moves; all recorded immutably on-chain.
+
+Why Hedera Guardian
+Haid uses Hedera Guardian, the open-source sustainability platform that enables verifiable, tamper-proof data management.
+
+We leverage:
+
+Hedera Consensus Service (HCS) for timestamped, immutable event records.
+Hedera Decentralized Identity (DID) for privacy-preserving user identity.
+Guardian Indexer for transparent data visualization and verification.
+Together, these components make Haid scalable, auditable, and affordable; ideal for high-impact humanitarian operations.
+
+User Roles and Flow
+Refugees
+Receive Haid Bands (or QR codes for the MVP). Simply tap or scan to collect aid. No paperwork, no waiting, no double-claiming.
+
+NGOs
+Create and manage aid events such as food or shelter distributions. Assign volunteers and monitor real-time collection data. Export on-chain verified reports for donors and partners.
+
+Volunteers
+Use mobile scanning devices to log each collection event. Every scan is instantly recorded on Hedera. Receive instant feedback when aid is successfully logged.
+
+Donors
+Get an automatic Hedera wallet at registration. Send donations directly to verified NGOs. See live dashboards showing every transaction and its on-chain proof.
+
+Auditors
+Verify all recorded events on the Hedera Guardian indexer. Ensure full compliance and integrity of all distributed aid.
+
+Revenue and Sustainability
+Platform-as-a-Service model: NGOs and partner organizations subscribe to Haid for transparent, verifiable distribution tracking.
+Transaction fees: Minimal service fees on donor-to-NGO transfers via Hedera tokens.
+Partnership and grants: Collaborations with UNHCR, UNICEF, and government bodies to adopt Haid as a compliance and traceability layer for social programs.
+Roadmap
+Hackathon MVP (Now)
+QR code simulation of the NFC band.
+Full dashboards for NGOs, volunteers, donors, and refugees.
+Immutable Hedera Guardian logging on Testnet.
+Real-time analytics and automatic wallet creation.
+Post-Hackathon
+Manufacture waterproof NFC Haid Bands.
+Move wallets and event logging to Hedera Mainnet.
+Pilot with partner NGOs in West African refugee camps.
+Integrate AI for predictive logistics and aid optimization.
+Add trackable Haid Bands for location safety and migration support.
+Architecture Overview
+Layer	Tools	Purpose
+Frontend	Javascript + Chakra UI	Accessible, multilingual dashboards in English, French, Swahili, Hausa, and Arabic, with voice and high-contrast modes.
+Backend	Node.js	Event creation, user management, and real-time logging.
+Blockchain Layer	Hedera Guardian (HCS, DID)	Immutable event storage, decentralized identity, and data transparency.
+Database	MongoDB	Off-chain caching and queryable records synced with Hedera.
+Impact
+100% tamper-proof logs for every aid event.
+Up to 10× faster registration and distribution.
+Unified dashboard for all stakeholders.
+Refugees receive fair, transparent, and dignified aid.
+Why Haid Wins
+Because it’s built with empathy, not ego. Haid combines real-world practicality with verifiable technology - solving one of the hardest humanitarian challenges through simplicity and trust.
+
+It’s not just a concept. It’s a working end-to-end system built on Hedera Guardian, designed to scale across Africa and beyond.
+
+Team Haid
+Lydia Solomon - Product Lead & Product Manager
+
+Timothy - Frontend Engineer
+
+Tobiloba - Product Designer
+
+Olumuyiwa - Hedera Developer
+
+Chinomso - Backend Engineer

--- a/Methodology Library/Hackathon/Haid/policy_haid.json
+++ b/Methodology Library/Hackathon/Haid/policy_haid.json
@@ -1,0 +1,30 @@
+{
+  "name": "Haid Aid Distribution Policy",
+  "description": "Policy governing issuance and verification of aid distribution credentials on Hedera Guardian for the Haid system.",
+  "version": "1.0.0",
+  "author": "Team Haid",
+  "schema": "schema_haid.json",
+  "roles": {
+    "NGO": {
+      "permissions": ["create_event", "issue_credential", "view_reports"]
+    },
+    "Volunteer": {
+      "permissions": ["log_distribution", "verify_recipient"]
+    },
+    "Recipient": {
+      "permissions": ["receive_aid", "view_personal_history"]
+    },
+    "Donor": {
+      "permissions": ["view_verified_reports", "track_donations"]
+    },
+    "Auditor": {
+      "permissions": ["verify_all_events", "access_full_logs"]
+    }
+  },
+  "verificationLogic": {
+    "requiresValidDID": true,
+    "requiresSignature": true,
+    "timestampOnChain": true,
+    "revokeIfDuplicateEvent": true
+  }
+}

--- a/Methodology Library/Hackathon/Haid/schema_haid.json
+++ b/Methodology Library/Hackathon/Haid/schema_haid.json
@@ -1,0 +1,46 @@
+{
+  "name": "Haid Aid Distribution Schema",
+  "description": "Schema defining verifiable credentials for aid distribution events using Hedera Guardian in the Haid system.",
+  "version": "1.0.0",
+  "author": "Team Haid",
+  "fields": {
+    "recipient_did": {
+      "type": "string",
+      "description": "Decentralized Identifier (DID) of the refugee or recipient."
+    },
+    "event_id": {
+      "type": "string",
+      "description": "Unique identifier of the aid event."
+    },
+    "aid_type": {
+      "type": "string",
+      "description": "Type of aid distributed (e.g. food, medical, shelter, cash)."
+    },
+    "quantity": {
+      "type": "number",
+      "description": "Quantity or number of units distributed."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp of the aid distribution recorded on Hedera."
+    },
+    "volunteer_id": {
+      "type": "string",
+      "description": "Identifier or DID of the volunteer who conducted the distribution."
+    },
+    "ngo_id": {
+      "type": "string",
+      "description": "Identifier or DID of the NGO managing this event."
+    },
+    "location": {
+      "type": "string",
+      "description": "Physical location or camp site of distribution."
+    },
+    "signature": {
+      "type": "string",
+      "description": "Cryptographic signature verifying authenticity of the record."
+    }
+  }
+}
+


### PR DESCRIPTION
**Description**:
Haid – Humanitarian Aid with Hedera is a verifiable aid distribution framework built on the Hedera Guardian network.
It enables NGOs, volunteers, donors, and recipients to interact in a transparent, accountable ecosystem where every aid event is immutably recorded on-chain.

The methodology defines:

A schema for verifiable credentials representing each aid distribution event (recipient DID, aid type, quantity, timestamp, etc.).

A policy that enforces role-based access control and verification logic for NGOs, volunteers, donors, and auditors.

By using Hedera’s DIDs and Guardian Indexer, Haid ensures aid reaches the right people with full traceability, reducing fraud and inefficiency in humanitarian operations.


**Setup Instructions / Notes**:

**1**. Import the Methodology in Guardian

- In your Guardian instance, navigate to the Policies tab.

- Choose Import Policy and upload the policy_haid.json file.

- The linked schema (schema_haid.json) will be automatically recognized.

**2**. Assign Roles

- Define participants as NGO, Volunteer, Recipient, Donor, or Auditor.

- Ensure each user has a valid Decentralized Identifier (DID) registered in Guardian.

**3**. Test the Flow

- NGOs create aid distribution events.

- Volunteers log each delivery using recipient DIDs.

- Donors and auditors can view immutable records through the Guardian dashboard or indexer.

