### PR TITLE
feat(events): add external event for token minting failure

### DIFF
--- a/interfaces/src/type/messages/message-api.type.ts
+++ b/interfaces/src/type/messages/message-api.type.ts
@@ -314,6 +314,7 @@ export enum MessageAPI {
 export enum ExternalMessageEvents {
     TOKEN_MINTED = 'external-events.token_minted',
     TOKEN_MINT_COMPLETE = 'external-events.token_mint_complete',
+    TOKEN_FAILED = 'external-events.token_failed',
     ERROR_LOG = 'external-events.error_logs',
     BLOCK_EVENTS = 'external-events.block_event',
     IPFS_ADDED_FILE = 'external-events.ipfs_added_file',

--- a/policy-service/src/policy-engine/mint/mint-service.ts
+++ b/policy-service/src/policy-engine/mint/mint-service.ts
@@ -200,7 +200,10 @@ export class MintService {
                         interception: null
                     })
                     .catch((error) =>
-                        MintService.error(PolicyUtils.getErrorMessage(error), null, userId)
+                        MintService.error(PolicyUtils.getErrorMessage(error), null, userId, {
+                            tokenId: token.tokenId,
+                            tokenType: token.tokenType,
+                        })
                     )
                     .finally(() => {
                         MintService.activeMintProcesses.delete(
@@ -233,7 +236,10 @@ export class MintService {
                         interception: null
                     })
                     .catch((error) =>
-                        MintService.error(PolicyUtils.getErrorMessage(error), null, userId)
+                        MintService.error(PolicyUtils.getErrorMessage(error), null, userId, {
+                            tokenId: token.tokenId,
+                            tokenType: token.tokenType,
+                        })
                     )
                     .finally(() => {
                         MintService.activeMintProcesses.delete(
@@ -551,7 +557,10 @@ export class MintService {
                     interception: null
                 })
                 .catch((error) =>
-                    MintService.error(PolicyUtils.getErrorMessage(error), null, userId)
+                    MintService.error(PolicyUtils.getErrorMessage(error), null, userId, {
+                        tokenId: token.tokenId,
+                        tokenType: token.tokenType,
+                    })
                 )
                 .finally(() => {
                     MintService.activeMintProcesses.delete(
@@ -584,7 +593,10 @@ export class MintService {
                     interception: null
                 })
                 .catch((error) =>
-                    MintService.error(PolicyUtils.getErrorMessage(error), null, userId)
+                    MintService.error(PolicyUtils.getErrorMessage(error), null, userId, {
+                        tokenId: token.tokenId,
+                        tokenType: token.tokenType,
+                    })
                 )
                 .finally(() => {
                     MintService.activeMintProcesses.delete(
@@ -733,7 +745,7 @@ export class MintService {
      * @param ref
      * @param userId
      */
-    public static error(message: string, ref: AnyBlockType, userId: string | null) {
+    public static error(message: string, ref: AnyBlockType | null, userId: string | null, data?: { tokenId?: string; tokenType?: string; [key: string]: any }) {
         if (ref) {
             MintService.logger.error(message, [
                 'POLICY_SERVICE',
@@ -744,6 +756,16 @@ export class MintService {
             ], userId);
         } else {
             MintService.logger.error(message, ['POLICY_SERVICE'], userId);
+        }
+
+        if (data) {
+            new ExternalEventChannel().publishMessage(
+                ExternalMessageEvents.TOKEN_FAILED,
+                {
+                    error: message,
+                    ...data,
+                }
+            );
         }
     }
 

--- a/policy-service/src/policy-engine/mint/types/typed-mint.ts
+++ b/policy-service/src/policy-engine/mint/types/typed-mint.ts
@@ -437,6 +437,9 @@ export abstract class TypedMint {
      * @param userId
      */
     protected error(error: any, userId: string | null) {
-        MintService.error(PolicyUtils.getErrorMessage(error), this._ref, userId);
+        MintService.error(PolicyUtils.getErrorMessage(error), this._ref, userId, {
+            tokenId: this._token.tokenId,
+            tokenType: this._token.tokenType,
+        });
     }
 }


### PR DESCRIPTION
[BOUNTY #5108]

Closes #5108

## Changes
- Add external event for token minting failure
- Users can subscribe to token minting failure events

Wallet: TGu4W5T6q4KvLAbmXmZSRpUBNRCxr2aFTP (USDT TRC20)