### PR TITLE
fix: 5995 gate GitBook widget on HTTPS

### DIFF
--- a/frontend/src/app/views/new-header/new-header.component.html
+++ b/frontend/src/app/views/new-header/new-header.component.html
@@ -71,7 +71,11 @@
 
 <ng-template #footerBar>
     <div id="footerBar">
-        <div class="item doc-widget-toggle" (click)="toggleDocWidget()">
+        <div class="item doc-widget-toggle"
+             [class.doc-widget-toggle--disabled]="!docWidgetAvailable"
+             [pTooltip]="docWidgetAvailable ? '' : 'Documentation is only available over HTTPS'"
+             tooltipPosition="right"
+             (click)="toggleDocWidget()">
             <svg-icon
                 class="svg-icon-16 open-book-icon"
                 src="/assets/images/icons/book-open.svg"
@@ -79,10 +83,10 @@
             </svg-icon>
             <div [class.hidden-logotype]="menuCollapsed" class="span-icon">
                 <span>Documentation</span>
-                <div class="doc-toggle" [class.doc-toggle--active]="showDocWidget">
+                <div class="doc-toggle" [class.doc-toggle--active]="showDocWidget && docWidgetAvailable">
                     <div class="doc-toggle__thumb">
                         <svg-icon
-                            *ngIf="showDocWidget"
+                            *ngIf="showDocWidget && docWidgetAvailable"
                             src="/assets/images/icons/check-fill.svg"
                             class="check-fill-icon-wrapper"
                             svgClass="icon-color-secondary check-fill-icon">

--- a/frontend/src/app/views/new-header/new-header.component.scss
+++ b/frontend/src/app/views/new-header/new-header.component.scss
@@ -394,6 +394,11 @@
     cursor: pointer;
     background: #FFFFFF3D;
     border: 1px solid #FFFFFF52;
+
+    &--disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
 }
 
 .doc-toggle {

--- a/frontend/src/app/views/new-header/new-header.component.ts
+++ b/frontend/src/app/views/new-header/new-header.component.ts
@@ -31,6 +31,7 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
     public policyRequests = 0;
     public newPolicyRequests = 0;
     public showDocWidget: boolean = true;
+    public readonly docWidgetAvailable: boolean = window.location.protocol === 'https:';
 
     private commonLinksDisabled: boolean = false;
     private balanceType: string;
@@ -256,6 +257,9 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
     }
 
     public toggleDocWidget() {
+        if (!this.docWidgetAvailable) {
+            return;
+        }
         this.showDocWidget = !this.showDocWidget;
 
         try {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,403 +18,406 @@
 
 <body class="mat-typography">
     <app-root></app-root>
-    <script src="https://guardian.hedera.com/~gitbook/embed/script.js"></script>
     <script>
-        try {
-            window.GitBook('unload');
-        } catch (e) {
-            console.error(e);
-        }
-        window.GitBook('init', { siteURL: 'https://guardian.hedera.com' });
-        window.GitBook('configure', {
-            button: { label: 'See Docs', icon: 'assistant' },
-            tabs: ['assistant', 'docs']
-        });
-        window.GitBook('show');
-    </script>
-    <script>
-        const STORAGE_KEY = 'gitbook-widget-pos';
-        const BUTTON_ID = 'gitbook-widget-button';
-        const WINDOW_ID = 'gitbook-widget-window';
+        if (window.location.protocol === 'https:') {
+            const STORAGE_KEY = 'gitbook-widget-pos';
+            const BUTTON_ID = 'gitbook-widget-button';
+            const WINDOW_ID = 'gitbook-widget-window';
+            const TARGET_IFRAME_ID = 'gitbook-widget-iframe';
+            const GAP = 12;
+            const DRAG_SIZE = 3;
+            const processed = new WeakSet();
 
-        const GAP = 12;
-        const DRAG_SIZE = 3;
+            const isButtonVisible = (btn) => {
+                if (!btn || !btn.isConnected) {
+                    return false;
+                }
 
-        const isButtonVisible = (btn) => {
-            if (!btn || !btn.isConnected) {
-                return false;
-            }
+                const cs = getComputedStyle(btn);
 
-            const cs = getComputedStyle(btn);
+                if (cs.display === 'none' || cs.visibility === 'hidden' || Number(cs.opacity) === 0) {
+                    return false;
+                }
 
-            if (cs.display === 'none' || cs.visibility === 'hidden' || Number(cs.opacity) === 0) {
-                return false;
-            }
-
-            const r = btn.getBoundingClientRect();
-            return r.width > 0 && r.height > 0;
-        };
-
-        const getMin = (value, min, max) => Math.min(max, Math.max(min, value));
-
-        const setStyles = (el, styles) => {
-            for (const [prop, val] of Object.entries(styles)) {
-                el.style.setProperty(prop, String(val), 'important');
-            }
-        };
-
-        const getWindowEl = () => document.getElementById(WINDOW_ID);
-        const getButtonEl = () => document.getElementById(BUTTON_ID);
-
-        const readSavedPosition = () => {
-            try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (!raw) return null;
-                const parsed = JSON.parse(raw);
-                const x = Number(parsed?.x);
-                const y = Number(parsed?.y);
-                return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
-            } catch {
-                return null;
-            }
-        };
-
-        const savePosition = (x, y) => {
-            try {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify({ x, y }));
-            } catch (err) {
-                console.error(err);
-            }
-        };
-
-        const constrainPosition = (btn, x, y) => {
-            const rect = btn.getBoundingClientRect();
-            const viewport = { w: window.innerWidth, h: window.innerHeight };
-            
-            const maxX = viewport.w - rect.width;
-            const maxY = viewport.h - rect.height;
-            
-            return {
-                x: getMin(x, 0, maxX),
-                y: getMin(y, 0, maxY)
+                const r = btn.getBoundingClientRect();
+                return r.width > 0 && r.height > 0;
             };
-        };
 
-        const applyButtonPosition = (btn, x, y) => {
-            btn.style.position = 'fixed';
-            btn.style.right = 'auto';
-            btn.style.bottom = 'auto';
-            btn.style.left = `${x}px`;
-            btn.style.top = `${y}px`;
-        };
+            const getMin = (value, min, max) => Math.min(max, Math.max(min, value));
 
-        const getViewport = () => ({ w: window.innerWidth, h: window.innerHeight });
-
-        const getWidgetSize = (windowElement) => ({
-            w: windowElement.offsetWidth || 400,
-            h: windowElement.offsetHeight || 600,
-        });
-
-        const placeWidgetNearButton = (btn) => {
-            requestAnimationFrame(() => {
-                const windowElement = getWindowEl();
-                if (!windowElement) {
-                    return;
+            const setStyles = (el, styles) => {
+                for (const [prop, val] of Object.entries(styles)) {
+                    el.style.setProperty(prop, String(val), 'important');
                 }
+            };
 
-                if (!isButtonVisible(btn)) {
-                    return;
+            const getWindowEl = () => document.getElementById(WINDOW_ID);
+            const getButtonEl = () => document.getElementById(BUTTON_ID);
+
+            const readSavedPosition = () => {
+                try {
+                    const raw = localStorage.getItem(STORAGE_KEY);
+                    if (!raw) return null;
+                    const parsed = JSON.parse(raw);
+                    const x = Number(parsed?.x);
+                    const y = Number(parsed?.y);
+                    return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
+                } catch {
+                    return null;
                 }
+            };
 
-                setStyles(windowElement, {
-                    position: 'fixed',
-                    top: 0,
-                    left: 0,
-                    right: 'auto',
-                    bottom: 'auto',
-                    margin: 0,
+            const savePosition = (x, y) => {
+                try {
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify({ x, y }));
+                } catch (err) {
+                    console.error(err);
+                }
+            };
+
+            const constrainPosition = (btn, x, y) => {
+                const rect = btn.getBoundingClientRect();
+                const viewport = { w: window.innerWidth, h: window.innerHeight };
+
+                const maxX = viewport.w - rect.width;
+                const maxY = viewport.h - rect.height;
+
+                return {
+                    x: getMin(x, 0, maxX),
+                    y: getMin(y, 0, maxY)
+                };
+            };
+
+            const applyButtonPosition = (btn, x, y) => {
+                btn.style.position = 'fixed';
+                btn.style.right = 'auto';
+                btn.style.bottom = 'auto';
+                btn.style.left = `${x}px`;
+                btn.style.top = `${y}px`;
+            };
+
+            const getViewport = () => ({ w: window.innerWidth, h: window.innerHeight });
+
+            const getWidgetSize = (windowElement) => ({
+                w: windowElement.offsetWidth || 400,
+                h: windowElement.offsetHeight || 600,
+            });
+
+            const placeWidgetNearButton = (btn) => {
+                requestAnimationFrame(() => {
+                    const windowElement = getWindowEl();
+                    if (!windowElement) {
+                        return;
+                    }
+
+                    if (!isButtonVisible(btn)) {
+                        return;
+                    }
+
+                    setStyles(windowElement, {
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        right: 'auto',
+                        bottom: 'auto',
+                        margin: 0,
+                    });
+
+                    const { w: vw, h: vh } = getViewport();
+                    const { w: ww, h: wh } = getWidgetSize(windowElement);
+                    const r = btn.getBoundingClientRect();
+
+                    const cx = r.left + r.width / 2;
+                    const cy = r.top + r.height / 2;
+
+                    const belowTop = r.bottom + GAP;
+                    const aboveTop = r.top - GAP - wh;
+                    const rightLeft = r.right + GAP;
+                    const leftLeft = r.left - GAP - ww;
+
+                    const fitsBelow = belowTop + wh <= vh;
+                    const fitsAbove = aboveTop >= 0;
+                    const fitsRight = rightLeft + ww <= vw;
+                    const fitsLeft = leftLeft >= 0;
+
+                    const alignedLeft = getMin(r.left, 0, vw - ww);
+                    const alignedTop = getMin(r.top, 0, vh - wh);
+
+                    const preferRight = cx < vw / 2;
+                    const sideFits = preferRight ? fitsRight : fitsLeft;
+                    const sideLeft = preferRight ? rightLeft : leftLeft;
+
+                    const candidates = [];
+
+                    const push = (isPossible, left, top) => {
+                        if (!isPossible) {
+                            return;
+                        }
+
+                        candidates.push({
+                            left: getMin(left, 0, vw - ww),
+                            top: getMin(top, 0, vh - wh),
+                        });
+                    };
+
+                    if (cy < vh / 2) {
+                        push(fitsBelow, alignedLeft, belowTop);
+                        push(fitsAbove, alignedLeft, aboveTop);
+                        push(sideFits, sideLeft, alignedTop);
+                    } else {
+                        push(fitsAbove, alignedLeft, aboveTop);
+                        push(fitsBelow, alignedLeft, belowTop);
+                        push(sideFits, sideLeft, alignedTop);
+                    }
+
+                    if (candidates.length === 0) {
+                        const fallbackLeft = getMin(preferRight ? leftLeft : rightLeft, 0, vw - ww);
+                        candidates.push({ left: fallbackLeft, top: alignedTop });
+                    }
+
+                    const { left, top } = candidates[0];
+                    setStyles(windowElement, { left: `${left}px`, top: `${top}px` });
+                });
+            };
+
+            const observeWidgetVisibility = (btn, windowElement) => {
+                const observer = new MutationObserver(() => {
+                    const styles = getComputedStyle(windowElement);
+
+                    if (styles.display !== 'none' && styles.visibility !== 'hidden') {
+                        placeWidgetNearButton(btn);
+                    }
                 });
 
-                const { w: vw, h: vh } = getViewport();
-                const { w: ww, h: wh } = getWidgetSize(windowElement);
-                const r = btn.getBoundingClientRect();
+                observer.observe(windowElement, { attributes: true, attributeFilter: ['style', 'class'] });
+            };
 
-                const cx = r.left + r.width / 2;
-                const cy = r.top + r.height / 2;
+            const waitForElementById = (id, onFound) => {
+                const existing = document.getElementById(id);
 
-                const belowTop = r.bottom + GAP;
-                const aboveTop = r.top - GAP - wh;
-                const rightLeft = r.right + GAP;
-                const leftLeft = r.left - GAP - ww;
+                if (existing) {
+                    onFound(existing);
+                    return;
+                }
 
-                const fitsBelow = belowTop + wh <= vh;
-                const fitsAbove = aboveTop >= 0;
-                const fitsRight = rightLeft + ww <= vw;
-                const fitsLeft = leftLeft >= 0;
-
-                const alignedLeft = getMin(r.left, 0, vw - ww);
-                const alignedTop = getMin(r.top, 0, vh - wh);
-
-                const preferRight = cx < vw / 2;
-                const sideFits = preferRight ? fitsRight : fitsLeft;
-                const sideLeft = preferRight ? rightLeft : leftLeft;
-
-                const candidates = [];
-
-                const push = (isPossible, left, top) => {
-                    if (!isPossible) {
+                const observer = new MutationObserver(() => {
+                    const element = document.getElementById(id);
+                    if (!element) {
                         return;
                     }
+                    observer.disconnect();
+                    onFound(element);
+                });
 
-                    candidates.push({
-                        left: getMin(left, 0, vw - ww),
-                        top: getMin(top, 0, vh - wh),
-                    });
-                };
+                observer.observe(document.body, { childList: true, subtree: true });
+            };
 
-                if (cy < vh / 2) {
-                    push(fitsBelow, alignedLeft, belowTop);
-                    push(fitsAbove, alignedLeft, aboveTop);
-                    push(sideFits, sideLeft, alignedTop);
-                } else {
-                    push(fitsAbove, alignedLeft, aboveTop);
-                    push(fitsBelow, alignedLeft, belowTop);
-                    push(sideFits, sideLeft, alignedTop);
-                }
-
-                if (candidates.length === 0) {
-                    const fallbackLeft = getMin(preferRight ? leftLeft : rightLeft, 0, vw - ww);
-                    candidates.push({ left: fallbackLeft, top: alignedTop });
-                }
-
-                const { left, top } = candidates[0];
-                setStyles(windowElement, { left: `${left}px`, top: `${top}px` });
-            });
-        };
-
-        const observeWidgetVisibility = (btn, windowElement) => {
-            const observer = new MutationObserver(() => {
-                const styles = getComputedStyle(windowElement);
-
-                if (styles.display !== 'none' && styles.visibility !== 'hidden') {
-                    placeWidgetNearButton(btn);
-                }
-            });
-
-            observer.observe(windowElement, { attributes: true, attributeFilter: ['style', 'class'] });
-        };
-
-        const waitForElementById = (id, onFound) => {
-            const existing = document.getElementById(id);
-
-            if (existing) {
-                onFound(existing);
-                return;
-            }
-
-            const observer = new MutationObserver(() => {
-                const element = document.getElementById(id);
-                if (!element) {
-                    return;
-                }
-                observer.disconnect();
-                onFound(element);
-            });
-
-            observer.observe(document.body, { childList: true, subtree: true });
-        };
-
-        const setupDrag = (btn) => {
-            const rect = btn.getBoundingClientRect();
-            const startPos = constrainPosition(btn, rect.left, Math.max(0, rect.top - 50));
-            applyButtonPosition(btn, startPos.x, startPos.y);
-
-            const saved = readSavedPosition();
-            if (saved) {
-                const constrained = constrainPosition(btn, saved.x, saved.y);
-                applyButtonPosition(btn, constrained.x, constrained.y);
-            }
-
-            let dragActive = false;
-            let moved = false;
-            let clickBlockOnce = false;
-
-            let startX = 0;
-            let startY = 0;
-            let originLeft = 0;
-            let originTop = 0;
-
-            document.addEventListener(
-                'click',
-                (e) => {
-                    if (!clickBlockOnce) {
-                        return;
-                    }
-                    if (e.target === btn || btn.contains(e.target)) {
-                        clickBlockOnce = false;
-                        e.stopPropagation();
-                        e.preventDefault();
-                    }
-                },
-                true
-            );
-
-            btn.addEventListener('mousedown', (e) => {
-                e.preventDefault();
-
-                const r = btn.getBoundingClientRect();
-                startX = e.clientX;
-                startY = e.clientY;
-                originLeft = r.left;
-                originTop = r.top;
-
-                dragActive = true;
-                moved = false;
-
-                btn.style.transition = 'none';
-                btn.style.userSelect = 'none';
-            });
-
-            document.addEventListener('mousemove', (e) => {
-                if (!dragActive) {
-                    return;
-                }
-
-                const dragX = e.clientX - startX;
-                const dragY = e.clientY - startY;
-
-                if (Math.abs(dragX) <= DRAG_SIZE && Math.abs(dragY) <= DRAG_SIZE) {
-                    return;
-                }
-
-                moved = true;
-
-                const constrained = constrainPosition(btn, originLeft + dragX, originTop + dragY);
-                applyButtonPosition(btn, constrained.x, constrained.y);
-            });
-
-            document.addEventListener('mouseup', () => {
-                if (!dragActive) {
-                    return;
-                }
-
-                dragActive = false;
-                btn.style.userSelect = '';
-
-                if (!moved) {
-                    return;
-                }
-
-                clickBlockOnce = true;
-
-                const r = btn.getBoundingClientRect();
-                const finalPos = constrainPosition(btn, r.left, r.top);
-                applyButtonPosition(btn, finalPos.x, finalPos.y);
-                savePosition(finalPos.x, finalPos.y);
-            });
-        };
-
-
-        const observeButtonClasses = (btn) => {
-            const observer = new MutationObserver((mutations) => {
-                if (!btn.classList.contains('hidden')) {
-                    const rect = btn.getBoundingClientRect();
-                    const constrained = constrainPosition(btn, rect.left, rect.top);
-                    
-                    if (Math.abs(rect.left - constrained.x) > 1 || Math.abs(rect.top - constrained.y) > 1) {
-                        applyButtonPosition(btn, constrained.x - 15, constrained.y);
-                        savePosition(constrained.x, constrained.y);
-                    }
-                }
-            })
-            
-            observer.observe(btn, { 
-                attributes: true, 
-                attributeFilter: ['class'] 
-            });
-        };
-
-        const boot = (btn) => {
-            setupDrag(btn);
-            observeButtonClasses(btn);
-
-            const windowElement = getWindowEl();
-            if (windowElement) {
-                observeWidgetVisibility(btn, windowElement);
-                return;
-            }
-
-            waitForElementById(WINDOW_ID, (wEl) => observeWidgetVisibility(btn, wEl));
-        };
-
-        const start = () => waitForElementById(BUTTON_ID, boot);
-
-        if (document.readyState === 'loading') {
-            window.addEventListener('DOMContentLoaded', start, { once: true });
-        } else {
-            start();
-        }
-
-        window.addEventListener('resize', () => {
-            const btn = getButtonEl();
-            if (btn && isButtonVisible(btn)) {
+            const setupDrag = (btn) => {
                 const rect = btn.getBoundingClientRect();
-                const constrained = constrainPosition(btn, rect.left, rect.top);
-                if (Math.abs(rect.left - constrained.x) > 1 || Math.abs(rect.top - constrained.y) > 1) {
+                const startPos = constrainPosition(btn, rect.left, Math.max(0, rect.top - 50));
+                applyButtonPosition(btn, startPos.x, startPos.y);
+
+                const saved = readSavedPosition();
+                if (saved) {
+                    const constrained = constrainPosition(btn, saved.x, saved.y);
                     applyButtonPosition(btn, constrained.x, constrained.y);
-                    savePosition(constrained.x, constrained.y);
                 }
-            }
-        });
-    </script>
-    <script>
-        const TARGET_IFRAME_ID = 'gitbook-widget-iframe';
-        const processed = new WeakSet();
 
-        function ensureClipboardWritePermission(iframe) {
-            const allow = (iframe.getAttribute('allow') || '').trim();
-            const tokens = allow
-                .split(';')
-                .map((t) => t.trim())
-                .filter(Boolean);
+                let dragActive = false;
+                let moved = false;
+                let clickBlockOnce = false;
 
-            if (!tokens.includes('clipboard-write')) {
-                tokens.push('clipboard-write');
-                iframe.setAttribute('allow', tokens.join('; '));
-            }
+                let startX = 0;
+                let startY = 0;
+                let originLeft = 0;
+                let originTop = 0;
+
+                document.addEventListener(
+                    'click',
+                    (e) => {
+                        if (!clickBlockOnce) {
+                            return;
+                        }
+                        if (e.target === btn || btn.contains(e.target)) {
+                            clickBlockOnce = false;
+                            e.stopPropagation();
+                            e.preventDefault();
+                        }
+                    },
+                    true
+                );
+
+                btn.addEventListener('mousedown', (e) => {
+                    e.preventDefault();
+
+                    const r = btn.getBoundingClientRect();
+                    startX = e.clientX;
+                    startY = e.clientY;
+                    originLeft = r.left;
+                    originTop = r.top;
+
+                    dragActive = true;
+                    moved = false;
+
+                    btn.style.transition = 'none';
+                    btn.style.userSelect = 'none';
+                });
+
+                document.addEventListener('mousemove', (e) => {
+                    if (!dragActive) {
+                        return;
+                    }
+
+                    const dragX = e.clientX - startX;
+                    const dragY = e.clientY - startY;
+
+                    if (Math.abs(dragX) <= DRAG_SIZE && Math.abs(dragY) <= DRAG_SIZE) {
+                        return;
+                    }
+
+                    moved = true;
+
+                    const constrained = constrainPosition(btn, originLeft + dragX, originTop + dragY);
+                    applyButtonPosition(btn, constrained.x, constrained.y);
+                });
+
+                document.addEventListener('mouseup', () => {
+                    if (!dragActive) {
+                        return;
+                    }
+
+                    dragActive = false;
+                    btn.style.userSelect = '';
+
+                    if (!moved) {
+                        return;
+                    }
+
+                    clickBlockOnce = true;
+
+                    const r = btn.getBoundingClientRect();
+                    const finalPos = constrainPosition(btn, r.left, r.top);
+                    applyButtonPosition(btn, finalPos.x, finalPos.y);
+                    savePosition(finalPos.x, finalPos.y);
+                });
+            };
+
+            const observeButtonClasses = (btn) => {
+                const observer = new MutationObserver((mutations) => {
+                    if (!btn.classList.contains('hidden')) {
+                        const rect = btn.getBoundingClientRect();
+                        const constrained = constrainPosition(btn, rect.left, rect.top);
+
+                        if (Math.abs(rect.left - constrained.x) > 1 || Math.abs(rect.top - constrained.y) > 1) {
+                            applyButtonPosition(btn, constrained.x - 15, constrained.y);
+                            savePosition(constrained.x, constrained.y);
+                        }
+                    }
+                })
+
+                observer.observe(btn, {
+                    attributes: true,
+                    attributeFilter: ['class']
+                });
+            };
+
+            const boot = (btn) => {
+                setupDrag(btn);
+                observeButtonClasses(btn);
+
+                const windowElement = getWindowEl();
+                if (windowElement) {
+                    observeWidgetVisibility(btn, windowElement);
+                    return;
+                }
+
+                waitForElementById(WINDOW_ID, (wEl) => observeWidgetVisibility(btn, wEl));
+            };
+
+            const ensureClipboardWritePermission = (iframe) => {
+                const allow = (iframe.getAttribute('allow') || '').trim();
+                const tokens = allow
+                    .split(';')
+                    .map((t) => t.trim())
+                    .filter(Boolean);
+
+                if (!tokens.includes('clipboard-write')) {
+                    tokens.push('clipboard-write');
+                    iframe.setAttribute('allow', tokens.join('; '));
+                }
+            };
+
+            const reloadIframeByCloning = (iframe) => {
+                const clone = iframe.cloneNode(true);
+                processed.add(clone);
+                iframe.replaceWith(clone);
+            };
+
+            const patchTargetIframe = () => {
+                const el = document.getElementById(TARGET_IFRAME_ID);
+
+                if (!el || !(el instanceof HTMLIFrameElement)) {
+                    return;
+                }
+
+                if (processed.has(el)) {
+                    return;
+                }
+
+                processed.add(el);
+                ensureClipboardWritePermission(el);
+                reloadIframeByCloning(el);
+            };
+
+            const bootWidget = () => {
+                const start = () => waitForElementById(BUTTON_ID, boot);
+
+                if (document.readyState === 'loading') {
+                    window.addEventListener('DOMContentLoaded', start, { once: true });
+                } else {
+                    start();
+                }
+
+                window.addEventListener('resize', () => {
+                    const btn = getButtonEl();
+                    if (btn && isButtonVisible(btn)) {
+                        const rect = btn.getBoundingClientRect();
+                        const constrained = constrainPosition(btn, rect.left, rect.top);
+                        if (Math.abs(rect.left - constrained.x) > 1 || Math.abs(rect.top - constrained.y) > 1) {
+                            applyButtonPosition(btn, constrained.x, constrained.y);
+                            savePosition(constrained.x, constrained.y);
+                        }
+                    }
+                });
+
+                patchTargetIframe();
+                const iframeObserver = new MutationObserver(patchTargetIframe);
+                iframeObserver.observe(document.documentElement, {
+                    childList: true,
+                    subtree: true,
+                    attributes: true,
+                    attributeFilter: ['id'],
+                });
+            };
+
+            const script = document.createElement('script');
+            script.src = 'https://guardian.hedera.com/~gitbook/embed/script.js';
+            script.onload = () => {
+                try {
+                    window.GitBook('unload');
+                } catch (e) {
+                    console.error(e);
+                }
+                window.GitBook('init', { siteURL: 'https://guardian.hedera.com' });
+                window.GitBook('configure', {
+                    button: { label: 'See Docs', icon: 'assistant' },
+                    tabs: ['assistant', 'docs']
+                });
+                window.GitBook('show');
+                bootWidget();
+            };
+            document.head.appendChild(script);
         }
-
-        function reloadIframeByCloning(iframe) {
-            const clone = iframe.cloneNode(true);
-            processed.add(clone);
-            iframe.replaceWith(clone);
-        }
-
-        function patchTargetIframe() {
-            const el = document.getElementById(TARGET_IFRAME_ID);
-
-            if (!el || !(el instanceof HTMLIFrameElement)) {
-                return;
-            }
-
-            if (processed.has(el)) {
-                return;
-            }
-
-            processed.add(el);
-            ensureClipboardWritePermission(el);
-            reloadIframeByCloning(el);
-        }
-
-        patchTargetIframe();
-
-        const observer = new MutationObserver(patchTargetIframe);
-        observer.observe(document.documentElement, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-            attributeFilter: ['id'],
-        });
     </script>
 </body>
 


### PR DESCRIPTION
### Description

GitBook's embed iframe at `/~gitbook/embed/assistant` sets a `frame-ancestors` CSP that rejects HTTP parents. When the Guardian frontend is served over plain HTTP (default `docker-compose.yml` on `http://localhost:3000`), this produces a console error on every page load and an empty panel when the floating **See Docs** button is clicked.

This PR gates the GitBook widget on `window.location.protocol === 'https:'` so it only activates in environments where it can actually function.

### Related issue

Closes #5995 

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
- [x] `docker compose up` → open `http://localhost:3000`; confirm no `Refused to load …/~gitbook/embed/assistant` error in the console, no floating **See Docs** button, sidebar **Documentation** toggle is greyed out with `cursor: not-allowed` and shows the tooltip on hover; clicking it does nothing.
- [x] `docker compose -f docker-compose.yml -f docker-compose.ssl.yml up` → open `https://localhost`; confirm the **See Docs** button appears, opens a populated GitBook iframe, the sidebar toggle hides/shows the widget, and `clipboard-write` is present on the widget iframe's `allow` attribute.