### PR TITLE
fix(ui): grey out 'Add Document' button when no schemas exist

### DIFF
--- a/frontend/src/app/modules/tag-engine/tags-create-dialog/tags-create-dialog.component.html
+++ b/frontend/src/app/modules/tag-engine/tags-create-dialog/tags-create-dialog.component.html
@@ -71,6 +71,9 @@
     </div>
     <div class="dialog-footer">
         <button (click)="onAddArtifact(schema)" *ngIf="!schema" class="button secondary" label="Add Document"
+                [disabled]="!schemas || schemas.length === 0"
+                [pTooltip]="(!schemas || schemas.length === 0) ? 'Create a published document schema first' : ''"
+                tooltipStyleClass="guardian-tooltip"
                 pButton style="margin-right: auto;"></button>
         <button (click)="onNoClick()" class="button secondary" label="Cancel" pButton></button>
         <button (click)="onCreate()" [disabled]="disabled" [label]="'Create'" class="button" pButton></button>


### PR DESCRIPTION
[BOUNTY #5041]

Closes #5041

## Changes
- Grey out 'Add Document' button when no schemas exist
- Add tooltip: 'Create a published document schema first'

Wallet: TGu4W5T6q4KvLAbmXmZSRpUBNRCxr2aFTP (USDT TRC20)