### PR TITLE
fix: sandbox JavaScript Custom Logic worker with vm.createContext

### DIFF
--- a/policy-service/src/policy-engine/helpers/workers/custom-logic-worker.ts
+++ b/policy-service/src/policy-engine/helpers/workers/custom-logic-worker.ts
@@ -2,9 +2,19 @@ import { workerData, parentPort } from 'node:worker_threads';
 import * as mathjs from 'mathjs';
 import * as formulajs from '@formulajs/formulajs'
 import { buildTableHelper } from '../table-field-core.js';
+import * as vm from 'node:vm';
 
 /**
- * Execute function
+ * Execute user-supplied JavaScript in a sandboxed V8 context.
+ *
+ * Previously, user code ran via Function() in the same Node.js context as
+ * the policy-service, giving access to process.env, require(), and the
+ * full filesystem. The Python worker already uses Pyodide (WASM sandbox)
+ * for isolation; this change brings the JavaScript worker to the same
+ * security level using Node.js vm module with code generation disabled.
+ *
+ * Only the documented API surface (done, debug, user, documents, mathjs,
+ * formulajs, artifacts, sources, table) is exposed to user code.
  */
 function execute(): void {
     const done = (result: any, final: boolean = true) => {
@@ -15,21 +25,52 @@ function execute(): void {
     }
 
     const { execFunc, user, documents, artifacts, sources, tablesPack } = workerData;
-    const importCode = `const [done, user, documents, mathjs, artifacts, formulajs, sources, debug, table] = arguments;\r\n`;
-    const code = `${importCode}${execFunc}`;
 
-    const func = Function(code);
-    func.apply(documents, [
-        done,
-        user,
-        documents,
-        mathjs,
-        artifacts,
-        formulajs,
-        sources,
-        debug,
-        buildTableHelper(tablesPack)
-    ]);
+    // Create sandbox with only the documented API surface
+    // Object.create(null) prevents prototype chain escapes
+    const sandbox = Object.create(null);
+    sandbox.done = done;
+    sandbox.debug = debug;
+    sandbox.user = user;
+    sandbox.documents = documents;
+    sandbox.mathjs = mathjs;
+    sandbox.artifacts = artifacts;
+    sandbox.formulajs = formulajs;
+    sandbox.sources = sources;
+    sandbox.table = buildTableHelper(tablesPack);
+
+    // Convenience globals expected by user code
+    sandbox.console = { log: debug, warn: debug, error: debug };
+    sandbox.JSON = JSON;
+    sandbox.Math = Math;
+    sandbox.Date = Date;
+    sandbox.Array = Array;
+    sandbox.Object = Object;
+    sandbox.String = String;
+    sandbox.Number = Number;
+    sandbox.Boolean = Boolean;
+    sandbox.RegExp = RegExp;
+    sandbox.Map = Map;
+    sandbox.Set = Set;
+    sandbox.Promise = Promise;
+    sandbox.parseInt = parseInt;
+    sandbox.parseFloat = parseFloat;
+    sandbox.isNaN = isNaN;
+    sandbox.isFinite = isFinite;
+    sandbox.undefined = undefined;
+    sandbox.NaN = NaN;
+    sandbox.Infinity = Infinity;
+
+    const context = vm.createContext(sandbox, {
+        codeGeneration: { strings: false, wasm: false }
+    });
+
+    try {
+        vm.runInContext(execFunc, context, { timeout: 30000 });
+    } catch (error) {
+        parentPort.postMessage({ type: 'debug', message: `Sandbox error: ${error.message}` });
+        parentPort.postMessage({ type: 'done', result: null, final: true });
+    }
 }
 
 execute();


### PR DESCRIPTION
## Summary

The JavaScript Custom Logic worker currently uses `Function()` to execute user-supplied code. This runs in the same Node.js context as the policy-service, giving user code full access to `process.env`, `require()`, `import()`, and native modules like `node:fs`.

The Python Custom Logic worker already uses **Pyodide** (WASM sandbox) for isolation. This PR brings the JavaScript worker to the same security level using Node.js built-in `vm.createContext()` with code generation disabled.

## What changed

Replaced `Function(code)` with `vm.createContext()` + `vm.runInContext()` in `custom-logic-worker.ts`.

User code now runs in a sandboxed V8 context with:
- **No access** to `process`, `require`, `import`, `node:fs`, or any Node.js API
- **Constructor chain escapes blocked** via `codeGeneration: { strings: false, wasm: false }`
- **Only** the documented API surface: `done`, `debug`, `user`, `documents`, `mathjs`, `formulajs`, `artifacts`, `sources`, `table`
- **Timeout**: 30 seconds per execution
- **Zero new dependencies** - uses only Node.js built-in `vm` module

## Tested escape vectors

| Attack | Before | After |
|---|---|---|
| `process.env` | Full env dump (JWT keys, Vault tokens) | BLOCKED |
| `require("fs")` | Arbitrary file read | BLOCKED |
| `import("node:fs")` | Arbitrary file read | BLOCKED |
| `Function("return process")()` | Process access | BLOCKED |
| `({}).constructor.constructor("return process")()` | Prototype chain escape | BLOCKED |
| `mathjs.evaluate("2+2")` | Works | Works |
| `done({ result: "hello" })` | Works | Works |

## Why

The Python worker uses Pyodide (WASM sandbox). The JavaScript worker uses `Function()` (no sandbox). This inconsistency shows that isolation was intended for custom code execution but not implemented on the JS side.

## Backward compatibility

The API surface for user code is unchanged. Existing Custom Logic blocks that use `done()`, `debug()`, `documents`, `mathjs`, `formulajs` work without modification. Only code relying on undocumented access to Node.js internals will break.