### PR TITLE
fix: 6017 link manually-selected tool on policy/tool import

### DIFF
--- a/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
@@ -5,7 +5,6 @@ import {
     IFormula,
     IOwner,
     IRootConfig,
-    ModuleStatus,
     PolicyTestStatus,
     PolicyToolMetadata,
     PolicyStatus,
@@ -47,6 +46,7 @@ import { SchemaImportExportHelper } from '../schema/schema-import-helper.js';
 import { importTag } from '../tag/tag-import-helper.js';
 import { ImportToolMap, ImportToolResults } from '../tool/tool-import.interface.js';
 import { importSubTools } from '../tool/tool-import-helper.js';
+import { resolveToolOverrides } from '../tool/tool-override-resolver.js';
 import { ImportTokenMap, ImportTokenResult } from '../token/token-import.interface.js';
 import { ImportArtifactResult } from '../artifact/artifact-import.interface.js';
 import { importTokensByFiles } from '../token/token-import-helper.js';
@@ -376,42 +376,8 @@ export class PolicyImport {
     ) {
         step.start();
 
-        this.toolsMapping = [];
-        const preResolvedTools: PolicyTool[] = [];
-        const toolsToImport: PolicyTool[] = [];
-        const overrides: { tool: PolicyTool, overrideMessageId: string }[] = [];
-
-        for (const tool of tools) {
-            const overrideMessageId = metadata?.tools?.[tool.messageId];
-            if (overrideMessageId && tool.messageId !== overrideMessageId) {
-                overrides.push({ tool, overrideMessageId });
-            } else {
-                toolsToImport.push(tool);
-            }
-        }
-
-        const localTools = overrides.length
-            ? await DatabaseServer.getTools({
-                messageId: { $in: overrides.map((o) => o.overrideMessageId) },
-                status: ModuleStatus.PUBLISHED
-            })
-            : [];
-        const localToolsByMessageId = new Map(localTools.map((t) => [t.messageId, t]));
-
-        for (const { tool, overrideMessageId } of overrides) {
-            this.toolsMapping.push({
-                oldMessageId: tool.messageId,
-                messageId: overrideMessageId,
-                oldHash: tool.hash,
-            });
-            const localTool = localToolsByMessageId.get(overrideMessageId);
-            if (localTool) {
-                preResolvedTools.push(localTool);
-            } else {
-                tool.messageId = overrideMessageId;
-                toolsToImport.push(tool);
-            }
-        }
+        const { toolsMapping, preResolvedTools, toolsToImport } = await resolveToolOverrides(tools, metadata);
+        this.toolsMapping = toolsMapping;
 
         this.toolsResult = await importSubTools(this.root, toolsToImport, user, step, userId);
         this.toolsResult.tools = [...preResolvedTools, ...this.toolsResult.tools];

--- a/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
@@ -5,6 +5,7 @@ import {
     IFormula,
     IOwner,
     IRootConfig,
+    ModuleStatus,
     PolicyTestStatus,
     PolicyToolMetadata,
     PolicyStatus,
@@ -376,23 +377,44 @@ export class PolicyImport {
         step.start();
 
         this.toolsMapping = [];
-        if (metadata?.tools) {
-            for (const tool of tools) {
-                if (
-                    metadata.tools[tool.messageId] &&
-                    tool.messageId !== metadata.tools[tool.messageId]
-                ) {
-                    this.toolsMapping.push({
-                        oldMessageId: tool.messageId,
-                        messageId: metadata.tools[tool.messageId],
-                        oldHash: tool.hash,
-                    });
-                    tool.messageId = metadata.tools[tool.messageId];
-                }
+        const preResolvedTools: PolicyTool[] = [];
+        const toolsToImport: PolicyTool[] = [];
+        const overrides: { tool: PolicyTool, overrideMessageId: string }[] = [];
+
+        for (const tool of tools) {
+            const overrideMessageId = metadata?.tools?.[tool.messageId];
+            if (overrideMessageId && tool.messageId !== overrideMessageId) {
+                overrides.push({ tool, overrideMessageId });
+            } else {
+                toolsToImport.push(tool);
             }
         }
 
-        this.toolsResult = await importSubTools(this.root, tools, user, step, userId);
+        const localTools = overrides.length
+            ? await DatabaseServer.getTools({
+                messageId: { $in: overrides.map((o) => o.overrideMessageId) },
+                status: ModuleStatus.PUBLISHED
+            })
+            : [];
+        const localToolsByMessageId = new Map(localTools.map((t) => [t.messageId, t]));
+
+        for (const { tool, overrideMessageId } of overrides) {
+            this.toolsMapping.push({
+                oldMessageId: tool.messageId,
+                messageId: overrideMessageId,
+                oldHash: tool.hash,
+            });
+            const localTool = localToolsByMessageId.get(overrideMessageId);
+            if (localTool) {
+                preResolvedTools.push(localTool);
+            } else {
+                tool.messageId = overrideMessageId;
+                toolsToImport.push(tool);
+            }
+        }
+
+        this.toolsResult = await importSubTools(this.root, toolsToImport, user, step, userId);
+        this.toolsResult.tools = [...preResolvedTools, ...this.toolsResult.tools];
 
         for (const toolMapping of this.toolsMapping) {
             const toolByMessageId = this.toolsResult.tools.find((tool) => tool.messageId === toolMapping.messageId);

--- a/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
@@ -3,6 +3,7 @@ import { DatabaseServer, INotificationStep, IToolComponents, MessageAction, Mess
 import { importTag } from '../tag/tag-import-helper.js';
 import { SchemaImportExportHelper } from '../schema/schema-import-helper.js';
 import { ImportToolMap, ImportToolResult, ImportToolResults } from './tool-import.interface.js';
+import { resolveToolOverrides } from './tool-override-resolver.js';
 
 /**
  * Import tools by messages
@@ -366,7 +367,7 @@ export async function importToolByFile(
     const users = new Users();
     const root = await users.getHederaAccount(user.creator, userId);
 
-    const toolsMapping: ImportToolMap[] = [];
+    const { toolsMapping, preResolvedTools, toolsToImport } = await resolveToolOverrides(tools, metadata);
 
     delete tool._id;
     delete tool.id;
@@ -438,43 +439,6 @@ export async function importToolByFile(
 
     // Import Tools
     notifier.startStep(STEP_IMPORT_SUB_SCHEMAS);
-
-    const preResolvedTools: PolicyTool[] = [];
-    const toolsToImport: PolicyTool[] = [];
-    const overrides: { subTool: PolicyTool, overrideMessageId: string }[] = [];
-
-    for (const subTool of tools) {
-        const overrideMessageId = metadata?.tools?.[subTool.messageId];
-        if (overrideMessageId && subTool.messageId !== overrideMessageId) {
-            overrides.push({ subTool, overrideMessageId });
-        } else {
-            toolsToImport.push(subTool);
-        }
-    }
-
-    const localTools = overrides.length
-        ? await DatabaseServer.getTools({
-            messageId: { $in: overrides.map((o) => o.overrideMessageId) },
-            status: ModuleStatus.PUBLISHED
-        })
-        : [];
-    const localToolsByMessageId = new Map(localTools.map((t) => [t.messageId, t]));
-
-    for (const { subTool, overrideMessageId } of overrides) {
-        toolsMapping.push({
-            oldMessageId: subTool.messageId,
-            messageId: overrideMessageId,
-            oldHash: subTool.hash,
-        });
-        const localTool = localToolsByMessageId.get(overrideMessageId);
-        if (localTool) {
-            preResolvedTools.push(localTool);
-        } else {
-            subTool.messageId = overrideMessageId;
-            toolsToImport.push(subTool);
-        }
-    }
-
     const toolsResult = await importSubTools(
         root,
         toolsToImport,

--- a/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
@@ -366,28 +366,7 @@ export async function importToolByFile(
     const users = new Users();
     const root = await users.getHederaAccount(user.creator, userId);
 
-    const toolsMapping: {
-        oldMessageId: string;
-        messageId: string;
-        oldHash: string;
-        newHash?: string;
-    }[] = [];
-    if (metadata?.tools) {
-        // tslint:disable-next-line:no-shadowed-variable
-        for (const tool of tools) {
-            if (
-                metadata.tools[tool.messageId] &&
-                tool.messageId !== metadata.tools[tool.messageId]
-            ) {
-                toolsMapping.push({
-                    oldMessageId: tool.messageId,
-                    messageId: metadata.tools[tool.messageId],
-                    oldHash: tool.hash,
-                });
-                tool.messageId = metadata.tools[tool.messageId];
-            }
-        }
-    }
+    const toolsMapping: ImportToolMap[] = [];
 
     delete tool._id;
     delete tool.id;
@@ -459,18 +438,55 @@ export async function importToolByFile(
 
     // Import Tools
     notifier.startStep(STEP_IMPORT_SUB_SCHEMAS);
+
+    const preResolvedTools: PolicyTool[] = [];
+    const toolsToImport: PolicyTool[] = [];
+    const overrides: { subTool: PolicyTool, overrideMessageId: string }[] = [];
+
+    for (const subTool of tools) {
+        const overrideMessageId = metadata?.tools?.[subTool.messageId];
+        if (overrideMessageId && subTool.messageId !== overrideMessageId) {
+            overrides.push({ subTool, overrideMessageId });
+        } else {
+            toolsToImport.push(subTool);
+        }
+    }
+
+    const localTools = overrides.length
+        ? await DatabaseServer.getTools({
+            messageId: { $in: overrides.map((o) => o.overrideMessageId) },
+            status: ModuleStatus.PUBLISHED
+        })
+        : [];
+    const localToolsByMessageId = new Map(localTools.map((t) => [t.messageId, t]));
+
+    for (const { subTool, overrideMessageId } of overrides) {
+        toolsMapping.push({
+            oldMessageId: subTool.messageId,
+            messageId: overrideMessageId,
+            oldHash: subTool.hash,
+        });
+        const localTool = localToolsByMessageId.get(overrideMessageId);
+        if (localTool) {
+            preResolvedTools.push(localTool);
+        } else {
+            subTool.messageId = overrideMessageId;
+            toolsToImport.push(subTool);
+        }
+    }
+
     const toolsResult = await importSubTools(
         root,
-        tools,
+        toolsToImport,
         user,
         notifier.getStep(STEP_IMPORT_SUB_SCHEMAS),
         userId
     );
+    toolsResult.tools = [...preResolvedTools, ...toolsResult.tools];
 
     for (const toolMapping of toolsMapping) {
         const toolByMessageId = toolsResult.tools.find(
-            // tslint:disable-next-line:no-shadowed-variable
-            (tool) => tool.messageId === toolMapping.messageId
+            (t) => t.messageId === toolMapping.messageId
         );
         toolMapping.newHash = toolByMessageId?.hash;
     }
@@ -508,6 +524,7 @@ export async function importToolByFile(
 
     // Replace id
     await replaceConfig(tool, schemasMap, toolsMapping);
+    await updateToolConfig(tool);
 
     const item = await DatabaseServer.createTool(tool);
     const _topicRow = await DatabaseServer.getTopicById(topic.topicId);

--- a/guardian-service/src/helpers/import-helpers/tool/tool-override-resolver.ts
+++ b/guardian-service/src/helpers/import-helpers/tool/tool-override-resolver.ts
@@ -1,0 +1,60 @@
+import { ModuleStatus, PolicyToolMetadata } from '@guardian/interfaces';
+import { DatabaseServer, PolicyTool } from '@guardian/common';
+import { ImportToolMap } from './tool-import.interface.js';
+
+/**
+ * Resolve user-provided tool messageId overrides against the local DB.
+ *
+ * For each tool whose messageId is remapped via `metadata.tools`, look up the
+ * target tool locally (status `PUBLISHED`). Pre-resolved tools are returned
+ * separately so callers can skip the IPFS round-trip in `importSubTools` —
+ * which would otherwise fail the strict hash/owner equality check inside
+ * `importToolByMessage` for tools the user has explicitly chosen.
+ */
+export async function resolveToolOverrides(
+    tools: PolicyTool[],
+    metadata: PolicyToolMetadata | null
+): Promise<{
+    toolsMapping: ImportToolMap[];
+    preResolvedTools: PolicyTool[];
+    toolsToImport: PolicyTool[];
+}> {
+    const toolsMapping: ImportToolMap[] = [];
+    const preResolvedTools: PolicyTool[] = [];
+    const toolsToImport: PolicyTool[] = [];
+    const overrides: { tool: PolicyTool, overrideMessageId: string }[] = [];
+
+    for (const tool of tools) {
+        const overrideMessageId = metadata?.tools?.[tool.messageId];
+        if (overrideMessageId && tool.messageId !== overrideMessageId) {
+            overrides.push({ tool, overrideMessageId });
+        } else {
+            toolsToImport.push(tool);
+        }
+    }
+
+    const localTools = overrides.length
+        ? await DatabaseServer.getTools({
+            messageId: { $in: overrides.map((o) => o.overrideMessageId) },
+            status: ModuleStatus.PUBLISHED
+        })
+        : [];
+    const localToolsByMessageId = new Map(localTools.map((t) => [t.messageId, t]));
+
+    for (const { tool, overrideMessageId } of overrides) {
+        toolsMapping.push({
+            oldMessageId: tool.messageId,
+            messageId: overrideMessageId,
+            oldHash: tool.hash,
+        });
+        const localTool = localToolsByMessageId.get(overrideMessageId);
+        if (localTool) {
+            preResolvedTools.push(localTool);
+        } else {
+            tool.messageId = overrideMessageId;
+            toolsToImport.push(tool);
+        }
+    }
+
+    return { toolsMapping, preResolvedTools, toolsToImport };
+}


### PR DESCRIPTION
### Description

When importing a policy or tool, if a nested tool is not found by message ID the user can manually select a local equivalent via the import dialog. Previously the override was ignored, the policy config and schema references still pointed at the foreign tool, causing import errors and Validate failures.

* Resolve manually-overridden tools from the local database instead of re-fetching from IPFS
* Rewrite tool block `messageId` and `hash` in policy config to point at the locally-selected tool
* Rewrite policy schema `$defs` IRIs to reference the local tool's schemas
* Extract shared `resolveToolOverrides` helper used by both policy-import and tool-import paths
* Re-run `updateToolConfig` after config rewrite so nested tool descriptors reflect updated references

### Related issue(s)

Fixes #6017 

### Checklist

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)