### PR TITLE
chore: bump mathjs to 15.2.0

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -37,7 +37,7 @@
         "jszip": "^3.7.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
-        "mathjs": "^14.4.0",
+        "mathjs": "^15.2.0",
         "moment": "^2.29.2",
         "mongodb": "6.16.0",
         "nats": "^2.6.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "js-yaml": "^4.1.0",
         "leader-line": "^1.0.7",
         "mark.js": "^8.11.1",
-        "mathjs": "^14.4.0",
+        "mathjs": "^15.2.0",
         "mathlive": "^0.103.0",
         "moment": "^2.29.2",
         "ngx-colors": "3.6.0",
@@ -10441,9 +10441,9 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "14.9.1",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.9.1.tgz",
-      "integrity": "sha512-xhqv8Xjf+caWG3WlaPekg4v8QFOR3D5+8ycfcjMcPcnCNDgAONQLaLfyGgrggJrcHx2yUGCpACRpiD4GmXwX+Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "^4.1.0",
     "leader-line": "^1.0.7",
     "mark.js": "^8.11.1",
-    "mathjs": "^14.4.0",
+    "mathjs": "^15.2.0",
     "mathlive": "^0.103.0",
     "moment": "^2.29.2",
     "ngx-colors": "3.6.0",

--- a/guardian-service/package.json
+++ b/guardian-service/package.json
@@ -33,7 +33,7 @@
         "fs-extra": "^10.0.0",
         "imurmurhash": "^0.1.4",
         "jszip": "^3.7.1",
-        "mathjs": "^14.4.0",
+        "mathjs": "^15.2.0",
         "module-alias": "^2.2.2",
         "mongodb": "6.16.0",
         "prom-client": "^14.1.1",

--- a/policy-service/package.json
+++ b/policy-service/package.json
@@ -29,7 +29,7 @@
         "express": "^5.1.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
-        "mathjs": "^14.4.0",
+        "mathjs": "^15.2.0",
         "module-alias": "^2.2.2",
         "moment": "^2.29.2",
         "prom-client": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9862,10 +9862,10 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-mathjs@^14.4.0:
-  version "14.9.1"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-14.9.1.tgz#cba4403b1bef0d0302a2c814ae6b2b7763a526c8"
-  integrity sha512-xhqv8Xjf+caWG3WlaPekg4v8QFOR3D5+8ycfcjMcPcnCNDgAONQLaLfyGgrggJrcHx2yUGCpACRpiD4GmXwX+Q==
+mathjs@^15.2.0:
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-15.2.0.tgz#ddfbf50a9aeaec2edfb524195e8202ca29f8e757"
+  integrity sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==
   dependencies:
     "@babel/runtime" "^7.26.10"
     complex.js "^2.2.5"


### PR DESCRIPTION
### Description

- Bump `mathjs` from `^14.4.0` to `^15.2.0` in `common`, `guardian-service`, `policy-service`, and `frontend`.
- Refresh `yarn.lock` (workspaces) and `frontend/package-lock.json` (frontend uses npm separately).

mathjs 15.0 introduces five breaking changes; checked against this codebase:
- Unary `%` precedence raised, `%` followed by a term re-parsed, and hex/bin/oct literals require a delimiter — affect parsing of customer-authored policy formulas. Repo code does not author such expressions.
- `size()` always returns `Array`, and `flatten(SparseMatrix)` now throws — no exposure (no `size`/`flatten` calls and no `SparseMatrix` usage in the repo).

Verified `tsc` builds for `@guardian/interfaces`, `@guardian/common`, `guardian-service`, `policy-service`, and the Angular `npm run build` for the frontend with no issues.
Worth a regression pass on existing policy-engine and xlsx test fixtures.