### PR TITLE
fix: 5994 silent WebSocket reconnects

### DIFF
--- a/frontend/src/app/services/web-socket.service.ts
+++ b/frontend/src/app/services/web-socket.service.ts
@@ -29,12 +29,15 @@ interface MeecoApproveSubmissionResponse {
 @Injectable()
 export class WebSocketService {
     private static HEARTBEAT_DELAY = 30 * 1000;
+    private static RECONNECT_NOTIFY_AFTER_MS = 15 * 1000;
     private socket: WebSocketSubject<string> | null;
     private wsSubjectConfig: WebSocketSubjectConfig<string>;
     private socketSubscription: Subscription | null = null;
     private heartbeatTimeout: any = null;
     private reconnectInterval: number = 5000;  /// pause between connections
     private reconnectAttempts: number = 10;  /// number of connection attempts
+    private reconnectingToastId: number | null = null;
+    private reconnectNotifyTimeout: any = null;
     private servicesReady: Subject<boolean>;
     private profileSubject: Subject<{ type: string, data: any }>;
     private recordUpdateSubject: Subject<any>;
@@ -124,16 +127,54 @@ export class WebSocketService {
         this.socketSubscription = null;
         this.heartbeatTimeout = null;
         this.socket = null;
+
+        this.scheduleReconnectingNotice();
         this.reconnect();
-        this.toastr.error(this.getBaseUrl(), 'Close Web Socket', {
-            timeOut: 10000,
-            closeButton: true,
-            positionClass: 'toast-bottom-right',
-            enableHtml: true
-        });
+    }
+
+    private scheduleReconnectingNotice() {
+        if (this.reconnectNotifyTimeout !== null || this.reconnectingToastId !== null) {
+            return;
+        }
+        this.reconnectNotifyTimeout = setTimeout(() => {
+            this.reconnectNotifyTimeout = null;
+            if (this.socket) {
+                return;
+            }
+            const toast = this.toastr.info(
+                'Trying to reconnect…',
+                'Connection lost',
+                {
+                    disableTimeOut: true,
+                    tapToDismiss: false,
+                    closeButton: false,
+                    positionClass: 'toast-bottom-right',
+                }
+            );
+            this.reconnectingToastId = toast ? toast.toastId : null;
+        }, WebSocketService.RECONNECT_NOTIFY_AFTER_MS);
+    }
+
+    private clearReconnectingNotice() {
+        if (this.reconnectNotifyTimeout !== null) {
+            clearTimeout(this.reconnectNotifyTimeout);
+            this.reconnectNotifyTimeout = null;
+        }
+        if (this.reconnectingToastId !== null) {
+            this.toastr.clear(this.reconnectingToastId);
+            this.reconnectingToastId = null;
+        }
     }
 
     private openWebSocket() {
+        const wasNotified = this.reconnectingToastId !== null;
+        this.clearReconnectingNotice();
+        if (wasNotified) {
+            this.toastr.success('Connection restored', '', {
+                timeOut: 2000,
+                positionClass: 'toast-bottom-right',
+            });
+        }
         this.reconnectAttempts = 10;
     }
 
@@ -174,11 +215,25 @@ export class WebSocketService {
     private reconnect(): void {
         setTimeout(() => {
             if (this.reconnectAttempts < 0) {
+                this.notifyReconnectFailed();
                 return;
             }
             this.reconnectAttempts--;
             this.connect();
         }, this.reconnectInterval);
+    }
+
+    private notifyReconnectFailed(): void {
+        this.clearReconnectingNotice();
+        this.toastr.error(
+            'Unable to reconnect to the server. Please check your network connection and refresh the page.',
+            'Connection lost',
+            {
+                disableTimeOut: true,
+                closeButton: true,
+                positionClass: 'toast-bottom-right',
+            }
+        );
     }
 
     private _send(data: string): Promise<void> {


### PR DESCRIPTION
### Description
The frontend shows a red `Close Web Socket ws://localhost:3000` error toast every time the WebSocket connection drops – typically after tab inactivity, a quick network blip, or a backend restart. The toast fires immediately on disconnect even though the service already silently retries every 5s (up to 10 attempts). In the vast majority of cases the reconnect succeeds within a few seconds, so users see a scary toast displaying a raw developer-facing URL for an issue that has already self-healed. Multiple drops can stack toasts on top of each other.

This fix introduces a small state machine around reconnection that suppresses UI during the expected silent-retry window and only surfaces notifications when the outage is long enough to matter:

| Phase | Trigger | User sees |
|---|---|---|
| Silent retry | First ~15s after disconnect (3 attempts @ 5s) | Nothing |
| Warning | Still disconnected after grace period | Info toast: "Connection lost. Trying to reconnect…" (sticky, auto-dismissed on recovery) |
| Recovered (after warning) | `openWebSocket()` fires while warning is visible | Warning clears, brief green "Connection restored" (2s) |
| Recovered silently | Reconnect inside grace window | Nothing |
| Gave up | All 10 retries exhausted (~50s) | Error toast: "Unable to reconnect to the server. Please check your network connection and refresh the page." (persistent, close button) |

User-facing notification is now free of raw `ws://…` URLs.

### Related issue(s)

Fixes #5994 

### Notes for reviewers

- Grace period (15s) and retry count (10) are intentionally independent – if retry parameters are tuned later, the grace period still caps how long before we tell the user anything.
- The final "Unable to reconnect" toast is persistent with a close button, so it won't disappear before the user notices.

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)