### PR TITLE
fix: 6000 silence access-token refresh toasts

### DIFF
--- a/frontend/src/app/constants/http-context-tokens.ts
+++ b/frontend/src/app/constants/http-context-tokens.ts
@@ -1,0 +1,3 @@
+import { HttpContextToken } from '@angular/common/http';
+
+export const SILENT_HTTP_ERRORS = new HttpContextToken<boolean>(() => false);

--- a/frontend/src/app/constants/index.ts
+++ b/frontend/src/app/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './headers';
+export * from './http-context-tokens';
 export * from './indexed-db'

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,8 +1,9 @@
-import { HttpClient, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ISession, IStandardRegistryResponse, IUser, UserCategory, UserRole } from '@guardian/interfaces';
 import { Observable, of, Subject, Subscription } from 'rxjs';
 import { API_BASE_URL } from './api';
+import { SILENT_HTTP_ERRORS } from '../constants';
 import { map } from 'rxjs/operators';
 
 /**
@@ -46,7 +47,11 @@ export class AuthService {
     }
 
     public updateAccessToken(): Observable<any> {
-        return this.http.post<any>(`${this.url}/access-token`, { refreshToken: this.getRefreshToken() }).pipe(
+        return this.http.post<any>(
+            `${this.url}/access-token`,
+            { refreshToken: this.getRefreshToken() },
+            { context: new HttpContext().set(SILENT_HTTP_ERRORS, true) }
+        ).pipe(
             map(result => {
                 const { accessToken } = result;
                 this.setAccessToken(accessToken);

--- a/frontend/src/app/services/handle-errors.service.ts
+++ b/frontend/src/app/services/handle-errors.service.ts
@@ -5,6 +5,7 @@ import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ToastrService } from 'ngx-toastr';
 import { MessageTranslationService } from './message-translation-service/message-translation-service';
+import { SILENT_HTTP_ERRORS } from '../constants';
 // import { AuthService } from './auth.service';
 // import { AuthStateService } from './auth-state.service';
 
@@ -142,6 +143,9 @@ export class HandleErrorsService implements HttpInterceptor {
                 //     this.router.navigate(['/login']);
                 //     return throwError(error);
                 // }
+                if (req.context.get(SILENT_HTTP_ERRORS)) {
+                    return throwError(error);
+                }
                 this.getMessage(error).then((result) => {
                     this.createMessage(result, error);
                 })


### PR DESCRIPTION
### Description

`AuthStateService` polls `POST /api/v1/accounts/access-token` every 29s in the background to keep the JWT fresh. When the API gateway is unreachable, the global HTTP error interceptor (`HandleErrorsService`) catches the failure and renders a toast error with the raw HTML response body, producing a stack of giant red "502 Bad Gateway" toasts every ~29s for what is a silent housekeeping call the user never initiated.

This PR introduces a `SILENT_HTTP_ERRORS` `HttpContextToken` (in `frontend/src/app/constants/http-context-tokens.ts`) and tags the access-token refresh request with it. The error interceptor checks the token and skips toast creation when it's set; the original error still propagates through `throwError` and is logged via `console.error`. User-initiated requests are unaffected and continue to surface error toasts as before.

### Related issue(s)

Fixes #6000

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
