### PR TITLE
Migrate to hiero-ledger/sdk

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -6,7 +6,7 @@
         "@azure/keyvault-secrets": "^4.9.0",
         "@google-cloud/secret-manager": "^4.2.2",
         "@guardian/interfaces": "3.4.0",
-        "@hashgraph/sdk": "2.72.0",
+        "@hiero-ledger/sdk": "2.72.0",
         "@mattrglobal/jsonld-signatures-bbs": "^1.1.2",
         "@meeco/cryppo": "^2.0.2",
         "@mikro-orm/core": "6.4.16",

--- a/common/src/database-modules/database-server.ts
+++ b/common/src/database-modules/database-server.ts
@@ -1,5 +1,5 @@
 import { AssignedEntityType, GenerateUUIDv4, IVC, MintTransactionStatus, PolicyTestStatus, PolicyStatus, SchemaEntity, TokenType, TopicType, ExternalPolicyStatus } from '@guardian/interfaces';
-import { TopicId } from '@hashgraph/sdk';
+import { TopicId } from '@hiero-ledger/sdk';
 import { FilterObject, FilterQuery, FindAllOptions, MikroORM } from '@mikro-orm/core';
 import type { FindOptions } from '@mikro-orm/core/drivers/IDatabaseDriver';
 import { MongoDriver, ObjectId, PopulatePath } from '@mikro-orm/mongodb';

--- a/common/src/hedera-modules/environment.ts
+++ b/common/src/hedera-modules/environment.ts
@@ -1,4 +1,4 @@
-import { AccountId, Client } from '@hashgraph/sdk';
+import { AccountId, Client } from '@hiero-ledger/sdk';
 
 /**
  * Environment class

--- a/common/src/hedera-modules/message/message-server.ts
+++ b/common/src/hedera-modules/message/message-server.ts
@@ -1,4 +1,4 @@
-import { AccountId, PrivateKey, TopicId, } from '@hashgraph/sdk';
+import { AccountId, PrivateKey, TopicId, } from '@hiero-ledger/sdk';
 import { GenerateUUIDv4, ISignOptions, SignType, WorkerTaskType } from '@guardian/interfaces';
 import { IPFS, PinoLogger, Workers } from '../../helpers/index.js';
 import { TransactionLogger } from '../transaction-logger.js';

--- a/common/src/hedera-modules/message/message.ts
+++ b/common/src/hedera-modules/message/message.ts
@@ -1,5 +1,5 @@
 import { GenerateUUIDv4 } from '@guardian/interfaces';
-import { TopicId } from '@hashgraph/sdk';
+import { TopicId } from '@hiero-ledger/sdk';
 import { Hashing } from '../hashing.js';
 import { MessageAction } from './message-action.js';
 import { MessageBody } from './message-body.interface.js';

--- a/common/src/hedera-modules/timestamp-utils.ts
+++ b/common/src/hedera-modules/timestamp-utils.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from '@hashgraph/sdk';
+import { Timestamp } from '@hiero-ledger/sdk';
 import moment from 'moment';
 
 /**

--- a/common/src/hedera-modules/utils.ts
+++ b/common/src/hedera-modules/utils.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, PublicKey } from '@hashgraph/sdk';
+import { PrivateKey, PublicKey } from '@hiero-ledger/sdk';
 
 /**
  * Timeout decorator

--- a/common/src/hedera-modules/vcjs/did-document.ts
+++ b/common/src/hedera-modules/vcjs/did-document.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, PublicKey, TopicId } from '@hashgraph/sdk';
+import { PrivateKey, PublicKey, TopicId } from '@hiero-ledger/sdk';
 import { Environment } from '../environment.js';
 import { Hashing } from '../hashing.js';
 import { IVerificationMethod, IDidDocument } from '@guardian/interfaces';

--- a/common/src/hedera-modules/vcjs/did/components/hedera-bbs-method.ts
+++ b/common/src/hedera-modules/vcjs/did/components/hedera-bbs-method.ts
@@ -1,4 +1,4 @@
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import { Bls12381G2KeyPair } from '@mattrglobal/jsonld-signatures-bbs';
 import { VerificationMethod } from './verification-method.js';
 

--- a/common/src/hedera-modules/vcjs/did/components/hedera-ed25519-method.ts
+++ b/common/src/hedera-modules/vcjs/did/components/hedera-ed25519-method.ts
@@ -1,4 +1,4 @@
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import { Hashing } from '../../../hashing.js';
 import { VerificationMethod } from './verification-method.js';
 

--- a/common/src/hedera-modules/vcjs/did/hedera-did-document.ts
+++ b/common/src/hedera-modules/vcjs/did/hedera-did-document.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, TopicId } from '@hashgraph/sdk';
+import { PrivateKey, TopicId } from '@hiero-ledger/sdk';
 import { DocumentContext } from './components/document-context.js';
 import { HederaDid } from './hedera-did.js';
 import { CommonDidDocument } from './common-did-document.js';

--- a/common/src/hedera-modules/vcjs/did/hedera-did.ts
+++ b/common/src/hedera-modules/vcjs/did/hedera-did.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, PublicKey, TopicId } from '@hashgraph/sdk';
+import { PrivateKey, PublicKey, TopicId } from '@hiero-ledger/sdk';
 import { Hashing } from '../../hashing.js';
 import { CommonDid } from './common-did.js';
 import { HederaDidComponents } from './types/did-components.js';

--- a/common/src/hedera-modules/vcjs/vc-document.ts
+++ b/common/src/hedera-modules/vcjs/vc-document.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from '@hashgraph/sdk';
+import { Timestamp } from '@hiero-ledger/sdk';
 import { Hashing } from '../hashing.js';
 import { TimestampUtils } from '../timestamp-utils.js';
 import { IVC, SignatureType } from '@guardian/interfaces';

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -2,7 +2,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { ld as vcjs } from '@transmute/vc.js';
 import { Ed25519Signature2018, Ed25519VerificationKey2018 } from '@transmute/ed25519-signature-2018';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import { CheckResult } from '@transmute/jsonld-schema';
 import { GenerateUUIDv4, ICredentialSubject, IVC, SignatureType } from '@guardian/interfaces';
 import { VcDocument } from './vc-document.js';

--- a/common/src/hedera-modules/vcjs/vp-document.ts
+++ b/common/src/hedera-modules/vcjs/vp-document.ts
@@ -3,7 +3,7 @@ import { IVP } from '@guardian/interfaces';
 import { VcDocument } from './vc-document.js';
 import { Issuer } from './issuer.js';
 import { TimestampUtils } from '../timestamp-utils.js';
-import { Timestamp } from '@hashgraph/sdk';
+import { Timestamp } from '@hiero-ledger/sdk';
 import { CommonDidDocument } from './did/index.js';
 
 /**

--- a/common/src/helpers/utils.ts
+++ b/common/src/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { IVC, IVCDocument, GenerateUUIDv4, ArtifactType } from '@guardian/interfaces';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 
 /**
  * Transaction response callback

--- a/common/src/helpers/vc-helper.ts
+++ b/common/src/helpers/vc-helper.ts
@@ -27,7 +27,7 @@ import {
     SchemaEntity,
     SignatureType,
 } from '@guardian/interfaces';
-import { PrivateKey, TopicId } from '@hashgraph/sdk';
+import { PrivateKey, TopicId } from '@hiero-ledger/sdk';
 import {
     BbsBlsSignatureProof2020,
     Bls12381G2KeyPair,

--- a/common/src/interfaces/database-server.ts
+++ b/common/src/interfaces/database-server.ts
@@ -1,6 +1,6 @@
 //entities
 import { AssignedEntityType, IVC, MintTransactionStatus, PolicyTestStatus, SchemaEntity, TopicType } from '@guardian/interfaces';
-import { TopicId } from '@hashgraph/sdk';
+import { TopicId } from '@hiero-ledger/sdk';
 import { FilterQuery } from '@mikro-orm/core';
 import {
     AggregateVC,

--- a/common/tests/unit-tests/hedera-modules/vcjs/did-document.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/did-document.test.mjs
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 
 import { DidRootKey, DIDDocument, DidDocumentBase } from '../../../../dist/hedera-modules/vcjs/did-document.js';
 

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs.test.mjs
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 
 import { VCJS } from '../../../../dist/hedera-modules/vcjs/vcjs.js';
 import { DefaultDocumentLoader } from '../../../../dist/hedera-modules/document-loader/document-loader-default.js';

--- a/guardian-cli/helpers/contract-publisher.helper.ts
+++ b/guardian-cli/helpers/contract-publisher.helper.ts
@@ -8,7 +8,7 @@ import {
     FileCreateTransaction,
     PrivateKey,
     Status,
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 
 /**
  * Network

--- a/guardian-cli/package.json
+++ b/guardian-cli/package.json
@@ -21,7 +21,7 @@
         "typescript": "^5.8.3"
     },
     "dependencies": {
-        "@hashgraph/sdk": "2.72.0",
+        "@hiero-ledger/sdk": "2.72.0",
         "axios": "^1.12.0",
         "commander": "^10.0.0",
         "solc": "0.8.11",

--- a/guardian-service/src/api/config.service.ts
+++ b/guardian-service/src/api/config.service.ts
@@ -1,7 +1,7 @@
 import { ApiResponse } from '../api/helpers/api-response.js';
 import { Environment, IAuthUser, MessageError, MessageResponse, PinoLogger, SecretManager, ValidateConfiguration, Workers } from '@guardian/common';
 import { CommonSettings, MessageAPI } from '@guardian/interfaces';
-import { AccountId, PrivateKey } from '@hashgraph/sdk';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 
 /**
  * Connecting to the message broker methods of working with root address book.

--- a/guardian-service/src/api/contract.service.ts
+++ b/guardian-service/src/api/contract.service.ts
@@ -42,7 +42,7 @@ import {
     UserRole,
     WorkerTaskType
 } from '@guardian/interfaces';
-import { AccountId, TokenId } from '@hashgraph/sdk';
+import { AccountId, TokenId } from '@hiero-ledger/sdk';
 import { proto } from '@hashgraph/proto';
 import * as ethers from 'ethers';
 import { contractCall, contractQuery, createContract, createContractV2, customContractCall } from './helpers/index.js';

--- a/guardian-service/src/api/helpers/profile-helper.ts
+++ b/guardian-service/src/api/helpers/profile-helper.ts
@@ -43,7 +43,7 @@ import {
     Wallet,
     Workers,
 } from '@guardian/common';
-import { AccountId, PrivateKey } from '@hashgraph/sdk';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { serDefaultRole } from '../permission.service.js';
 import { publishSystemSchema } from '../../helpers/import-helpers/index.js';
 

--- a/guardian-service/src/api/profile.service.ts
+++ b/guardian-service/src/api/profile.service.ts
@@ -22,7 +22,7 @@ import {
 import { RestoreDataFromHedera } from '../helpers/restore-data-from-hedera.js';
 import { Controller, Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
-import { AccountId, PrivateKey } from '@hashgraph/sdk';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { setupUserProfile, validateCommonDid } from './helpers/profile-helper.js';
 
 @Controller()

--- a/guardian-service/src/app.ts
+++ b/guardian-service/src/app.ts
@@ -35,7 +35,7 @@ import {
     NotificationEvents
 } from '@guardian/common';
 import { ApplicationStates, PolicyEvents, PolicyStatus, WorkerTaskType } from '@guardian/interfaces';
-import { AccountId, PrivateKey, TopicId } from '@hashgraph/sdk';
+import { AccountId, PrivateKey, TopicId } from '@hiero-ledger/sdk';
 import { ipfsAPI } from './api/ipfs.service.js';
 import { artifactAPI } from './api/artifact.service.js';
 import { sendKeysToVault } from './helpers/send-keys-to-vault.js';

--- a/guardian-service/src/policy-engine/policy-comments-utils.ts
+++ b/guardian-service/src/policy-engine/policy-comments-utils.ts
@@ -1,7 +1,7 @@
 import { DatabaseServer, IAuthUser, Policy, PolicyDiscussion, VcDocument, VcHelper, Schema as SchemaCollection, MessageServer, NewNotifier, Users, TopicConfig, TopicHelper, Wallet, KeyType, EncryptVcHelper } from '@guardian/common';
 import { EntityOwner, GenerateUUIDv4, LocationType, PolicyStatus, Schema, SchemaEntity, SchemaHelper, TopicType } from '@guardian/interfaces';
 import { publishSystemSchema } from '../helpers/import-helpers/index.js';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import * as crypto from 'crypto';
 
 /**

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -56,7 +56,7 @@ import {
     IgnoreRule,
     SchemaStatus
 } from '@guardian/interfaces';
-import { AccountId, PrivateKey } from '@hashgraph/sdk';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { NatsConnection } from 'nats';
 import { CompareUtils, HashComparator } from '../analytics/index.js';
 import { compareResults, getDetails } from '../api/record.service.js';

--- a/guardian-service/tests/stability.test.mjs
+++ b/guardian-service/tests/stability.test.mjs
@@ -9,7 +9,7 @@ import {
     AccountInfoQuery,
     TopicCreateTransaction,
     FileCreateTransaction
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import dotenv from 'dotenv';
 
 dotenv.config();

--- a/policy-service/src/policy-engine/blocks/external-topic-block.ts
+++ b/policy-service/src/policy-engine/blocks/external-topic-block.ts
@@ -27,7 +27,7 @@ import {
     ExternalEvent,
     ExternalEventType
 } from '../interfaces/external-event.js';
-import { TopicId } from '@hashgraph/sdk';
+import { TopicId } from '@hiero-ledger/sdk';
 
 /**
  * Search Topic Result

--- a/policy-service/src/policy-engine/helpers/components-service.ts
+++ b/policy-service/src/policy-engine/helpers/components-service.ts
@@ -9,7 +9,7 @@ import {
     VcHelper
 } from '@guardian/common';
 import { GenerateUUIDv4, PolicyHelper, SchemaEntity } from '@guardian/interfaces';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import { IPolicyBlock } from '../policy-engine.interface.js';
 import { PolicyUser } from '../policy-user.js';
 import { Recording, Running } from '../record/index.js';

--- a/policy-service/src/policy-engine/helpers/utils.ts
+++ b/policy-service/src/policy-engine/helpers/utils.ts
@@ -20,7 +20,7 @@ import {
     SchemaConverterUtils
 } from '@guardian/common';
 import { DidDocumentStatus, DocumentSignature, DocumentStatus, ISchema, Schema, SchemaEntity, SchemaField, SignatureType, TopicType, WorkerTaskType } from '@guardian/interfaces';
-import { TokenId, TopicId } from '@hashgraph/sdk';
+import { TokenId, TopicId } from '@hiero-ledger/sdk';
 import { FilterQuery } from '@mikro-orm/core';
 import * as mathjs from 'mathjs';
 import { DocumentType } from '../interfaces/document.type.js';

--- a/policy-service/src/policy-engine/mint/mint-service.ts
+++ b/policy-service/src/policy-engine/mint/mint-service.ts
@@ -1,7 +1,7 @@
 import { AnyBlockType } from '../policy-engine.interface.js';
 import { ContractParamType, ExternalMessageEvents, GenerateUUIDv4, IRootConfig, ISignOptions, NotificationAction, TokenType, WorkerTaskType, } from '@guardian/interfaces';
 import { DatabaseServer, ExternalEventChannel, KeyType, MessageAction, MessageServer, MintRequest, MultiPolicy, MultiPolicyTransaction, NotificationHelper, PinoLogger, SynchronizationMessage, Token, TopicConfig, Users, VcDocumentDefinition as VcDocument, Wallet, Workers } from '@guardian/common';
-import { AccountId, PrivateKey, TokenId } from '@hashgraph/sdk';
+import { AccountId, PrivateKey, TokenId } from '@hiero-ledger/sdk';
 import { PolicyUtils } from '../helpers/utils.js';
 import { IHederaCredentials, PolicyUser } from '../policy-user.js';
 import { TokenConfig } from './configs/token-config.js';

--- a/policy-service/src/policy-engine/record/running.ts
+++ b/policy-service/src/policy-engine/record/running.ts
@@ -9,7 +9,7 @@ import { PolicyComponentsUtils } from '../policy-components-utils.js';
 import { DatabaseServer, HederaDidDocument, IRecordResult, RecordImportExport, VcDocument as VcDocumentCollection, VcDocument, VcHelper, VpDocument } from '@guardian/common';
 import { RecordItem } from './record-item.js';
 import { GenerateDID, GenerateUUID, IGenerateValue, RecordItemStack, RowDocument, Utils } from './utils.js';
-import { AccountId, PrivateKey } from '@hashgraph/sdk';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 
 interface RecordOptions {
     mode?: string;

--- a/topic-listener-service/package.json
+++ b/topic-listener-service/package.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "@guardian/common": "3.4.0",
         "@guardian/interfaces": "3.4.0",
-        "@hashgraph/sdk": "2.72.0",
+        "@hiero-ledger/sdk": "2.72.0",
         "@nestjs/common": "^11.0.11",
         "@nestjs/core": "^11.0.11",
         "@nestjs/microservices": "^11.0.11",

--- a/worker-service/package.json
+++ b/worker-service/package.json
@@ -4,7 +4,7 @@
         "@filebase/client": "^0.0.5",
         "@guardian/common": "3.4.0",
         "@guardian/interfaces": "3.4.0",
-        "@hashgraph/sdk": "2.72.0",
+        "@hiero-ledger/sdk": "2.72.0",
         "@nestjs/common": "^11.0.11",
         "@nestjs/core": "^11.0.11",
         "@nestjs/microservices": "^11.0.11",

--- a/worker-service/src/api/helpers/environment.ts
+++ b/worker-service/src/api/helpers/environment.ts
@@ -1,4 +1,4 @@
-import { AccountId, Client } from '@hashgraph/sdk';
+import { AccountId, Client } from '@hiero-ledger/sdk';
 
 /**
  * Environment class

--- a/worker-service/src/api/helpers/hedera-sdk-helper.ts
+++ b/worker-service/src/api/helpers/hedera-sdk-helper.ts
@@ -45,7 +45,7 @@ import {
     TransactionRecord,
     TransactionRecordQuery,
     TransferTransaction
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import { HederaUtils, timeout } from './utils.js';
 import axios, { AxiosResponse } from 'axios';
 import { Environment } from './environment.js';

--- a/worker-service/src/api/helpers/transaction-logger.ts
+++ b/worker-service/src/api/helpers/transaction-logger.ts
@@ -16,7 +16,7 @@ import {
     TopicMessageSubmitTransaction,
     Transaction,
     TransferTransaction
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 
 /**
  * Transaction logger

--- a/worker-service/src/api/helpers/utils.ts
+++ b/worker-service/src/api/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { TimeoutError } from '@guardian/interfaces';
-import { PrivateKey } from '@hashgraph/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 
 /**
  * Timeout decorator

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -25,7 +25,7 @@ import {
     ContractId,
     PrivateKey,
     TokenId
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import {HederaUtils} from './helpers/utils.js';
 import axios from 'axios';
 import process from 'process';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,10 +1421,10 @@
     long "^5.2.3"
     protobufjs "7.2.5"
 
-"@hashgraph/sdk@2.72.0":
+"@hiero-ledger/sdk@2.72.0":
   version "2.72.0"
-  resolved "https://registry.yarnpkg.com/@hashgraph/sdk/-/sdk-2.72.0.tgz#f55e905e1cc0e37d8d064c2447c1cfbd93e0cb4e"
-  integrity sha512-w35M77OAkJutENG4CldUGzfT+qubDjEYCQR5Ran75uHB+SLeCodR87AXWJ3ocr5vPaZ7lsflBXEYZLhgCi1G2g==
+  resolved "https://registry.yarnpkg.com/@hiero-ledger/sdk/-/sdk-2.72.0.tgz#98ec5a6591bd005c9efde8aa48786baf3f1c689d"
+  integrity sha512-uY1Z7avAQRCcQyDpqlbnAMfx6VPajQARd6m+LrId6OA/qTsK8Xzdqb/BmyuukKQgPeY6tRgkWaKz9Lt4/TUO4A==
   dependencies:
     "@ethersproject/abi" "^5.8.0"
     "@ethersproject/bignumber" "^5.8.0"
@@ -11456,9 +11456,9 @@ one-webcrypto@^1.0.3:
   resolved "https://registry.yarnpkg.com/one-webcrypto/-/one-webcrypto-1.0.3.tgz#f951243cde29b79b6745ad14966fc598a609997c"
   integrity sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==
 
-"one-webcrypto@git+https://github.com/web3-storage/one-webcrypto.git":
+"one-webcrypto@https://github.com/web3-storage/one-webcrypto":
   version "1.0.1"
-  resolved "git+https://github.com/web3-storage/one-webcrypto.git#9e029e2fd477bd95bb80abd3553bbac704ccc7a6"
+  resolved "https://github.com/web3-storage/one-webcrypto#9e029e2fd477bd95bb80abd3553bbac704ccc7a6"
 
 onetime@^5.1.0:
   version "5.1.2"


### PR DESCRIPTION
**Description**:
This PR migrates the references from the old @hashgraph/sdk to the new @hiero-ledger/sdk

**Related issue(s)**:

Fixes N/A

**Notes for reviewer**:

- [Hedera Projects Moving to Hiero](https://hedera.com/blog/namespace-transition-announcement-hedera-projects-moving-to-hiero)
- [JavaScript SDK Migration guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/migration_hiero.md)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
