### PR TITLE
feat: expose schemaId on /policies/{id}/about entries

### DIFF
--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -1,7 +1,7 @@
 import { Auth, AuthUser } from '#auth';
 import { CACHE, POLICY_REQUIRED_PROPS, PREFIXES } from '#constants';
 import { AnyFilesInterceptor, CacheService, EntityOwner, getCacheKey, InternalException, ONLY_SR, PolicyEngine, ProjectService, ServiceError, TaskManager, UploadedFiles, UseCache, parseSavepointIdsJson, FilenameSanitizer } from '#helpers';
-import { IAuthUser, MockType, PinoLogger, RunFunctionAsync } from '@guardian/common';
+import { findBlocks, IAuthUser, MockType, PinoLogger, RunFunctionAsync } from '@guardian/common';
 import { DocumentType, MigrationRunStatus, Permissions, PolicyHelper, PolicyStatus, TaskAction, UserRole } from '@guardian/interfaces';
 import {
     Body,
@@ -1486,10 +1486,18 @@ export class PolicyApi {
                     { name: 'filterByUUID', type: 'string', description: 'Filter by document UUID' },
                 ],
             };
+            const schemaByTag = new Map<string, string>(
+                entries.length
+                    ? findBlocks(policy.config, (node: any) => !!(node.tag && node.schema))
+                        .map((block: any) => [block.tag, block.schema])
+                    : []
+            );
             return entries.map((entry: any) => {
                 const getParams = getParamsByBlockType[entry.blockType] || [];
+                const schemaId = schemaByTag.get(entry.target);
                 return {
                     ...entry,
+                    ...(schemaId ? { schemaId } : {}),
                     getQueryParams: entry.method !== 'POST' ? getParams : [],
                     postQueryParams: entry.method !== 'GET' ? postParams : [],
                 };

--- a/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
+++ b/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
@@ -135,6 +135,8 @@ Authorization: Bearer <token>
 
 Returns the configured documentation entries.
 
+When the target block references a schema (e.g. `requestVcDocumentBlock`, `documentValidatorBlock`), the entry includes a `schemaId` field with the schema's IRI. The field is omitted for blocks that don't reference a schema.
+
 **Response example:**
 
 ```json
@@ -156,6 +158,18 @@ Returns the configured documentation entries.
       { "name": "filterByUUID",  "type": "string",   "description": "Filter by document UUID" },
       { "name": "savepointIds",  "type": "string[]", "description": "Savepoint IDs filter (JSON array)" }
     ]
+  },
+  {
+    "name": "Create Application",
+    "description": "Submit a new applicant registration",
+    "target": "create_application",
+    "method": "POST",
+    "alias": "create-application",
+    "url": "/api/v1/policies/69c3dbe9a4d2ac84f75cdfc4/tag/create_application/blocks",
+    "dmrvUrl": "/api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/create-application",
+    "blockType": "requestVcDocumentBlock",
+    "schemaId": "#9bd1c75b-76df-4d3c-8775-1f76d18d7d8c",
+    "queryParams": []
   }
 ]
 ```

--- a/interfaces/src/interface/policy.interface.ts
+++ b/interfaces/src/interface/policy.interface.ts
@@ -34,6 +34,10 @@ export interface IPolicyDocumentationEntry {
    * Block type (auto-populated for query params display)
    */
   blockType?: string;
+  /**
+   * Schema IRI bound to the target block (auto-populated by /about)
+   */
+  schemaId?: string;
 }
 
 /**


### PR DESCRIPTION
### Description

- Walk `policy.config` in `getPolicyDocumentation` to map block tag → top-level `schema` field and attach the resulting IRI to each alias entry as `schemaId` (omitted when the target block has no schema).
- Reuse `findBlocks` from `@guardian/common` for the traversal; skip the walk entirely when there are no documented entries.
- Add `schemaId?: string` to `IPolicyDocumentationEntry`.
- Refresh `docs/guardian/policy-api-documentation-and-dmrv-aliases.md` with a note and a second response example covering the new field.