### PR TITLE
fix: Python sandbox mode - docker CLI, socket permissions, entrypoint

### DIFF
--- a/configs/.env.develop.guardian.system
+++ b/configs/.env.develop.guardian.system
@@ -89,6 +89,7 @@ MULTI_POLICY_SCHEDULER="0 0 * * *"
 # FEATURES
 # --------------
 BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 # IMPORT_KEYS_FROM_DB=1
 # MQ_MESSAGE_CHUNK=5000000
 # RAW_REQUEST_LIMIT="1gb"

--- a/configs/.env.quickstart.guardian.system
+++ b/configs/.env.quickstart.guardian.system
@@ -109,6 +109,7 @@ MULTI_POLICY_SCHEDULER="0 0 * * *"
 # FEATURES
 # --------------
 BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 # IMPORT_KEYS_FROM_DB=1
 # MQ_MESSAGE_CHUNK=5000000
 # RAW_REQUEST_LIMIT="1gb"

--- a/configs/.env.template.guardian.system
+++ b/configs/.env.template.guardian.system
@@ -105,6 +105,7 @@ MULTI_POLICY_SCHEDULER="0 0 * * *"
 # FEATURES
 # --------------
 BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 # IMPORT_KEYS_FROM_DB=1
 # MQ_MESSAGE_CHUNK=5000000
 # RAW_REQUEST_LIMIT="1gb"

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -212,7 +212,7 @@ services:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
       # Uncomment for PYTHON_SANDBOX_MODE=docker:
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - /var/run/docker.sock:/var/run/docker.sock
     <<: *service-template
     expose:
       - '5006'

--- a/docker-compose-production-build.yml
+++ b/docker-compose-production-build.yml
@@ -195,7 +195,7 @@ services:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
       # Uncomment for PYTHON_SANDBOX_MODE=docker:
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - /var/run/docker.sock:/var/run/docker.sock
     <<: *service-template
     expose:
       - '5006'

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -178,7 +178,7 @@ services:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
       # Uncomment for PYTHON_SANDBOX_MODE=docker:
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - /var/run/docker.sock:/var/run/docker.sock
     <<: *service-template
     expose:
       - '5006'

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -134,7 +134,7 @@ services:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
       # Uncomment for PYTHON_SANDBOX_MODE=docker:
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - /var/run/docker.sock:/var/run/docker.sock
     <<: *service-template
     expose:
       - '5006'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
       - ./policy-service/tls:/usr/local/app/tls:ro
       - ./policy-service/configs:/usr/local/app/configs:ro
       # Uncomment for PYTHON_SANDBOX_MODE=docker:
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
+      # - /var/run/docker.sock:/var/run/docker.sock
     <<: *service-template
     expose:
       - '5006'

--- a/docs/guardian/standard-registry/policies/python-implementation-in-guardian.md
+++ b/docs/guardian/standard-registry/policies/python-implementation-in-guardian.md
@@ -169,18 +169,17 @@ Runs Python code in an ephemeral Docker container using native CPython 3.12. Pro
 ```bash
 docker buildx build -t guardian/python-sandbox:latest policy-service/docker/python-sandbox
 ```
-Or via docker-compose:
+Or uncomment the `python-sandbox` image build definition in the compose file and run:
 ```bash
 docker compose -f docker-compose-build.yml build python-sandbox
 ```
 
-2. Set the environment variable in policy-service configuration:
-```
-PYTHON_SANDBOX_MODE=docker
-```
+2. Set `PYTHON_SANDBOX_MODE=docker` in `configs/.env..guardian.system` (or the corresponding system env file for your environment). The variable is present as a commented-out example in all env templates.
 
-3. Ensure the policy-service container has Docker socket access. For docker-compose deployments, uncomment the Docker socket volume mount and the `python-sandbox` image build definition in the relevant compose file:
-   - `docker-compose-build.yml`, `docker-compose.yml`, `docker-compose-production.yml`, `docker-compose-production-build.yml`, `docker-compose-quickstart.yml` — uncomment the Docker socket volume and `python-sandbox` image build
+3. For docker-compose deployments, uncomment the Docker socket volume mount for policy-service in the relevant compose file:
+   - `docker-compose-build.yml`, `docker-compose.yml`, `docker-compose-production.yml`, `docker-compose-production-build.yml`, `docker-compose-quickstart.yml`
+   - The socket must be mounted without `:ro` (policy-service needs read-write access to communicate with the Docker daemon)
+   - For non-Docker deployments (running services directly), skip this step — Docker socket is already accessible on the host
 
 {% hint style="warning" %}
 Docker mode requires the Docker daemon to be available. The policy-service needs access to the Docker socket to spawn sandbox containers. For production deployments, consider using a Docker API proxy to restrict operations to sandbox container management only.

--- a/policy-service/Dockerfile
+++ b/policy-service/Dockerfile
@@ -54,10 +54,15 @@ COPY --link --from=deps /usr/local/app/node_modules node_modules/
 COPY --link --from=deps /usr/local/app/package.json ./
 COPY --link --from=build /usr/local/app/dist dist/
 
+# Docker CLI for PYTHON_SANDBOX_MODE=docker (spawns sandbox containers via docker.sock)
+RUN apk add --no-cache docker-cli su-exec
+
 # Allow node user to write Pyodide package cache (warmup downloads wheels at startup)
 RUN chown -R node:node node_modules/pyodide/ 2>/dev/null || true
 
-# Change the user to node
-USER node
+# Entrypoint: if docker.sock exists, match its GID so node user can access it, then drop to node
+COPY --link policy-service/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD [ "node", "dist/index.js" ]

--- a/policy-service/docker/entrypoint.sh
+++ b/policy-service/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# If docker.sock is mounted, create/update a docker group matching its GID
+# so the node user can spawn sandbox containers.
+if [ -S /var/run/docker.sock ]; then
+    SOCK_GID=$(stat -c '%g' /var/run/docker.sock)
+    if ! getent group "$SOCK_GID" > /dev/null 2>&1; then
+        addgroup -g "$SOCK_GID" docker 2>/dev/null
+    fi
+    DOCKER_GROUP=$(getent group "$SOCK_GID" | cut -d: -f1)
+    addgroup node "$DOCKER_GROUP" 2>/dev/null
+fi
+
+exec su-exec node "$@"


### PR DESCRIPTION
 - Install docker-cli and su-exec in policy-service Docker image for PYTHON_SANDBOX_MODE=docker
  - Add entrypoint script that detects docker.sock GID at runtime and grants access to node user (works on Docker Desktop and Linux)
  - Remove :ro from docker.sock mount in all compose files (policy-service needs   read-write)
  - Add PYTHON_SANDBOX_MODE variable to env templates (commented out)
  - Update documentation with setup instructions