### PR TITLE
feat: 5926 Mint event retry

### DIFF
--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3824,7 +3824,9 @@ export class PolicyApi {
     @ApiOperation({
         summary: 'Retry mint by VP message ID.',
         description:
-            'Retries failed mint/transfer operations for the specified VP message within the given policy.',
+            'Retries failed mint/transfer operations for the specified VP message within the given policy. ' +
+            'Fire-and-forget: the endpoint performs synchronous validation (policy access, owner check, per-request cooldown / in-progress checks) and returns as soon as validation passes; the actual Hedera mint/transfer runs in the background. ' +
+            'Poll GET /policies/{policyId}/mint-requests to observe progress and final state.',
     })
     @ApiParam({
         name: 'policyId',
@@ -3841,8 +3843,28 @@ export class PolicyApi {
         example: '1774449700.283746192'
     })
     @ApiOkResponse({
-        description: 'Successful operation.',
-        example: {}
+        description: 'Validation passed; retry has been queued (fire-and-forget). `warnings` contains any per-request messages surfaced synchronously during validation (e.g. cooldown or already-in-progress); an empty array means every request was accepted for background processing. `message` is set only when no retry was needed because every mint request for the VP is already fully minted and transferred.',
+        examples: {
+            queued: {
+                summary: 'Fresh retry accepted and queued',
+                value: { warnings: [] }
+            },
+            cooldown: {
+                summary: 'Request is on cooldown after a recent attempt',
+                value: {
+                    warnings: [
+                        'Mint process for 1776887993.927747137 can\'t be retried. Try after 6 minutes'
+                    ]
+                }
+            },
+            allMinted: {
+                summary: 'No retry needed — every mint request is complete',
+                value: {
+                    warnings: [],
+                    message: 'All tokens for 1776887993.927747137 are minted and transferred'
+                }
+            }
+        }
     })
     @ApiForbiddenResponse({
         description: 'Forbidden. Only the policy owner can retry mint requests.',

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3693,6 +3693,87 @@ export class PolicyApi {
     }
 
     /**
+     * Get mint requests for a policy
+     */
+    @Get('/:policyId/mint-requests')
+    @Auth(
+        Permissions.POLICIES_POLICY_READ,
+        Permissions.POLICIES_POLICY_MANAGE,
+    )
+    @ApiOperation({
+        summary: 'Get mint requests for a policy.',
+        description: 'Returns paginated mint requests for the specified policy with optional filters.',
+    })
+    @ApiParam({
+        name: 'policyId',
+        type: String,
+        description: 'Policy Id',
+        required: true,
+        example: Examples.DB_ID
+    })
+    @ApiQuery({
+        name: 'status',
+        type: String,
+        description: 'Status filter (error, pending, success)',
+        required: false,
+    })
+    @ApiQuery({
+        name: 'tokenId',
+        type: String,
+        description: 'Token ID filter',
+        required: false,
+    })
+    @ApiQuery({
+        name: 'pageIndex',
+        type: Number,
+        description: 'The number of pages to skip before starting to collect the result set',
+        required: false,
+        example: 0
+    })
+    @ApiQuery({
+        name: 'pageSize',
+        type: Number,
+        description: 'The numbers of items to return',
+        required: false,
+        example: 20
+    })
+    @ApiOkResponse({
+        description: 'Mint requests.',
+        isArray: true,
+        headers: pageHeader,
+    })
+    @ApiInternalServerErrorResponse({
+        description: 'Internal server error.',
+        type: InternalServerErrorDTO,
+        example: { statusCode: 500, message: 'Error message' }
+    })
+    @HttpCode(HttpStatus.OK)
+    async getMintRequests(
+        @AuthUser() user: IAuthUser,
+        @Response() res: any,
+        @Param('policyId') policyId: string,
+        @Query('status') status?: string,
+        @Query('tokenId') tokenId?: string,
+        @Query('pageIndex') pageIndex?: number,
+        @Query('pageSize') pageSize?: number,
+    ): Promise<any> {
+        try {
+            const engineService = new PolicyEngine();
+            const [requests, count] = await engineService.getMintRequests(
+                new EntityOwner(user),
+                policyId,
+                status,
+                tokenId,
+                pageIndex,
+                pageSize,
+            );
+            return res.header('X-Total-Count', count).send(requests);
+        } catch (error) {
+            await InternalException(error, this.logger, user.id);
+        }
+    }
+
+    /**
      * Retry mint for the specified VP message
      */
     @Post('/:policyId/mint/:vpMessageId/retry')

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3693,6 +3693,60 @@ export class PolicyApi {
     }
 
     /**
+     * Retry mint for the specified VP message
+     */
+    @Post('/:policyId/mint/:vpMessageId/retry')
+    @Auth(
+        Permissions.POLICIES_POLICY_EXECUTE,
+        Permissions.POLICIES_POLICY_MANAGE,
+    )
+    @ApiOperation({
+        summary: 'Retry mint by VP message ID.',
+        description:
+            'Retries failed mint/transfer operations for the specified VP message within the given policy.',
+    })
+    @ApiParam({
+        name: 'policyId',
+        type: String,
+        description: 'Policy Id',
+        required: true,
+        example: Examples.DB_ID
+    })
+    @ApiParam({
+        name: 'vpMessageId',
+        type: String,
+        description: 'VP Message Id',
+        required: true,
+    })
+    @ApiOkResponse({
+        description: 'Successful operation.',
+    })
+    @ApiUnprocessableEntityResponse({
+        description: 'Unprocessable entity.',
+        type: UnprocessableEntityErrorDTO,
+        example: { statusCode: 422, message: 'Error message', error: 'Unprocessable Entity' }
+    })
+    @ApiInternalServerErrorResponse({
+        description: 'Internal server error.',
+        type: InternalServerErrorDTO,
+        example: { statusCode: 500, message: 'Error message' }
+    })
+    @HttpCode(HttpStatus.OK)
+    async retryMint(
+        @AuthUser() user: IAuthUser,
+        @Param('policyId') policyId: string,
+        @Param('vpMessageId') vpMessageId: string,
+    ): Promise<any> {
+        try {
+            const engineService = new PolicyEngine();
+            return await engineService.retryMint(user, policyId, vpMessageId);
+        } catch (error) {
+            error.code = HttpStatus.UNPROCESSABLE_ENTITY;
+            await InternalException(error, this.logger, user.id);
+        }
+    }
+
+    /**
      * Sends data to the specified block
      */
     @Post('/:policyId/blocks/:uuid/sync-events')

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3844,6 +3844,10 @@ export class PolicyApi {
         description: 'Successful operation.',
         example: {}
     })
+    @ApiForbiddenResponse({
+        description: 'Forbidden. Only the policy owner can retry mint requests.',
+        example: { statusCode: 403, message: 'Only the policy owner can retry mint requests.', error: 'Forbidden' }
+    })
     @ApiUnprocessableEntityResponse({
         description: 'Unprocessable entity.',
         type: UnprocessableEntityErrorDTO,
@@ -3864,7 +3868,9 @@ export class PolicyApi {
             const engineService = new PolicyEngine();
             return await engineService.retryMint(user, policyId, vpMessageId);
         } catch (error) {
-            error.code = HttpStatus.UNPROCESSABLE_ENTITY;
+            if (!error.code) {
+                error.code = HttpStatus.UNPROCESSABLE_ENTITY;
+            }
             await InternalException(error, this.logger, user.id);
         }
     }

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3716,12 +3716,14 @@ export class PolicyApi {
         type: String,
         description: 'Status filter (error, pending, success)',
         required: false,
+        example: 'error'
     })
     @ApiQuery({
         name: 'tokenId',
         type: String,
         description: 'Token ID filter',
         required: false,
+        example: '0.0.6046500'
     })
     @ApiQuery({
         name: 'pageIndex',
@@ -3741,12 +3743,36 @@ export class PolicyApi {
         description: 'Mint requests.',
         isArray: true,
         headers: pageHeader,
+        schema: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    amount: { type: 'number', description: 'Amount to mint', example: 100 },
+                    tokenId: { type: 'string', description: 'Token identifier', example: '0.0.6046500' },
+                    tokenType: { type: 'string', enum: ['FUNGIBLE', 'NON_FUNGIBLE'], description: 'Token type' },
+                    target: { type: 'string', description: 'Target account', example: '0.0.6046379' },
+                    vpMessageId: { type: 'string', description: 'VP message identifier', example: '1774449622.177353801' },
+                    isMintNeeded: { type: 'boolean', description: 'Whether minting is still needed' },
+                    isTransferNeeded: { type: 'boolean', description: 'Whether transfer is needed' },
+                    memo: { type: 'string', description: 'Transaction memo' },
+                    metadata: { type: 'string', nullable: true, description: 'Metadata' },
+                    error: { type: 'string', nullable: true, description: 'Error message if mint failed' },
+                    processDate: { type: 'string', format: 'date-time', nullable: true, description: 'Last process date' },
+                    policyId: { type: 'string', description: 'Associated policy ID' },
+                    owner: { type: 'string', nullable: true, description: 'Owner DID' },
+                    id: { type: 'string', description: 'Mint request ID' },
+                }
+            }
+        },
+        example: ObjectExamples.MINT_REQUEST
     })
     @ApiInternalServerErrorResponse({
         description: 'Internal server error.',
         type: InternalServerErrorDTO,
         example: { statusCode: 500, message: 'Error message' }
     })
+    @ApiExtraModels(InternalServerErrorDTO)
     @HttpCode(HttpStatus.OK)
     async getMintRequests(
         @AuthUser() user: IAuthUser,
@@ -3798,9 +3824,11 @@ export class PolicyApi {
         type: String,
         description: 'VP Message Id',
         required: true,
+        example: '1774449700.283746192'
     })
     @ApiOkResponse({
         description: 'Successful operation.',
+        example: {}
     })
     @ApiUnprocessableEntityResponse({
         description: 'Unprocessable entity.',

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3719,11 +3719,11 @@ export class PolicyApi {
         example: 'error'
     })
     @ApiQuery({
-        name: 'tokenId',
+        name: 'target',
         type: String,
-        description: 'Token ID filter',
+        description: 'Account ID filter',
         required: false,
-        example: '0.0.6046500'
+        example: '0.0.6046379'
     })
     @ApiQuery({
         name: 'vpMessageId',
@@ -3791,7 +3791,7 @@ export class PolicyApi {
         @Response() res: any,
         @Param('policyId') policyId: string,
         @Query('status') status?: string,
-        @Query('tokenId') tokenId?: string,
+        @Query('target') target?: string,
         @Query('vpMessageId') vpMessageId?: string,
         @Query('pageIndex') pageIndex?: number,
         @Query('pageSize') pageSize?: number,
@@ -3802,7 +3802,7 @@ export class PolicyApi {
                 new EntityOwner(user),
                 policyId,
                 status,
-                tokenId,
+                target,
                 vpMessageId,
                 pageIndex,
                 pageSize,

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3726,6 +3726,13 @@ export class PolicyApi {
         example: '0.0.6046500'
     })
     @ApiQuery({
+        name: 'vpMessageId',
+        type: String,
+        description: 'VP Message ID filter',
+        required: false,
+        example: '1775659196.584626142'
+    })
+    @ApiQuery({
         name: 'pageIndex',
         type: Number,
         description: 'The number of pages to skip before starting to collect the result set',
@@ -3762,6 +3769,11 @@ export class PolicyApi {
                     policyId: { type: 'string', description: 'Associated policy ID' },
                     owner: { type: 'string', nullable: true, description: 'Owner DID' },
                     id: { type: 'string', description: 'Mint request ID' },
+                    mintedAmount: { type: 'number', description: 'Minted amount from successful transactions' },
+                    mintedExpected: { type: 'number', description: 'Expected total mint amount' },
+                    transferredAmount: { type: 'number', description: 'Transferred amount from successful transactions' },
+                    transferredExpected: { type: 'number', description: 'Expected total transfer amount' },
+                    wasTransferNeeded: { type: 'boolean', description: 'Whether transfer was needed' },
                 }
             }
         },
@@ -3780,6 +3792,7 @@ export class PolicyApi {
         @Param('policyId') policyId: string,
         @Query('status') status?: string,
         @Query('tokenId') tokenId?: string,
+        @Query('vpMessageId') vpMessageId?: string,
         @Query('pageIndex') pageIndex?: number,
         @Query('pageSize') pageSize?: number,
     ): Promise<any> {
@@ -3790,6 +3803,7 @@ export class PolicyApi {
                 policyId,
                 status,
                 tokenId,
+                vpMessageId,
                 pageIndex,
                 pageSize,
             );

--- a/api-gateway/src/helpers/policy-engine.ts
+++ b/api-gateway/src/helpers/policy-engine.ts
@@ -368,6 +368,22 @@ export class PolicyEngine extends NatsService {
     }
 
     /**
+     * Retry mint
+     * @param user
+     * @param policyId
+     * @param vpMessageId
+     */
+    public async retryMint(
+        user: IAuthUser,
+        policyId: string,
+        vpMessageId: string
+    ): Promise<any> {
+        return await this.sendMessage(PolicyEngineEvents.RETRY_MINT, {
+            user, policyId, vpMessageId
+        });
+    }
+
+    /**
      * Set block data
      * @param user
      * @param policyId

--- a/api-gateway/src/helpers/policy-engine.ts
+++ b/api-gateway/src/helpers/policy-engine.ts
@@ -398,11 +398,12 @@ export class PolicyEngine extends NatsService {
         policyId: string,
         status?: string,
         tokenId?: string,
+        vpMessageId?: string,
         pageIndex?: number | string,
         pageSize?: number | string
     ): Promise<any> {
         return await this.sendMessage(PolicyEngineEvents.GET_MINT_REQUESTS, {
-            owner, policyId, status, tokenId, pageIndex, pageSize
+            owner, policyId, status, tokenId, vpMessageId, pageIndex, pageSize
         });
     }
 

--- a/api-gateway/src/helpers/policy-engine.ts
+++ b/api-gateway/src/helpers/policy-engine.ts
@@ -388,7 +388,7 @@ export class PolicyEngine extends NatsService {
      * @param owner Owner
      * @param policyId Policy identifier
      * @param status Status filter
-     * @param tokenId Token ID filter
+     * @param target Account ID filter
      * @param pageIndex Page index
      * @param pageSize Page size
      * @returns Mint requests and count
@@ -397,13 +397,13 @@ export class PolicyEngine extends NatsService {
         owner: IOwner,
         policyId: string,
         status?: string,
-        tokenId?: string,
+        target?: string,
         vpMessageId?: string,
         pageIndex?: number | string,
         pageSize?: number | string
     ): Promise<any> {
         return await this.sendMessage(PolicyEngineEvents.GET_MINT_REQUESTS, {
-            owner, policyId, status, tokenId, vpMessageId, pageIndex, pageSize
+            owner, policyId, status, target, vpMessageId, pageIndex, pageSize
         });
     }
 

--- a/api-gateway/src/helpers/policy-engine.ts
+++ b/api-gateway/src/helpers/policy-engine.ts
@@ -384,6 +384,29 @@ export class PolicyEngine extends NatsService {
     }
 
     /**
+     * Get mint requests
+     * @param owner Owner
+     * @param policyId Policy identifier
+     * @param status Status filter
+     * @param tokenId Token ID filter
+     * @param pageIndex Page index
+     * @param pageSize Page size
+     * @returns Mint requests and count
+     */
+    public async getMintRequests(
+        owner: IOwner,
+        policyId: string,
+        status?: string,
+        tokenId?: string,
+        pageIndex?: number | string,
+        pageSize?: number | string
+    ): Promise<any> {
+        return await this.sendMessage(PolicyEngineEvents.GET_MINT_REQUESTS, {
+            owner, policyId, status, tokenId, pageIndex, pageSize
+        });
+    }
+
+    /**
      * Set block data
      * @param user
      * @param policyId

--- a/api-gateway/src/middlewares/validation/examples.ts
+++ b/api-gateway/src/middlewares/validation/examples.ts
@@ -8415,5 +8415,42 @@ export const ObjectExamples = {
             tests: [],
             id: '69c81d7fc778760bac62cf66'
         }
-    ]
+    ],
+
+    MINT_REQUEST: [
+        {
+            amount: 100,
+            tokenId: '0.0.6046500',
+            tokenType: 'FUNGIBLE',
+            target: '0.0.6046379',
+            vpMessageId: '1774449622.177353801',
+            isMintNeeded: false,
+            isTransferNeeded: false,
+            wasTransferNeeded: false,
+            memo: 'f3b2a9c1e4d5678901234567',
+            metadata: null,
+            error: null,
+            processDate: '2026-03-25T14:40:28.853Z',
+            policyId: '69b83f18cd6b7c4adf4139bc',
+            owner: 'did:hedera:testnet:Cvzp5kKVUuipBCQjcF54fBjdicvaKsB8zHeQ6Qq22U2Z_0.0.8200599',
+            id: '69c3ff9de85d8b6ef99ef870'
+        },
+        {
+            amount: 50,
+            tokenId: '0.0.6046500',
+            tokenType: 'NON_FUNGIBLE',
+            target: '0.0.6046379',
+            vpMessageId: '1774449700.283746192',
+            isMintNeeded: true,
+            isTransferNeeded: false,
+            wasTransferNeeded: false,
+            memo: 'a1b2c3d4e5f6789012345678',
+            metadata: null,
+            error: 'INSUFFICIENT_PAYER_BALANCE',
+            processDate: '2026-03-25T15:30:37.191Z',
+            policyId: '69b83f18cd6b7c4adf4139bc',
+            owner: 'did:hedera:testnet:EthnLQfQnh8x6vKyegyekhy72oSAok6cH59pfVssKLDw_0.0.8200599',
+            id: '69c3ff9de85d8b6ef99ef871'
+        }
+    ],
 }

--- a/common/src/database-modules/database-server.ts
+++ b/common/src/database-modules/database-server.ts
@@ -5508,6 +5508,19 @@ export class DatabaseServer extends AbstractDatabaseServer {
     }
 
     /**
+     * Get mint requests with count
+     * @param filters Filters
+     * @param options Options
+     * @returns Mint requests and count
+     */
+    public static async getMintRequestsAndCount(
+        filters?: FilterObject<MintRequest>,
+        options?: FindOptions<object>
+    ): Promise<[MintRequest[], number]> {
+        return await new DataBaseHelper(MintRequest).findAndCount(filters, options);
+    }
+
+    /**
      * Get remote requests
      * @param filters
      */

--- a/frontend/src/app/modules/policy-engine/policy-engine.module.ts
+++ b/frontend/src/app/modules/policy-engine/policy-engine.module.ts
@@ -158,6 +158,7 @@ import { SearchExternalPolicyDialog } from './dialogs/search-external-policy-dia
 import { PolicyRequestsComponent } from './requests/requests.component';
 import { TestCodeDialog } from './dialogs/test-code-dialog/test-code-dialog.component';
 import { ProjectDataExportComponent } from './project-data-export/project-data-export.component';
+import { MintRequestsComponent } from './policy-viewer/mint-requests/mint-requests.component';
 import { TransformationButtonBlockComponent } from './policy-viewer/blocks/transformation-button-block/transformation-button-block.component';
 import { IntegrationButtonBlockComponent } from './policy-viewer/blocks/integration-button-block/integration-button-block.component';
 import { RestoreSavepointDialog } from './policy-viewer/dialogs/restore-savepoint-dialog/restore-savepoint-dialog.component';
@@ -296,6 +297,7 @@ import { MockDialog } from './dialogs/mock-dialog/mock-dialog.component';
         RequestDocumentBlockDialog,
         DataTransformationConfigComponent,
         ProjectDataExportComponent,
+        MintRequestsComponent,
         ExternalPolicyComponent,
         PolicyRequestsComponent,
         SearchExternalPolicyDialog,

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
@@ -25,6 +25,17 @@
                                 />
                             </span>
                         </div>
+                        <div class="filter">
+                            <span class="p-input-icon-right">
+                                <input
+                                    formControlName="vpMessageId"
+                                    pInputText
+                                    placeholder="VP Message ID"
+                                    type="text"
+                                    class="vp-message-id-input"
+                                />
+                            </span>
+                        </div>
                     </div>
                     <div class="filter-actions">
                         <button
@@ -57,22 +68,22 @@
                 >
                     <ng-template pTemplate="header">
                         <tr class="guardian-grid-header">
-                            <th class="col-200">VP Message ID</th>
-                            <th class="col-150">Token ID</th>
-                            <th class="col-120">Token Type</th>
-                            <th class="col-100">Amount</th>
-                            <th class="col-200">Target</th>
-                            <th class="col-200">Owner</th>
-                            <th class="col-100">Status</th>
-                            <th class="col-auto">Error</th>
-                            <th class="col-150">Process Date</th>
+                            <th class="col-220">VP Message ID</th>
+                            <th class="col-150">Token</th>
+                            <th class="col-80">Token Type</th>
+                            <th class="col-140">Amount</th>
+                            <th class="col-150">Account</th>
+                            <th class="col-200">Minted</th>
+                            <th class="col-200">Transferred</th>
+                            <th class="col-120">Status</th>
+                            <th class="col-180">Process Date</th>
                             <th class="col-80">Actions</th>
                         </tr>
                     </ng-template>
                     <ng-template let-row pTemplate="body">
                         <tr class="guardian-grid-row">
                             <td
-                                class="col-200"
+                                class="col-220"
                                 pTooltip="{{row.vpMessageId}}"
                                 tooltipPosition="top"
                                 [showDelay]="1000"
@@ -85,43 +96,35 @@
                                 tooltipPosition="top"
                                 [showDelay]="1000"
                             >
-                                <span class="text-truncate">{{row.tokenId}}</span>
+                                <span class="text-truncate">
+                                    <hedera-explorer [params]="row.tokenId" type="tokens">{{row.tokenId}}</hedera-explorer>
+                                </span>
                             </td>
-                            <td class="col-120">{{row.tokenType}}</td>
-                            <td class="col-100">{{row.amount}}</td>
+                            <td class="col-80">{{getTokenTypeLabel(row.tokenType)}}</td>
+                            <td class="col-140">{{getFormattedAmount(row)}}</td>
                             <td
-                                class="col-200"
+                                class="col-150"
                                 pTooltip="{{row.target}}"
                                 tooltipPosition="top"
                                 [showDelay]="1000"
                             >
-                                <span class="text-truncate">{{row.target}}</span>
+                                <span class="text-truncate">
+                                    <hedera-explorer [params]="row.target" type="accounts">{{row.target}}</hedera-explorer>
+                                </span>
                             </td>
-                            <td
-                                class="col-200"
-                                pTooltip="{{row.owner}}"
-                                tooltipPosition="top"
-                                [showDelay]="1000"
-                            >
-                                <span class="text-truncate">{{row.owner}}</span>
-                            </td>
-                            <td class="col-100">
+                            <td class="col-200">{{getMintedDisplay(row)}}</td>
+                            <td class="col-200">{{getTransferredDisplay(row)}}</td>
+                            <td class="col-120">
                                 <span
-                                    class="status-badge"
                                     [ngClass]="getStatusClass(row)"
+                                    [pTooltip]="row.error"
+                                    tooltipPosition="top"
+                                    [showDelay]="500"
                                 >
                                     {{getStatusLabel(row)}}
                                 </span>
                             </td>
-                            <td
-                                class="col-auto"
-                                pTooltip="{{row.error}}"
-                                tooltipPosition="top"
-                                [showDelay]="1000"
-                            >
-                                <span class="text-truncate error-text">{{row.error}}</span>
-                            </td>
-                            <td class="col-150">{{row.processDate | date:'short'}}</td>
+                            <td class="col-180">{{row.processDate | date:'short'}}</td>
                             <td class="col-80">
                                 <button
                                     *ngIf="hasError(row)"

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
@@ -1,0 +1,165 @@
+<div class="mint-requests-container">
+    <div class="guardian-user-page-toolbar">
+        <div class="guardian-user-page-filters">
+            <form [formGroup]="filtersForm" class="filters">
+                <div class="filter-row">
+                    <div class="filter-controls">
+                        <div class="filter">
+                            <p-dropdown
+                                formControlName="status"
+                                [options]="statusOptions"
+                                optionLabel="label"
+                                optionValue="value"
+                                placeholder="Status"
+                                class="status-dropdown"
+                            ></p-dropdown>
+                        </div>
+                        <div class="filter">
+                            <span class="p-input-icon-right">
+                                <input
+                                    formControlName="tokenId"
+                                    pInputText
+                                    placeholder="Token ID"
+                                    type="text"
+                                    class="token-input"
+                                />
+                            </span>
+                        </div>
+                    </div>
+                    <div class="filter-actions">
+                        <button
+                            (click)="applyFilters()"
+                            type="button"
+                            class="button"
+                            label="Apply"
+                            pButton
+                        ></button>
+                        <button
+                            (click)="clearFilters()"
+                            type="button"
+                            class="button secondary"
+                            label="Clear"
+                            pButton
+                        ></button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="guardian-user-page-grid">
+        <ng-container *ngIf="page && page.length > 0; else noData">
+            <div class="guardian-grid-container">
+                <p-table
+                    class="guardian-grid-table"
+                    [value]="page"
+                    [scrollable]="true"
+                >
+                    <ng-template pTemplate="header">
+                        <tr class="guardian-grid-header">
+                            <th class="col-200">VP Message ID</th>
+                            <th class="col-150">Token ID</th>
+                            <th class="col-120">Token Type</th>
+                            <th class="col-100">Amount</th>
+                            <th class="col-200">Target</th>
+                            <th class="col-200">Owner</th>
+                            <th class="col-100">Status</th>
+                            <th class="col-auto">Error</th>
+                            <th class="col-150">Process Date</th>
+                            <th class="col-80">Actions</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template let-row pTemplate="body">
+                        <tr class="guardian-grid-row">
+                            <td
+                                class="col-200"
+                                pTooltip="{{row.vpMessageId}}"
+                                tooltipPosition="top"
+                                [showDelay]="1000"
+                            >
+                                <span class="text-truncate">{{row.vpMessageId}}</span>
+                            </td>
+                            <td
+                                class="col-150"
+                                pTooltip="{{row.tokenId}}"
+                                tooltipPosition="top"
+                                [showDelay]="1000"
+                            >
+                                <span class="text-truncate">{{row.tokenId}}</span>
+                            </td>
+                            <td class="col-120">{{row.tokenType}}</td>
+                            <td class="col-100">{{row.amount}}</td>
+                            <td
+                                class="col-200"
+                                pTooltip="{{row.target}}"
+                                tooltipPosition="top"
+                                [showDelay]="1000"
+                            >
+                                <span class="text-truncate">{{row.target}}</span>
+                            </td>
+                            <td
+                                class="col-200"
+                                pTooltip="{{row.owner}}"
+                                tooltipPosition="top"
+                                [showDelay]="1000"
+                            >
+                                <span class="text-truncate">{{row.owner}}</span>
+                            </td>
+                            <td class="col-100">
+                                <span
+                                    class="status-badge"
+                                    [ngClass]="getStatusClass(row)"
+                                >
+                                    {{getStatusLabel(row)}}
+                                </span>
+                            </td>
+                            <td
+                                class="col-auto"
+                                pTooltip="{{row.error}}"
+                                tooltipPosition="top"
+                                [showDelay]="1000"
+                            >
+                                <span class="text-truncate error-text">{{row.error}}</span>
+                            </td>
+                            <td class="col-150">{{row.processDate | date:'short'}}</td>
+                            <td class="col-80">
+                                <button
+                                    *ngIf="hasError(row)"
+                                    (click)="onRetry(row)"
+                                    pButton
+                                    icon="pi pi-refresh"
+                                    class="p-button-text p-button-sm"
+                                    pTooltip="Retry mint"
+                                    tooltipPosition="top"
+                                ></button>
+                            </td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+                <div class="guardian-grid-paginator">
+                    <app-paginator
+                        [pageIndex]="pageIndex"
+                        [pageSize]="pageSize"
+                        [length]="pageCount"
+                        (page)="onPage($event)"
+                    ></app-paginator>
+                </div>
+            </div>
+        </ng-container>
+        <ng-template #noData>
+            <div class="guardian-user-not-data">
+                <svg-icon
+                    class="svg-icon-32"
+                    src="/assets/images/icons/32/list.svg"
+                    svgClass="icon-color-disabled"
+                ></svg-icon>
+                <span class="guardian-user-not-data__text-strong">No mint requests found</span>
+                <span class="guardian-user-not-data__text">Try adjusting your filters</span>
+            </div>
+        </ng-template>
+    </div>
+</div>
+
+<div *ngIf="loading" class="loading">
+    <div class="preloader-image preloader-image-l-size"></div>
+</div>

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.html
@@ -17,11 +17,11 @@
                         <div class="filter">
                             <span class="p-input-icon-right">
                                 <input
-                                    formControlName="tokenId"
+                                    formControlName="target"
                                     pInputText
-                                    placeholder="Token ID"
+                                    placeholder="Account ID"
                                     type="text"
-                                    class="token-input"
+                                    class="account-input"
                                 />
                             </span>
                         </div>
@@ -68,11 +68,11 @@
                 >
                     <ng-template pTemplate="header">
                         <tr class="guardian-grid-header">
-                            <th class="col-220">VP Message ID</th>
-                            <th class="col-150">Token</th>
-                            <th class="col-80">Token Type</th>
+                            <th class="col-230">VP Message ID</th>
+                            <th class="col-140">Token</th>
+                            <th class="col-110">Token Type</th>
                             <th class="col-140">Amount</th>
-                            <th class="col-150">Account</th>
+                            <th class="col-140">Account</th>
                             <th class="col-200">Minted</th>
                             <th class="col-200">Transferred</th>
                             <th class="col-120">Status</th>
@@ -83,7 +83,7 @@
                     <ng-template let-row pTemplate="body">
                         <tr class="guardian-grid-row">
                             <td
-                                class="col-220"
+                                class="col-230"
                                 pTooltip="{{row.vpMessageId}}"
                                 tooltipPosition="top"
                                 [showDelay]="1000"
@@ -91,7 +91,7 @@
                                 <span class="text-truncate">{{row.vpMessageId}}</span>
                             </td>
                             <td
-                                class="col-150"
+                                class="col-140"
                                 pTooltip="{{row.tokenId}}"
                                 tooltipPosition="top"
                                 [showDelay]="1000"
@@ -100,10 +100,10 @@
                                     <hedera-explorer [params]="row.tokenId" type="tokens">{{row.tokenId}}</hedera-explorer>
                                 </span>
                             </td>
-                            <td class="col-80">{{getTokenTypeLabel(row.tokenType)}}</td>
+                            <td class="col-110">{{getTokenTypeLabel(row.tokenType)}}</td>
                             <td class="col-140">{{getFormattedAmount(row)}}</td>
                             <td
-                                class="col-150"
+                                class="col-140"
                                 pTooltip="{{row.target}}"
                                 tooltipPosition="top"
                                 [showDelay]="1000"

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
@@ -53,7 +53,7 @@
             }
         }
 
-        .token-input,
+        .account-input,
         .vp-message-id-input {
             width: 220px;
             height: 40px;
@@ -118,10 +118,10 @@
     }
 }
 
-.col-220 {
-    width: 220px;
-    min-width: 220px;
-    max-width: 220px;
+.col-230 {
+    width: 230px;
+    min-width: 230px;
+    max-width: 230px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -145,15 +145,6 @@
     text-overflow: ellipsis;
 }
 
-.col-150 {
-    width: 150px;
-    min-width: 150px;
-    max-width: 150px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .col-140 {
     width: 140px;
     min-width: 140px;
@@ -167,6 +158,15 @@
     width: 120px;
     min-width: 120px;
     max-width: 120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-110 {
+    width: 110px;
+    min-width: 110px;
+    max-width: 110px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
@@ -53,7 +53,8 @@
             }
         }
 
-        .token-input {
+        .token-input,
+        .vp-message-id-input {
             width: 220px;
             height: 40px;
             border: 1px solid #e1e7ef;
@@ -117,8 +118,10 @@
     }
 }
 
-.col-auto {
-    width: 100%;
+.col-220 {
+    width: 220px;
+    min-width: 220px;
+    max-width: 220px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -133,6 +136,15 @@
     text-overflow: ellipsis;
 }
 
+.col-180 {
+    width: 180px;
+    min-width: 180px;
+    max-width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .col-150 {
     width: 150px;
     min-width: 150px;
@@ -142,19 +154,19 @@
     text-overflow: ellipsis;
 }
 
-.col-120 {
-    width: 120px;
-    min-width: 120px;
-    max-width: 120px;
+.col-140 {
+    width: 140px;
+    min-width: 140px;
+    max-width: 140px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.col-100 {
-    width: 100px;
-    min-width: 100px;
-    max-width: 100px;
+.col-120 {
+    width: 120px;
+    min-width: 120px;
+    max-width: 120px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -174,31 +186,30 @@
     display: block;
 }
 
-.error-text {
-    color: var(--color-error, #D32F2F);
-}
-
-.status-badge {
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 12px;
+.chip {
+    display: inline;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-family: Inter;
+    font-size: 14px;
+    font-style: normal;
     font-weight: 500;
-    white-space: nowrap;
+    line-height: 16px;
 }
 
-.status-error {
-    background: #FFE0E0;
-    color: #D32F2F;
+.chip-color-green {
+    color: #19be47;
+    background: #cafdd9;
 }
 
-.status-pending {
-    background: #FFF3E0;
-    color: #F57C00;
+.chip-color-red {
+    color: var(--color-accent-red-1, #FF432A);
+    background: var(--color-accent-red-2, #F5D7D7);
 }
 
-.status-success {
-    background: #E8F5E9;
-    color: #388E3C;
+.chip-color-yellow {
+    color: var(--color-accent-yellow-1, #DA9B22);
+    background: var(--color-accent-yellow-2, #FFF2D8);
 }
 
 .guardian-grid-container {

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.scss
@@ -1,0 +1,224 @@
+.mint-requests-container {
+    margin: 24px 48px 48px 48px;
+    position: relative;
+    overflow-y: auto;
+    padding: 5px 3px 20px 3px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .filters {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+
+        .filter-row {
+            height: 40px;
+            position: relative;
+            width: 100%;
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .filter-controls {
+            display: flex;
+            flex-direction: row;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .filter-actions {
+            display: flex;
+            flex-direction: row;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .button {
+            padding: 6px 12px;
+        }
+
+        .status-dropdown {
+            width: 180px;
+
+            &::ng-deep {
+                .p-dropdown {
+                    width: 100%;
+                    height: 40px;
+                    border: 1px solid #e1e7ef;
+                    border-radius: 8px;
+                }
+            }
+        }
+
+        .token-input {
+            width: 220px;
+            height: 40px;
+            border: 1px solid #e1e7ef;
+            border-radius: 8px;
+            padding-left: 16px;
+
+            &:hover {
+                border-color: #2196F3;
+            }
+
+            &:focus {
+                outline: 1px solid #2196F3;
+            }
+        }
+    }
+
+    .guardian-user-not-data {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        color: var(--color-grey-black-2);
+        font-family: Inter, serif;
+        font-size: 20px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 16px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        row-gap: 8px;
+        justify-content: center;
+
+        &__text {
+            color: var(--color-grey-5, #848fa9);
+            text-align: center;
+            font-family: Inter, sans-serif;
+            font-size: 16px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: normal;
+        }
+
+        &__text-strong {
+            color: var(--color-grey-5, #848fa9);
+            text-align: center;
+            font-family: Inter, sans-serif;
+            font-size: 16px;
+            font-style: normal;
+            font-weight: 600;
+            line-height: normal;
+        }
+    }
+
+    .guardian-user-page-grid {
+        height: 100%;
+        min-height: 400px;
+        width: 100%;
+        margin-top: 8px;
+        position: relative;
+    }
+}
+
+.col-auto {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-200 {
+    width: 200px;
+    min-width: 200px;
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-150 {
+    width: 150px;
+    min-width: 150px;
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-120 {
+    width: 120px;
+    min-width: 120px;
+    max-width: 120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-100 {
+    width: 100px;
+    min-width: 100px;
+    max-width: 100px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.col-80 {
+    width: 80px;
+    min-width: 80px;
+    max-width: 80px;
+    text-align: center;
+}
+
+.text-truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+}
+
+.error-text {
+    color: var(--color-error, #D32F2F);
+}
+
+.status-badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.status-error {
+    background: #FFE0E0;
+    color: #D32F2F;
+}
+
+.status-pending {
+    background: #FFF3E0;
+    color: #F57C00;
+}
+
+.status-success {
+    background: #E8F5E9;
+    color: #388E3C;
+}
+
+.guardian-grid-container {
+    ::ng-deep .guardian-grid-table {
+        .p-datatable-wrapper {
+            max-height: calc(-420px + 100vh);
+        }
+    }
+}
+
+.loading {
+    position: fixed;
+    z-index: 101;
+    top: var(--header-height);
+    left: 0;
+    bottom: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-items: center;
+    justify-content: center;
+    align-content: center;
+}

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
@@ -1,0 +1,156 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { PolicyEngineService } from 'src/app/services/policy-engine.service';
+import { DialogService } from 'primeng/dynamicdialog';
+import { CustomConfirmDialogComponent } from 'src/app/modules/common/custom-confirm-dialog/custom-confirm-dialog.component';
+
+@Component({
+    selector: 'app-mint-requests',
+    templateUrl: './mint-requests.component.html',
+    styleUrls: ['./mint-requests.component.scss'],
+})
+export class MintRequestsComponent implements OnInit, OnDestroy {
+    @Input() policyId: string;
+
+    public loading: boolean = true;
+    public page: any[] = [];
+    public pageIndex: number = 0;
+    public pageSize: number = 10;
+    public pageCount: number = 0;
+
+    public statusOptions = [
+        { label: 'All', value: '' },
+        { label: 'Pending', value: 'pending' },
+        { label: 'Error', value: 'error' },
+        { label: 'Success', value: 'success' },
+    ];
+
+    public filtersForm = new UntypedFormGroup({
+        status: new UntypedFormControl(''),
+        tokenId: new UntypedFormControl(''),
+    });
+
+    private subscription = new Subscription();
+
+    constructor(
+        private policyEngineService: PolicyEngineService,
+        private dialogService: DialogService
+    ) {}
+
+    ngOnInit() {
+        this.loadData();
+    }
+
+    ngOnDestroy(): void {
+        this.subscription.unsubscribe();
+    }
+
+    public loadData() {
+        this.loading = true;
+        const filters: any = {};
+        const status = this.filtersForm.get('status')?.value;
+        const tokenId = this.filtersForm.get('tokenId')?.value;
+        if (status) {
+            filters.status = status;
+        }
+        if (tokenId) {
+            filters.tokenId = tokenId;
+        }
+
+        this.subscription.add(
+            this.policyEngineService
+                .getMintRequests(this.policyId, filters, this.pageIndex, this.pageSize)
+                .subscribe({
+                    next: (response) => {
+                        const { page, count } = this.policyEngineService.parsePage(response);
+                        this.page = page;
+                        this.pageCount = count;
+                        setTimeout(() => {
+                            this.loading = false;
+                        }, 500);
+                    },
+                    error: () => {
+                        this.loading = false;
+                    },
+                })
+        );
+    }
+
+    public onPage(event: any) {
+        if (this.pageSize !== event.pageSize) {
+            this.pageIndex = 0;
+            this.pageSize = event.pageSize;
+        } else {
+            this.pageIndex = event.pageIndex;
+            this.pageSize = event.pageSize;
+        }
+        this.loadData();
+    }
+
+    public applyFilters() {
+        this.pageIndex = 0;
+        this.loadData();
+    }
+
+    public clearFilters() {
+        this.filtersForm.reset({ status: '', tokenId: '' });
+        this.pageIndex = 0;
+        this.loadData();
+    }
+
+    public onRetry(row: any) {
+        const dialogRef = this.dialogService.open(CustomConfirmDialogComponent, {
+            showHeader: false,
+            width: '640px',
+            styleClass: 'guardian-dialog',
+            data: {
+                header: 'Retry Mint',
+                text: `Are you sure you want to retry minting for VP ${row.vpMessageId}?`,
+                buttons: [
+                    { name: 'Cancel', class: 'secondary' },
+                    { name: 'Retry', class: 'primary' },
+                ],
+            },
+        });
+        dialogRef.onClose.subscribe((result: string) => {
+            if (result === 'Retry') {
+                this.loading = true;
+                this.policyEngineService
+                    .retryMint(this.policyId, row.vpMessageId)
+                    .subscribe({
+                        next: () => {
+                            this.loadData();
+                        },
+                        error: () => {
+                            this.loading = false;
+                        },
+                    });
+            }
+        });
+    }
+
+    public getStatusLabel(row: any): string {
+        if (row.error) {
+            return 'Error';
+        }
+        if (row.isMintNeeded) {
+            return 'Pending';
+        }
+        return 'Success';
+    }
+
+    public getStatusClass(row: any): string {
+        if (row.error) {
+            return 'status-error';
+        }
+        if (row.isMintNeeded) {
+            return 'status-pending';
+        }
+        return 'status-success';
+    }
+
+    public hasError(row: any): boolean {
+        return !!row.error;
+    }
+}

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
@@ -29,6 +29,7 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
     public filtersForm = new UntypedFormGroup({
         status: new UntypedFormControl(''),
         tokenId: new UntypedFormControl(''),
+        vpMessageId: new UntypedFormControl(''),
     });
 
     private subscription = new Subscription();
@@ -51,11 +52,15 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
         const filters: any = {};
         const status = this.filtersForm.get('status')?.value;
         const tokenId = this.filtersForm.get('tokenId')?.value;
+        const vpMessageId = this.filtersForm.get('vpMessageId')?.value;
         if (status) {
             filters.status = status;
         }
         if (tokenId) {
             filters.tokenId = tokenId;
+        }
+        if (vpMessageId) {
+            filters.vpMessageId = vpMessageId;
         }
 
         this.subscription.add(
@@ -94,7 +99,7 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
     }
 
     public clearFilters() {
-        this.filtersForm.reset({ status: '', tokenId: '' });
+        this.filtersForm.reset({ status: '', tokenId: '', vpMessageId: '' });
         this.pageIndex = 0;
         this.loadData();
     }
@@ -142,15 +147,48 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
 
     public getStatusClass(row: any): string {
         if (row.error) {
-            return 'status-error';
+            return 'chip chip-color-red';
         }
         if (row.isMintNeeded) {
-            return 'status-pending';
+            return 'chip chip-color-yellow';
         }
-        return 'status-success';
+        return 'chip chip-color-green';
     }
 
     public hasError(row: any): boolean {
         return !!row.error;
+    }
+
+    public getTokenTypeLabel(tokenType: string): string {
+        if (tokenType === 'non-fungible') {
+            return 'NFT';
+        }
+        if (tokenType === 'fungible') {
+            return 'FT';
+        }
+        return tokenType || '';
+    }
+
+    public getFormattedAmount(row: any): string {
+        if (row.amount == null) {
+            return '-';
+        }
+        return row.decimals > 0
+            ? String(row.amount / Math.pow(10, row.decimals))
+            : String(row.amount);
+    }
+
+    public getMintedDisplay(row: any): string {
+        if (row.mintedExpected == null) {
+            return '-';
+        }
+        return `${row.mintedAmount} / ${row.mintedExpected}`;
+    }
+
+    public getTransferredDisplay(row: any): string {
+        if (!row.wasTransferNeeded) {
+            return 'N/A';
+        }
+        return `${row.transferredAmount} / ${row.transferredExpected}`;
     }
 }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
@@ -41,6 +41,11 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.loadData();
+        this.subscription.add(
+            this.filtersForm.get('status')!.valueChanges.subscribe(() => {
+                this.applyFilters();
+            })
+        );
     }
 
     ngOnDestroy(): void {

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
@@ -28,7 +28,7 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
 
     public filtersForm = new UntypedFormGroup({
         status: new UntypedFormControl(''),
-        tokenId: new UntypedFormControl(''),
+        target: new UntypedFormControl(''),
         vpMessageId: new UntypedFormControl(''),
     });
 
@@ -56,13 +56,13 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
         this.loading = true;
         const filters: any = {};
         const status = this.filtersForm.get('status')?.value;
-        const tokenId = this.filtersForm.get('tokenId')?.value;
+        const target = this.filtersForm.get('target')?.value;
         const vpMessageId = this.filtersForm.get('vpMessageId')?.value;
         if (status) {
             filters.status = status;
         }
-        if (tokenId) {
-            filters.tokenId = tokenId;
+        if (target) {
+            filters.target = target;
         }
         if (vpMessageId) {
             filters.vpMessageId = vpMessageId;
@@ -104,7 +104,7 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
     }
 
     public clearFilters() {
-        this.filtersForm.reset({ status: '', tokenId: '', vpMessageId: '' });
+        this.filtersForm.reset({ status: '', target: '', vpMessageId: '' });
         this.pageIndex = 0;
         this.loadData();
     }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/mint-requests/mint-requests.component.ts
@@ -120,17 +120,10 @@ export class MintRequestsComponent implements OnInit, OnDestroy {
         });
         dialogRef.onClose.subscribe((result: string) => {
             if (result === 'Retry') {
-                this.loading = true;
                 this.policyEngineService
                     .retryMint(this.policyId, row.vpMessageId)
-                    .subscribe({
-                        next: () => {
-                            this.loadData();
-                        },
-                        error: () => {
-                            this.loading = false;
-                        },
-                    });
+                    .subscribe();
+                this.loadData();
             }
         });
     }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.html
@@ -337,6 +337,9 @@
                     <p-tabPanel [header]="'Export Documents'">
                         <app-project-data-export></app-project-data-export>
                     </p-tabPanel>
+                    <p-tabPanel *ngIf="permissions?.STANDARD_REGISTRY" [header]="'Mint Requests'">
+                        <app-mint-requests [policyId]="policyId"></app-mint-requests>
+                    </p-tabPanel>
                 </p-tabView>
             </ng-container>
             <ng-template #dryRunContent>

--- a/frontend/src/app/services/policy-engine.service.ts
+++ b/frontend/src/app/services/policy-engine.service.ts
@@ -426,6 +426,23 @@ export class PolicyEngineService {
         return this.http.get<any>(`${this.url}/${policyId}/search-documents`, { observe: 'response', params });
     }
 
+    public getMintRequests(
+        policyId: string,
+        filters: any,
+        pageIndex?: number,
+        pageSize?: number
+    ): Observable<HttpResponse<any[]>> {
+        const params = this.getOptions(filters, pageIndex, pageSize);
+        return this.http.get<any>(`${this.url}/${policyId}/mint-requests`, { observe: 'response', params });
+    }
+
+    public retryMint(
+        policyId: string,
+        vpMessageId: string
+    ): Observable<any> {
+        return this.http.post<any>(`${this.url}/${policyId}/mint/${vpMessageId}/retry`, {});
+    }
+
     public exportDocuments(
         policyId: string,
         filters: any,

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -41,6 +41,7 @@ import {
     TopicConfig,
     Users,
     VcHelper,
+    MintTransaction,
     XlsxToJson
 } from '@guardian/common';
 import {
@@ -64,6 +65,8 @@ import {
     IgnoreRule,
     SchemaStatus,
     MigrationConfig, MigrationRunStatus,
+    MintTransactionStatus,
+    TokenType,
     IPolicyDocumentationEntry
 } from '@guardian/interfaces';
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
@@ -653,11 +656,12 @@ export class PolicyEngineService {
                 policyId: string,
                 status: string,
                 tokenId: string,
+                vpMessageId: string,
                 pageIndex: string,
                 pageSize: string
             }): Promise<IMessageResponse<any>> => {
                 try {
-                    const { owner, policyId, status, tokenId, pageIndex, pageSize } = msg;
+                    const { owner, policyId, status, tokenId, vpMessageId, pageIndex, pageSize } = msg;
 
                     const parsedPageSize = parseInt(pageSize, 10) || 10;
                     const parsedPageIndex = parseInt(pageIndex, 10) || 0;
@@ -671,6 +675,10 @@ export class PolicyEngineService {
 
                     if (tokenId) {
                         filters.tokenId = tokenId;
+                    }
+
+                    if (vpMessageId) {
+                        filters.vpMessageId = vpMessageId;
                     }
 
                     if (status === 'error') {
@@ -692,7 +700,69 @@ export class PolicyEngineService {
                         }
                     );
 
-                    return new MessageResponse([items, count]);
+                    const requestIds = items.map((item: any) => item.id);
+                    const allTransactions = requestIds.length > 0
+                        ? await new DataBaseHelper(MintTransaction).find({ mintRequestId: { $in: requestIds } } as any)
+                        : [];
+
+                    const txByRequest = new Map<string, any[]>();
+                    for (const tx of allTransactions) {
+                        const key = tx.mintRequestId;
+                        if (!txByRequest.has(key)) {
+                            txByRequest.set(key, []);
+                        }
+                        txByRequest.get(key)!.push(tx);
+                    }
+
+                    const enrichedItems = items.map((item: any) => {
+                        const plain = typeof item.toJSON === 'function' ? item.toJSON() : { ...item };
+                        const transactions = txByRequest.get(plain.id) || [];
+
+                        let mintedAmount = 0;
+                        let transferredAmount = 0;
+
+                        if (plain.tokenType === TokenType.NON_FUNGIBLE) {
+                            for (const tx of transactions) {
+                                if (tx.mintStatus === MintTransactionStatus.SUCCESS && tx.serials) {
+                                    mintedAmount += tx.serials.length;
+                                }
+                                if (tx.transferStatus === MintTransactionStatus.SUCCESS && tx.serials) {
+                                    transferredAmount += tx.serials.length;
+                                }
+                            }
+                        } else {
+                            const hasSuccessMint = transactions.some(
+                                (tx: any) => tx.mintStatus === MintTransactionStatus.SUCCESS
+                            );
+                            if (hasSuccessMint) {
+                                mintedAmount = plain.decimals > 0
+                                    ? plain.amount / Math.pow(10, plain.decimals)
+                                    : plain.amount;
+                            }
+
+                            const hasSuccessTransfer = transactions.some(
+                                (tx: any) => tx.transferStatus === MintTransactionStatus.SUCCESS
+                            );
+                            if (hasSuccessTransfer) {
+                                transferredAmount = plain.decimals > 0
+                                    ? plain.amount / Math.pow(10, plain.decimals)
+                                    : plain.amount;
+                            }
+                        }
+
+                        const expectedAmount = plain.tokenType === TokenType.NON_FUNGIBLE
+                            ? plain.amount
+                            : (plain.decimals > 0 ? plain.amount / Math.pow(10, plain.decimals) : plain.amount);
+
+                        plain.mintedAmount = mintedAmount;
+                        plain.mintedExpected = expectedAmount;
+                        plain.transferredAmount = transferredAmount;
+                        plain.transferredExpected = plain.wasTransferNeeded ? expectedAmount : 0;
+
+                        return plain;
+                    });
+
+                    return new MessageResponse([enrichedItems, count]);
                 } catch (error) {
                     await logger.error(error, ['GUARDIAN_SERVICE']);
                     return new MessageError(error, error.code);

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -673,6 +673,10 @@ export class PolicyEngineService {
 
                     const filters: any = { policyId };
 
+                    if (!policy || owner.creator !== policy.creator) {
+                        filters.owner = owner.creator;
+                    }
+
                     if (target) {
                         filters.target = target;
                     }

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -623,6 +623,30 @@ export class PolicyEngineService {
                 }
             });
 
+        this.channel.getMessages<any, any>(PolicyEngineEvents.RETRY_MINT,
+            async (msg: {
+                user: IAuthUser,
+                policyId: string,
+                vpMessageId: string
+            }): Promise<IMessageResponse<any>> => {
+                try {
+                    const { user, policyId, vpMessageId } = msg;
+                    const policy = await DatabaseServer.getPolicyById(policyId);
+                    await this.policyEngine.accessPolicy(policy, new EntityOwner(user), 'execute');
+
+                    const blockData = await new GuardiansService()
+                        .sendBlockMessage(PolicyEvents.RETRY_MINT, policyId, {
+                            user,
+                            policyId,
+                            vpMessageId
+                        }, 5 * 60 * 1000) as any;
+                    return new MessageResponse(blockData);
+                } catch (error) {
+                    await logger.error(error, ['GUARDIAN_SERVICE'], msg?.user?.id);
+                    return new MessageError(error, error.code);
+                }
+            });
+
         this.channel.getMessages<any, any>(PolicyEngineEvents.BLOCK_BY_TAG,
             async (msg: {
                 user: IAuthUser,

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -635,7 +635,14 @@ export class PolicyEngineService {
                 try {
                     const { user, policyId, vpMessageId } = msg;
                     const policy = await DatabaseServer.getPolicyById(policyId);
-                    await this.policyEngine.accessPolicy(policy, new EntityOwner(user), 'execute');
+                    const owner = new EntityOwner(user);
+                    await this.policyEngine.accessPolicy(policy, owner, 'execute');
+
+                    if (!policy || owner.creator !== policy.creator) {
+                        const err: any = new Error('Only the policy owner can retry mint requests.');
+                        err.code = 403;
+                        throw err;
+                    }
 
                     const blockData = await new GuardiansService()
                         .sendBlockMessage(PolicyEvents.RETRY_MINT, policyId, {

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -655,13 +655,13 @@ export class PolicyEngineService {
                 owner: IOwner,
                 policyId: string,
                 status: string,
-                tokenId: string,
+                target: string,
                 vpMessageId: string,
                 pageIndex: string,
                 pageSize: string
             }): Promise<IMessageResponse<any>> => {
                 try {
-                    const { owner, policyId, status, tokenId, vpMessageId, pageIndex, pageSize } = msg;
+                    const { owner, policyId, status, target, vpMessageId, pageIndex, pageSize } = msg;
 
                     const parsedPageSize = parseInt(pageSize, 10) || 10;
                     const parsedPageIndex = parseInt(pageIndex, 10) || 0;
@@ -673,8 +673,8 @@ export class PolicyEngineService {
 
                     const filters: any = { policyId };
 
-                    if (tokenId) {
-                        filters.tokenId = tokenId;
+                    if (target) {
+                        filters.target = target;
                     }
 
                     if (vpMessageId) {
@@ -696,7 +696,7 @@ export class PolicyEngineService {
                         {
                             offset,
                             limit,
-                            orderBy: { processDate: 'DESC' } as any
+                            orderBy: { vpMessageId: 'DESC' } as any
                         }
                     );
 

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -647,6 +647,58 @@ export class PolicyEngineService {
                 }
             });
 
+        this.channel.getMessages<any, any>(PolicyEngineEvents.GET_MINT_REQUESTS,
+            async (msg: {
+                owner: IOwner,
+                policyId: string,
+                status: string,
+                tokenId: string,
+                pageIndex: string,
+                pageSize: string
+            }): Promise<IMessageResponse<any>> => {
+                try {
+                    const { owner, policyId, status, tokenId, pageIndex, pageSize } = msg;
+
+                    const parsedPageSize = parseInt(pageSize, 10) || 10;
+                    const parsedPageIndex = parseInt(pageIndex, 10) || 0;
+                    const offset = parsedPageIndex * parsedPageSize;
+                    const limit = parsedPageSize;
+
+                    const policy = await DatabaseServer.getPolicyById(policyId);
+                    await this.policyEngine.accessPolicy(policy, owner, 'read');
+
+                    const filters: any = { policyId };
+
+                    if (tokenId) {
+                        filters.tokenId = tokenId;
+                    }
+
+                    if (status === 'error') {
+                        filters.error = { $ne: null };
+                    } else if (status === 'pending') {
+                        filters.error = null;
+                        filters.isMintNeeded = true;
+                    } else if (status === 'success') {
+                        filters.error = null;
+                        filters.isMintNeeded = false;
+                    }
+
+                    const [items, count] = await DatabaseServer.getMintRequestsAndCount(
+                        filters,
+                        {
+                            offset,
+                            limit,
+                            orderBy: { processDate: 'DESC' } as any
+                        }
+                    );
+
+                    return new MessageResponse([items, count]);
+                } catch (error) {
+                    await logger.error(error, ['GUARDIAN_SERVICE']);
+                    return new MessageError(error, error.code);
+                }
+            });
+
         this.channel.getMessages<any, any>(PolicyEngineEvents.BLOCK_BY_TAG,
             async (msg: {
                 user: IAuthUser,

--- a/interfaces/src/type/messages/policy-engine-events.ts
+++ b/interfaces/src/type/messages/policy-engine-events.ts
@@ -126,5 +126,6 @@ export enum PolicyEngineEvents {
     GET_POLICY_REPOSITORY_SCHEMAS = 'policy-engine-policy-repository-schemas',
     CREATE_NEW_VERSION_VC_DOCUMENT = 'policy-engine-create-new-version-vc-document',
     GET_All_NEW_VERSION_VC_DOCUMENTS = 'policy-engine-get-all-new-version-vc-documents',
-    RETRY_MINT = 'policy-engine-event-retry-mint'
+    RETRY_MINT = 'policy-engine-event-retry-mint',
+    GET_MINT_REQUESTS = 'policy-engine-event-get-mint-requests'
 }

--- a/interfaces/src/type/messages/policy-engine-events.ts
+++ b/interfaces/src/type/messages/policy-engine-events.ts
@@ -125,5 +125,6 @@ export enum PolicyEngineEvents {
     GET_POLICY_REPOSITORY_DOCUMENTS = 'policy-engine-policy-repository-documents',
     GET_POLICY_REPOSITORY_SCHEMAS = 'policy-engine-policy-repository-schemas',
     CREATE_NEW_VERSION_VC_DOCUMENT = 'policy-engine-create-new-version-vc-document',
-    GET_All_NEW_VERSION_VC_DOCUMENTS = 'policy-engine-get-all-new-version-vc-documents'
+    GET_All_NEW_VERSION_VC_DOCUMENTS = 'policy-engine-get-all-new-version-vc-documents',
+    RETRY_MINT = 'policy-engine-event-retry-mint'
 }

--- a/interfaces/src/type/messages/policy-events.ts
+++ b/interfaces/src/type/messages/policy-events.ts
@@ -62,4 +62,5 @@ export enum PolicyEvents {
     GET_ALL_NEW_VERSION_VC_DOCUMENTS = 'policy-event-get-all-new-version-vc-documents',
     GET_MOCK_CONFIG = 'policy-event-get-mock-config',
     SET_MOCK_CONFIG = 'policy-event-set-mock-config',
+    RETRY_MINT = 'policy-event-retry-mint',
 }

--- a/policy-service/src/policy-engine/block-tree-generator.ts
+++ b/policy-service/src/policy-engine/block-tree-generator.ts
@@ -286,8 +286,8 @@ export class BlockTreeGenerator extends NatsService {
                 try {
                     const { user, vpMessageId } = msg;
                     const userFull = await this.getUser(policyInstance, user);
-                    await MintService.retry(vpMessageId, userFull.did, policy.owner, null, user?.id);
-                    return new MessageResponse({});
+                    const result = await MintService.retry(vpMessageId, userFull.did, policy.owner, null, user?.id, true);
+                    return new MessageResponse(result);
                 } catch (error) {
                     return new MessageError(error, error.code);
                 }

--- a/policy-service/src/policy-engine/block-tree-generator.ts
+++ b/policy-service/src/policy-engine/block-tree-generator.ts
@@ -11,6 +11,7 @@ import { RecordUtils } from './record-utils.js';
 import { PolicyBackupService, PolicyRestoreService } from './restore-service.js';
 import { PolicyActionsService } from './actions-service.js';
 import { RecordActionStep } from './record-action-step.js';
+import { MintService } from './mint/mint-service.js';
 import { PolicyVcDocumentsUtils } from './policy-vc-documents-utils.js';
 
 /**
@@ -273,6 +274,22 @@ export class BlockTreeGenerator extends NatsService {
                     }
                 } else {
                     return res;
+                }
+            });
+
+        this.getPolicyMessages(PolicyEvents.RETRY_MINT, policyId,
+            async (msg: {
+                user: IAuthUser,
+                policyId: string,
+                vpMessageId: string
+            }) => {
+                try {
+                    const { user, vpMessageId } = msg;
+                    const userFull = await this.getUser(policyInstance, user);
+                    await MintService.retry(vpMessageId, userFull.did, policy.owner, null, user?.id);
+                    return new MessageResponse({});
+                } catch (error) {
+                    return new MessageError(error, error.code);
                 }
             });
 

--- a/policy-service/src/policy-engine/mint/mint-service.ts
+++ b/policy-service/src/policy-engine/mint/mint-service.ts
@@ -52,7 +52,7 @@ export class MintService {
             treasuryKey: null,
             tokenName: token.tokenName,
         };
-        if (ref.dryRun) {
+        if (ref?.dryRun) {
             const tokenPK = PrivateKey.generate().toString();
             tokenConfig.supplyKey = tokenPK;
             tokenConfig.treasuryKey = tokenPK;

--- a/policy-service/src/policy-engine/mint/mint-service.ts
+++ b/policy-service/src/policy-engine/mint/mint-service.ts
@@ -289,8 +289,9 @@ export class MintService {
         userDId: string,
         rootDid: string,
         ref: any,
-        userId: string | null
-    ) {
+        userId: string | null,
+        detached: boolean = false
+    ): Promise<{ warnings: string[], message?: string }> {
         const db = new DatabaseServer(ref?.dryRun);
         const requests = await db.getMintRequests({
             $and: [
@@ -312,25 +313,35 @@ export class MintService {
         const policyOwnerCred = await users.getHederaAccount(rootDid, userId);
 
         let processed = false;
+        const warnings: string[] = [];
         for (const request of requests) {
-            processed ||= await MintService.retryRequest(
+            const result = await MintService.retryRequest(
                 request,
                 actor?.id,
                 policyOwner?.id,
                 policyOwnerCred,
                 documentOwner?.id,
                 ref,
-                userId
+                userId,
+                detached
             );
+            processed ||= result.processed;
+            if (result.warning) {
+                warnings.push(result.warning);
+            }
         }
 
         if (!processed) {
+            const message = `All tokens for ${vpMessageId} are minted and transferred`;
             NotificationHelper.success(
-                `All tokens for ${vpMessageId} are minted and transferred`,
+                message,
                 `Retry is not needed`,
                 ref?.dryRun ? policyOwner?.id : actor?.id
             );
+            return { warnings, message };
         }
+
+        return { warnings };
     }
 
     /**
@@ -341,7 +352,9 @@ export class MintService {
      * @param root Root
      * @param ownerId Owner identifier
      * @param ref Block ref
-     * @returns Mint or transfer is processed
+     * @returns Object with `processed` (whether a mint/transfer was kicked off
+     *          or was already active/cooling-down) and an optional `warning`
+     *          message when the request couldn't be retried right now.
      */
     public static async retryRequest(
         request: MintRequest,
@@ -350,95 +363,110 @@ export class MintService {
         policyOwnerCred: IRootConfig,
         documentOwnerId: string,
         ref: any,
-        userId: string | null
-    ) {
+        userId: string | null,
+        detached: boolean = false
+    ): Promise<{ processed: boolean, warning?: string }> {
         if (!request) {
             throw new Error('There is no mint request');
         }
         if (MintService.activeMintProcesses.has(request.id)) {
-            NotificationHelper.warn(
-                'Retry mint',
-                `Mint process for ${request.vpMessageId} is already in progress`,
-                actorId
-            );
-            return true;
+            const warning = `Mint process for ${request.vpMessageId} is already in progress`;
+            NotificationHelper.warn('Retry mint', warning, actorId);
+            return { processed: true, warning };
         }
         if (
             request.processDate &&
             Date.now() - request.processDate.getTime() <
             MintService.RETRY_MINT_INTERVAL * (60 * 1000)
         ) {
-            NotificationHelper.warn(
-                `Retry mint`,
-                `Mint process for ${request.vpMessageId
-                } can't be retried. Try after ${Math.ceil(
-                    (request.processDate.getTime() +
-                        MintService.RETRY_MINT_INTERVAL * (60 * 1000) -
-                        Date.now()) /
-                    (60 * 1000)
-                )} minutes`,
-                actorId
+            const minutes = Math.ceil(
+                (request.processDate.getTime() +
+                    MintService.RETRY_MINT_INTERVAL * (60 * 1000) -
+                    Date.now()) /
+                (60 * 1000)
             );
-            return true;
+            const warning = `Mint process for ${request.vpMessageId} can't be retried. Try after ${minutes} minutes`;
+            NotificationHelper.warn('Retry mint', warning, actorId);
+            return { processed: true, warning };
+        }
+
+        // Nothing to do — mirrors the short-circuit in TypedMint.mint().
+        // Lets detached mode surface the "all minted" message synchronously.
+        if (!request.isMintNeeded && !request.isTransferNeeded) {
+            return { processed: false };
         }
 
         MintService.activeMintProcesses.add(request.id);
-        try {
-            let token = await new DatabaseServer().getToken(request.tokenId);
-            if (!token) {
-                token = await new DatabaseServer().getToken(
-                    request.tokenId,
-                    ref
+        const runMint = async (): Promise<{ processed: boolean }> => {
+            try {
+                let token = await new DatabaseServer().getToken(request.tokenId);
+                if (!token) {
+                    token = await new DatabaseServer().getToken(
+                        request.tokenId,
+                        ref
+                    );
+                }
+                const tokenConfig: TokenConfig = await MintService.getTokenConfig(
+                    ref,
+                    token,
+                    userId
                 );
-            }
-            const tokenConfig: TokenConfig = await MintService.getTokenConfig(
-                ref,
-                token,
-                userId
-            );
-            let processed = false;
+                let processed = false;
 
-            switch (token.tokenType) {
-                case TokenType.FUNGIBLE:
-                    processed = await (
-                        await MintFT.init(
-                            request,
-                            policyOwnerCred,
-                            tokenConfig,
-                            ref,
-                            NotificationHelper.init([policyOwnerId, actorId, documentOwnerId]),
-                            actorId
-                        )
-                    ).mint({
-                        userId,
-                        interception: null
-                    });
-                    break;
-                case TokenType.NON_FUNGIBLE:
-                    processed = await (
-                        await MintNFT.init(
-                            request,
-                            policyOwnerCred,
-                            tokenConfig,
-                            ref,
-                            NotificationHelper.init([policyOwnerId, actorId, documentOwnerId]),
-                            actorId
-                        )
-                    ).mint({
-                        userId,
-                        interception: null
-                    });
-                    break;
-                default:
-                    throw new Error('Unknown token type');
-            }
+                switch (token.tokenType) {
+                    case TokenType.FUNGIBLE:
+                        processed = await (
+                            await MintFT.init(
+                                request,
+                                policyOwnerCred,
+                                tokenConfig,
+                                ref,
+                                NotificationHelper.init([policyOwnerId, actorId, documentOwnerId]),
+                                actorId
+                            )
+                        ).mint({
+                            userId,
+                            interception: null
+                        });
+                        break;
+                    case TokenType.NON_FUNGIBLE:
+                        processed = await (
+                            await MintNFT.init(
+                                request,
+                                policyOwnerCred,
+                                tokenConfig,
+                                ref,
+                                NotificationHelper.init([policyOwnerId, actorId, documentOwnerId]),
+                                actorId
+                            )
+                        ).mint({
+                            userId,
+                            interception: null
+                        });
+                        break;
+                    default:
+                        throw new Error('Unknown token type');
+                }
 
-            return processed;
-        } catch (error) {
-            throw error;
-        } finally {
-            MintService.activeMintProcesses.delete(request.id);
+                return { processed };
+            } finally {
+                MintService.activeMintProcesses.delete(request.id);
+            }
+        };
+
+        if (detached) {
+            // Fire-and-forget: return after validation; mint runs in background.
+            runMint().catch((error) => {
+                MintService.logger.error(
+                    error,
+                    ['POLICY_SERVICE', 'retryRequest', request.vpMessageId],
+                    userId
+                );
+            });
+            return { processed: true };
         }
+
+        return await runMint();
     }
 
     /**

--- a/policy-service/src/policy-engine/mint/types/typed-mint.ts
+++ b/policy-service/src/policy-engine/mint/types/typed-mint.ts
@@ -309,6 +309,7 @@ export abstract class TypedMint {
             }
 
             try {
+                this._mintRequest.error = undefined;
                 this._mintRequest.processDate = new Date();
                 await this._db.saveMintRequest(this._mintRequest);
                 await this.mintTokens(notifier, options);
@@ -378,6 +379,7 @@ export abstract class TypedMint {
             }
 
             try {
+                this._mintRequest.error = undefined;
                 this._mintRequest.processDate = new Date();
                 await this._db.saveMintRequest(this._mintRequest);
                 await this.transferTokens(notifier, options);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -18846,6 +18846,72 @@ paths:
       summary: Send data to block by UUID.
       tags:
         - policies
+  /policies/{policyId}/mint/{vpMessageId}/retry:
+    post:
+      description: >-
+        Retries failed mint/transfer operations for the specified VP message
+        within the given policy.
+      operationId: PolicyApi_retryMint
+      parameters:
+        - name: policyId
+          required: true
+          in: path
+          description: Policy Id
+          schema:
+            example: 69aeb71ef8c5b278e3bab4e5
+            type: string
+        - name: vpMessageId
+          required: true
+          in: path
+          description: VP Message Id
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation.
+        '401':
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedErrorDTO'
+              example:
+                statusCode: 401
+                message: Unauthorized request
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenErrorDTO'
+              example:
+                message: Forbidden resource
+                error: Forbidden
+                statusCode: 403
+        '422':
+          description: Unprocessable entity.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnprocessableEntityErrorDTO'
+              example:
+                statusCode: 422
+                message: Error message
+                error: Unprocessable Entity
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorDTO'
+              example:
+                statusCode: 500
+                message: Error message
+      security:
+        - bearer: []
+      summary: Retry mint by VP message ID.
+      tags:
+        - policies
   /policies/{policyId}/blocks/{uuid}/sync-events:
     post:
       description: >-

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -18865,12 +18865,14 @@ paths:
           in: query
           description: Status filter (error, pending, success)
           schema:
+            example: error
             type: string
         - name: tokenId
           required: false
           in: query
           description: Token ID filter
           schema:
+            example: 0.0.6046500
             type: string
         - name: pageIndex
           required: false
@@ -18896,6 +18898,100 @@ paths:
               schema:
                 type: integer
               description: Total items in the collection.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    amount:
+                      type: number
+                      description: Amount to mint
+                      example: 100
+                    tokenId:
+                      type: string
+                      description: Token identifier
+                      example: 0.0.6046500
+                    tokenType:
+                      type: string
+                      enum:
+                        - FUNGIBLE
+                        - NON_FUNGIBLE
+                      description: Token type
+                    target:
+                      type: string
+                      description: Target account
+                      example: 0.0.6046379
+                    vpMessageId:
+                      type: string
+                      description: VP message identifier
+                      example: '1774449622.177353801'
+                    isMintNeeded:
+                      type: boolean
+                      description: Whether minting is still needed
+                    isTransferNeeded:
+                      type: boolean
+                      description: Whether transfer is needed
+                    memo:
+                      type: string
+                      description: Transaction memo
+                    metadata:
+                      type: string
+                      nullable: true
+                      description: Metadata
+                    error:
+                      type: string
+                      nullable: true
+                      description: Error message if mint failed
+                    processDate:
+                      type: string
+                      format: date-time
+                      nullable: true
+                      description: Last process date
+                    policyId:
+                      type: string
+                      description: Associated policy ID
+                    owner:
+                      type: string
+                      nullable: true
+                      description: Owner DID
+                    id:
+                      type: string
+                      description: Mint request ID
+              example:
+                - amount: 100
+                  tokenId: 0.0.6046500
+                  tokenType: FUNGIBLE
+                  target: 0.0.6046379
+                  vpMessageId: '1774449622.177353801'
+                  isMintNeeded: false
+                  isTransferNeeded: false
+                  wasTransferNeeded: false
+                  memo: f3b2a9c1e4d5678901234567
+                  metadata: null
+                  error: null
+                  processDate: '2026-03-25T14:40:28.853Z'
+                  policyId: 69b83f18cd6b7c4adf4139bc
+                  owner: >-
+                    did:hedera:testnet:Cvzp5kKVUuipBCQjcF54fBjdicvaKsB8zHeQ6Qq22U2Z_0.0.8200599
+                  id: 69c3ff9de85d8b6ef99ef870
+                - amount: 50
+                  tokenId: 0.0.6046500
+                  tokenType: NON_FUNGIBLE
+                  target: 0.0.6046379
+                  vpMessageId: '1774449700.283746192'
+                  isMintNeeded: true
+                  isTransferNeeded: false
+                  wasTransferNeeded: false
+                  memo: a1b2c3d4e5f6789012345678
+                  metadata: null
+                  error: INSUFFICIENT_PAYER_BALANCE
+                  processDate: '2026-03-25T15:30:37.191Z'
+                  policyId: 69b83f18cd6b7c4adf4139bc
+                  owner: >-
+                    did:hedera:testnet:EthnLQfQnh8x6vKyegyekhy72oSAok6cH59pfVssKLDw_0.0.8200599
+                  id: 69c3ff9de85d8b6ef99ef871
         '401':
           description: Unauthorized request.
           content:
@@ -18948,10 +19044,14 @@ paths:
           in: path
           description: VP Message Id
           schema:
+            example: '1774449700.283746192'
             type: string
       responses:
         '200':
           description: Successful operation.
+          content:
+            application/json:
+              example: {}
         '401':
           description: Unauthorized request.
           content:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -18867,12 +18867,19 @@ paths:
           schema:
             example: error
             type: string
-        - name: tokenId
+        - name: target
           required: false
           in: query
-          description: Token ID filter
+          description: Account ID filter
           schema:
-            example: 0.0.6046500
+            example: 0.0.6046379
+            type: string
+        - name: vpMessageId
+          required: false
+          in: query
+          description: VP Message ID filter
+          schema:
+            example: '1775659196.584626142'
             type: string
         - name: pageIndex
           required: false
@@ -18959,6 +18966,21 @@ paths:
                     id:
                       type: string
                       description: Mint request ID
+                    mintedAmount:
+                      type: number
+                      description: Minted amount from successful transactions
+                    mintedExpected:
+                      type: number
+                      description: Expected total mint amount
+                    transferredAmount:
+                      type: number
+                      description: Transferred amount from successful transactions
+                    transferredExpected:
+                      type: number
+                      description: Expected total transfer amount
+                    wasTransferNeeded:
+                      type: boolean
+                      description: Whether transfer was needed
               example:
                 - amount: 100
                   tokenId: 0.0.6046500
@@ -19029,7 +19051,11 @@ paths:
     post:
       description: >-
         Retries failed mint/transfer operations for the specified VP message
-        within the given policy.
+        within the given policy. Fire-and-forget: the endpoint performs
+        synchronous validation (policy access, owner check, per-request cooldown
+        / in-progress checks) and returns as soon as validation passes; the
+        actual Hedera mint/transfer runs in the background. Poll GET
+        /policies/{policyId}/mint-requests to observe progress and final state.
       operationId: PolicyApi_retryMint
       parameters:
         - name: policyId
@@ -19048,10 +19074,34 @@ paths:
             type: string
       responses:
         '200':
-          description: Successful operation.
+          description: >-
+            Validation passed; retry has been queued (fire-and-forget).
+            `warnings` contains any per-request messages surfaced synchronously
+            during validation (e.g. cooldown or already-in-progress); an empty
+            array means every request was accepted for background processing.
+            `message` is set only when no retry was needed because every mint
+            request for the VP is already fully minted and transferred.
           content:
             application/json:
-              example: {}
+              examples:
+                queued:
+                  summary: Fresh retry accepted and queued
+                  value:
+                    warnings: []
+                cooldown:
+                  summary: Request is on cooldown after a recent attempt
+                  value:
+                    warnings:
+                      - >-
+                        Mint process for 1776887993.927747137 can't be retried.
+                        Try after 6 minutes
+                allMinted:
+                  summary: No retry needed — every mint request is complete
+                  value:
+                    warnings: []
+                    message: >-
+                      All tokens for 1776887993.927747137 are minted and
+                      transferred
         '401':
           description: Unauthorized request.
           content:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -18846,6 +18846,89 @@ paths:
       summary: Send data to block by UUID.
       tags:
         - policies
+  /policies/{policyId}/mint-requests:
+    get:
+      description: >-
+        Returns paginated mint requests for the specified policy with optional
+        filters.
+      operationId: PolicyApi_getMintRequests
+      parameters:
+        - name: policyId
+          required: true
+          in: path
+          description: Policy Id
+          schema:
+            example: 69aeb71ef8c5b278e3bab4e5
+            type: string
+        - name: status
+          required: false
+          in: query
+          description: Status filter (error, pending, success)
+          schema:
+            type: string
+        - name: tokenId
+          required: false
+          in: query
+          description: Token ID filter
+          schema:
+            type: string
+        - name: pageIndex
+          required: false
+          in: query
+          description: >-
+            The number of pages to skip before starting to collect the result
+            set
+          schema:
+            example: 0
+            type: number
+        - name: pageSize
+          required: false
+          in: query
+          description: The numbers of items to return
+          schema:
+            example: 20
+            type: number
+      responses:
+        '200':
+          description: Mint requests.
+          headers:
+            X-Total-Count:
+              schema:
+                type: integer
+              description: Total items in the collection.
+        '401':
+          description: Unauthorized request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedErrorDTO'
+              example:
+                statusCode: 401
+                message: Unauthorized request
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenErrorDTO'
+              example:
+                message: Forbidden resource
+                error: Forbidden
+                statusCode: 403
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorDTO'
+              example:
+                statusCode: 500
+                message: Error message
+      security:
+        - bearer: []
+      summary: Get mint requests for a policy.
+      tags:
+        - policies
   /policies/{policyId}/mint/{vpMessageId}/retry:
     post:
       description: >-


### PR DESCRIPTION
### Description:

Adds the Mint Event Retry feature. The policy owner gets a dedicated UI panel inside the Policy Viewer and a pair of REST endpoints to inspect these requests and retry any that failed, without resubmitting the original VP or re-running policy logic.

#### Feature summary

- Mint Requests panel in the Policy Viewer (Standard Registry only) with a paginated, filterable, sortable grid – columns for VP Message ID, Token, Token Type, Amount, Account, Minted progress (<done> / <expected>), Transferred progress, Status chip (green/yellow/red), Process Date, and per-row actions.
- Multi-criteria filtering by status (All / Pending / Error / Success – applied immediately), Account ID, and VP Message ID (applied via Apply / Clear buttons). Default sort is VP Message ID descending so newest requests appear first.
- Error visibility: failed requests show a red "Error" chip with the full error message on hover.
- One-click retry: a refresh icon on every failed row opens a confirmation dialog ("Are you sure you want to retry minting for VP {vpMessageId}?") and, on confirm, re-queues the mint/transfer pipeline for that VP. The grid refreshes so operators can watch the status and progress counts update.

The Mint Requests tab in the Policy Viewer is rendered only for Standard Registry users. Non-SR users with POLICIES_POLICY_READ can still hit GET .../mint-requests programmatically, scoped to requests they own.

#### Documentation
[mint-event-retry-docs.md](https://github.com/user-attachments/files/27027530/mint-event-retry-docs.md)

### Related issue(s):

Closes #5926

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
