### PR TITLE
Fix: Fix docker compose quickstart template environment variables issue

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -108,6 +108,7 @@ services:
         environment:
             - OPERATOR_ID=${OPERATOR_ID}
             - OPERATOR_KEY=${OPERATOR_KEY}
+            - GUARDIAN_ENV=${GUARDIAN_ENV}
 
     auth-service:
         <<: *service-template
@@ -173,6 +174,7 @@ services:
         environment:
             - OPERATOR_ID=${OPERATOR_ID}
             - OPERATOR_KEY=${OPERATOR_KEY}
+            - GUARDIAN_ENV=${GUARDIAN_ENV}
 
     topic-viewer:
         image: gcr.io/hedera-registry/topic-viewer:${GUARDIAN_VERSION:-latest}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

## The issue: 
In some services if you use `<<: *service-template` it passes all configuration elements correctly. 
But if you add/change some of the configuration elements (e.g. how it is done in `guardian-service`), where `OPERATOR_ID` and `OPERATOR_KEY` added as `environment`, `environment` from the `service-template` won't be merged, thus omitting `GUARDIAN_ENV` and breaking services. 

## The fix:
Manually added `GUARDIAN_ENV` to the necessary services. 

### System details 
Docker Engine: 28.3.3
Docker Desktop: 4.45.0 (203075)
Compose: v2.39.2-desktop.1
