### PR TITLE
fix: 5592 surface IPFS errors during profile setup

### DIFF
--- a/guardian-service/src/api/helpers/profile-helper.ts
+++ b/guardian-service/src/api/helpers/profile-helper.ts
@@ -271,7 +271,7 @@ export async function createSystemSchemas({
         return null;
     } catch (error) {
         logger.error(error, ['GUARDIAN_SERVICE'], logId);
-        return null;
+        throw error;
     }
 }
 
@@ -499,11 +499,13 @@ export async function createUserProfile({
         notifier.startStep(STEP_PUBLISH_VC);
         logger.info('Create VC Document', ['GUARDIAN_SERVICE'], logId);
 
+        if (!schemaObject) {
+            throw new Error(`System schema for entity "${entity}" not found.`);
+        }
+
         let credentialSubject: any = { ...vcDocument };
         credentialSubject.id = userDID;
-        if (schemaObject) {
-            credentialSubject = SchemaHelper.updateObjectContext(schemaObject, credentialSubject);
-        }
+        credentialSubject = SchemaHelper.updateObjectContext(schemaObject, credentialSubject);
 
         const vcObject = await vcHelper.createVerifiableCredential(credentialSubject, currentDidDocument, null, null);
         const vcMessage = new VCMessage(MessageAction.CreateVC);

--- a/guardian-service/src/api/helpers/profile-helper.ts
+++ b/guardian-service/src/api/helpers/profile-helper.ts
@@ -465,8 +465,7 @@ export async function createUserProfile({
         await dataBaseServer.update(DidDocumentCollection, null, didRow);
     } catch (error) {
         logger.error(error, ['GUARDIAN_SERVICE'], logId);
-        // didRow.status = DidDocumentStatus.FAILED;
-        // await new DataBaseHelper(DidDocumentCollection).update(didRow);
+        throw error;
     }
     notifier.completeStep(STEP_PUBLISH_DID);
     // ------------------------

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -55,18 +55,14 @@ export class QueueService extends NatsService {
                 } else {
                     task.isError = true;
                     task.errorReason = data.error;
-                    if (!task.interception) {
-                        await this.completeTaskInQueue(data.id, data.data, data.error);
-                    }
+                    await this.completeTaskInQueue(data.id, data.data, data.error);
                 }
             } else {
                 task.attempt = 0;
                 task.isError = true;
                 task.errorReason = data.error;
 
-                if (!task.interception) {
-                    await this.completeTaskInQueue(data.id, data.data, data.error);
-                }
+                await this.completeTaskInQueue(data.id, data.data, data.error);
             }
 
             await dataBaseServer.save(TaskEntity, task);

--- a/worker-service/src/api/ipfs-client-class.ts
+++ b/worker-service/src/api/ipfs-client-class.ts
@@ -64,6 +64,16 @@ export class IpfsClientClass {
     }
 
     /**
+     * Guard against an uninitialized client.
+     * @private
+     */
+    private assertClientReady(): void {
+        if (!this.client) {
+            throw new Error(`IPFS client not initialized (provider="${this.IPFS_PROVIDER}"); check IPFS_PROVIDER and credentials.`);
+        }
+    }
+
+    /**
      * Create ipfs client
      * @private
      */
@@ -121,6 +131,7 @@ export class IpfsClientClass {
      * @param beforeCallback
      */
     public async addFile(file: Buffer): Promise<string> {
+        this.assertClientReady();
         let cid: string;
         switch (this.IPFS_PROVIDER) {
             case IpfsProvider.WEB3STORAGE: {
@@ -152,6 +163,7 @@ export class IpfsClientClass {
      * @param cid
      */
     public async deleteCid(cid: string): Promise<boolean> {
+        this.assertClientReady();
         switch (this.IPFS_PROVIDER) {
             case IpfsProvider.LOCAL: {
                 await this.client.pin.rm(cid);


### PR DESCRIPTION
### Description
Fixes two user-visible failure modes when IPFS is misconfigured:

1. UI hangs indefinitely at "Publish DID Document" with no error surfaced.
2. Misleading `MISSING_PROPERTIES_IN_CONTEXT` JSON-LD error that hides the real cause.

Four chained defects are addressed:
- `IpfsClientClass` dereferences an uninitialized client. Added `assertClientReady()` guard on `addFile` / `deleteCid` so a failed client init produces a readable error instead of `TypeError: Cannot read properties of undefined (reading 'uploadFile')`. The worker process is intentionally kept alive so per-tenant misconfiguration in multi-tenant forks doesn't take the whole worker down.
- `queue-service` suppressed `TASK_COMPLETE` for user-facing tasks. Removed two `if (!task.interception)` guards so terminal failures always publish the completion event. Every call site that sets `interception` already pairs with `registerCallback: true`, and no alternate completion path exists, the guards were dormant-bug code. Awaiting `Promise`s in `addRetryableTask` / `addNonRetryableTask` now reject instead of hanging.
- `createSystemSchemas` swallowed publish errors. Rethrow instead of returning `null`. The `null` return is now reserved for the legitimate "no entity schema" case. A fail-fast guard in `createUserProfile` now throws `System schema for entity "X" not found`. when the template is missing, rather than signing a VC without `@context`.
- DID publish step silently swallowed its own error. Rethrow so profile setup aborts at the failing step instead of cascading through schema publishing and VC creation with corrupt state.

### Related issue(s):

Fixes #5992

### Notes for reviewer:
- `worker-service/src/api/ipfs-client-class.ts` – `assertClientReady()` guard added to `addFile` and `deleteCid`.
- `queue-service/src/queue-service/queue-service.ts` – removed `!task.interception` guards in the `TASK_COMPLETE` handler.
- `guardian-service/src/api/helpers/profile-helper.ts` – rethrow in `createSystemSchemas`, rethrow on DID publish failure, fail-fast guard before VC signing.

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)