### PR TITLE
feat(minting): configurable rounding strategy for token minting

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.html
@@ -86,6 +86,22 @@
     </tr>
     <tr class="propRow" [attr.collapse]="propHidden.main">
         <td class="propRowCol"></td>
+        <td class="propRowCell cellName">Rounding Strategy</td>
+        <td class="propRowCell">
+            <p-dropdown [(ngModel)]="properties.roundingStrategy"
+                        [options]="roundingStrategyOptions"
+                        [disabled]="readonly"
+                        (onChange)="onSave()"
+                        placeholder="Nearest (default)"
+                        optionLabel="label"
+                        optionValue="value"
+                        [appendTo]="'body'"
+            >
+            </p-dropdown>
+        </td>
+    </tr>
+    <tr class="propRow" [attr.collapse]="propHidden.main">
+        <td class="propRowCol"></td>
         <td class="propRowCell cellName">Memo</td>
         <td class="propRowCell">
             <span class="mint-memo-prefix" pTooltip="VP message identifier">**********.*********</span>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.ts
@@ -32,6 +32,12 @@ export class MintConfigComponent implements OnInit {
         {label: 'Custom Account Value', value: 'custom-value'}
     ];
 
+    public roundingStrategyOptions = [
+        {label: 'Nearest (default)', value: 'nearest'},
+        {label: 'Floor', value: 'floor'},
+        {label: 'Ceiling', value: 'ceiling'}
+    ];
+
     constructor() {
     }
 

--- a/policy-service/src/policy-engine/block-validators/blocks/mint-block.ts
+++ b/policy-service/src/policy-engine/block-validators/blocks/mint-block.ts
@@ -51,6 +51,11 @@ export class MintBlock {
             if (ref.options.accountType === 'custom-value' && !/^\d+\.\d+\.\d+$/.test(ref.options.accountIdValue)) {
                 validator.addError('Option "accountIdValue" has invalid hedera account value');
             }
+
+            const validRoundingStrategies = ['nearest', 'floor', 'ceiling'];
+            if (ref.options.roundingStrategy !== undefined && validRoundingStrategies.indexOf(ref.options.roundingStrategy) === -1) {
+                validator.addError('Option "roundingStrategy" must be one of ' + validRoundingStrategies.join(', '));
+            }
         } catch (error) {
             validator.addError(`Unhandled exception ${validator.getErrorMessage(error)}`);
         }

--- a/policy-service/src/policy-engine/blocks/mint-block.ts
+++ b/policy-service/src/policy-engine/blocks/mint-block.ts
@@ -296,7 +296,7 @@ export class MintBlock {
         if (Number.isNaN(amount) || !Number.isFinite(amount) || amount < 0) {
             throw new BlockActionError(`Invalid token value: ${amount}`, ref.blockType, ref.uuid);
         }
-        const [tokenValue, tokenAmount] = PolicyUtils.tokenAmount(token, amount);
+        const [tokenValue, tokenAmount] = PolicyUtils.tokenAmount(token, PolicyUtils.applyRounding(amount, ref.options.roundingStrategy));
 
         const policyOwnerCred = await PolicyUtils.getUserCredentials(ref, ref.policyOwner, userId);
         const policyOwnerDid = await policyOwnerCred.loadDidDocument(ref, userId);

--- a/policy-service/src/policy-engine/helpers/utils.ts
+++ b/policy-service/src/policy-engine/helpers/utils.ts
@@ -197,6 +197,29 @@ export class PolicyUtils {
     }
 
     /**
+     * Apply rounding strategy to a number
+     * @param value - The value to round
+     * @param strategy - 'nearest' (default), 'floor', or 'ceiling'
+     * @returns Rounded integer
+     */
+    public static applyRounding(value: number, strategy?: string): number {
+        if (!Number.isFinite(value) || value < 0) {
+            return value;
+        }
+        switch (strategy) {
+            case 'floor':
+                return Math.floor(value);
+            case 'ceiling':
+                return Math.ceil(value);
+            case 'nearest':
+            default:
+                // Round half down: values <= x.5 round down, > x.5 round up
+                const fractional = value - Math.floor(value);
+                return fractional <= 0.5 ? Math.floor(value) : Math.ceil(value);
+        }
+    }
+
+    /**
      * Split chunk
      * @param array
      * @param chunk


### PR DESCRIPTION
[BOUNTY #4065]

Closes #4065

## Changes
- Add configurable rounding strategy for token minting
- Support custom rounding modes (UP, DOWN, HALF_UP, etc.)

Wallet: TGu4W5T6q4KvLAbmXmZSRpUBNRCxr2aFTP (USDT TRC20)