### PR TITLE
chore: docker-compose file improvements

### DIFF
--- a/.dclintrc
+++ b/.dclintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {},
+  "quiet": false,
+  "debug": false,
+  "exclude": []
+}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ In the memo field of each token mint transaction you will find a unique Hedera m
 
 Please see p.17 in the FAQ for more information. This is further defined in [Hedera Improvement Proposal 28 (HIP-28)](https://hips.hedera.com/hip/hip-28).
 
-([back to top](#readme))
-
 ## Quickstart
 
 This procedure is useful for demos, quick testing, and hackathons. It will only start the minimum required services for using the main Guardian features. It will not start features like the AI or MRV sender services, Prometheus integration, Grafana integration, etc.
@@ -25,73 +23,74 @@ This procedure is useful for demos, quick testing, and hackathons. It will only 
 1. Ensure to have [Git](https://git-scm.com/downloads) and [Docker](https://www.docker.com/) installed on your machine.
 2. Clone this repository
 
-```bash
-git clone https://github.com/hashgraph/guardian.git
-cd guardian
-```
+   ```shell
+   git clone https://github.com/hashgraph/guardian.git
+   cd guardian
+   ```
 
 3. Login or register on the [Hedera Developer Portal](https://portal.hedera.com/login).
 4. Generate an ED25519 key pair and account.
 5. Copy your AccountID (i.e, `0.0.123456...`) and the associated DER Encoded Private Key (i.e., `302e020100300506032b657004220420....`).
 6. Create a local `.env` file in the root directory of your project and update it with your AccountID and private key.
 
-```dotenv
-OPERATOR_ID=0.0.123456...
-OPERATOR_KEY=302e020100300506032b657004220420....
-```
+   ```dotenv
+   OPERATOR_ID=0.0.123456...
+   OPERATOR_KEY=302e020100300506032b657004220420....
+   ```
 
 7. Start the environment with:
 
-```bash
-docker compose -f docker-compose-quickstart.yml up --pull=always -d
-```
+   ```shell
+   docker compose -f docker-compose-quickstart.yml up --pull=always -d
+   ```
 
 8. Navigate to <http://localhost:3000> in your web browser.
-
 9. If you want to stop the environment, preserving all the local data, use:
 
-```bash
-docker compose -f docker-compose-quickstart.yml stop
-```
+   ```shell
+   docker compose -f docker-compose-quickstart.yml stop
+   ```
 
 10. If you want to destroy the environment, loosing all the local data, use:
 
-```bash
-docker compose -f docker-compose-quickstart.yml down
-```
+    ```shell
+    docker compose -f docker-compose-quickstart.yml down
+    ```
 
 ## Getting started
 
-To get a local copy up and running quickly, follow the steps below. Please refer to <https://docs.hedera.com/guardian> for complete documentation.
+To get a local copy up and running quickly, follow the steps below. Please refer to <https://guardian.hedera.com> for complete documentation.
 
 **Note**. If you have already installed another version of Guardian, remember to **perform a backup operation before upgrading**.
 
 ## Prerequisites
 
-### 2.1 Universal software
+### Software
 
 1. **[Git](https://git-scm.com/downloads)** – source-control tooling
 2. **[Docker](https://www.docker.com/)** – one-command build & run (recommended)
 3. **[MongoDB v6](https://www.mongodb.com/)**, **[Node.js v20.19](https://nodejs.org/en/download)**, and **[NATS 2.9.25](https://nats.io/)** – auto-provisioned when using Docker Compose
 4. **[IPFS storage](https://docs.ipfs.tech/concepts/what-is-ipfs/)** (choose one):
- - **[Storacha account](https://storacha.network/)** – IPFS pinning service (formerly Web3.Storage)
- - **[Filebase account](https://filebase.com/)** – S3-compatible IPFS pinning
- - Local IPFS node (e.g., **[Kubo](https://github.com/ipfs/kubo)**) – auto-provisioned when using Docker Compose
+
+   - **[Storacha account](https://storacha.network/)** – IPFS pinning service (formerly Web3.Storage)
+   - **[Filebase account](https://filebase.com/)** – S3-compatible IPFS pinning
+   - Local IPFS node (e.g., **[Kubo](https://github.com/ipfs/kubo)**) – auto-provisioned when using Docker Compose
+
 5. **[Redict](https://redict.io/)** – in-memory cache & message broker, independent fork of Redis® (auto-provisioned by the Docker stack)
 
 When building the reference implementation, you can [manually build every component](#manual-installation) or run a single command with Docker.
 
-### 2.2 Hedera network
+### Hedera network
 
-|                | Testnet (default)                      | Mainnet (production)                                                                               |
+| Component | Testnet (default) | Mainnet (production) |
 | -------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Account**    | Create via [Hedera Developer Portal](https://portal.hedera.com/login) | Create via Hedera-enabled wallet (e.g.HashPack) |
-| **Key type**   | ED25519                            | ED25519                                                                                        |
-| **Network**    | `testnet`                              | `mainnet`                                                                                          |
+| **Account** | Create via [Hedera Developer Portal](https://portal.hedera.com/register) | Create via Hedera-enabled wallet (e.g.HashPack) |
+| **Key type** | ED25519 | ED25519 |
+| **Network** | `testnet` | `mainnet` |
 
 > **Fees**: Mainnet operations incur HBAR costs—fund your account before running Guardian.
 
-## 2.3. Preparing a Mainnet Account & Keys
+#### Preparing a Mainnet Account & Keys
 
 1. Install a Hedera-enabled wallet (e.g., [HashPack](https://www.hashpack.app/)).
 2. Create a Mainnet account and note the Account ID (`0.0.x`).
@@ -105,9 +104,9 @@ When building the reference implementation, you can [manually build every compon
    OPERATOR_KEY=302e020100300506032b657004220420....
    ```
 
-## 2.4. Preparing a Testnet Account & Keys
+#### Preparing a Testnet Account & Keys
 
-1. Create a Testnet account via the [Hedera Developer Portal](https://portal.hedera.com/login).
+1. Create a Testnet account via the [Hedera Developer Portal](https://portal.hedera.com/register).
 2. Record your Account ID (0.0.x).
 3. Download the ED25519 private key (ignore ECDSA)
    - Select the DER Encoded Private Key — do not choose HEX Encoded.
@@ -119,24 +118,24 @@ When building the reference implementation, you can [manually build every compon
    OPERATOR_KEY=302e020100300506032b657004220420....
    ```
 
-## 2.5. Automatic installation
+## Automatic installation
 
 ### Prerequisites for automatic installation
 
-* [Docker](https://www.docker.com)
+- [Docker](https://www.docker.com)
 
 If you build with docker [MongoDB V6](https://www.mongodb.com), [Node.js v20.19](https://nodejs.org), [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) and [Nats 2.9.25](https://nats.io/) will be installed and configured automatically.
 
-## Installation
+### Installation
 
 The following steps need to be executed in order to start Guardian using docker:
 
 1. Clone the repo
 2. Configure project level .env file
-3. Update BC access variables
+3. Update Hedera access variables
 4. Setup IPFS
 5. Build and launch with Docker
-6. Browse to http://localhost:3000
+6. Browse to <http://localhost:3000>
 7. For increased security remove credentials from .env file
 
 Here the steps description follows:
@@ -147,7 +146,7 @@ Here the steps description follows:
    git clone https://github.com/hashgraph/guardian.git
    ```
 
-#### 2. Configure project level .env file.
+#### 2. Configure project level .env file
 
 The main configuration file that needs to be provided to the Guardian system is the .env file. Note that these files contain sensitive configuration such as keys and access credentials which are only used at the initial start of Guardian. For increased security it is recommended to disable inbound network access until after the first run of Guardian, when the credentials configuration has been removed from .env file (see p8 below).
 
@@ -157,11 +156,11 @@ For this example purpose let's name the Guardian platform as "develop"
    GUARDIAN_ENV="develop"
 ```
 
-> **_NOTE:_**  Every single service is provided in its folder with a `.env.template` file, this set of files are only needed for the case of Manual installation.
+> ***NOTE:***  Every single service is provided in its folder with a `.env.template` file, this set of files are only needed for the case of Manual installation.
 
-#### 3. Update BC access variables.
+#### 3. Update Hedera access variables
 
-Update the following files with your Hedera Mainnet or Testnet account info (see prerequisites). Please check complete steps to generate Operator_ID and Operator_Key by looking at the link: [How to Create Operator_ID and Operator_Key](https://docs.hedera.com/guardian/getting-started/getting-started/how-to-create-operator-id-and-operator-key).
+Update the following files with your Hedera Mainnet or Testnet account info (see prerequisites). Please check complete steps to generate Operator_ID and Operator_Key by looking at the link: [How to Create Operator_ID and Operator_Key](https://guardian.hedera.com/getting-started/getting-started/how-to-create-operator-id-and-operator-key).
 The Operator_ID and Operator_Key and HEDERA_NET are all that Guardian needs to access the Hedera Blockchain assuming a role on it. This parameters needs to be configured in a file at the path `./configs`, the file should use the following naming convention:
 
    `./configs/.env.\<GUARDIAN_ENV\>.guardian.system`
@@ -174,7 +173,7 @@ The parameter `HEDERA_NET` may assume the following values: `mainnet`, `testnet`
 
    following the previous example, the file to configure should be named: `./configs/.env.develop.guardian.system`, this file is already provided in the folder as an example, only update the variables OPERATOR_ID, OPERATOR_KEY and HEDERA_NET.
 
-   ```plaintext
+   ```text
    OPERATOR_ID="..."
    OPERATOR_KEY="..."
    HEDERA_NET="..."
@@ -195,7 +194,7 @@ To let the Multi-environment transition happen in a transparent way the `GUARDIA
 
 `PREUSED_HEDERA_NET` never needs to be changed after the first initialization. On the contrary it will be possible to change `HEDERA_NET` to dials with all the Hedera different networks.
 
-   - as first Example:
+- As first Example:
 
    in case of the upgrading from a release minor then 2.13.0 to a bigger one and keep using the same HEDERA_NET="Mainnet"(as example)
 
@@ -207,20 +206,21 @@ To let the Multi-environment transition happen in a transparent way the `GUARDIA
 
    In this case the configuration is stored in the file named: `./configs/.env..guardian.system`, and is already provided in the folder as an example, updating the variables OPERATOR_ID and OPERATOR_KEY.
 
-   ```plaintext
+   ```text
    OPERATOR_ID="..."
    OPERATOR_KEY="..."
    ```
+
    PREUSED_HEDERA_NET is the reference to your previous HEDERA_NET configuration then you should set its value to match your previous HEDERA_NET configuration.
 
-   ```plaintext
+   ```text
    HEDERA_NET="mainnet"
    PREUSED_HEDERA_NET="mainnet"
    ```
 
    because you are keeping on using HEDERA_NET as it was pointing to the "mainnet" in the previous installation too.
 
-   - As a second example: to test the new release change the HEDERA_NET to "testnet". This is the complete configuration:
+- As a second example: to test the new release change the HEDERA_NET to "testnet". This is the complete configuration:
 
    Set the name of the Guardian platform to whatever description name in the `.env` file
 
@@ -230,24 +230,24 @@ To let the Multi-environment transition happen in a transparent way the `GUARDIA
 
    In this case the configuration is stored in the file named: `./configs/.env.testupgrading.guardian.system` again update the variables OPERATOR_ID and OPERATOR_KEY using your testnet account.
 
-   ```plaintext
+   ```text
    OPERATOR_ID="..."
    OPERATOR_KEY="..."
    ```
 
    set the HEDERA_NET="testnet" and set the PREUSED_HEDERA_NET to refer to the mainnet as you wish that Mainet data remains unchanged.
 
-   ```plaintext
+   ```text
    HEDERA_NET="testnet"
    PREUSED_HEDERA_NET="mainnet"
    ```
 
    This configuration allows you to leave untouched all the data referring to Mainnet in the Database while testing on Testnet. Refer to Guardian
-   [documentation](https://docs.hedera.com/guardian/guardian/readme/environments/multi-session-consistency-according-to-environment) for more details.
+   [documentation](https://guardian.hedera.com/guardian/readme/environments/multi-session-consistency-according-to-environment) for more details.
 
-> **_NOTE:_**  You can use the Schema Topic ID (`INITIALIZATION_TOPIC_ID`) already present in the configuration files, or you can specify your own.
-
-> **_NOTE:_**  for any other GUARDIAN\_ENV name of your choice just copy and paste the file `./configs/.env.template.guardian.system` and rename as `./configs/.env.<choosen name>.guardian.system`
+> ***NOTE 1:*** You can use the Schema Topic ID (`INITIALIZATION_TOPIC_ID`) already present in the configuration files, or you can specify your own.
+>
+> ***NOTE 2:***  for any other GUARDIAN\_ENV name of your choice just copy and paste the file `./configs/.env.template.guardian.system` and rename as `./configs/.env.<choosen name>.guardian.system`
 
 ##### 3.2. Setting up JWT keys in /.env file
 
@@ -256,13 +256,15 @@ To start of auth-service it is necessary to fill in `JWT_PRIVATE_KEY` and `JWT_P
 ##### 3.3. Setting up JWT keys for each service in the .env file
 
 To start all services, you need to create a 2048-bit RSA key pair for each service. You can generate a key pair in any convenient way—for example, using [the online tool](https://mkjwk.org/) with the following settings:
-   - key size: 2048
-   - key use: signature
-   - algorithm: RS256: RSA
-   - key ID: sha256
-   - show: yes
+
+- key size: 2048
+- key use: signature
+- algorithm: RS256: RSA
+- key ID: sha256
+- show: yes
 
 For each service, you must add its secret key `SERVICE_JWT_SECRET_KEY` and a list of all public keys from every service:
+
 - `SERVICE_JWT_PUBLIC_KEY_WORKER_SERVICE`
 - `SERVICE_JWT_PUBLIC_KEY_TOPIC_LISTENER_SERVICE`
 - `SERVICE_JWT_PUBLIC_KEY_QUEUE_SERVICE`
@@ -277,37 +279,39 @@ For each service, you must add its secret key `SERVICE_JWT_SECRET_KEY` and a lis
 
 Alternatively, you can create a single key pair and, instead of adding the public keys for each individual service, you can add `SERVICE_JWT_SECRET_KEY_ALL` and `SERVICE_JWT_PUBLIC_KEY_ALL` to use the same keys for all services. However, it is recommended to generate a separate key pair for each service.
 
-#### 4. Now, we have these options to setup IPFS storage:
- - Local IPFS node
- - Storacha
- - Filebase bucket
+#### 4. Now, we have these options to setup IPFS storage
 
-##### 4.1 Setting up Local IPFS node:
+- Local IPFS node
+- Storacha
+- Filebase bucket
 
-   - 4.1.1 We need to install and configure any IPFS node (e.g., [Kubo](https://github.com/ipfs/kubo))
-   - 4.1.2 For setup IPFS local node you need to set variables in the same file `./configs/.env.develop.guardian.system`
+##### 4.1 Setting up Local IPFS node
 
-   ```
+- Install and configure an IPFS node (e.g., [Kubo](https://github.com/ipfs/kubo))
+- Setup the IPFS local node configuring the variables in the file `./configs/.env.develop.guardian.system` file:
+
+   ```text
    IPFS_NODE_ADDRESS="..." # Default IPFS_NODE_ADDRESS="http://localhost:5001"
    IPFS_PUBLIC_GATEWAY='...' # Default IPFS_PUBLIC_GATEWAY='https://localhost:8080/ipfs/${cid}'
    IPFS_PROVIDER="local"
    ```
 
-##### 4.2 Setting up Storacha account:
+##### 4.2 Setting up Storacha account
 
 To select this option ensure that `IPFS_PROVIDER="web3storage"` setting exists in your `./configs/.env.<environment>.guardian.system` file.
 
 To configure access to the [Storacha upload service](https://github.com/storacha/upload-service) (a w3up protocol implementation) for your Guardian instance you need to set correct values to the following variables in the `./configs/.env.<environment>.guardian.system` file:
 
-   ```
+   ```text
    IPFS_STORAGE_KEY="..."
    IPFS_STORAGE_PROOF="..."
    ```
 
-> **_NOTE:_**  When Windows OS is used for creating the IPFS values, please use bash shell to prevent issues with base64 encoding.
+> ***NOTE:***  When Windows OS is used for creating the IPFS values, please use bash shell to prevent issues with base64 encoding.
 
 To obtain the values for these variables please follow the steps below:
-- Create an account on https://storacha.network, please specify the email you have access to as the account authentication is based on the email validation. Make sure to follow through the registration process to the end, choose an appropriate billing plan for your needs (e.g. 'STARTER') and enter your payment details.
+
+- Create an account on <https://storacha.network>, please specify the email you have access to as the account authentication is based on the email validation. Make sure to follow through the registration process to the end, choose an appropriate billing plan for your needs (e.g. 'STARTER') and enter your payment details.
 - Install CLI as described in the [corresponding section](https://docs.storacha.network/cli/) of the Storacha documentation.
 - Create your 'space' as described in the ['Create a Space'](https://docs.storacha.network/how-to/create-space/) section of the documentation.
 - Execute the following to set the Space you intend on delegating access to: `storacha space use <space_did>`.
@@ -315,19 +319,20 @@ To obtain the values for these variables please follow the steps below:
 - Retrieve the PROOF by executing the following: ```storacha delegation create <did_from_ucan-key_command_above> --base64```. The output of this command is the value to be used in the environment variable `IPFS_STORAGE_PROOF`.
 
 To summarise, the process of configuring a UCAN delegated access to the Space you intend on delegating access to consists of execution the following command sequence:
+
 1. `storacha login`
 2. `storacha space create`
 3. `storacha space use`
 4. `storacha key create`
 5. `storacha delegation`
 
-The complete guide to using the new Storacha client is available at https://docs.storacha.network/how-to/upload/.
+The complete guide to using the new Storacha client is available at <https://docs.storacha.network/how-to/upload/>.
 
-#### 4.3 Setting up IPFS Filebase Bucket:
+##### 4.3 Setting up IPFS Filebase Bucket
 
 To configure the Filebase IPFS provider, set the following variables in the file *`./configs/.env.<environment>.guardian.system`*
 
-   ```
+   ```text
    IPFS_STORAGE_API_KEY="Generated Firebase Bucket Token"
    IPFS_PROVIDER="filebase"
    ```
@@ -339,7 +344,7 @@ configuration.
 For detailed setup instructions, refer to the
 official <https://docs.filebase.com/api-documentation/ipfs-pinning-service-api>.
 
-#### 5. Setting up Chat GPT API KEY to enable AI Search and Guided Search:
+#### 5. Setting up Chat GPT API KEY to enable AI Search and Guided Search
 
 For setting up AI and Guided Search, we need to set OPENAI_API_KEY variable in `./configs/.env*` files.
 
@@ -347,20 +352,21 @@ For setting up AI and Guided Search, we need to set OPENAI_API_KEY variable in `
 OPENAI_API_KEY="..."
 ```
 
-#### 6. Build and launch with Docker.
+#### 6. Build and launch with Docker
 
 The following list outlines various Docker Compose configurations for different purposes. Choose the one that best suits your needs.
 
 | Configuration | Description | Command to Run |
-|---------------|-------------|----------------|
-| Guardian (Demo Mode) | Guardian using pre-built images | `docker-compose up -d --build --pull always` |
-| Guardian Build (Demo Mode) | Builds Guardian from source code | `docker-compose -f docker-compose-build.yml up -d --build` |
-| Production Guardian | Guardian using pre-built images, no demo mode | `docker-compose -f docker-compose-production.yml up -d --build --pull always` |
-| Production Guardian Build | Builds Guardian from source code, no demo mode | `docker-compose -f docker-compose-production-build.yml up -d --build` |
-| Indexer | Indexer using pre-built images | `docker-compose -f docker-compose-indexer.yml up -d --build --pull always` |
-| Indexer Build | Builds Indexer from source code | `docker-compose -f docker-compose-indexer-build.yml up -d --build` |
-| Analytics Service | Analytics Service using pre-built images | `docker-compose -f docker-compose-analytics.yml up -d --build --pull always` |
-| Analytics Service Build | Builds Analytics Service from source code | `docker-compose -f docker-compose-analytics-build.yml up -d --build` |
+| --------------- | ------------- | ---------------- |
+| Guardian (Quickstart) | Guardian using minimal number of services with pre-built images | `docker compose -f docker-compose-quickstart.yml up -d --pull always` |
+| Guardian (Demo Mode) | Guardian demo using pre-built images | `docker compose up -d --build --pull always` |
+| Guardian Build (Demo Mode) | Guardian demo building services from source code | `docker compose -f docker-compose-build.yml up -d --build` |
+| Production Guardian | Guardian using pre-built images, no demo mode | `docker compose -f docker-compose-production.yml up -d --build --pull always` |
+| Production Guardian Build | Guardian building services from source code, no demo mode | `docker compose -f docker-compose-production-build.yml up -d --build` |
+| Indexer | Indexer using pre-built images | `docker compose -f docker-compose-indexer.yml up -d --build --pull always` |
+| Indexer Build | Indexer building services from source code | `docker compose -f docker-compose-indexer-build.yml up -d --build` |
+| Analytics Service | Analytics Service using pre-built images | `docker compose -f docker-compose-analytics.yml up -d --build --pull always` |
+| Analytics Service Build | Analytics Service building services from source code | `docker compose -f docker-compose-analytics-build.yml up -d --build` |
 
 To proceed:
 
@@ -371,28 +377,28 @@ To proceed:
 For example, to run the standard Guardian in demo mode:
 
 ```shell
-docker-compose up -d --build --pull always
+docker compose up -d --build --pull always
 ```
 
 This will start the containers in detached mode (-d) and build them if necessary.
 
-> **_NOTE:_** Configurations with "Build" in their name compile the application from source code, which may take longer but allows for customization.
+> ***NOTE 1:*** Configurations with "Build" in their name compile the application from source code, which may take longer but allows for customization.
+>
+> ***NOTE 2:*** Production configurations do not include demo features and will not contain any debug information.
+>
+> ***NOTE 3:*** From the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions. Make sure you use Docker Compose V2 (comes with Docker Desktop > 3.6.0) as at <https://docs.docker.com/compose/install/>
 
-> **_NOTE:_** Production configurations do not include demo features and will not contain any debug information.
+#### 7. Browse to <http://localhost:3000> and complete the setup
 
-> **_NOTE:_** From the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions. Make sure you use Docker Compose V2 (comes with Docker Desktop > 3.6.0) as at https://docs.docker.com/compose/install/
+For other examples go to:
 
-#### 7. Browse to http://localhost:3000 and complete the setup.
-
-for other examples go to:
-* [Deploying Guardian using a specific environment( DEVELOP)](https://docs.hedera.com/guardian/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-a-specific-environment-develop)
-* [Steps to deploy Guardian using a specific Environment ( QA)](https://docs.hedera.com/guardian/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-a-specific-environment-qa)
-* [Steps to deploy Guardian using default Environment](https://docs.hedera.com/guardian/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-default-environment)
+- [Deploying Guardian using a specific environment( DEVELOP)](https://guardian.hedera.com/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-a-specific-environment-develop)
+- [Steps to deploy Guardian using a specific Environment ( QA)](https://guardian.hedera.com/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-a-specific-environment-qa)
+- [Steps to deploy Guardian using default Environment](https://guardian.hedera.com/guardian/readme/getting-started/installation/building-from-source-and-run-using-docker/deploying-guardian-using-default-environment)
 
 #### 8. For increased security remove credentials from .env file and enable network access
 
 On first state the credentials from .env file are copied into the secure storage as configured (e.g. Vault). After that Guardian does not use any credentials stored in the .env file, thus they should be removed for security reasons.
-
 
 ## Manual installation
 
@@ -400,418 +406,339 @@ If you want to manually build every component with debug information, then build
 
 ### Prerequisites for manual installation
 
-* [MongoDB V6](https://www.mongodb.com)
-* [Node.js v20.19](https://nodejs.org)
-* [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
-* [Nats 2.9.25](https://nats.io/)
-* [Redict](https://redict.io/)
-* [Seq 2025.2 - optional for logging](https://datalust.co/seq)
+- [MongoDB V6](https://www.mongodb.com)
+- [Node.js v20.19](https://nodejs.org)
+- [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
+- [Nats 2.9.25](https://nats.io/)
+- [Redict](https://redict.io/)
+- [Seq 2025.2 - optional for logging](https://datalust.co/seq)
 
 ### Build and start each component
 
 Install, configure and start all the prerequisites, then build and start each component.
 
-#### Services Configuration:
+#### Services Configuration
 
--  for each of the services create the file `./<service_name>/.env` to do this copy, paste and rename  the file `./<service_name>/.env.template`
+- For each of the services create the file `./<service_name>/.env` to do this copy, paste and rename  the file `./<service_name>/.env.template`. For example, in `./guardian-service/.env`:
 
-   For example:
-
-   in `./guardian-service/.env`:
-   ```plaintext
-       GUARDIAN_ENV="develop"
+   ```text
+   GUARDIAN_ENV="develop"
    ```
 
    If need to configure OVERRIDE uncomment the variable in file `./guardian-service/.env`:
-   ```plaintext
-       OVERRIDE="false"
+
+   ```text
+   OVERRIDE="false"
    ```
 
--  configure the file `./<service_name>/configs/.env.<service>.<GUARDIAN_ENV>` file: to do this copy,
-   paste and rename the file  `./<service_name>/.env.<service>.template`
+- Configure the file `./<service_name>/configs/.env.<service>.<GUARDIAN_ENV>` file: to do this copy, paste and rename the file  `./<service_name>/.env.<service>.template`
 
    following previous example:
 
    in `./guardian-service/configs/.env.guardian.develop`:
-   ```plaintext
+
+   ```text
    OPERATOR_ID="..."
    OPERATOR_KEY="..."
    ```
-- Setting up Chat GPT API KEY to enable AI Search and Guided Search:
-For setting up AI and Guided Search, we need to set OPENAI_API_KEY variable in `./ai-service/configs/.env*` files.
 
-  ```plaintext
-   OPENAI_KEY="..."
-  ```
-> **_NOTE:_** Once you start each service, please wait for the initialization process to be completed.**
+- Set up Chat GPT API KEY to enable AI Search and Guided Search. For setting up AI and Guided Search, we need to set OPENAI_API_KEY variable in `./ai-service/configs/.env*` files.
 
-#### 1. Clone the repo
-
-   ```shell
-   git clone https://github.com/hashgraph/guardian.git
-   ```
-#### 2. Install dependencies
-
-   Yarn:
-   ```
-   yarn
+   ```text
+   OPENAI_API_KEY="..."
    ```
 
-   Npm:
-   ```
-   npm install
-   ```
-#### 3. From the **interfaces** folder
+> ***NOTE:*** Once you start each service, please wait for the initialization process to be completed.**
 
-   Yarn:
-   ```
-    yarn workspace @guardian/interfaces run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=@guardian/interfaces run build
-   ```
-
-#### 4. From the **common** folder
-
-   Yarn:
-   ```
-    yarn workspace @guardian/common run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=@guardian/common run build
-   ```
-#### 5. From the **logger-service** folder
-
-   To build the service:
-
-   Yarn:
-   ```shell
-   yarn workspace logger-service run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=logger-service run build
-   ```
-
-   Configure the service as previously described. Do not need special configuration variables.
-
-   To start the service:
-
-   Yarn:
-   ```shell
-   yarn workspace logger-service start
-   ```
-
-   Npm:
-   ```
-   npm --workspace=logger-service start
-   ```
-#### 6. From the **auth-service** folder
-
-   To build the service:
-
-   Yarn:
-   ```shell
-   yarn workspace auth-service run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=auth-service run build
-   ```
-
-   Configure the service as previously described. Do not need special configuration variables.
-
-   To start the service:
-
-   Yarn:
-   ```shell
-   yarn workspace auth-service start
-   ```
-
-   Npm:
-   ```
-   npm --workspace=auth-service start
-   ```
-
-#### 7. From the **policy-service** folder
-
-   To build the service:
-
-   Yarn:
-   ```shell
-   yarn workspace policy-service run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=policy-service run build
-   ```
-   Configure the service as previously described. Do not need special configuration variables.
-
-   To start the service:
-
-   Yarn:
-   ```shell
-   yarn workspace policy-service start
-   ```
-
-   Npm:
-   ```
-   npm --workspace=policy-service start
-   ```
-#### 8. Build and start **worker-service** service
-
-   Yarn:
-   To build the service:
-   ```
-   yarn workspace worker-service run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=worker-service run build
-   ```
-   Configure the service as previously described. Update **IPFS_STORAGE_API_KEY** value in `./worker-service/configs/.env.worker` file.
-
-   Yarn:
-   To start the service:
-   ```
-   yarn workspace worker-service start
-   ```
-
-   Npm:
-   ```
-   npm --workspace=worker-service start
-   ```
-#### 9. Build and start **notification-service** service
-
-   To build the service:
-
-   Yarn:
-   ```shell
-   yarn workspace notification-service run build
-   ```
-
-   Npm:
-   ```
-   npm --workspace=notification-service run build
-   ```
-   Configure the service as previously described. Update **OPERATOR_ID** and **OPERATOR_KEY** values in `./guardian-service/configs/.env.worker` file as in the example above.
-
-   To start the service (found on http://localhost:3002):
-
-   Yarn:
-   ```shell
-   yarn workspace notification-service start
-   ```
-
-   Npm:
-   ```
-   npm --workspace=notification-service start
-   ```
-#### 10. Build and start **guardian-service** service
-
-To build the service:
+#### 1. Clone the repo and install dependencies
 
 Yarn:
+
 ```shell
-yarn workspace guardian-service run build
+git clone https://github.com/hashgraph/guardian.git
+cd guardian
+yarn
 ```
 
 Npm:
-```
-npm --workspace=guardian-service run build
-```
-Configure the service as previously described. Update **OPERATOR_ID** and **OPERATOR_KEY** values
-in `./guardian-service/configs/.env.worker` file as in the example above.
 
-To start the service (found on http://localhost:3002):
+```shell
+git clone https://github.com/hashgraph/guardian.git
+cd guardian
+npm install
+```
+
+#### 2. From the **interfaces** folder
 
 Yarn:
+
 ```shell
+yarn workspace @guardian/interfaces run build
+```
+
+Npm:
+
+```shell
+npm --workspace=@guardian/interfaces run build
+```
+
+#### 3. From the **common** folder
+
+Yarn:
+
+```shell
+yarn workspace @guardian/common run build
+```
+
+Npm:
+
+```shell
+npm --workspace=@guardian/common run build
+```
+
+#### 4. From the **logger-service** folder
+
+Configure the service as previously described. Do not need special configuration variables.
+
+Yarn:
+
+```shell
+yarn workspace logger-service run build
+yarn workspace logger-service start
+```
+
+Npm:
+
+```shell
+npm --workspace=logger-service run build
+npm --workspace=logger-service start
+```
+
+#### 5. From the **auth-service** folder
+
+Configure the service as previously described. Do not need special configuration variables.
+
+Yarn:
+
+```shell
+yarn workspace auth-service run build
+yarn workspace auth-service start
+```
+
+Npm:
+
+```shell
+npm --workspace=auth-service run build
+npm --workspace=auth-service start
+```
+
+#### 6. From the **policy-service** folder
+
+Configure the service as previously described. Do not need special configuration variables.
+
+Yarn:
+
+```shell
+yarn workspace policy-service run build
+yarn workspace policy-service start
+```
+
+Npm:
+
+```shell
+npm --workspace=policy-service run build
+npm --workspace=policy-service start
+```
+
+#### 7. Build and start the **worker-service** service
+
+Configure the service as previously described. Update **IPFS_STORAGE_API_KEY** value in `./worker-service/configs/.env.worker` file.
+
+Yarn:
+
+```shell
+yarn workspace worker-service run build
+yarn workspace worker-service start
+```
+
+Npm:
+
+```shell
+npm --workspace=worker-service run build
+npm --workspace=worker-service start
+```
+
+#### 8. Build and start the **notification-service** service
+
+Configure the service as previously described. Update **OPERATOR_ID** and **OPERATOR_KEY** values in `./notification-service/configs/.env.worker` file as in the example above. The service will start on <http://localhost:3002> by default.
+
+Yarn:
+
+```shell
+yarn workspace notification-service run build
+yarn workspace notification-service start
+```
+
+Npm:
+
+```shell
+npm --workspace=notification-service run build
+npm --workspace=notification-service start
+```
+
+#### 9. Build and start the **guardian-service** service
+
+Configure the service as previously described. Update **OPERATOR_ID** and **OPERATOR_KEY** values in `./guardian-service/configs/.env.worker` file as in the example above. The service will start on <http://localhost:3002> by default.
+
+Yarn:
+
+```shell
+yarn workspace guardian-service run build
 yarn workspace guardian-service start
 ```
 
 Npm:
-```
+
+```shell
+npm --workspace=guardian-service run build
 npm --workspace=guardian-service start
 ```
 
-#### 11. From the **api-gateway** folder
+#### 10. From the **api-gateway** folder
 
-   To build the service:
+Configure the service as previously described. Do not need special configuration variables. The service will start on <http://localhost:3002> by default.
 
 Yarn:
-   ```shell
-   yarn workspace api-gateway run build
-   ```
+
+```shell
+yarn workspace api-gateway run build
+yarn workspace api-gateway start
+```
 
 Npm:
-```
+
+```shell
 npm --workspace=api-gateway run build
-```
-
-Configure the service as previously described. Do not need special configuration variables.
-
-To start the service (found on http://localhost:3002):
-
-Yarn:
-   ```shell
-   yarn workspace api-gateway start
-   ```
-
-Npm:
-```
 npm --workspace=api-gateway start
 ```
 
-#### 12. From the **mrv-sender** folder
+#### 11. From the **mrv-sender** folder
 
-    To build the service:
+Configure the service as previously described. Do not need special configuration variables. The service will start on <http://localhost:3005> by default.
 
-    ```shell
-    npm install
-    npm run build
-    ```
-
-    Configure the service as previously described. Do not need special configuration variables.
-
-    To start the service (found on http://localhost:3005):
-
-    ```shell
-    npm start
-    ```
-
-#### 13. From the **ai-service** folder
-
-To build the service:
-
-Yarn:
 ```shell
-yarn workspace ai-service run build
+npm install
+npm run build
+npm start
 ```
 
-Npm:
-```
-npm --workspace=ai-service run build
-```
+#### 12. From the **ai-service** folder
 
 Configure the service as previously described. Do not need special configuration variables.
 
 Yarn:
-```
+
+```shell
+yarn workspace ai-service run build
 yarn workspace ai-service start
 ```
 
 Npm:
-```
+
+```shell
+npm --workspace=ai-service run build
 npm --workspace=ai-service start
 ```
 
-#### 14. From the **frontend** folder
+#### 13. From the **frontend** folder
 
-    To build the service:
+The service will start on <http://localhost:4200> by default.
 
-    ```shell
-    npm install
-    npm run build
-    ```
+```shell
+npm install
+npm run build
+npm start
+```
 
-    To start the service (found on http://localhost:4200):
+### Configuring a Hedera local network
 
-    ```shell
-    npm start
-    ```
+- Install a Hedera Local Network following the [official documentation](https://github.com/hashgraph/hedera-local-node#docker)
+- Configure Guardian's configuration files `/.env/.env.docker` accordingly:
 
-## Configuring a Hedera local network
-
-#### 1. Install a Hedera Local Network following the [official documentation](https://github.com/hashgraph/hedera-local-node#docker)
-
-#### 2. Configure Guardian's configuration files `/.env/.env.docker` accordingly:
-
-   ```shell
-   OPERATOR_ID=""
-   OPERATOR_KEY=""
-   LOCALNODE_ADDRESS="11.11.11.11"
-   LOCALNODE_PROTOCOL="http"
-   HEDERA_NET="localnode"
-   ```
-
-  **Note:**
-   * Set `LOCALNODE_ADDRESS` to the IP address of your local node instance. The value above is given as an example.
-   * Set `HEDERA_NET` to `localnode`. If not specified, the default value is `testnet`.
-   * Configure `OPERATOR_ID` and `OPERATOR_KEY` accordingly with your local node configuration.
-   * Remove `INITIALIZATION_TOPIC_ID` as the topic will be created automatically.
-   * Set `LOCALNODE_PROTOCOL` to `http` or `https` accordingly with your local node configuration (it uses HTTP by default).
-
-## Configuring Hashicorp Vault
-#### 1. Configure .env/.env.docker files in the auth-service folder
-
-   ```
-    VAULT_PROVIDER = "hashicorp"
-   ```
-
-    Note: VAULT_PROVIDER can be set to "database" or "hashicorp" to select Database instance or a hashicorp vault instance correspondingly.
-
-   If the VAULT_PROVIDER value is set to "hashicorp" the following 3 parameters should be configured in the auth-service folder.
-
-   1. HASHICORP_ADDRESS : http://localhost:8200 for using local vault. For remote vault, we need to use the value from the configuration settings of    Hashicorp vault service.
-   2. HASHICORP_TOKEN : the token from the Hashicorp vault.
-   3. HASHICORP_WORKSPACE : this is only needed when we are using cloud vault for Hashicorp. Default value is "admin".
-
-#### 2. Hashicorp should be configured with the created Key-Value storage, named "secret" by default, with the settingKey=<value> records for the following keys:
-    1. OPERATOR_ID
-    2. OPERATOR_KEY
-    3. IPFS_STORAGE_API_KEY
-
-    Note: These records in the vault will be created automatically if there are environment variables with the matching names.
-
- **How to import existing user keys from DB into the vault:**
-
- During Guardian services initialization, we need to set the following configuration settings in **auth-service** folder:
-
+  ```shell
+  OPERATOR_ID=""
+  OPERATOR_KEY=""
+  LOCALNODE_ADDRESS="11.11.11.11"
+  LOCALNODE_PROTOCOL="http"
+  HEDERA_NET="localnode"
   ```
-    IMPORT_KEYS_FROM_DB = 1
-    VAULT_PROVIDER = "hashicorp"
+
+Note:
+
+- Set `LOCALNODE_ADDRESS` to the IP address of your local node instance. The value above is given as an example.
+- Set `HEDERA_NET` to `localnode`. If not specified, the default value is `testnet`.
+- Configure `OPERATOR_ID` and `OPERATOR_KEY` accordingly with your local node configuration.
+- Remove `INITIALIZATION_TOPIC_ID` as the topic will be created automatically.
+- Set `LOCALNODE_PROTOCOL` to `http` or `https` accordingly with your local node configuration (it uses HTTP by default).
+
+### Configuring Hashicorp Vault
+
+1. Configure .env/.env.docker files in the auth-service folder
+
+   ```text
+   VAULT_PROVIDER = "hashicorp"
    ```
 
-## Local development using Docker
+   Note: `VAULT_PROVIDER` can be set to "database" or "hashicorp" to select Database instance or a hashicorp vault instance correspondingly.
 
-#### 1. create .env file at the root level and update all variable requires for docker
+   If the `VAULT_PROVIDER` value is set to "hashicorp" the following 3 parameters should be configured in the auth-service folder.
+
+   - `HASHICORP_ADDRESS`: <http://localhost:8200> for using local vault. For remote vault, we need to use the value from the configuration settings of    Hashicorp vault service.
+   - `HASHICORP_TOKEN`: the token from the Hashicorp vault.
+   - `HASHICORP_WORKSPACE`: this is only needed when we are using cloud vault for Hashicorp. Default value is "admin".
+
+2. Hashicorp should be configured with the created Key-Value storage, named `secret` by default, with the `settingKey=<value>` records for the following keys: `OPERATOR_ID`, `OPERATOR_KEY`, `IPFS_STORAGE_API_KEY`.
+
+   Note: These records in the vault will be created automatically if there are environment variables with the matching names.
+
+**How to import existing user keys from DB into the vault:**
+
+During Guardian services initialization, we need to set the following configuration settings in **auth-service** folder:
+
+```text
+IMPORT_KEYS_FROM_DB = 1
+VAULT_PROVIDER = "hashicorp"
+```
+
+### Local development using Docker
+
+1. Create .env file at the root level and update all variable requires for docker
 
    ```shell
    cp .env.example .env
    ```
 
-#### 2. Start local development using docker compose
+2. Start local development using docker compose
 
    ```shell
    docker compose -f docker-compose-build.yml up --build
    ```
 
-#### 3. Access local development using http://localhost:3000 or http://localhost:4200
+3. Access local development using <http://localhost:3000> or <http://localhost:4200>
 
 ## Troubleshoot
 
-**To delete all the containers**:
+### Delete all the containers
 
-   ```shell
-   docker builder prune --all
-   ```
+```shell
+docker builder prune --all
+```
 
-**To run by cleaning Docker cache**:
+### Build with clean cache
 
-   ```shell
-   docker compose build --no-cache
-   ```
-
-([back to top](readme))
+```shell
+docker compose build --no-cache
+```
 
 ## Unit tests
 
@@ -834,29 +761,31 @@ To run stability tests (certain transactions will be executed 10 times each), th
 npm run test:stability
 ```
 
-([back to top](readme))
+## Additional documentation
 
-Please refer to <https://docs.hedera.com/guardian> for complete documentation about the following topics:
+Please refer to <https://guardian.hedera.com/> for complete documentation about the following topics:
 
-* Swagger API
-* Postman Collection
-* Demo Usage guide
-* Contribute a New Policy
-* Reference Implementation
-* Technologies Built on
-* Roadmap
-* Changelog
-* Contributing
-* License
-* Security
+- Swagger API
+- Postman Collection
+- Demo Usage guide
+- Contribute a New Policy
+- Reference Implementation
+- Technologies Built on
+- Roadmap
+- Changelog
+- Contributing
+- License
+- Security
 
-## Contact
+## Contact information
 
 For any questions, please reach out to the Envision Blockchain Solutions team at:
 
-* Website: <www.envisionblockchain.com>
-* Email: [info@envisionblockchain.com](mailto:info@envisionblockchain.com)
+- Website: <www.envisionblockchain.com>
+- Email: [info@envisionblockchain.com](mailto:info@envisionblockchain.com)
 
-([back to top](#readme))
+([back to top](#guardian))
 
-[license-url]: https://github.com/hashgraph/guardian/blob/main/LICENSE
+## License
+
+MIT License. See the [LICENSE](LICENSE) file for details.

--- a/docker-compose-analytics-build.yml
+++ b/docker-compose-analytics-build.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,28 +10,43 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-analytics
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
+  analytics-service:
+    build:
+      context: .
+      dockerfile: ./analytics-service/Dockerfile
+    depends_on:
+      - message-broker
+      - queue-service
     volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
+      - ./analytics-service/configs:/usr/local/app/configs:ro
+    ports:
+      - '127.0.0.1:3000:3020'
+    <<: *service-template
+    expose:
+      - '6555'
+
+  auth-service:
+    build:
+      context: .
+      dockerfile: ./auth-service/Dockerfile
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
   logger-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./logger-service/Dockerfile
@@ -38,69 +54,55 @@ services:
       - message-broker
     volumes:
       - ./logger-service/configs:/usr/local/app/configs:ro
-
-  auth-service:
     <<: *service-template
-    build:
-      context: .
-      dockerfile: ./auth-service/Dockerfile
+
+  message-broker:
+    image: nats:2.9.25
     volumes:
-      - ./auth-service/tls:/usr/local/app/tls:ro
-      - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
     expose:
-      - 6555
-      - 5005
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
 
   queue-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./queue-service/Dockerfile
     depends_on:
-      - mongo
       - message-broker
-    expose:
-      - 6555
+      - mongo
     volumes:
       - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   worker-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./worker-service/Dockerfile
     depends_on:
-      queue-service:
-        condition: service_started
       auth-service:
         condition: service_started
-    expose:
-      - 6555
+      queue-service:
+        condition: service_started
     volumes:
       - ./worker-service/tls:/usr/local/app/tls:ro
       - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
     deploy:
       replicas: 10
-
-  analytics-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./analytics-service/Dockerfile
-    depends_on:
-      - message-broker
-      - queue-service
     expose:
-      - 6555
-    ports:
-      - "3000:3020"
-    volumes:
-      - ./analytics-service/configs:/usr/local/app/configs:ro
-
-networks:
-  monitoring:
-    driver: bridge
+      - '6555'

--- a/docker-compose-analytics.yml
+++ b/docker-compose-analytics.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,89 +10,90 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-analytics
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
+  analytics-service:
+    image: gcr.io/hedera-registry/analytics-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+      - queue-service
     volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
+      - ./analytics-service/configs:/usr/local/app/configs:ro
+    ports:
+      - '127.0.0.1:3000:3020'
+    <<: *service-template
+    expose:
+      - '6555'
+
+  auth-service:
+    image: gcr.io/hedera-registry/auth-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
   logger-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
     depends_on:
       - message-broker
     volumes:
       - ./logger-service/configs:/usr/local/app/configs:ro
-
-  auth-service:
     <<: *service-template
-    image: gcr.io/hedera-registry/auth-service:${GUARDIAN_VERSION:-latest}
+
+  message-broker:
+    image: nats:2.9.25
     volumes:
-      - ./auth-service/tls:/usr/local/app/tls:ro
-      - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
     expose:
-      - 6555
-      - 5005
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
 
   queue-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
     depends_on:
-      - mongo
-      - message-broker
       - logger-service
-    expose:
-      - 6555
+      - message-broker
+      - mongo
     volumes:
       - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   worker-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
     depends_on:
-      queue-service:
-        condition: service_started
       auth-service:
         condition: service_started
-    expose:
-      - 6555
+      queue-service:
+        condition: service_started
     volumes:
       - ./worker-service/tls:/usr/local/app/tls:ro
       - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
     deploy:
       replicas: 10
-
-  analytics-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/analytics-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - message-broker
-      - queue-service
     expose:
-      - 6555
-    ports:
-      - "3000:3020"
-    volumes:
-      - ./analytics-service/configs:/usr/local/app/configs:ro
-
-networks:
-  monitoring:
-    driver: bridge
+      - '6555'

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,80 +10,187 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-demo
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  mongo-express:
-    image: mongo-express:1.0.2-20
-    expose:
-      - 8081
-    environment:
-      ME_CONFIG_MONGODB_SERVER: mongo
-      ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_SITE_BASEURL: /mongo-admin # default credentials: admin/pass
+  ai-service:
+    build:
+      context: .
+      dockerfile: ./ai-service/Dockerfile
     depends_on:
+      - logger-service
+      - message-broker
       - mongo
+    volumes:
+      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
+      - ./ai-service/data:/usr/local/app/data:rw
+    environment:
+      VECTOR_STORAGE_PATH: ./faiss-vector
+      DOCS_STORAGE_PATH: ./data/generated-data
+    <<: *service-template
+    expose:
+      - '3013'
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: ./api-gateway/Dockerfile.demo
+    depends_on:
+      - auth-service
+      - cache
+      - guardian-service
+      - message-broker
+      - mongo
+      # - seq
+    volumes:
+      - ./api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3002'
+      - '6555'
+
+  application-events:
+    build:
+      context: .
+      dockerfile: application-events/Dockerfile
+    depends_on:
+      - auth-service
+      - guardian-service
+      - message-broker
+      - mongo
+    <<: *service-template
+    expose:
+      - '3012'
+
+  auth-service:
+    build:
+      context: .
+      dockerfile: ./auth-service/Dockerfile.demo
+    depends_on:
+      - message-broker
+      - mongo
+      - vault
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
   cache:
     image: registry.redict.io/redict:7.3.6-alpine
     restart: always
     expose:
-      - 6379
+      - '6379'
+    init: true
 
-#  seq:
-#    image: datalust/seq
-#    restart: unless-stopped
-#    environment:
-#      ACCEPT_EULA: "Y"
-#    ports:
-#      - "5341:80"
-#    volumes:
-#      - seq_data:/data
+  grafana:
+    image: grafana/grafana:10.0.10
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/etc/grafana/dashboards
+    environment:
+      GF_AUTH_DISABLE_LOGIN_FORM: true
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_SERVER_HTTP_PORT: 9080
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/dashboards/prometheus-dashboard.json
+    ports:
+      - '127.0.0.1:9080:9080'
+    networks:
+      - monitoring
+    init: true
+
+  guardian-service:
+    build:
+      context: .
+      dockerfile: ./guardian-service/Dockerfile
+    depends_on:
+      - auth-service
+      - message-broker
+      - mongo
+      - policy-service
+      - queue-service
+    volumes:
+      - ./guardian-service/tls:/usr/local/app/tls:ro
+      - ./guardian-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.38.2
-    ports:
-      - "5001:5001"
-      - "4001:4001"
-      - "8080:8080"
+    image: ipfs/kubo:v0.39.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    ports:
+      - '127.0.0.1:4001:4001'
+      - '127.0.0.1:5001:5001'
+      - '127.0.0.1:8080:8080'
+    init: true
+
+  logger-service:
+    build:
+      context: .
+      dockerfile: ./logger-service/Dockerfile
+    depends_on:
+      - message-broker
+    volumes:
+      - ./logger-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   message-broker:
     image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
     volumes:
       - ./configs/nats.conf:/etc/nats/nats.conf
-
-  vault:
-    image: hashicorp/vault:1.12.11
-    expose:
-      - 8200
     ports:
-      - '8200:8200'
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  mongo-express:
+    image: mongo-express:1.0.2-20
+    depends_on:
+      - mongo
     environment:
-      VAULT_SERVER: "http://0.0.0.0:8200"
-      VAULT_DEV_ROOT_TOKEN_ID: "1234"
-    cap_add:
-      - IPC_LOCK
-    volumes:
-      - ./file:/vault/file:rw
-      - ./config:/vault/config:rw
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:27017
+      ME_CONFIG_SITE_BASEURL: /mongo-admin
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: pass
+    expose:
+      - '8081'
+    init: true
+
+  mrv-sender:
+    build:
+      context: .
+      dockerfile: ./mrv-sender/Dockerfile
+    expose:
+      - '3005'
+      - '5008'
+    init: true
 
   notification-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./notification-service/Dockerfile
@@ -90,186 +198,115 @@ services:
       - message-broker
     volumes:
       - ./notification-service/configs:/usr/local/app/configs:ro
-
-  logger-service:
     <<: *service-template
-    build:
-      context: .
-      dockerfile: ./logger-service/Dockerfile
-    depends_on:
-      - message-broker
-    expose:
-      - 6555
-    volumes:
-      - ./logger-service/configs:/usr/local/app/configs:ro
-
-  queue-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./queue-service/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-    expose:
-      - 6555
-    volumes:
-      - ./queue-service/configs:/usr/local/app/configs:ro
-
-  topic-listener-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./topic-listener-service/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-      - queue-service
-    expose:
-      - 6555
-    volumes:
-      - ./topic-listener-service/configs:/usr/local/app/configs:ro
-
-  worker-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./worker-service/Dockerfile
-    depends_on:
-      queue-service:
-        condition: service_started
-      ipfs-node:
-        condition: service_healthy
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/app/tls:ro
-      - ./worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 2
-
-  auth-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./auth-service/Dockerfile.demo
-    volumes:
-      - ./auth-service/tls:/usr/local/app/tls:ro
-      - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - vault
-      - message-broker
-    expose:
-      - 6555
-      - 5005
-
-  api-gateway:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./api-gateway/Dockerfile.demo
-    expose:
-      - 3002
-      - 6555
-    depends_on:
-      - mongo
-      - cache
-#      - seq
-      - message-broker
-      - guardian-service
-      - auth-service
-    volumes:
-      - ./api-gateway/configs:/usr/local/app/configs:ro
-
-  ai-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./ai-service/Dockerfile
-    expose:
-      - 3013
-    depends_on:
-      - mongo
-      - message-broker
-    volumes:
-      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
-      - ./ai-service/data:/usr/local/app/data:rw
-    environment:
-      - VECTOR_STORAGE_PATH=./faiss-vector
-      - DOCS_STORAGE_PATH=./data/generated-data
 
   policy-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./policy-service/Dockerfile
     depends_on:
-      - mongo
-      - message-broker
       - auth-service
-    expose:
-      - 5006
+      - message-broker
+      - mongo
     volumes:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
-
-  guardian-service:
     <<: *service-template
-    build:
-      context: .
-      dockerfile: ./guardian-service/Dockerfile
+    expose:
+      - '5006'
+
+  prometheus:
+    image: prom/prometheus:v2.44.0
     volumes:
-      - ./guardian-service/tls:/usr/local/app/tls:ro
-      - ./guardian-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - queue-service
-      - policy-service
-    expose:
-      - 6555
-      - 5007
-
-  application-events:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: application-events/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-      - guardian-service
-      - auth-service
-    expose:
-      - 3012
-
-  mrv-sender:
-    build:
-      context: .
-      dockerfile: ./mrv-sender/Dockerfile
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    networks:
+      - monitoring
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
     init: true
+
+  queue-service:
+    build:
+      context: .
+      dockerfile: ./queue-service/Dockerfile
+    depends_on:
+      - message-broker
+      - mongo
+    volumes:
+      - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
     expose:
-      - 3005
-      - 5008
+      - '6555'
+
+  # seq:
+  #   image: datalust/seq:2025.2
+  #   volumes:
+  #     - seq_data:/data
+  #   environment:
+  #     ACCEPT_EULA: "Y"
+  #     SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
+  #   ports:
+  #     - '127.0.0.1:5341:80'
+  #   restart: unless-stopped
+  #   init: true
+
+  topic-listener-service:
+    build:
+      context: .
+      dockerfile: ./topic-listener-service/Dockerfile
+    depends_on:
+      - message-broker
+      - mongo
+      - queue-service
+    volumes:
+      - ./topic-listener-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   topic-viewer:
     build:
       context: .
       dockerfile: ./topic-viewer/Dockerfile
-    init: true
     expose:
-      - 3006
-      - 5009
+      - '3006'
+      - '5009'
+    init: true
+
+  vault:
+    image: hashicorp/vault:1.12.11
+    volumes:
+      - ./file:/vault/file:rw
+      - ./config:/vault/config:rw
+    environment:
+      VAULT_SERVER: "http://0.0.0.0:8200"
+      VAULT_DEV_ROOT_TOKEN_ID: "1234"
+    ports:
+      - '127.0.0.1:8200:8200'
+    cap_add:
+      - IPC_LOCK
+    expose:
+      - '8200'
+    init: true
 
   web-proxy:
     build:
       context: .
       dockerfile: ./web-proxy/Dockerfile.demo
-    init: true
+    depends_on:
+      - api-gateway
+      - auth-service
+      - guardian-service
+      - mongo-express
+      - mrv-sender
     environment:
       GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
       GATEWAY_HOST: api-gateway
@@ -279,55 +316,36 @@ services:
       TOPIC_VIEWER_HOST: topic-viewer
       TOPIC_VIEWER_PORT: 3006
     ports:
-      - "3000:80"
+      - '127.0.0.1:3000:80'
+    init: true
+
+  worker-service:
+    build:
+      context: .
+      dockerfile: ./worker-service/Dockerfile
     depends_on:
-      - guardian-service
-      - auth-service
-      - api-gateway
-      - mrv-sender
-      - mongo-express
-
-  prometheus:
-    image: prom/prometheus:v2.44.0
-    restart: unless-stopped
+      auth-service:
+        condition: service_started
+      ipfs-node:
+        condition: service_healthy
+      queue-service:
+        condition: service_started
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    ports:
-      - "9090:9090"
-    networks:
-      - monitoring
-
-  grafana:
-    image: grafana/grafana:10.0.10
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/etc/grafana/dashboards
-    environment:
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_SERVER_HTTP_PORT=9080
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/prometheus-dashboard.json
-    ports:
-      - "9080:9080"
-    networks:
-      - monitoring
-
-volumes:
-  prometheus_data:
-  grafana_data:
-  ipfs_data:
-  ipfs_export:
-#  seq_data:
+      - ./worker-service/tls:/usr/local/app/tls:ro
+      - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 2
+    expose:
+      - '6555'
 
 networks:
   monitoring:
     driver: bridge
+
+volumes:
+  # seq_data:
+  prometheus_data:
+  grafana_data:
+  ipfs_data:
+  ipfs_export:

--- a/docker-compose-indexer-build.yml
+++ b/docker-compose-indexer-build.yml
@@ -1,104 +1,120 @@
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
+
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
   init: true
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.indexer.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-indexer
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  mongo-express:
-    image: mongo-express:1.0.2-20
-    expose:
-      - 8081
-    environment:
-      ME_CONFIG_MONGODB_SERVER: mongo
-      ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_SITE_BASEURL: /mongo-admin # default credentials: admin/pass
-    depends_on:
-      - mongo
-
-  ipfs-node:
-    image: ipfs/kubo:v0.38.2
-
-  ipfs-check:
-    image: ghcr.io/ipfs/ipfs-check:main-latest
-    expose:
-      - 3333
-    ports:
-      - 3333:3333
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
-    volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
-
-  indexer-worker-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./indexer-worker-service/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-      - indexer-service
-    expose:
-      - 6555
-    volumes:
-      - ./indexer-worker-service/tls:/usr/local/app/tls:ro
-      - ./indexer-worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 3
-
   indexer-api-gateway:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./indexer-api-gateway/Dockerfile
-    expose:
-      - 3021
-      - 6555
     depends_on:
-      - mongo
-      - message-broker
       - indexer-service
+      - message-broker
+      - mongo
     volumes:
       - ./indexer-api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3021'
+      - '6555'
 
   indexer-service:
-    <<: *service-template
     build:
       context: .
       dockerfile: ./indexer-service/Dockerfile
+    depends_on:
+      - message-broker
+      - mongo
     volumes:
       - ./indexer-service/tls:/usr/local/app/tls:ro
       - ./indexer-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
+    <<: *service-template
     expose:
-      - 6555
-      - 5007
+      - '6555'
+      - '5007'
 
   indexer-web-proxy:
     build:
       context: .
       dockerfile: ./indexer-web-proxy/Dockerfile
-    init: true
-    ports:
-      - "3005:80"
     depends_on:
       - indexer-api-gateway
       - indexer-service
+    ports:
+      - '127.0.0.1:3005:80'
+    init: true
+
+  indexer-worker-service:
+    build:
+      context: .
+      dockerfile: ./indexer-worker-service/Dockerfile
+    depends_on:
+      - indexer-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./indexer-worker-service/tls:/usr/local/app/tls:ro
+      - ./indexer-worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 3
+    expose:
+      - '6555'
+
+  ipfs-check:
+    image: ghcr.io/ipfs/ipfs-check:main-latest
+    ports:
+      - '127.0.0.1:3333:3333'
+    expose:
+      - '3333'
+
+  ipfs-node:
+    image: ipfs/kubo:v0.39.0
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    init: true
+
+  message-broker:
+    image: nats:2.9.25
+    volumes:
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  mongo-express:
+    image: mongo-express:1.0.2-20
+    depends_on:
+      - mongo
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:27017
+      ME_CONFIG_SITE_BASEURL: /mongo-admin
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: pass
+    expose:
+      - '8081'
+    init: true

--- a/docker-compose-indexer.yml
+++ b/docker-compose-indexer.yml
@@ -1,96 +1,112 @@
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
+
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
   init: true
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.indexer.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-indexer
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  mongo-express:
-    image: mongo-express:1.0.2-20
-    expose:
-      - 8081
-    environment:
-      ME_CONFIG_MONGODB_SERVER: mongo
-      ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_SITE_BASEURL: /mongo-admin # default credentials: admin/pass
-    depends_on:
-      - mongo
-
-  ipfs-node:
-    image: ipfs/kubo:v0.38.2
-
-  ipfs-check:
-    image: ghcr.io/ipfs/ipfs-check:main-latest
-    expose:
-      - 3333
-    ports:
-      - 3333:3333
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
-    volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
-
-  indexer-worker-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/indexer-worker-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - indexer-service
-    expose:
-      - 6555
-    volumes:
-      - ./indexer-worker-service/tls:/usr/local/app/tls:ro
-      - ./indexer-worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 3
-
   indexer-api-gateway:
-    <<: *service-template
     image: gcr.io/hedera-registry/indexer-api-gateway:${GUARDIAN_VERSION:-latest}
-    expose:
-      - 3021
-      - 6555
     depends_on:
-      - mongo
-      - message-broker
       - indexer-service
+      - message-broker
+      - mongo
     volumes:
       - ./indexer-api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3021'
+      - '6555'
 
   indexer-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/indexer-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+      - mongo
     volumes:
       - ./indexer-service/tls:/usr/local/app/tls:ro
       - ./indexer-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
+    <<: *service-template
     expose:
-      - 6555
-      - 5007
+      - '6555'
+      - '5007'
 
   indexer-web-proxy:
     image: gcr.io/hedera-registry/indexer-web-proxy:${GUARDIAN_VERSION:-latest}
-    init: true
-    ports:
-      - "3005:80"
     depends_on:
       - indexer-api-gateway
       - indexer-service
+    ports:
+      - '127.0.0.1:3005:80'
+    init: true
+
+  indexer-worker-service:
+    image: gcr.io/hedera-registry/indexer-worker-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - indexer-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./indexer-worker-service/tls:/usr/local/app/tls:ro
+      - ./indexer-worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 3
+    expose:
+      - '6555'
+
+  ipfs-check:
+    image: ghcr.io/ipfs/ipfs-check:main-latest
+    ports:
+      - '127.0.0.1:3333:3333'
+    expose:
+      - '3333'
+
+  ipfs-node:
+    image: ipfs/kubo:v0.39.0
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    init: true
+
+  message-broker:
+    image: nats:2.9.25
+    volumes:
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  mongo-express:
+    image: mongo-express:1.0.2-20
+    depends_on:
+      - mongo
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:27017
+      ME_CONFIG_SITE_BASEURL: /mongo-admin
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: pass
+    expose:
+      - '8081'
+    init: true

--- a/docker-compose-production-build.yml
+++ b/docker-compose-production-build.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,271 +10,85 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  cache:
-    image: registry.redict.io/redict:7.3.6-alpine
-    restart: always
-    expose:
-      - 6379
-
-#  seq:
-#    image: datalust/seq
-#    restart: unless-stopped
-#    environment:
-#      ACCEPT_EULA: "Y"
-#    ports:
-#      - "5341:80"
-#    volumes:
-#      - seq_data:/data
-
-  ipfs-node:
-    image: ipfs/kubo:v0.38.2
-    ports:
-      - "5001:5001"
-      - "4001:4001"
-      - "8080:8080"
-    volumes:
-      - ipfs_data:/data/ipfs:rw
-      - ipfs_export:/export:rw
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
-    volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
-
-  vault:
-    image: hashicorp/vault:1.12.11
-    expose:
-      - 8200
-    ports:
-      - '8200:8200'
-    environment:
-      VAULT_SERVER: "http://0.0.0.0:8200"
-      VAULT_DEV_ROOT_TOKEN_ID: "1234"
-    cap_add:
-      - IPC_LOCK
-    volumes:
-      - ./file:/vault/file:rw
-      - ./config:/vault/config:rw
-
-  notification-service:
-    <<: *service-template
+  ai-service:
     build:
       context: .
-      dockerfile: ./notification-service/Dockerfile
+      dockerfile: ./ai-service/Dockerfile
     depends_on:
-      - message-broker
-    volumes:
-      - ./notification-service/configs:/usr/local/app/configs:ro
-
-  logger-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./logger-service/Dockerfile
-    depends_on:
-      - message-broker
-    expose:
-      - 6555
-    volumes:
-      - ./logger-service/configs:/usr/local/app/configs:ro
-
-  queue-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./queue-service/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
       - logger-service
-    expose:
-      - 6555
-    volumes:
-      - ./queue-service/configs:/usr/local/app/configs:ro
-
-  topic-listener-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./topic-listener-service/Dockerfile
-    depends_on:
-      - mongo
       - message-broker
-      - queue-service
-    expose:
-      - 6555
+      - mongo
     volumes:
-      - ./topic-listener-service/configs:/usr/local/app/configs:ro
-
-  worker-service:
+      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
+      - ./ai-service/data:/usr/local/app/data:rw
+    environment:
+      VECTOR_STORAGE_PATH: ./faiss-vector
+      DOCS_STORAGE_PATH: ./data/generated-data
     <<: *service-template
+    expose:
+      - '3013'
+
+  api-gateway:
     build:
       context: .
-      dockerfile: ./worker-service/Dockerfile
+      dockerfile: ./api-gateway/Dockerfile
     depends_on:
-      queue-service:
-        condition: service_started
-      ipfs-node:
-        condition: service_healthy
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
+      - auth-service
+      - cache
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+      # - seq
     volumes:
-      - ./worker-service/tls:/usr/local/app/tls:ro
-      - ./worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 2
+      - ./api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3002'
+      - '6555'
+
+  application-events:
+    build:
+      context: .
+      dockerfile: application-events/Dockerfile
+    depends_on:
+      - auth-service
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+    <<: *service-template
+    expose:
+      - '3012'
 
   auth-service:
     build:
       context: .
       dockerfile: ./auth-service/Dockerfile
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+      - vault
     volumes:
       - ./auth-service/tls:/usr/local/app/tls:ro
       - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - vault
-      - message-broker
-      - logger-service
-    expose:
-      - 6555
-      - 5005
-
-  api-gateway:
     <<: *service-template
-    build:
-      context: .
-      dockerfile: ./api-gateway/Dockerfile
     expose:
-      - 3002
-      - 6555
-    depends_on:
-      - mongo
-      - cache
-#      - seq
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    volumes:
-      - ./api-gateway/configs:/usr/local/app/configs:ro
+      - '6555'
+      - '5005'
 
-  ai-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./ai-service/Dockerfile
+  cache:
+    image: registry.redict.io/redict:7.3.6-alpine
+    restart: always
     expose:
-      - 3013
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
-    volumes:
-      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
-      - ./ai-service/data:/usr/local/app/data:rw
-    environment:
-      - VECTOR_STORAGE_PATH=./faiss-vector
-      - DOCS_STORAGE_PATH=./data/generated-data
-
-  policy-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./policy-service/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - logger-service
-    expose:
-      - 5006
-    volumes:
-      - ./policy-service/tls:/usr/local/app/tls:ro
-      - ./policy-service/configs:/usr/local/app/configs:ro
-
-  guardian-service:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: ./guardian-service/Dockerfile
-    volumes:
-      - ./guardian-service/tls:/usr/local/app/tls:ro
-      - ./guardian-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - logger-service
-      - worker-service
-      - policy-service
-    expose:
-      - 6555
-      - 5007
-
-  application-events:
-    <<: *service-template
-    build:
-      context: .
-      dockerfile: application-events/Dockerfile
-    depends_on:
-      - mongo
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    expose:
-      - 3012
-
-  web-proxy:
-    build:
-      context: .
-      dockerfile: ./web-proxy/Dockerfile.ci
+      - '6379'
     init: true
-    environment:
-      GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
-      GATEWAY_HOST: api-gateway
-      GATEWAY_PORT: 3002
-    ports:
-      - "3000:80"
-    depends_on:
-      - guardian-service
-      - auth-service
-      - api-gateway
-
-  prometheus:
-    image: prom/prometheus:v2.44.0
-    restart: unless-stopped
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    ports:
-      - "9090:9090"
-    networks:
-      - monitoring
 
   grafana:
     image: grafana/grafana:10.0.10
@@ -282,23 +97,224 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/etc/grafana/dashboards
     environment:
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_SERVER_HTTP_PORT=9080
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/prometheus-dashboard.json
+      GF_AUTH_DISABLE_LOGIN_FORM: true
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_SERVER_HTTP_PORT: 9080
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/dashboards/prometheus-dashboard.json
     ports:
-      - "9080:9080"
+      - '127.0.0.1:9080:9080'
     networks:
       - monitoring
+    init: true
 
-volumes:
-  prometheus_data:
-  grafana_data:
-  ipfs_data:
-  ipfs_export:
-#  seq_data:
+  guardian-service:
+    build:
+      context: .
+      dockerfile: ./guardian-service/Dockerfile
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+      - policy-service
+      - worker-service
+    volumes:
+      - ./guardian-service/tls:/usr/local/app/tls:ro
+      - ./guardian-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5007'
+
+  ipfs-node:
+    image: ipfs/kubo:v0.39.0
+    volumes:
+      - ipfs_data:/data/ipfs:rw
+      - ipfs_export:/export:rw
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    ports:
+      - '127.0.0.1:4001:4001'
+      - '127.0.0.1:5001:5001'
+      - '127.0.0.1:8080:8080'
+    init: true
+
+  logger-service:
+    build:
+      context: .
+      dockerfile: ./logger-service/Dockerfile
+    depends_on:
+      - message-broker
+    volumes:
+      - ./logger-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  message-broker:
+    image: nats:2.9.25
+    volumes:
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  notification-service:
+    build:
+      context: .
+      dockerfile: ./notification-service/Dockerfile
+    depends_on:
+      - message-broker
+    volumes:
+      - ./notification-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+
+  policy-service:
+    build:
+      context: .
+      dockerfile: ./policy-service/Dockerfile
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./policy-service/tls:/usr/local/app/tls:ro
+      - ./policy-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '5006'
+
+  prometheus:
+    image: prom/prometheus:v2.44.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    networks:
+      - monitoring
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
+    init: true
+
+  queue-service:
+    build:
+      context: .
+      dockerfile: ./queue-service/Dockerfile
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  # seq:
+  #   image: datalust/seq:2025.2
+  #   volumes:
+  #     - seq_data:/data
+  #   environment:
+  #     ACCEPT_EULA: "Y"
+  #     SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
+  #   ports:
+  #     - '127.0.0.1:5341:80'
+  #   restart: unless-stopped
+  #   init: true
+
+  topic-listener-service:
+    build:
+      context: .
+      dockerfile: ./topic-listener-service/Dockerfile
+    depends_on:
+      - message-broker
+      - mongo
+      - queue-service
+    volumes:
+      - ./topic-listener-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  vault:
+    image: hashicorp/vault:1.12.11
+    volumes:
+      - ./file:/vault/file:rw
+      - ./config:/vault/config:rw
+    environment:
+      VAULT_SERVER: "http://0.0.0.0:8200"
+      VAULT_DEV_ROOT_TOKEN_ID: "1234"
+    ports:
+      - '127.0.0.1:8200:8200'
+    cap_add:
+      - IPC_LOCK
+    expose:
+      - '8200'
+    init: true
+
+  web-proxy:
+    build:
+      context: .
+      dockerfile: ./web-proxy/Dockerfile.ci
+    depends_on:
+      - api-gateway
+      - auth-service
+      - guardian-service
+    environment:
+      GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
+      GATEWAY_HOST: api-gateway
+      GATEWAY_PORT: 3002
+    ports:
+      - '127.0.0.1:3000:80'
+    init: true
+
+  worker-service:
+    build:
+      context: .
+      dockerfile: ./worker-service/Dockerfile
+    depends_on:
+      auth-service:
+        condition: service_started
+      ipfs-node:
+        condition: service_healthy
+      queue-service:
+        condition: service_started
+    volumes:
+      - ./worker-service/tls:/usr/local/app/tls:ro
+      - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 2
+    expose:
+      - '6555'
 
 networks:
   monitoring:
     driver: bridge
+
+volumes:
+  # seq_data:
+  prometheus_data:
+  grafana_data:
+  ipfs_data:
+  ipfs_export:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,248 +10,77 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
+  ai-service:
+    image: gcr.io/hedera-registry/ai-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
+      - ./ai-service/data:/usr/local/app/data:rw
+    environment:
+      VECTOR_STORAGE_PATH: ./faiss-vector
+      DOCS_STORAGE_PATH: ./data/generated-data
+    <<: *service-template
     expose:
-      - 27017
+      - '3013'
+
+  api-gateway:
+    image: gcr.io/hedera-registry/api-gateway:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - cache
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+      # - seq
+    volumes:
+      - ./api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3002'
+      - '6555'
+
+  application-events:
+    image: gcr.io/hedera-registry/application-events:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+    <<: *service-template
+    expose:
+      - '3012'
+
+  auth-service:
+    image: gcr.io/hedera-registry/auth-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+      - vault
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
   cache:
     image: registry.redict.io/redict:7.3.6-alpine
     restart: always
     expose:
-      - 6379
-
-#  seq:
-#    image: datalust/seq
-#    restart: unless-stopped
-#    environment:
-#      ACCEPT_EULA: "Y"
-#    ports:
-#      - "5341:80"
-#    volumes:
-#      - seq_data:/data
-
-  ipfs-node:
-    image: ipfs/kubo:v0.38.2
-    ports:
-      - "5001:5001"
-      - "4001:4001"
-      - "8080:8080"
-    volumes:
-      - ipfs_data:/data/ipfs:rw
-      - ipfs_export:/export:rw
-
-  message-broker:
-    image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
-    volumes:
-      - ./configs/nats.conf:/etc/nats/nats.conf
-
-  vault:
-    image: hashicorp/vault:1.12.11
-    expose:
-      - 8200
-    ports:
-      - '8200:8200'
-    environment:
-      VAULT_SERVER: "http://0.0.0.0:8200"
-      VAULT_DEV_ROOT_TOKEN_ID: "1234"
-    cap_add:
-      - IPC_LOCK
-    volumes:
-      - ./file:/vault/file:rw
-      - ./config:/vault/config:rw
-
-  notification-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - message-broker
-    volumes:
-      - ./notification-service/configs:/usr/local/app/configs:ro
-
-  logger-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - message-broker
-    expose:
-      - 6555
-    volumes:
-      - ./logger-service/configs:/usr/local/app/configs:ro
-
-  queue-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
-    expose:
-      - 6555
-    volumes:
-      - ./queue-service/configs:/usr/local/app/configs:ro
-
-  topic-listener-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - queue-service
-    expose:
-      - 6555
-    volumes:
-      - ./topic-listener-service/configs:/usr/local/app/configs:ro
-
-  worker-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      queue-service:
-        condition: service_started
-      ipfs-node:
-        condition: service_healthy
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/app/tls:ro
-      - ./worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 2
-
-  auth-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/auth-service:${GUARDIAN_VERSION:-latest}
-    volumes:
-      - ./auth-service/tls:/usr/local/app/tls:ro
-      - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - vault
-      - message-broker
-      - logger-service
-    expose:
-      - 6555
-      - 5005
-
-  api-gateway:
-    <<: *service-template
-    image: gcr.io/hedera-registry/api-gateway:${GUARDIAN_VERSION:-latest}
-    expose:
-      - 3002
-      - 6555
-    depends_on:
-      - mongo
-      - cache
-#      - seq
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    volumes:
-      - ./api-gateway/configs:/usr/local/app/configs:ro
-
-  ai-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/ai-service:${GUARDIAN_VERSION:-latest}
-    expose:
-      - 3013
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
-    volumes:
-      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
-      - ./ai-service/data:/usr/local/app/data:rw
-    environment:
-      - VECTOR_STORAGE_PATH=./faiss-vector
-      - DOCS_STORAGE_PATH=./data/generated-data
-
-  policy-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - logger-service
-    expose:
-      - 5006
-    volumes:
-      - ./policy-service/tls:/usr/local/app/tls:ro
-      - ./policy-service/configs:/usr/local/app/configs:ro
-
-  guardian-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
-    volumes:
-      - ./guardian-service/tls:/usr/local/app/tls:ro
-      - ./guardian-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - logger-service
-      - worker-service
-      - policy-service
-    expose:
-      - 6555
-      - 5007
-
-  application-events:
-    <<: *service-template
-    image: gcr.io/hedera-registry/application-events:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    expose:
-      - 3012
-
-  web-proxy:
-    image: gcr.io/hedera-registry/frontend:${GUARDIAN_VERSION:-latest}
+      - '6379'
     init: true
-    environment:
-      GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
-      GATEWAY_HOST: api-gateway
-      GATEWAY_PORT: 3002
-    ports:
-      - "3000:80"
-    depends_on:
-      - guardian-service
-      - auth-service
-      - api-gateway
-
-  prometheus:
-    image: prom/prometheus:v2.44.0
-    restart: unless-stopped
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    ports:
-      - "9090:9090"
-    networks:
-      - monitoring
 
   grafana:
     image: grafana/grafana:10.0.10
@@ -259,23 +89,207 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/etc/grafana/dashboards
     environment:
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_SERVER_HTTP_PORT=9080
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/prometheus-dashboard.json
+      GF_AUTH_DISABLE_LOGIN_FORM: true
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_SERVER_HTTP_PORT: 9080
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/dashboards/prometheus-dashboard.json
     ports:
-      - "9080:9080"
+      - '127.0.0.1:9080:9080'
     networks:
       - monitoring
 
-volumes:
-  prometheus_data:
-  grafana_data:
-  ipfs_data:
-  ipfs_export:
-#  seq_data:
+  guardian-service:
+    image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+      - policy-service
+      - worker-service
+    volumes:
+      - ./guardian-service/tls:/usr/local/app/tls:ro
+      - ./guardian-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5007'
+
+  ipfs-node:
+    image: ipfs/kubo:v0.39.0
+    volumes:
+      - ipfs_data:/data/ipfs:rw
+      - ipfs_export:/export:rw
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    ports:
+      - '127.0.0.1:4001:4001'
+      - '127.0.0.1:5001:5001'
+      - '127.0.0.1:8080:8080'
+    init: true
+
+  logger-service:
+    image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+    volumes:
+      - ./logger-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  message-broker:
+    image: nats:2.9.25
+    volumes:
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  notification-service:
+    image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+    volumes:
+      - ./notification-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+
+  policy-service:
+    image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./policy-service/tls:/usr/local/app/tls:ro
+      - ./policy-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '5006'
+
+  prometheus:
+    image: prom/prometheus:v2.44.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    networks:
+      - monitoring
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
+    init: true
+
+  queue-service:
+    image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  # seq:
+  #   image: datalust/seq:2025.2
+  #   volumes:
+  #     - seq_data:/data
+  #   environment:
+  #     ACCEPT_EULA: "Y"
+  #     SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
+  #   ports:
+  #     - '127.0.0.1:5341:80'
+  #   restart: unless-stopped
+  #   init: true
+
+  topic-listener-service:
+    image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+      - mongo
+      - queue-service
+    volumes:
+      - ./topic-listener-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+
+  vault:
+    image: hashicorp/vault:1.12.11
+    volumes:
+      - ./file:/vault/file:rw
+      - ./config:/vault/config:rw
+    environment:
+      VAULT_SERVER: "http://0.0.0.0:8200"
+      VAULT_DEV_ROOT_TOKEN_ID: "1234"
+    ports:
+      - '127.0.0.1:8200:8200'
+    cap_add:
+      - IPC_LOCK
+    expose:
+      - '8200'
+    init: true
+
+  web-proxy:
+    image: gcr.io/hedera-registry/frontend:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - api-gateway
+      - auth-service
+      - guardian-service
+    environment:
+      GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
+      GATEWAY_HOST: api-gateway
+      GATEWAY_PORT: 3002
+    ports:
+      - '127.0.0.1:3000:80'
+    init: true
+
+  worker-service:
+    image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      auth-service:
+        condition: service_started
+      ipfs-node:
+        condition: service_healthy
+      queue-service:
+        condition: service_started
+    volumes:
+      - ./worker-service/tls:/usr/local/app/tls:ro
+      - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 2
+    expose:
+      - '6555'
 
 networks:
   monitoring:
     driver: bridge
+
+volumes:
+  # seq_data:
+  prometheus_data:
+  grafana_data:
+  ipfs_data:
+  ipfs_export:

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -1,208 +1,212 @@
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
 # Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
 # See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
-    init: true
-    env_file:
-        - ./configs/.env.quickstart.guardian.system
-    environment:
-        - GUARDIAN_ENV=${GUARDIAN_ENV}
+  init: true
+  env_file:
+    - ./configs/.env.quickstart.guardian.system
+  environment:
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-quickstart
 
 services:
-    mongo:
-        image: mongo:6.0.26
-        #command: "--setParameter allowDiskUseByDefault=true"
-        # This command line options gets rid of mongodb messages in the logs, so you can see more clearly what's happening
-        command: "--setParameter allowDiskUseByDefault=true  --quiet --logpath /dev/null"
-        restart: always
-        expose:
-            - 27017
+  api-gateway:
+    image: gcr.io/hedera-registry/api-gateway-demo:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - cache
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3002'
+      - '6555'
 
-    cache:
-        image: registry.redict.io/redict:7.3.6-alpine
-        restart: always
-        expose:
-            - 6379
+  auth-service:
+    image: gcr.io/hedera-registry/auth-service-demo:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
-    ipfs-node:
-        image: ipfs/kubo:v0.38.2
-        ports:
-            - "5001:5001"
-            - "4001:4001"
-            - "8080:8080"
-        volumes:
-            - ipfs_data:/data/ipfs:rw
-            - ipfs_export:/export:rw
+  cache:
+    image: registry.redict.io/redict:7.3.6-alpine
+    restart: always
+    expose:
+      - '6379'
+    init: true
 
-    message-broker:
-        image: nats:2.9.25
-        expose:
-            - 4222
-        ports:
-            - "8222:8222"
-        command: "-c /etc/nats/nats.conf --http_port 8222"
-        volumes:
-            - ./configs/nats.conf:/etc/nats/nats.conf
+  guardian-service:
+    image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+      - policy-service
+      - worker-service
+    volumes:
+      - ./guardian-service/tls:/usr/local/app/tls:ro
+      - ./guardian-service/configs:/usr/local/app/configs:ro
+    environment:
+      OPERATOR_ID: ${OPERATOR_ID}
+      OPERATOR_KEY: ${OPERATOR_KEY}
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5007'
 
-    notification-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            - message-broker
-        volumes:
-            - ./notification-service/configs:/usr/local/app/configs:ro
+  ipfs-node:
+    image: ipfs/kubo:v0.39.0
+    volumes:
+      - ipfs_data:/data/ipfs:rw
+      - ipfs_export:/export:rw
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    ports:
+      - '127.0.0.1:4001:4001'
+      - '127.0.0.1:5001:5001'
+      - '127.0.0.1:8080:8080'
+    init: true
 
-    logger-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            - message-broker
-        expose:
-            - 6555
-        volumes:
-            - ./logger-service/configs:/usr/local/app/configs:ro
+  logger-service:
+    image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+    volumes:
+      - ./logger-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
-    queue-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            - mongo
-            - message-broker
-            - logger-service
-        expose:
-            - 6555
-        volumes:
-            - ./queue-service/configs:/usr/local/app/configs:ro
+  message-broker:
+    image: nats:2.9.25
+    volumes:
+      - ./configs/nats.conf:/etc/nats/nats.conf
+    ports:
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
 
-    topic-listener-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            - mongo
-            - message-broker
-            - queue-service
-        expose:
-            - 6555
-        volumes:
-            - ./topic-listener-service/configs:/usr/local/app/configs:ro
+  mongo:
+    image: mongo:6.0.26
+    # command: "--setParameter allowDiskUseByDefault=true"
+    command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
 
-    worker-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            queue-service:
-                condition: service_started
-            ipfs-node:
-                condition: service_healthy
-            auth-service:
-                condition: service_started
-        expose:
-            - 6555
-        volumes:
-            - ./worker-service/tls:/usr/local/app/tls:ro
-            - ./worker-service/configs:/usr/local/app/configs:ro
-        deploy:
-            replicas: 1
-        environment:
-            - OPERATOR_ID=${OPERATOR_ID}
-            - OPERATOR_KEY=${OPERATOR_KEY}
-            - GUARDIAN_ENV=${GUARDIAN_ENV}
+  notification-service:
+    image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+    volumes:
+      - ./notification-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
 
-    auth-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/auth-service-demo:${GUARDIAN_VERSION:-latest}
-        volumes:
-            - ./auth-service/tls:/usr/local/app/tls:ro
-            - ./auth-service/configs:/usr/local/app/configs:ro
-        depends_on:
-            - mongo
-            - message-broker
-            - logger-service
-        expose:
-            - 6555
-            - 5005
+  policy-service:
+    image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./policy-service/tls:/usr/local/app/tls:ro
+      - ./policy-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '5006'
 
-    api-gateway:
-        <<: *service-template
-        image: gcr.io/hedera-registry/api-gateway-demo:${GUARDIAN_VERSION:-latest}
-        expose:
-            - 3002
-            - 6555
-        depends_on:
-            - mongo
-            - cache
-            - message-broker
-            - guardian-service
-            - auth-service
-            - logger-service
-        volumes:
-            - ./api-gateway/configs:/usr/local/app/configs:ro
+  queue-service:
+    image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
-    policy-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
-        depends_on:
-            - mongo
-            - message-broker
-            - auth-service
-            - logger-service
-        expose:
-            - 5006
-        volumes:
-            - ./policy-service/tls:/usr/local/app/tls:ro
-            - ./policy-service/configs:/usr/local/app/configs:ro
+  topic-listener-service:
+    image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+      - mongo
+      - queue-service
+    volumes:
+      - ./topic-listener-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
-    guardian-service:
-        <<: *service-template
-        image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
-        volumes:
-            - ./guardian-service/tls:/usr/local/app/tls:ro
-            - ./guardian-service/configs:/usr/local/app/configs:ro
-        depends_on:
-            - mongo
-            - message-broker
-            - auth-service
-            - logger-service
-            - worker-service
-            - policy-service
-        expose:
-            - 6555
-            - 5007
-        environment:
-            - OPERATOR_ID=${OPERATOR_ID}
-            - OPERATOR_KEY=${OPERATOR_KEY}
-            - GUARDIAN_ENV=${GUARDIAN_ENV}
+  topic-viewer:
+    image: gcr.io/hedera-registry/topic-viewer:${GUARDIAN_VERSION:-latest}
+    expose:
+      - '3006'
+      - '5009'
+    init: true
 
-    topic-viewer:
-        image: gcr.io/hedera-registry/topic-viewer:${GUARDIAN_VERSION:-latest}
-        init: true
-        expose:
-            - 3006
-            - 5009
+  web-proxy:
+    image: gcr.io/hedera-registry/frontend-demo:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - api-gateway
+      - auth-service
+      - guardian-service
+    environment:
+      GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
+      GATEWAY_HOST: api-gateway
+      GATEWAY_PORT: 3002
+      MRV_SENDER_HOST: mrv-sender
+      MRV_SENDER_PORT: 3005
+      TOPIC_VIEWER_HOST: topic-viewer
+      TOPIC_VIEWER_PORT: 3006
+    ports:
+      - '127.0.0.1:3000:80'
+    init: true
 
-    web-proxy:
-        image: gcr.io/hedera-registry/frontend-demo:${GUARDIAN_VERSION:-latest}
-        init: true
-        environment:
-            GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
-            GATEWAY_HOST: api-gateway
-            GATEWAY_PORT: 3002
-            MRV_SENDER_HOST: mrv-sender
-            MRV_SENDER_PORT: 3005
-            TOPIC_VIEWER_HOST: topic-viewer
-            TOPIC_VIEWER_PORT: 3006
-        ports:
-            - "3000:80"
-        depends_on:
-            - guardian-service
-            - auth-service
-            - api-gateway
+  worker-service:
+    image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      auth-service:
+        condition: service_started
+      ipfs-node:
+        condition: service_healthy
+      queue-service:
+        condition: service_started
+    volumes:
+      - ./worker-service/tls:/usr/local/app/tls:ro
+      - ./worker-service/configs:/usr/local/app/configs:ro
+    environment:
+      OPERATOR_ID: ${OPERATOR_ID}
+      OPERATOR_KEY: ${OPERATOR_KEY}
+    <<: *service-template
+    deploy:
+      replicas: 1
+    expose:
+      - '6555'
 
 volumes:
-    ipfs_data:
-    ipfs_export:
-
-networks:
-    monitoring:
-        driver: bridge
+  ipfs_data:
+  ipfs_export:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-# https://docs.docker.com/compose/environment-variables/envvars-precedence/
-# Environment leverage the gerarchy defined in the docker compose between "env_file" and "environment" attributes
-# ecosystem variables defined in the "env_file" .env.${GUARDIAN_ENV}.guardian.system
-# specific service variables defined by "environment" can override what is defined in the ecosystem file
+# This file is linted and formatted using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter):
+# npx dclint . --fix=true
+
+# Please note variables defined in the "environment" section will override the same variables defined in the "env_file"
+# See # https://docs.docker.com/compose/environment-variables/envvars-precedence/ for more details
 
 # YAML anchor that contains common configuration elements for our services
 x-service-template: &service-template
@@ -9,246 +10,282 @@ x-service-template: &service-template
   env_file:
     - ./configs/.env.${GUARDIAN_ENV}.guardian.system
   environment:
-    - GUARDIAN_ENV=${GUARDIAN_ENV}
+    GUARDIAN_ENV: ${GUARDIAN_ENV}
+
+name: guardian-demo
 
 services:
-  mongo:
-    image: mongo:6.0.26
-    command: "--setParameter allowDiskUseByDefault=true"
-    restart: always
-    expose:
-      - 27017
-
-  mongo-express:
-    image: mongo-express:1.0.2-20
-    expose:
-      - 8081
-    environment:
-      ME_CONFIG_MONGODB_SERVER: mongo
-      ME_CONFIG_MONGODB_PORT: 27017
-      ME_CONFIG_SITE_BASEURL: /mongo-admin # default credentials: admin/pass
+  ai-service:
+    image: gcr.io/hedera-registry/ai-service:${GUARDIAN_VERSION:-latest}
     depends_on:
+      - logger-service
+      - message-broker
       - mongo
+    volumes:
+      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
+      - ./ai-service/data:/usr/local/app/data:rw
+    environment:
+      VECTOR_STORAGE_PATH: ./faiss-vector
+      DOCS_STORAGE_PATH: ./data/generated-data
+    <<: *service-template
+    expose:
+      - '3013'
+
+  api-gateway:
+    image: gcr.io/hedera-registry/api-gateway-demo:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - cache
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+    # - seq
+    volumes:
+      - ./api-gateway/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '3002'
+      - '6555'
+
+  application-events:
+    image: gcr.io/hedera-registry/application-events:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - guardian-service
+      - logger-service
+      - message-broker
+      - mongo
+    <<: *service-template
+    expose:
+      - '3012'
+
+  auth-service:
+    image: gcr.io/hedera-registry/auth-service-demo:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+      - vault
+    volumes:
+      - ./auth-service/tls:/usr/local/app/tls:ro
+      - ./auth-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5005'
 
   cache:
     image: registry.redict.io/redict:7.3.6-alpine
     restart: always
     expose:
-      - 6379
+      - '6379'
+    init: true
 
-#  seq:
-#    image: datalust/seq
-#    restart: unless-stopped
-#    environment:
-#      ACCEPT_EULA: "Y"
-#    ports:
-#      - "5341:80"
-#    volumes:
-#      - seq_data:/data
+  grafana:
+    image: grafana/grafana:10.0.10
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/etc/grafana/dashboards
+    environment:
+      GF_AUTH_DISABLE_LOGIN_FORM: true
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_SERVER_HTTP_PORT: 9080
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/dashboards/prometheus-dashboard.json
+    ports:
+      - '127.0.0.1:9080:9080'
+    networks:
+      - monitoring
+    init: true
+
+  guardian-service:
+    image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - auth-service
+      - logger-service
+      - message-broker
+      - mongo
+      - policy-service
+      - worker-service
+    volumes:
+      - ./guardian-service/tls:/usr/local/app/tls:ro
+      - ./guardian-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
+      - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.38.2
-    ports:
-      - "5001:5001"
-      - "4001:4001"
-      - "8080:8080"
+    image: ipfs/kubo:v0.39.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw
+    environment:
+      IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
+    ports:
+      - '127.0.0.1:4001:4001'
+      - '127.0.0.1:5001:5001'
+      - '127.0.0.1:8080:8080'
+    init: true
+
+  logger-service:
+    image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+    volumes:
+      - ./logger-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   message-broker:
     image: nats:2.9.25
-    expose:
-      - 4222
-    ports:
-      - '8222:8222'
-    command: '-c /etc/nats/nats.conf --http_port 8222'
     volumes:
       - ./configs/nats.conf:/etc/nats/nats.conf
-
-  vault:
-    image: hashicorp/vault:1.12.11
-    expose:
-      - 8200
     ports:
-      - '8200:8200'
+      - '127.0.0.1:8222:8222'
+    command: "-c /etc/nats/nats.conf --http_port 8222"
+    expose:
+      - '4222'
+    init: true
+
+  mongo:
+    image: mongo:6.0.26
+    command: "--setParameter allowDiskUseByDefault=true"
+    # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
+    restart: always
+    expose:
+      - '27017'
+    init: true
+
+  mongo-express:
+    image: mongo-express:1.0.2-20
+    depends_on:
+      - mongo
     environment:
-      VAULT_SERVER: "http://0.0.0.0:8200"
-      VAULT_DEV_ROOT_TOKEN_ID: "Q5D>3nu+Z#TbN.@9PWHSyL"
-    cap_add:
-      - IPC_LOCK
-    volumes:
-      - ./file:/vault/file:rw
-      - ./config:/vault/config:rw
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:27017
+      ME_CONFIG_SITE_BASEURL: /mongo-admin
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: pass
+    expose:
+      - '8081'
+    init: true
+
+  mrv-sender:
+    image: gcr.io/hedera-registry/mrv-sender:${GUARDIAN_VERSION:-latest}
+    expose:
+      - '3005'
+      - '5008'
+    init: true
 
   notification-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/notification-service:${GUARDIAN_VERSION:-latest}
     depends_on:
       - message-broker
     volumes:
       - ./notification-service/configs:/usr/local/app/configs:ro
-
-  logger-service:
     <<: *service-template
-    image: gcr.io/hedera-registry/logger-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - message-broker
-    expose:
-      - 6555
-    volumes:
-      - ./logger-service/configs:/usr/local/app/configs:ro
-
-  queue-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
-    expose:
-      - 6555
-    volumes:
-      - ./queue-service/configs:/usr/local/app/configs:ro
-
-  topic-listener-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - queue-service
-    expose:
-      - 6555
-    volumes:
-      - ./topic-listener-service/configs:/usr/local/app/configs:ro
-
-  worker-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      queue-service:
-        condition: service_started
-      ipfs-node:
-        condition: service_healthy
-      auth-service:
-        condition: service_started
-    expose:
-      - 6555
-    volumes:
-      - ./worker-service/tls:/usr/local/app/tls:ro
-      - ./worker-service/configs:/usr/local/app/configs:ro
-    deploy:
-      replicas: 2
-
-  auth-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/auth-service-demo:${GUARDIAN_VERSION:-latest}
-    volumes:
-      - ./auth-service/tls:/usr/local/app/tls:ro
-      - ./auth-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - vault
-      - message-broker
-      - logger-service
-    expose:
-      - 6555
-      - 5005
-
-  api-gateway:
-    <<: *service-template
-    image: gcr.io/hedera-registry/api-gateway-demo:${GUARDIAN_VERSION:-latest}
-    expose:
-      - 3002
-      - 6555
-    depends_on:
-      - mongo
-      - cache
-#      - seq
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    volumes:
-      - ./api-gateway/configs:/usr/local/app/configs:ro
-
-  ai-service:
-    <<: *service-template
-    image: gcr.io/hedera-registry/ai-service:${GUARDIAN_VERSION:-latest}
-    expose:
-      - 3013
-    depends_on:
-      - mongo
-      - message-broker
-      - logger-service
-    volumes:
-      - ./ai-service/faiss-vector:/usr/local/app/faiss-vector:rw
-      - ./ai-service/data:/usr/local/app/data:rw
-    environment:
-      - VECTOR_STORAGE_PATH=./faiss-vector
-      - DOCS_STORAGE_PATH=./data/generated-data
 
   policy-service:
-    <<: *service-template
     image: gcr.io/hedera-registry/policy-service:${GUARDIAN_VERSION:-latest}
     depends_on:
-      - mongo
-      - message-broker
       - auth-service
       - logger-service
-    expose:
-      - 5006
+      - message-broker
+      - mongo
     volumes:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
-
-  guardian-service:
     <<: *service-template
-    image: gcr.io/hedera-registry/guardian-service:${GUARDIAN_VERSION:-latest}
+    expose:
+      - '5006'
+
+  prometheus:
+    image: prom/prometheus:v2.44.0
     volumes:
-      - ./guardian-service/tls:/usr/local/app/tls:ro
-      - ./guardian-service/configs:/usr/local/app/configs:ro
-    depends_on:
-      - mongo
-      - message-broker
-      - auth-service
-      - logger-service
-      - worker-service
-      - policy-service
-    expose:
-      - 6555
-      - 5007
-
-  application-events:
-    <<: *service-template
-    image: gcr.io/hedera-registry/application-events:${GUARDIAN_VERSION:-latest}
-    depends_on:
-      - mongo
-      - message-broker
-      - guardian-service
-      - auth-service
-      - logger-service
-    expose:
-      - 3012
-
-  mrv-sender:
-    image: gcr.io/hedera-registry/mrv-sender:${GUARDIAN_VERSION:-latest}
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - '127.0.0.1:9090:9090'
+    networks:
+      - monitoring
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
     init: true
+
+  queue-service:
+    image: gcr.io/hedera-registry/queue-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - logger-service
+      - message-broker
+      - mongo
+    volumes:
+      - ./queue-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
     expose:
-      - 3005
-      - 5008
+      - '6555'
+
+  # seq:
+  #   image: datalust/seq:2025.2
+  #   volumes:
+  #     - seq_data:/data
+  #   environment:
+  #     ACCEPT_EULA: "Y"
+  #     SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
+  #   ports:
+  #     - '127.0.0.1:5341:80'
+  #   restart: unless-stopped
+  #   init: true
+
+  topic-listener-service:
+    image: gcr.io/hedera-registry/topic-listener-service:${GUARDIAN_VERSION:-latest}
+    depends_on:
+      - message-broker
+      - mongo
+      - queue-service
+    volumes:
+      - ./topic-listener-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    expose:
+      - '6555'
 
   topic-viewer:
     image: gcr.io/hedera-registry/topic-viewer:${GUARDIAN_VERSION:-latest}
-    init: true
     expose:
-      - 3006
-      - 5009
+      - '3006'
+      - '5009'
+    init: true
+
+  vault:
+    image: hashicorp/vault:1.12.11
+    volumes:
+      - ./file:/vault/file:rw
+      - ./config:/vault/config:rw
+    environment:
+      VAULT_SERVER: "http://0.0.0.0:8200"
+      VAULT_DEV_ROOT_TOKEN_ID: "Q5D>3nu+Z#TbN.@9PWHSyL"
+    ports:
+      - '127.0.0.1:8200:8200'
+    cap_add:
+      - IPC_LOCK
+    expose:
+      - '8200'
+    init: true
 
   web-proxy:
     image: gcr.io/hedera-registry/frontend-demo:${GUARDIAN_VERSION:-latest}
-    init: true
+    depends_on:
+      - api-gateway
+      - auth-service
+      - guardian-service
+      - mrv-sender
     environment:
       GATEWAY_CLIENT_MAX_BODY_SIZE: 1024m
       GATEWAY_HOST: api-gateway
@@ -258,54 +295,34 @@ services:
       TOPIC_VIEWER_HOST: topic-viewer
       TOPIC_VIEWER_PORT: 3006
     ports:
-      - "3000:80"
+      - '127.0.0.1:3000:80'
+    init: true
+
+  worker-service:
+    image: gcr.io/hedera-registry/worker-service:${GUARDIAN_VERSION:-latest}
     depends_on:
-      - guardian-service
-      - auth-service
-      - api-gateway
-      - mrv-sender
-
-  prometheus:
-    image: prom/prometheus:v2.44.0
-    restart: unless-stopped
+      auth-service:
+        condition: service_started
+      ipfs-node:
+        condition: service_healthy
+      queue-service:
+        condition: service_started
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--web.enable-lifecycle'
-    ports:
-      - "9090:9090"
-    networks:
-      - monitoring
-
-  grafana:
-    image: grafana/grafana:10.0.10
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/etc/grafana/dashboards
-    environment:
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_SERVER_HTTP_PORT=9080
-      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/prometheus-dashboard.json
-    ports:
-      - "9080:9080"
-    networks:
-      - monitoring
-
-volumes:
-  prometheus_data:
-  grafana_data:
-  ipfs_data:
-  ipfs_export:
-#  seq_data:
+      - ./worker-service/tls:/usr/local/app/tls:ro
+      - ./worker-service/configs:/usr/local/app/configs:ro
+    <<: *service-template
+    deploy:
+      replicas: 2
+    expose:
+      - '6555'
 
 networks:
   monitoring:
     driver: bridge
+
+volumes:
+  # seq_data:
+  prometheus_data:
+  grafana_data:
+  ipfs_data:
+  ipfs_export:


### PR DESCRIPTION
**Description**:

This PR:
- Disables IPFS Kubo telemetry and update the image to the latest version
- Modifies docker-compose files in order to make them more consistent:
  - Using Docker Compose Linter (https://github.com/zavoloklom/docker-compose-linter) for linting and formatting
  - Environment variables as mappings;
  - Host machine interface 127.0.0.1 when exposing container ports
  - Single quote for ports
  - `init: true` for all services
  - List of services in alphabetical order
  - etc...
- Improves the README, fixing paragraphs and linting issues

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
