### PR TITLE
chore: Increase initial standard registry balance

### DIFF
--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -146,7 +146,7 @@ jobs:
           MIN_PASSWORD_LENGTH: 4
           PASSWORD_COMPLEXITY: easy
           INITIAL_BALANCE: 2
-          INITIAL_STANDARD_REGISTRY_BALANCE: 10
+          INITIAL_STANDARD_REGISTRY_BALANCE: 20
 
       - name: Build Cypress Docker image
         run: docker build -t cypress-runner ./e2e-tests

--- a/swagger-analytics.yaml
+++ b/swagger-analytics.yaml
@@ -215,7 +215,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.5.0
+  version: 3.5.1
   contact:
     name: API developer
     url: https://envisionblockchain.com

--- a/swagger-indexer.yaml
+++ b/swagger-indexer.yaml
@@ -3264,7 +3264,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.5.0
+  version: 3.5.1
   contact:
     name: API developer
     url: https://envisionblockchain.com

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -18302,7 +18302,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.5.0
+  version: 3.5.1
   contact:
     name: API developer
     url: https://envisionblockchain.com


### PR DESCRIPTION
Bump INITIAL_STANDARD_REGISTRY_BALANCE from 13 to 20 in .github/workflows/api-after-commit.yml. This raises the default standard registry funds used by the CI workflow to avoid tests failing due to insufficient balance.
