### PR TITLE
fix: correct methodology from VM0040 to ACM0002 for hydropower ( Verra)

### DIFF
--- a/methodologies/hydropower-mrv/BOUNTY_REQUEST.md
+++ b/methodologies/hydropower-mrv/BOUNTY_REQUEST.md
@@ -22,12 +22,10 @@ Current Guardian library covers:
 5. Complete testnet deployment with evidence
 
 ### Verra Alignment
-- VM0040: Methodology for Improved Hydrological Systems
+- Verra ACM0002 v22.0: Grid-connected electricity generation from renewable sources
 - I-REC Standard compliance
 - Gold Standard renewable energy requirements
 
-## Request
-We request DLT Earth/Exponential Science/HBAR Foundation to:
 1. Add Hydropower MRV to the official bounty list
 2. Or provide guidance on alternative funding/recognition pathways
 3. Or accept as a pioneering general contribution with community recognition

--- a/methodologies/hydropower-mrv/METHODOLOGY.md
+++ b/methodologies/hydropower-mrv/METHODOLOGY.md
@@ -39,7 +39,7 @@ Where Project EF = 0 (renewable source)
 - Monthly aggregation for certificate issuance
 ## References
 - I-REC Standard: https://www.irecstandard.org/
-- Verra VM0040 (Hydro methodology)
+- Verra ACM0002 v22.0: Grid-connected electricity generation from renewable sources
 - Gold Standard Renewable Energy Requirements
 ## Technical Implementation
 Full implementation details: https://github.com/BikramBiswas786/hedera-hydropower-mrv

--- a/methodologies/hydropower-mrv/README.md
+++ b/methodologies/hydropower-mrv/README.md
@@ -29,7 +29,7 @@ Guardian currently supports general renewable energy and carbon methodologies, b
 4. **Verifier/orchestrator flow:** resolve DID → verify signature → audit → mint
 5. **Resale/royalty demo + retirement** (token burn)
 ## Methodology Compliance
-- ✅ **Verra VM0040** alignment (Improved Hydrological Systems)
+- ✅ **Verra ACM0002** alignment (Improved Hydrological Systems)
 - ✅ **I-REC Standard** compliance (Device Registry + Energy Tracking)
 - ✅ **Gold Standard** renewable energy requirements
 - ✅ **Formal methodology document** (see METHODOLOGY.md)

--- a/methodologies/hydropower-mrv/VERRA-ALIGNMENT.md
+++ b/methodologies/hydropower-mrv/VERRA-ALIGNMENT.md
@@ -1,29 +1,34 @@
-﻿# Verra Methodology Alignment
+# Verra Methodology Alignment
 ## Compatible Methodologies
-**VM0040 - Methodology for Improved Hydrological Systems**
-- **Applicability:** Small-scale hydro projects
-- **Alignment:** Our system digitizes VM0040 monitoring requirements
-- **Enhancement:** Adds device-level verification via DIDs
+**Verra ACM0002 v22.0 - Grid-connected Electricity Generation from Renewable Sources**
+
+- **Applicability:** Small-scale hydropower facilities (< 15 MW) generating renewable electricity
+- **Alignment:** Our system digitizes ACM0002 monitoring requirements for hydropower projects
+- **Enhancement:** Adds device-level verification via DIDs and real-time cryptographic attestation
+
 ## Key Alignments
 | Verra Requirement | Our Implementation |
-|-------------------|-------------------|
+|-------------------|--------------------|
 | Energy measurement | Flow meter + head height sensors |
 | Data integrity | Cryptographic signatures on HCS |
 | Verification | Automated verifier microservice |
 | Issuance | HTS tokens (fungible RECs) |
 | Retirement | Token burn mechanism |
+
 ## I-REC Standard Compliance
 ✅ Device registry (DID-based)  
 ✅ Energy output tracking (MWh)  
 ✅ Monthly aggregation  
 ✅ Unique identifiers (HTS token IDs)  
 ✅ Transfer and retirement tracking
+
 ## Enhancement Beyond Traditional MRV
 1. **Device-Level Identity:** Each turbine has cryptographic DID
 2. **Real-Time Verification:** Automated signature verification (vs. periodic audits)
 3. **Immutable Audit Trail:** Public DLT (vs. centralized databases)
 4. **Tamper Detection:** Instant signature invalidation
 5. **Replay Protection:** Nonce-based duplicate prevention
+
 ## Future Work
 - Formal Verra validation for specific project sites
 - Gold Standard methodology integration


### PR DESCRIPTION
CRITICAL REGULATORY CORRECTION:

VM0040 ("Methodology for Greenhouse Gas Capture and Utilization in Plastic Materials") is NOT applicable to hydropower or renewable energy projects.

This PR corrects the methodology reference to:
- Verra ACM0002 v22.0: "Grid-connected Electricity Generation from Renewable Sources"
- Applicable to small-scale hydropower facilities (< 15 MW)
- Proper alignment with renewable energy carbon credit standards

Changes:
- Updated methodology name and version
- Corrected applicability statement
- Updated alignment description to reference ACM0002 requirements
- Added clarification about device-level verification enhancement

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
