### PR TITLE
fix: 6004 header balance after user switch and Connect User

### DIFF
--- a/api-gateway/src/api/service/websockets.ts
+++ b/api-gateway/src/api/service/websockets.ts
@@ -356,27 +356,17 @@ export class WebSocketsService {
         });
 
         this.channel.subscribe('update-user-balance', async (msg) => {
-            this.wss.clients.forEach((client) => {
-                new Users()
-                    .getUserByAccount(msg.operatorAccountId)
-                    .then((user) => {
-                        {
-                            Object.assign(msg, {
-                                user: user
-                                    ? {
-                                        username: user.username,
-                                        did: user.did,
-                                    }
-                                    : null,
-                            });
-                            if (this.checkUserByName(client, msg)) {
-                                this.send(client, {
-                                    type: 'PROFILE_BALANCE',
-                                    data: msg,
-                                });
-                            }
-                        }
+            this.wss.clients.forEach((client: any) => {
+                const wsUser = client.user;
+                if (wsUser && wsUser.id?.toString() === msg.userId) {
+                    this.send(client, {
+                        type: 'PROFILE_BALANCE',
+                        data: {
+                            ...msg,
+                            user: { username: wsUser.username, did: wsUser.did },
+                        },
                     });
+                }
             });
 
             return new MessageResponse({});
@@ -556,22 +546,6 @@ export class WebSocketsService {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Get User by url
-     * @param client
-     * @param msg
-     * @private
-     */
-    private checkUserByName(client: any, msg: any): boolean {
-        return (
-            client &&
-            client.user &&
-            msg &&
-            msg.user &&
-            client.user.username === msg.user.username
-        );
     }
 
     /**

--- a/frontend/src/app/views/new-header/new-header.component.ts
+++ b/frontend/src/app/views/new-header/new-header.component.ts
@@ -36,6 +36,7 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
     private commonLinksDisabled: boolean = false;
     private balanceType: string;
     private balanceInit: boolean = false;
+    private lastToken: string | null = null;
     private ws!: any;
     private authSubscription!: any;
     private policyRequestsSubscription = new Subscription();
@@ -95,10 +96,12 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
             this.balanceType = '';
         });
 
+        this.lastToken = this.auth.getAccessToken();
         this.authSubscription = this.auth.subscribe((token) => {
-            if (token) {
+            if (token && !this.lastToken) {
                 this.getBalance();
             }
+            this.lastToken = token;
         });
 
         this.policyRequestsSubscription.add(
@@ -134,6 +137,12 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
             this.authSubscription = null;
         }
         this.policyRequestsSubscription.unsubscribe();
+    }
+
+    private resetBalance() {
+        this.balance = '';
+        this.balanceType = '';
+        this.balanceInit = false;
     }
 
     private getBalance() {
@@ -231,6 +240,7 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
     }
 
     public logOut() {
+        this.resetBalance();
         this.auth.removeAccessToken();
         this.auth.removeUsername();
         this.authState.updateState(false);

--- a/worker-service/src/api/helpers/hedera-sdk-helper.ts
+++ b/worker-service/src/api/helpers/hedera-sdk-helper.ts
@@ -1461,7 +1461,7 @@ export class HederaSDKHelper {
                 receipt = await this.receiptQuery(client, transaction.transactionId);
             }
             await this.transactionEndLog(id, type, userId, transaction, metadata);
-            HederaSDKHelper.transactionResponse(account);
+            HederaSDKHelper.transactionResponse(account, userId);
             return receipt;
         } catch (error) {
             await this.transactionErrorLog(id, type, transaction, error, userId);
@@ -1549,7 +1549,7 @@ export class HederaSDKHelper {
                 );
             }
             await this.transactionEndLog(id, type, userId, transaction, metadata);
-            HederaSDKHelper.transactionResponse(account);
+            HederaSDKHelper.transactionResponse(account, userId);
             return record;
         } catch (error) {
             await this.transactionErrorLog(id, type, transaction, error, userId);
@@ -1640,12 +1640,13 @@ export class HederaSDKHelper {
     /**
      * Transaction response
      * @param account
+     * @param userId
      * @private
      */
-    private static transactionResponse(account: string) {
+    private static transactionResponse(account: string, userId: string | null) {
         if (HederaSDKHelper.fn) {
             try {
-                const result = HederaSDKHelper.fn(account);
+                const result = HederaSDKHelper.fn(account, userId);
                 if (typeof result.then === 'function') {
                     result.then(null, (error) => {
                         console.error(error);

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -272,13 +272,14 @@ export class Worker extends NatsService {
             }
         });
 
-        HederaSDKHelper.setTransactionResponseCallback(async (operatorAccountId: string) => {
+        HederaSDKHelper.setTransactionResponseCallback(async (operatorAccountId: string, userId: string | null) => {
             try {
                 const balance = await HederaSDKHelper.balanceRest(operatorAccountId, HederaSDKHelper.DEFAULT_API_OPTIONS);
                 await this.sendMessage('update-user-balance', {
                     balance,
                     unit: 'Hbar',
-                    operatorAccountId
+                    operatorAccountId,
+                    userId
                 }, false);
             } catch (error) {
                 throw new Error(`Worker (${['api-gateway', 'update-user-balance'].join('.')}) send: ` + error);


### PR DESCRIPTION
### Description
Fix two distinct sidebar Hbar balance bugs – stale value after a user switch, and missing real-time updates during initial Connect User setup, so the badge reliably reflects the current user's balance across all auth-state transitions.

* Reset header balance on logout and only refetch on a `null → token` transition, skipping the redundant refetch on every 29s access-token refresh
* Forward `userId` from the worker through `HederaSDKHelper.transactionResponse` into the `update-user-balance` payload
* Match WS clients in api-gateway by `client.user.id` instead of looking up users by `hederaAccountId`, removing a per-client DB lookup and fixing the silent drop of balance updates during profile setup
* Remove the now-unused `checkUserByName` helper from the WebSocket service

### Related issue(s)

Fixes #6004

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
