### PR TITLE
fix: 5699 6009 notifications popup and sidebar interactions

### DIFF
--- a/frontend/src/app/components/notification/notification.component.html
+++ b/frontend/src/app/components/notification/notification.component.html
@@ -12,8 +12,8 @@
         <p-overlayPanel
             #notificationMenu
             appendTo="body"
-            (onShow)="menuOpened = true"
-            (onHide)="menuOpened = false"
+            (onShow)="menuOpened = true; menuOpenedChange.emit(true)"
+            (onHide)="menuOpened = false; menuOpenedChange.emit(false)"
             class="notification-menu-panel"
         >
             <div class="notification-menu">
@@ -24,8 +24,8 @@
                             class="link-btn">Mark all as read
                     </button>
                 </div>
-                <div (scroll)="onScrollNotifications($event)" *ngIf="progressNotifications.length"
-                     class="notification-list">
+                <div *ngIf="progressNotifications.length"
+                     class="notification-list notification-list--progress">
                     <div *ngFor="let notification of progressNotifications" [attr.unread]="true" class="notification">
                         <div *ngIf="notification.taskId" [routerLink]="'/task/' + notification.taskId"
                              style="display: flex; flex-direction: column; max-width: calc(100% - 32px);">
@@ -47,7 +47,7 @@
                 </div>
                 <div class="notification-menu__delimiter" *ngIf="progressNotifications.length && notifications.length">
                 </div>
-                <div class="notification-list" *ngIf="notifications.length" (scroll)="onScrollNotifications($event)">
+                <div class="notification-list notification-list--feed" *ngIf="notifications.length" (scroll)="onScrollNotifications($event)">
                     <div (click)="viewDetails($event, notification)"
                          *ngFor="let notification of notifications"
                          [attr.notificationId]="notification.id"

--- a/frontend/src/app/components/notification/notification.component.scss
+++ b/frontend/src/app/components/notification/notification.component.scss
@@ -79,6 +79,7 @@
     flex-direction: column;
     gap: 10px;
     padding: 15px 15px 5px 15px;
+    width: 360px;
 
     &__delimiter {
         width: 60%;
@@ -109,9 +110,13 @@
 
 .notification-list {
     padding: 5px;
-    max-height: 300px;
-    overflow-y: auto;
     position: relative;
+
+    &--feed {
+        max-height: 300px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
 }
 
 .link-btn {
@@ -146,7 +151,8 @@
 .progress,
 .notification {
     padding: 10px;
-    width: 300px;
+    width: auto;
+    box-sizing: border-box;
     border-radius: 8px;
     outline: 1px solid #2c78f654;
 }
@@ -173,6 +179,8 @@
     &__title {
         display: flex;
         column-gap: 8px;
+        min-width: 0;
+        overflow: hidden;
 
         span {
             color: #000;
@@ -181,6 +189,10 @@
             font-style: normal;
             font-weight: 600;
             line-height: normal;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 

--- a/frontend/src/app/components/notification/notification.component.ts
+++ b/frontend/src/app/components/notification/notification.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { NotificationType, NotifyAPI, } from '@guardian/interfaces';
 import { ToastrService } from 'ngx-toastr';
@@ -17,6 +17,8 @@ export class NotificationComponent implements OnInit {
     progressNotifications: any[] = [];
     menuOpened: boolean = false;
     subscription = new Subscription();
+
+    @Output() menuOpenedChange = new EventEmitter<boolean>();
 
     viewDetails($event: MouseEvent, notification: any) {
         if (!notification.action) {

--- a/frontend/src/app/components/notification/notification.component.ts
+++ b/frontend/src/app/components/notification/notification.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { NotificationType, NotifyAPI, } from '@guardian/interfaces';
 import { ToastrService } from 'ngx-toastr';
@@ -17,8 +17,6 @@ export class NotificationComponent implements OnInit {
     progressNotifications: any[] = [];
     menuOpened: boolean = false;
     subscription = new Subscription();
-
-    @Input() menuCollapsed: boolean;
 
     viewDetails($event: MouseEvent, notification: any) {
         if (!notification.action) {

--- a/frontend/src/app/services/web-socket.service.ts
+++ b/frontend/src/app/services/web-socket.service.ts
@@ -476,9 +476,6 @@ export class WebSocketService {
         error?: (error: any) => void,
         complete?: () => void
     ) {
-        if (this.updateNotification.observers.length > 0) {
-            this.updateNotification = new Subject();
-        }
         return this.updateNotification.subscribe(next, error, complete);
     }
 
@@ -489,9 +486,6 @@ export class WebSocketService {
         error?: (error: any) => void,
         complete?: () => void
     ) {
-        if (this.deleteNotification.observers.length > 0) {
-            this.deleteNotification = new Subject();
-        }
         return this.deleteNotification.subscribe(next, error, complete);
     }
 
@@ -502,9 +496,6 @@ export class WebSocketService {
         error?: (error: any) => void,
         complete?: () => void
     ) {
-        if (this.createProgress.observers.length > 0) {
-            this.createProgress = new Subject();
-        }
         return this.createProgress.subscribe(next, error, complete);
     }
 
@@ -515,9 +506,6 @@ export class WebSocketService {
         error?: (error: any) => void,
         complete?: () => void
     ) {
-        if (this.updateProgress.observers.length > 0) {
-            this.updateProgress = new Subject();
-        }
         return this.updateProgress.subscribe(next, error, complete);
     }
 
@@ -528,9 +516,6 @@ export class WebSocketService {
         error?: (error: any) => void,
         complete?: () => void
     ) {
-        if (this.deleteProgress.observers.length > 0) {
-            this.deleteProgress = new Subject();
-        }
         return this.deleteProgress.subscribe(next, error, complete);
     }
 

--- a/frontend/src/app/views/new-header/new-header.component.html
+++ b/frontend/src/app/views/new-header/new-header.component.html
@@ -1,18 +1,20 @@
 <ng-container *ngIf="isLogin">
-    <ng-container [ngTemplateOutlet]="remoteButton"></ng-container>
-    <div (mouseleave)="menuCollapsed = smallMenuMode" (mousemove)="menuCollapsed = false" [class.collapse]="menuCollapsed" id="navbar">
-        <ng-container [ngTemplateOutlet]="logotype"></ng-container>
-        <ng-container *ngIf="menuItems">
-            <ng-container [ngTemplateOutlet]="menuBar"></ng-container>
-            <ng-container [ngTemplateOutlet]="footerBar"></ng-container>
-        </ng-container>
+    <div (mouseleave)="onNavbarMouseLeave()" class="navbar-wrapper">
+        <ng-container [ngTemplateOutlet]="remoteButton"></ng-container>
+        <div (mousemove)="onNavbarMouseMove()" [class.collapse]="menuCollapsed" id="navbar">
+            <ng-container [ngTemplateOutlet]="logotype"></ng-container>
+            <ng-container *ngIf="menuItems">
+                <ng-container [ngTemplateOutlet]="menuBar"></ng-container>
+                <ng-container [ngTemplateOutlet]="footerBar"></ng-container>
+            </ng-container>
+        </div>
     </div>
 </ng-container>
 
 <ng-template #remoteButton>
     <div (click)="toggleMenuMode()" [class.collapse-button]="menuCollapsed"
          id="remoteButton">
-        <svg fill="none" height="14" viewBox="0 0 8 14" width="8" xmlns="http://www.w3.org/2000/svg">
+        <svg [class.rotate-180]="smallMenuMode" fill="none" height="14" viewBox="0 0 8 14" width="8" xmlns="http://www.w3.org/2000/svg">
             <path class="icon-color"
                   d="M7.28273 0.689065C6.89223 0.298565 6.25903 0.298565 5.86853 0.689065L0.981094 5.58127C0.200694 6.36247 0.201003 7.62827 0.981783 8.40907L5.87213 13.2994C6.26263 13.6899 6.89583 13.6899 7.28633 13.2994C7.67693 12.9089 7.67693 12.2757 7.28633 11.8852L3.10073 7.69956C2.71023 7.30896 2.71023 6.67587 3.10073 6.28536L7.28273 2.10326C7.67323 1.71276 7.67323 1.07956 7.28273 0.689065Z"/>
         </svg>
@@ -119,11 +121,13 @@
         >
             <img alt="" src="assets/images/icons/notification.svg">
             <div [class.hidden-logotype]="!menuCollapsed" class="collapsed-notify-counter">
-                <app-notification *ngIf="menuCollapsed"></app-notification>
+                <app-notification *ngIf="menuCollapsed"
+                                  (menuOpenedChange)="onNotificationOpenChange($event)"></app-notification>
             </div>
             <div [class.hidden-logotype]="menuCollapsed" class="span-icon">
                 <span>Notifications</span>
-                <app-notification *ngIf="!menuCollapsed"></app-notification>
+                <app-notification *ngIf="!menuCollapsed"
+                                  (menuOpenedChange)="onNotificationOpenChange($event)"></app-notification>
             </div>
         </div>
 

--- a/frontend/src/app/views/new-header/new-header.component.html
+++ b/frontend/src/app/views/new-header/new-header.component.html
@@ -119,11 +119,11 @@
         >
             <img alt="" src="assets/images/icons/notification.svg">
             <div [class.hidden-logotype]="!menuCollapsed" class="collapsed-notify-counter">
-                <app-notification [menuCollapsed]="smallMenuMode"></app-notification>
+                <app-notification *ngIf="menuCollapsed"></app-notification>
             </div>
             <div [class.hidden-logotype]="menuCollapsed" class="span-icon">
                 <span>Notifications</span>
-                <app-notification [menuCollapsed]="smallMenuMode"></app-notification>
+                <app-notification *ngIf="!menuCollapsed"></app-notification>
             </div>
         </div>
 

--- a/frontend/src/app/views/new-header/new-header.component.scss
+++ b/frontend/src/app/views/new-header/new-header.component.scss
@@ -62,7 +62,6 @@
 #remoteButton.collapse-button,
 .collapse-button {
     left: calc(var(--header-width-collapse) - 1px) !important;
-    transform: translate(-50%, -50%) rotate(180deg);
 }
 
 .collapsed-notify-counter {

--- a/frontend/src/app/views/new-header/new-header.component.ts
+++ b/frontend/src/app/views/new-header/new-header.component.ts
@@ -24,6 +24,7 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
     public balance: string = '';
     public menuCollapsed: boolean = false;
     public smallMenuMode: boolean = false;
+    public notificationOpen: boolean = false;
     public menuItems: NavbarMenuItem[];
     public activeLink: string = '';
     public activeLinkRoot: string = '';
@@ -245,6 +246,27 @@ export class NewHeaderComponent implements OnInit, AfterViewChecked {
         this.auth.removeUsername();
         this.authState.updateState(false);
         this.router.navigate(['/login']);
+    }
+
+    public onNotificationOpenChange(open: boolean) {
+        this.notificationOpen = open;
+        if (!open && this.menuCollapsed !== this.smallMenuMode) {
+            this.menuCollapsed = this.smallMenuMode;
+        }
+    }
+
+    public onNavbarMouseLeave() {
+        if (this.notificationOpen) {
+            return;
+        }
+        this.menuCollapsed = this.smallMenuMode;
+    }
+
+    public onNavbarMouseMove() {
+        if (this.notificationOpen || !this.menuCollapsed) {
+            return;
+        }
+        this.menuCollapsed = false;
     }
 
     public toggleMenuMode() {


### PR DESCRIPTION
### Description

This PR fixes several notifications popup and sidebar interaction quirks (popup scrollbars, popup disappearing on hover, pin/unpin button unreachable, misleading chevron) and removes a duplicate `<app-notification>` instance that caused intermittent badge counter drift between collapsed and expanded sidebar states.

* Render only one `<app-notification>` instance at a time via `*ngIf`
* Remove the dead `menuCollapsed` `@Input` from `NotificationComponent`
* Remove the orphan-on-second-subscriber blocks from the five notification/progress subscribe methods in `WebSocketService`
* Pin progress notifications and scroll only the regular feed
* Eliminate horizontal overflow in the popup via flexible row width, title ellipsis, and a fixed-width menu container
* Add `menuOpenedChange` output on `NotificationComponent` and gate the navbar `mouseleave`/`mousemove` on it so the popup stays alive when the cursor moves onto it
* Group the navbar and pin/unpin toggle button under a shared wrapper so the cursor can transit between them without firing `mouseleave`
* Rotate the toggle chevron based on `smallMenuMode` using the existing `.rotate-180` utility on the inner SVG, instead of the transient `menuCollapsed` hover state
* Guard `onNavbarMouseMove` against no-op assignments

### Related issue(s)

Fixes #5699, #6009 

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
