### PR TITLE
feat: convert cid v0 to v1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "mathjs": "^14.4.0",
         "mathlive": "^0.103.0",
         "moment": "^2.29.2",
+        "multiformats": "^9.9.0",
         "ngx-colors": "3.6.0",
         "ngx-drag-drop": "^18.0.2",
         "ngx-file-drop": "^16.0.0",
@@ -10968,6 +10969,12 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "mathjs": "^14.4.0",
     "mathlive": "^0.103.0",
     "moment": "^2.29.2",
+    "multiformats": "^9.9.0",
     "ngx-colors": "3.6.0",
     "ngx-drag-drop": "^18.0.2",
     "ngx-file-drop": "^16.0.0",

--- a/frontend/src/app/modules/policy-engine/policy-viewer/code/ipfs-transformation-ui-addon.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/code/ipfs-transformation-ui-addon.ts
@@ -2,6 +2,7 @@ import { IPFSService } from "src/app/services/ipfs.service";
 import { firstValueFrom } from 'rxjs';
 import { fileTypeFromBuffer } from 'file-type';
 import { PolicyEngineService } from "src/app/services/policy-engine.service";
+import { CID } from 'multiformats/cid';
 
 interface DocumentData {
     document: any;
@@ -95,7 +96,16 @@ export class IpfsTransformationUIAddonCode {
             return ipfsString;
         }
 
-        const cid = match[1];
+        const rawCid = match[1];
+        let cid = rawCid;
+
+        if (!this.dryRun) {
+            try {
+                cid = CID.parse(rawCid).toV1().toString();
+            } catch (error) {
+                console.warn(`Skipping CID v1 conversion for "${rawCid}":`, error);
+            }
+        }
 
         if (this.transformationType === TransformationIpfsLinkType.IpfsGateway) {
             return this.convertToIpfsGateway(cid);


### PR DESCRIPTION
### Description
- Normalize IPFS CIDs to v1 (base32) before building gateway URLs or fetching base64 content, so links resolve consistently regardless of which CID form a document carries.
- Skip the conversion in dry-run mode, where mock CIDs are not real and cannot be re-encoded.
- Use the actively-maintained `multiformats` package directly instead of the deprecated `cids` package.
- Fall back to the original CID if parsing fails, so a malformed input no longer aborts the whole document render.