### PR TITLE
feat: 5928 extend CE math engine with custom lookup and string comparison

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/field-link.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/field-link.ts
@@ -102,7 +102,7 @@ export class FieldLink {
         this._update();
     }
 
-    public getLatex(): any {
+    public getLatex(): string | unknown[] | null {
         if (this.invalid) {
             return null;
         }

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/field-link.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/field-link.ts
@@ -102,7 +102,7 @@ export class FieldLink {
         this._update();
     }
 
-    public getLatex(): string | null {
+    public getLatex(): any {
         if (this.invalid) {
             return null;
         }

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
@@ -114,12 +114,12 @@ describe('Lookup (CE integration)', () => {
         expect(result.value).toBe(20);
     });
 
-    it('returns NaN when key is not found', () => {
+    it('returns 0 when key is not found', () => {
         const result = call(ce, 'Lookup',
             numList(ce, [10, 20]),
             strList(ce, ['a', 'b']),
             ce.string('z'));
-        expect(Number.isNaN(result.value as number)).toBeTrue();
+        expect(result.value).toBe(0);
     });
 
     it('returns 0 when matched value is not numeric', () => {
@@ -127,7 +127,7 @@ describe('Lookup (CE integration)', () => {
             ce.box(['List', ce.string('not-a-number')]),
             strList(ce, ['k']),
             ce.string('k'));
-        expect(result.value).toBeNaN();
+        expect(result.value).toBe(0);
     });
 
     it('matches via numeric coercion: key 5 matches id "5"', () => {
@@ -152,20 +152,20 @@ describe('LookupTwo (CE integration)', () => {
         expect(result.value).toBe(20);
     });
 
-    it('returns NaN when first key matches but second does not', () => {
+    it('returns 0 when first key matches but second does not', () => {
         const result = call(ce, 'LookupTwo',
             numList(ce, [10, 20]),
             strList(ce, ['a', 'a']), ce.string('a'),
             strList(ce, ['x', 'x']), ce.string('y'));
-        expect(Number.isNaN(result.value as number)).toBeTrue();
+        expect(result.value).toBe(0);
     });
 
-    it('returns NaN when value and key array lengths differ', () => {
+    it('returns 0 when value and key array lengths differ', () => {
         const result = call(ce, 'LookupTwo',
             numList(ce, [10, 20]),
             strList(ce, ['a']),       ce.string('a'),
             strList(ce, ['x', 'y']), ce.string('x'));
-        expect(Number.isNaN(result.value as number)).toBeTrue();
+        expect(result.value).toBe(0);
     });
 });
 
@@ -184,13 +184,13 @@ describe('LookupMin (CE integration)', () => {
         expect(result.value).toBe(20);
     });
 
-    it('returns NaN when no key matches', () => {
+    it('returns 0 when no key matches', () => {
         const result = call(ce, 'LookupMin',
             numList(ce, [10]),
             strList(ce, ['a']),
             ce.string('z'),
             numList(ce, [1]));
-        expect(Number.isNaN(result.value as number)).toBeTrue();
+        expect(result.value).toBe(0);
     });
 });
 
@@ -209,13 +209,13 @@ describe('LookupMax (CE integration)', () => {
         expect(result.value).toBe(10);
     });
 
-    it('returns NaN when no key matches', () => {
+    it('returns 0 when no key matches', () => {
         const result = call(ce, 'LookupMax',
             numList(ce, [10]),
             strList(ce, ['a']),
             ce.string('z'),
             numList(ce, [1]));
-        expect(Number.isNaN(result.value as number)).toBeTrue();
+        expect(result.value).toBe(0);
     });
 });
 

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
@@ -127,7 +127,7 @@ describe('Lookup (CE integration)', () => {
             ce.box(['List', ce.string('not-a-number')]),
             strList(ce, ['k']),
             ce.string('k'));
-        expect(result.value).toBe(0);
+        expect(result.value).toBeNaN();
     });
 
     it('matches via numeric coercion: key 5 matches id "5"', () => {

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.spec.ts
@@ -1,0 +1,243 @@
+import { ComputeEngine } from '@cortex-js/compute-engine';
+import { getList, getString, getNumber, registerCEFunctions } from './math-context';
+
+function makeTestCe(): ComputeEngine {
+    const ce = new ComputeEngine();
+    registerCEFunctions(ce);
+    return ce;
+}
+
+// ─── getList ──────────────────────────────────────────────────────────────────
+describe('getList', () => {
+    it('returns [] for undefined', () => {
+        expect(getList(undefined)).toEqual([]);
+    });
+
+    it('returns [] for null', () => {
+        expect(getList(null)).toEqual([]);
+    });
+
+    it('returns expr.ops when present', () => {
+        const ops = [1, 2, 3];
+        expect(getList({ ops })).toBe(ops);
+    });
+
+    it('collects items via expr.each() when ops is absent', () => {
+        const items = [10, 20, 30];
+        let i = 0;
+        const mock = {
+            each: () => ({
+                next: () => i < items.length
+                    ? { done: false as const, value: items[i++] }
+                    : { done: true  as const, value: undefined }
+            })
+        };
+        expect(getList(mock)).toEqual([10, 20, 30]);
+    });
+
+    it('returns [] when each() returns null', () => {
+        expect(getList({ each: () => null })).toEqual([]);
+    });
+});
+
+// ─── getString ────────────────────────────────────────────────────────────────
+describe('getString', () => {
+    it('returns null for undefined', () => {
+        expect(getString(undefined)).toBeNull();
+    });
+
+    it('returns expr.string when present', () => {
+        expect(getString({ string: 'hello' })).toBe('hello');
+    });
+
+    it('returns expr.value when it is a string', () => {
+        expect(getString({ value: 'world' })).toBe('world');
+    });
+
+    it('coerces numeric value to string', () => {
+        expect(getString({ value: 5 })).toBe('5');
+    });
+
+    it('returns expr.symbol when present', () => {
+        expect(getString({ symbol: 'x' })).toBe('x');
+    });
+
+    it('returns null when no recognised field', () => {
+        expect(getString({ ops: [] })).toBeNull();
+    });
+
+    it('string field takes precedence over value', () => {
+        expect(getString({ string: 'from-string', value: 'from-value' })).toBe('from-string');
+    });
+});
+
+// ─── getNumber ────────────────────────────────────────────────────────────────
+describe('getNumber', () => {
+    it('returns expr.value when numeric', () => {
+        expect(getNumber({ value: 42 })).toBe(42);
+    });
+
+    it('returns 0 for undefined', () => {
+        expect(getNumber(undefined)).toBe(0);
+    });
+
+    it('returns 0 when value is not a number', () => {
+        expect(getNumber({ value: 'text' })).toBe(0);
+    });
+
+    it('returns 0 for null', () => {
+        expect(getNumber(null)).toBe(0);
+    });
+});
+
+// ─── CE integration helpers ───────────────────────────────────────────────────
+function numList(ce: ComputeEngine, nums: number[]) {
+    return ce.box(['List', ...nums.map(n => ce.number(n))]);
+}
+function strList(ce: ComputeEngine, strs: string[]) {
+    return ce.box(['List', ...strs.map(s => ce.string(s))]);
+}
+function call(ce: ComputeEngine, name: string, ...args: any[]) {
+    return ce.box([name, ...args]).evaluate();
+}
+
+// ─── Lookup ───────────────────────────────────────────────────────────────────
+describe('Lookup (CE integration)', () => {
+    let ce: ComputeEngine;
+    beforeEach(() => { ce = makeTestCe(); });
+
+    it('returns the value at the matching key position', () => {
+        const result = call(ce, 'Lookup',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'b', 'c']),
+            ce.string('b'));
+        expect(result.value).toBe(20);
+    });
+
+    it('returns NaN when key is not found', () => {
+        const result = call(ce, 'Lookup',
+            numList(ce, [10, 20]),
+            strList(ce, ['a', 'b']),
+            ce.string('z'));
+        expect(Number.isNaN(result.value as number)).toBeTrue();
+    });
+
+    it('returns 0 when matched value is not numeric', () => {
+        const result = call(ce, 'Lookup',
+            ce.box(['List', ce.string('not-a-number')]),
+            strList(ce, ['k']),
+            ce.string('k'));
+        expect(result.value).toBe(0);
+    });
+
+    it('matches via numeric coercion: key 5 matches id "5"', () => {
+        const result = call(ce, 'Lookup',
+            numList(ce, [99]),
+            ce.box(['List', ce.number(5)]),
+            ce.string('5'));
+        expect(result.value).toBe(99);
+    });
+});
+
+// ─── LookupTwo ────────────────────────────────────────────────────────────────
+describe('LookupTwo (CE integration)', () => {
+    let ce: ComputeEngine;
+    beforeEach(() => { ce = makeTestCe(); });
+
+    it('returns value when both keys match', () => {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'b']), ce.string('a'),
+            strList(ce, ['x', 'y', 'y']), ce.string('y'));
+        expect(result.value).toBe(20);
+    });
+
+    it('returns NaN when first key matches but second does not', () => {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20]),
+            strList(ce, ['a', 'a']), ce.string('a'),
+            strList(ce, ['x', 'x']), ce.string('y'));
+        expect(Number.isNaN(result.value as number)).toBeTrue();
+    });
+
+    it('returns NaN when value and key array lengths differ', () => {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20]),
+            strList(ce, ['a']),       ce.string('a'),
+            strList(ce, ['x', 'y']), ce.string('x'));
+        expect(Number.isNaN(result.value as number)).toBeTrue();
+    });
+});
+
+// ─── LookupMin ────────────────────────────────────────────────────────────────
+describe('LookupMin (CE integration)', () => {
+    let ce: ComputeEngine;
+    beforeEach(() => { ce = makeTestCe(); });
+
+    it('returns the value whose sortKey is smallest', () => {
+        // values [10,20,30], all keys 'a', sortKeys [3,1,2] → min sort=1 at index 1 → value 20
+        const result = call(ce, 'LookupMin',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'a']),
+            ce.string('a'),
+            numList(ce, [3, 1, 2]));
+        expect(result.value).toBe(20);
+    });
+
+    it('returns NaN when no key matches', () => {
+        const result = call(ce, 'LookupMin',
+            numList(ce, [10]),
+            strList(ce, ['a']),
+            ce.string('z'),
+            numList(ce, [1]));
+        expect(Number.isNaN(result.value as number)).toBeTrue();
+    });
+});
+
+// ─── LookupMax ────────────────────────────────────────────────────────────────
+describe('LookupMax (CE integration)', () => {
+    let ce: ComputeEngine;
+    beforeEach(() => { ce = makeTestCe(); });
+
+    it('returns the value whose sortKey is largest', () => {
+        // values [10,20,30], all keys 'a', sortKeys [3,1,2] → max sort=3 at index 0 → value 10
+        const result = call(ce, 'LookupMax',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'a']),
+            ce.string('a'),
+            numList(ce, [3, 1, 2]));
+        expect(result.value).toBe(10);
+    });
+
+    it('returns NaN when no key matches', () => {
+        const result = call(ce, 'LookupMax',
+            numList(ce, [10]),
+            strList(ce, ['a']),
+            ce.string('z'),
+            numList(ce, [1]));
+        expect(Number.isNaN(result.value as number)).toBeTrue();
+    });
+});
+
+// ─── EqualString ─────────────────────────────────────────────────────────────
+describe('EqualString (CE integration)', () => {
+    let ce: ComputeEngine;
+    beforeEach(() => { ce = makeTestCe(); });
+
+    it('returns 1 for equal strings', () => {
+        expect(call(ce, 'EqualString', ce.string('hello'), ce.string('hello')).value).toBe(1);
+    });
+
+    it('returns 0 for unequal strings', () => {
+        expect(call(ce, 'EqualString', ce.string('foo'), ce.string('bar')).value).toBe(0);
+    });
+
+    it('coerces numeric 5 to "5" and matches string "5"', () => {
+        expect(call(ce, 'EqualString', ce.number(5), ce.string('5')).value).toBe(1);
+    });
+
+    it('returns 0 when one side has no string representation', () => {
+        // An empty List has no string/value/symbol → getString returns null
+        expect(call(ce, 'EqualString', ce.box(['List']), ce.string('a')).value).toBe(0);
+    });
+});

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
@@ -4,6 +4,144 @@ import { getValueByPath, convertValue, createComputeEngine, getDocumentValueByPa
 import { MathItemType } from './math-item.type';
 import { IContext } from './math.interface';
 import { DocumentMap } from './document-map';
+import { BoxedExpression, ComputeEngine } from '@cortex-js/compute-engine';
+
+export function getList(expr: any): any[] {
+    if (!expr) { return []; }
+    if (expr.ops) { return expr.ops; }
+    if (expr.each) {
+        const result = [];
+        const iter = expr.each();
+        if (iter) {
+            let next = iter.next();
+            while (next && !next.done) {
+                result.push(next.value);
+                next = iter.next();
+            }
+        }
+        return result;
+    }
+    return [];
+}
+
+/**
+ * getString coerces numeric values to string via String(expr.value).
+ * This means numeric key 5 and string key "5" are treated as equal.
+ * All lookup key arrays must use consistent types (all strings or all numbers).
+ */
+export function getString(expr: any): string | null {
+    if (!expr) { return null; }
+    if (typeof expr.string === 'string') { return expr.string; }
+    if (typeof expr.value === 'string') { return expr.value; }
+    if (typeof expr.value === 'number') { return String(expr.value); }
+    if (typeof expr.symbol === 'string') { return expr.symbol; }
+    return null;
+}
+
+export function getNumber(expr: any): number {
+    if (!expr) { return 0; }
+    if (typeof expr.value === 'number') { return expr.value; }
+    return 0;
+}
+
+function lookupExtremum(
+    ops: ReadonlyArray<BoxedExpression>,
+    compare: (a: number, b: number) => boolean,
+    seed: number,
+    ce: ComputeEngine
+): BoxedExpression {
+    const vList = getList(ops[0]);
+    const kList = getList(ops[1]);
+    const sList = getList(ops[3]);
+    const idVal = getString(ops[2]);
+
+    let bestVal: BoxedExpression | null = null;
+    let bestSort = seed;
+
+    for (let n = 0; n < kList.length; n++) {
+        if (getString(kList[n]) !== idVal) { continue; }
+        const s = getNumber(sList[n]);
+        if (compare(s, bestSort)) {
+            bestSort = s;
+            bestVal = vList[n];
+        }
+    }
+
+    if (bestVal === null) { return ce.number(NaN); }
+    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(NaN);
+}
+
+export function registerCEFunctions(ce: ComputeEngine): void {
+    ce.declare('Lookup', {
+        signature: '(value: list, keys: list, id: any) -> number',
+        evaluate: (ops: ReadonlyArray<any>) => {
+            const values = ops[0];
+            const keys = ops[1];
+            const id = ops[2];
+
+            const vList = getList(values);
+            const kList = getList(keys);
+            const idVal = getString(id);
+
+            for (let n = 0; n < kList.length; n++) {
+                const k = getString(kList[n]);
+                if (k === idVal) {
+                    const v = vList[n];
+                    const num = typeof v?.value === 'number' ? v.value : 0;
+                    return ce.number(num);
+                }
+            }
+            return ce.number(NaN);
+        }
+    });
+
+    ce.declare('LookupTwo', {
+        signature: '(value: list, keys1: list, id1: any, keys2: list, id2: any) -> number',
+        evaluate: (ops: ReadonlyArray<any>, options: any) => {
+            const values = ops[0];
+            const keys1  = ops[1];
+            const id1    = ops[2];
+            const keys2  = ops[3];
+            const id2    = ops[4];
+
+            const vList  = getList(values);
+            const k1List = getList(keys1);
+            const k2List = getList(keys2);
+
+            if (vList.length !== k1List.length || k1List.length !== k2List.length) {
+                return ce.number(NaN);
+            }
+
+            const id1Val = getString(id1);
+            const id2Val = getString(id2);
+
+            for (let n = 0; n < k1List.length; n++) {
+                if (getString(k1List[n]) !== id1Val) { continue; }
+                if (getString(k2List[n]) !== id2Val) { continue; }
+                const v = vList[n];
+                return ce.number(typeof v?.value === 'number' ? v.value : 0);
+            }
+            return ce.number(NaN);
+        }
+    });
+
+    ce.declare('LookupMin', {
+        signature: '(value: list, keys: list, id: any, sortKeys: list) -> number',
+        evaluate: (ops) => lookupExtremum(ops, (a, b) => a < b, Infinity, ce)
+    });
+
+    ce.declare('LookupMax', {
+        signature: '(value: list, keys: list, id: any, sortKeys: list) -> number',
+        evaluate: (ops) => lookupExtremum(ops, (a, b) => a > b, -Infinity, ce)
+    });
+
+    ce.declare('EqualString', {
+        signature: '(a: any, b: any) -> number',
+        evaluate: (ops) => {
+            return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
+        }
+    });
+}
 
 export class MathContext {
     private readonly list: (MathFormula | FieldLink)[];
@@ -122,238 +260,7 @@ export class MathContext {
             const ce = createComputeEngine();
 
             // Custom functions
-            ce.declare('Lookup', {
-                signature: '(value: any, keys: any, id: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values = ops[0];
-                    const keys = ops[1];
-                    const id = ops[2];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const idVal = getString(id);
-
-                    for (let n = 0; n < kList.length; n++) {
-                        const k = getString(kList[n]);
-                        if (k === idVal) {
-                            const v = vList[n];
-                            const num = typeof v?.value === 'number' ? v.value : 0;
-                            return ce.number(num);
-                        }
-                    }
-                    return ce.number(0);
-                }
-            });
-
-            ce.declare('LookupTwo', {
-                signature: '(value: any, keys1: any, id1: any, keys2: any, id2: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values = ops[0];
-                    const keys1  = ops[1];
-                    const id1    = ops[2];
-                    const keys2  = ops[3];
-                    const id2    = ops[4];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const vList  = getList(values);
-                    const k1List = getList(keys1);
-                    const k2List = getList(keys2);
-                    const id1Val = getString(id1);
-                    const id2Val = getString(id2);
-
-                    for (let n = 0; n < k1List.length; n++) {
-                        if (getString(k1List[n]) !== id1Val) { continue; }
-                        if (getString(k2List[n]) !== id2Val) { continue; }
-                        const v = vList[n];
-                        return ce.number(typeof v?.value === 'number' ? v.value : 0);
-                    }
-                    return ce.number(0);
-                }
-            });
-
-            ce.declare('LookupMin', {
-                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values   = ops[0];
-                    const keys     = ops[1];
-                    const id       = ops[2];
-                    const sortKeys = ops[3];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const getNumber = (expr: any): number => {
-                        if (!expr) { return 0; }
-                        if (typeof expr.value === 'number') { return expr.value; }
-                        return 0;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const sList = getList(sortKeys);
-                    const idVal = getString(id);
-
-                    let bestVal: any = null;
-                    let bestSort = Infinity;
-
-                    for (let n = 0; n < kList.length; n++) {
-                        if (getString(kList[n]) !== idVal) { continue; }
-                        const s = getNumber(sList[n]);
-                        if (s < bestSort) {
-                            bestSort = s;
-                            bestVal = vList[n];
-                        }
-                    }
-
-                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
-                }
-            });
-
-            ce.declare('LookupMax', {
-                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values   = ops[0];
-                    const keys     = ops[1];
-                    const id       = ops[2];
-                    const sortKeys = ops[3];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const getNumber = (expr: any): number => {
-                        if (!expr) { return 0; }
-                        if (typeof expr.value === 'number') { return expr.value; }
-                        return 0;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const sList = getList(sortKeys);
-                    const idVal = getString(id);
-
-                    let bestVal: any = null;
-                    let bestSort = -Infinity;
-
-                    for (let n = 0; n < kList.length; n++) {
-                        if (getString(kList[n]) !== idVal) { continue; }
-                        const s = getNumber(sList[n]);
-                        if (s > bestSort) {
-                            bestSort = s;
-                            bestVal = vList[n];
-                        }
-                    }
-
-                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
-                }
-            });
-
-            ce.declare('EqualString', {
-                signature: '(a: any, b: any) -> number',
-                evaluate: (ops) => {
-                    const getString = (e: any) =>
-                        typeof e?.string === 'string' ? e.string :
-                            typeof e?.value  === 'string' ? e.value  :
-                                typeof e?.symbol === 'string' ? e.symbol : null;
-                    return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
-                }
-            });
+            registerCEFunctions(ce);
 
             const systemFunctions = MathFormula.createSystemFunctions();
             for (const systemFunction of systemFunctions) {
@@ -373,7 +280,7 @@ export class MathContext {
                     const value = item.value;
                     if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
                         const ceList = ['List', ...value.map((s: string) => `'${s}'`)];
-                        ce.assign(item.name, ce.box(ceList as any));
+                        ce.assign(item.name, ce.box(ceList as any)); // CE types don't accept string[] directly
                     } else if (typeof value === 'number') {
                         ce.assign(item.name, ce.number(value));
                     } else if (value !== null && value !== undefined && !Array.isArray(value)) {

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
@@ -53,6 +53,11 @@ function lookupExtremum(
     const vList = getList(ops[0]);
     const kList = getList(ops[1]);
     const sList = getList(ops[3]);
+
+    if (vList.length !== kList.length || kList.length !== sList.length) {
+        return ce.number(NaN);
+    }
+
     const idVal = getString(ops[2]);
 
     let bestVal: BoxedExpression | null = null;
@@ -81,14 +86,15 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
             const vList = getList(values);
             const kList = getList(keys);
+            if (vList.length !== kList.length) { return ce.number(NaN); }
+
             const idVal = getString(id);
 
             for (let n = 0; n < kList.length; n++) {
                 const k = getString(kList[n]);
                 if (k === idVal) {
                     const v = vList[n];
-                    const num = typeof v?.value === 'number' ? v.value : 0;
-                    return ce.number(num);
+                    return ce.number(typeof v?.value === 'number' ? v.value : NaN);
                 }
             }
             return ce.number(NaN);
@@ -97,7 +103,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
     ce.declare('LookupTwo', {
         signature: '(value: list, keys1: list, id1: any, keys2: list, id2: any) -> number',
-        evaluate: (ops: ReadonlyArray<any>, options: any) => {
+        evaluate: (ops: ReadonlyArray<any>) => {
             const values = ops[0];
             const keys1  = ops[1];
             const id1    = ops[2];
@@ -119,7 +125,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 if (getString(k1List[n]) !== id1Val) { continue; }
                 if (getString(k2List[n]) !== id2Val) { continue; }
                 const v = vList[n];
-                return ce.number(typeof v?.value === 'number' ? v.value : 0);
+                return ce.number(typeof v?.value === 'number' ? v.value : NaN);
             }
             return ce.number(NaN);
         }

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
@@ -55,7 +55,7 @@ function lookupExtremum(
     const sList = getList(ops[3]);
 
     if (vList.length !== kList.length || kList.length !== sList.length) {
-        return ce.number(NaN);
+        return ce.number(0);
     }
 
     const idVal = getString(ops[2]);
@@ -72,8 +72,10 @@ function lookupExtremum(
         }
     }
 
-    if (bestVal === null) { return ce.number(NaN); }
-    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(NaN);
+    // Returns 0 on no-match (not NaN):
+    // NaN * 0 = NaN which would corrupt downstream calculations
+    if (bestVal === null) { return ce.number(0); }
+    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(0);
 }
 
 export function registerCEFunctions(ce: ComputeEngine): void {
@@ -86,7 +88,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
             const vList = getList(values);
             const kList = getList(keys);
-            if (vList.length !== kList.length) { return ce.number(NaN); }
+            if (vList.length !== kList.length) { return ce.number(0); }
 
             const idVal = getString(id);
 
@@ -94,10 +96,13 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 const k = getString(kList[n]);
                 if (k === idVal) {
                     const v = vList[n];
-                    return ce.number(typeof v?.value === 'number' ? v.value : NaN);
+                    return ce.number(typeof v?.value === 'number' ? v.value : 0);
                 }
             }
-            return ce.number(NaN);
+
+            // Returns 0 on no-match (not NaN):
+            // NaN * 0 = NaN which would corrupt downstream calculations
+            return ce.number(0);
         }
     });
 
@@ -115,7 +120,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
             const k2List = getList(keys2);
 
             if (vList.length !== k1List.length || k1List.length !== k2List.length) {
-                return ce.number(NaN);
+                return ce.number(0);
             }
 
             const id1Val = getString(id1);
@@ -125,9 +130,12 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 if (getString(k1List[n]) !== id1Val) { continue; }
                 if (getString(k2List[n]) !== id2Val) { continue; }
                 const v = vList[n];
-                return ce.number(typeof v?.value === 'number' ? v.value : NaN);
+                return ce.number(typeof v?.value === 'number' ? v.value : 0);
             }
-            return ce.number(NaN);
+
+            // Returns 0 on no-match (not NaN):
+            // NaN * 0 = NaN which would corrupt downstream calculations
+            return ce.number(0);
         }
     });
 

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-context.ts
@@ -120,6 +120,241 @@ export class MathContext {
         this.getField = this.__get.bind(doc);
         try {
             const ce = createComputeEngine();
+
+            // Custom functions
+            ce.declare('Lookup', {
+                signature: '(value: any, keys: any, id: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values = ops[0];
+                    const keys = ops[1];
+                    const id = ops[2];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const idVal = getString(id);
+
+                    for (let n = 0; n < kList.length; n++) {
+                        const k = getString(kList[n]);
+                        if (k === idVal) {
+                            const v = vList[n];
+                            const num = typeof v?.value === 'number' ? v.value : 0;
+                            return ce.number(num);
+                        }
+                    }
+                    return ce.number(0);
+                }
+            });
+
+            ce.declare('LookupTwo', {
+                signature: '(value: any, keys1: any, id1: any, keys2: any, id2: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values = ops[0];
+                    const keys1  = ops[1];
+                    const id1    = ops[2];
+                    const keys2  = ops[3];
+                    const id2    = ops[4];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const vList  = getList(values);
+                    const k1List = getList(keys1);
+                    const k2List = getList(keys2);
+                    const id1Val = getString(id1);
+                    const id2Val = getString(id2);
+
+                    for (let n = 0; n < k1List.length; n++) {
+                        if (getString(k1List[n]) !== id1Val) { continue; }
+                        if (getString(k2List[n]) !== id2Val) { continue; }
+                        const v = vList[n];
+                        return ce.number(typeof v?.value === 'number' ? v.value : 0);
+                    }
+                    return ce.number(0);
+                }
+            });
+
+            ce.declare('LookupMin', {
+                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values   = ops[0];
+                    const keys     = ops[1];
+                    const id       = ops[2];
+                    const sortKeys = ops[3];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const getNumber = (expr: any): number => {
+                        if (!expr) { return 0; }
+                        if (typeof expr.value === 'number') { return expr.value; }
+                        return 0;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const sList = getList(sortKeys);
+                    const idVal = getString(id);
+
+                    let bestVal: any = null;
+                    let bestSort = Infinity;
+
+                    for (let n = 0; n < kList.length; n++) {
+                        if (getString(kList[n]) !== idVal) { continue; }
+                        const s = getNumber(sList[n]);
+                        if (s < bestSort) {
+                            bestSort = s;
+                            bestVal = vList[n];
+                        }
+                    }
+
+                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
+                }
+            });
+
+            ce.declare('LookupMax', {
+                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values   = ops[0];
+                    const keys     = ops[1];
+                    const id       = ops[2];
+                    const sortKeys = ops[3];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const getNumber = (expr: any): number => {
+                        if (!expr) { return 0; }
+                        if (typeof expr.value === 'number') { return expr.value; }
+                        return 0;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const sList = getList(sortKeys);
+                    const idVal = getString(id);
+
+                    let bestVal: any = null;
+                    let bestSort = -Infinity;
+
+                    for (let n = 0; n < kList.length; n++) {
+                        if (getString(kList[n]) !== idVal) { continue; }
+                        const s = getNumber(sList[n]);
+                        if (s > bestSort) {
+                            bestSort = s;
+                            bestVal = vList[n];
+                        }
+                    }
+
+                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
+                }
+            });
+
+            ce.declare('EqualString', {
+                signature: '(a: any, b: any) -> number',
+                evaluate: (ops) => {
+                    const getString = (e: any) =>
+                        typeof e?.string === 'string' ? e.string :
+                            typeof e?.value  === 'string' ? e.value  :
+                                typeof e?.symbol === 'string' ? e.symbol : null;
+                    return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
+                }
+            });
+
             const systemFunctions = MathFormula.createSystemFunctions();
             for (const systemFunction of systemFunctions) {
                 const latex = systemFunction.getLatex();
@@ -135,9 +370,30 @@ export class MathContext {
             }
             for (const item of this.list) {
                 if (item.type === MathItemType.LINK) {
-                    const latex = item.getLatex();
-                    if (latex) {
-                        ce.assign(item.name, latex);
+                    const value = item.value;
+                    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+                        const ceList = ['List', ...value.map((s: string) => `'${s}'`)];
+                        ce.assign(item.name, ce.box(ceList as any));
+                    } else if (typeof value === 'number') {
+                        ce.assign(item.name, ce.number(value));
+                    } else if (value !== null && value !== undefined && !Array.isArray(value)) {
+                        if (typeof value === 'string') {
+                            ce.assign(item.name, ce.string(value));
+                        } else {
+                            const num = Number(value);
+                            if (!isNaN(num)) {
+                                ce.assign(item.name, ce.number(num));
+                            }
+                        }
+                    } else {
+                        const latex = item.getLatex();
+                        if (latex) {
+                            if (typeof latex === 'string') {
+                                ce.assign(item.name, ce.parse(latex));
+                            } else if (Array.isArray(latex)) {
+                                ce.assign(item.name, ce.box(latex as any));
+                            }
+                        }
                     }
                     this.variables[item.name] = item.value;
                     this.scope[item.name] = item.value;
@@ -149,8 +405,13 @@ export class MathContext {
                         item.value = parseValue(result);
                         this.variables[item.functionName] = item.value;
                         this.scope[item.functionName] = item.value;
-                        if (item.value) {
-                            ce.assign(item.functionName, convertValue(item.value));
+                        if (item.value !== null && item.value !== undefined) {
+                            const converted = convertValue(item.value);
+                            if (typeof converted === 'number') {
+                                ce.assign(item.functionName, ce.number(converted));
+                            } else if (Array.isArray(converted)) {
+                                ce.assign(item.functionName, ce.box(converted as any));
+                            }
                         }
                     }
                 }

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-engine.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/math-engine.ts
@@ -102,6 +102,11 @@ export class MathEngine {
 
         list.set('_', new FieldLink('_'));
         list.set('index', new FieldLink('index'));
+        list.set('Lookup', new FieldLink('Lookup'));
+        list.set('LookupTwo', new FieldLink('LookupTwo'));
+        list.set('LookupMin', new FieldLink('LookupMin'));
+        list.set('LookupMax', new FieldLink('LookupMax'));
+        list.set('EqualString', new FieldLink('EqualString'));
 
         // Variables
         for (const page of this.variables.pages) {

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/utils.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-model/utils.ts
@@ -14,7 +14,7 @@ export function convertValue(value: any): any {
         const list: any = ['List'];
         for (const item of value) {
             const e = convertValue(item);
-            if (e) {
+            if (e !== null && e !== undefined) {
                 list.push(e);
             } else {
                 return null;

--- a/policy-service/src/policy-engine/helpers/math-model/field-link.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/field-link.ts
@@ -102,7 +102,7 @@ export class FieldLink {
         this._update();
     }
 
-    public getLatex(): any {
+    public getLatex(): string | unknown[] | null {
         if (this.invalid) {
             return null;
         }

--- a/policy-service/src/policy-engine/helpers/math-model/field-link.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/field-link.ts
@@ -102,7 +102,7 @@ export class FieldLink {
         this._update();
     }
 
-    public getLatex(): string | null {
+    public getLatex(): any {
         if (this.invalid) {
             return null;
         }

--- a/policy-service/src/policy-engine/helpers/math-model/math-context.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/math-context.ts
@@ -48,6 +48,11 @@ function lookupExtremum(
     const vList = getList(ops[0]);
     const kList = getList(ops[1]);
     const sList = getList(ops[3]);
+
+    if (vList.length !== kList.length || kList.length !== sList.length) {
+        return ce.number(NaN);
+    }
+
     const idVal = getString(ops[2]);
 
     let bestVal: BoxedExpression | null = null;
@@ -76,14 +81,15 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
             const vList = getList(values);
             const kList = getList(keys);
+            if (vList.length !== kList.length) { return ce.number(NaN); }
+
             const idVal = getString(id);
 
             for (let n = 0; n < kList.length; n++) {
                 const k = getString(kList[n]);
                 if (k === idVal) {
                     const v = vList[n];
-                    const num = typeof v?.value === 'number' ? v.value : 0;
-                    return ce.number(num);
+                    return ce.number(typeof v?.value === 'number' ? v.value : NaN);
                 }
             }
             return ce.number(NaN);
@@ -92,7 +98,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
     ce.declare('LookupTwo', {
         signature: '(value: list, keys1: list, id1: any, keys2: list, id2: any) -> number',
-        evaluate: (ops: ReadonlyArray<any>, options: any) => {
+        evaluate: (ops: ReadonlyArray<any>) => {
             const values = ops[0];
             const keys1  = ops[1];
             const id1    = ops[2];
@@ -114,7 +120,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 if (getString(k1List[n]) !== id1Val) { continue; }
                 if (getString(k2List[n]) !== id2Val) { continue; }
                 const v = vList[n];
-                return ce.number(typeof v?.value === 'number' ? v.value : 0);
+                return ce.number(typeof v?.value === 'number' ? v.value : NaN);
             }
             return ce.number(NaN);
         }

--- a/policy-service/src/policy-engine/helpers/math-model/math-context.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/math-context.ts
@@ -50,7 +50,7 @@ function lookupExtremum(
     const sList = getList(ops[3]);
 
     if (vList.length !== kList.length || kList.length !== sList.length) {
-        return ce.number(NaN);
+        return ce.number(0);
     }
 
     const idVal = getString(ops[2]);
@@ -67,8 +67,10 @@ function lookupExtremum(
         }
     }
 
-    if (bestVal === null) { return ce.number(NaN); }
-    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(NaN);
+    // Returns 0 on no-match (not NaN):
+    // NaN * 0 = NaN which would corrupt downstream calculations
+    if (bestVal === null) { return ce.number(0); }
+    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(0);
 }
 
 export function registerCEFunctions(ce: ComputeEngine): void {
@@ -81,7 +83,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
 
             const vList = getList(values);
             const kList = getList(keys);
-            if (vList.length !== kList.length) { return ce.number(NaN); }
+            if (vList.length !== kList.length) { return ce.number(0); }
 
             const idVal = getString(id);
 
@@ -89,10 +91,13 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 const k = getString(kList[n]);
                 if (k === idVal) {
                     const v = vList[n];
-                    return ce.number(typeof v?.value === 'number' ? v.value : NaN);
+                    return ce.number(typeof v?.value === 'number' ? v.value : 0);
                 }
             }
-            return ce.number(NaN);
+
+            // Returns 0 on no-match (not NaN):
+            // NaN * 0 = NaN which would corrupt downstream calculations
+            return ce.number(0);
         }
     });
 
@@ -110,7 +115,7 @@ export function registerCEFunctions(ce: ComputeEngine): void {
             const k2List = getList(keys2);
 
             if (vList.length !== k1List.length || k1List.length !== k2List.length) {
-                return ce.number(NaN);
+                return ce.number(0);
             }
 
             const id1Val = getString(id1);
@@ -120,9 +125,12 @@ export function registerCEFunctions(ce: ComputeEngine): void {
                 if (getString(k1List[n]) !== id1Val) { continue; }
                 if (getString(k2List[n]) !== id2Val) { continue; }
                 const v = vList[n];
-                return ce.number(typeof v?.value === 'number' ? v.value : NaN);
+                return ce.number(typeof v?.value === 'number' ? v.value : 0);
             }
-            return ce.number(NaN);
+
+            // Returns 0 on no-match (not NaN):
+            // NaN * 0 = NaN which would corrupt downstream calculations
+            return ce.number(0);
         }
     });
 

--- a/policy-service/src/policy-engine/helpers/math-model/math-context.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/math-context.ts
@@ -4,6 +4,139 @@ import { getValueByPath, convertValue, createComputeEngine, getDocumentValueByPa
 import { MathItemType } from './math-item.type.js';
 import { IContext } from './math.interface.js';
 import { DocumentMap } from './document-map.js';
+import { BoxedExpression, ComputeEngine } from '@cortex-js/compute-engine';
+
+export function getList(expr: any): any[] {
+    if (!expr) { return []; }
+    if (expr.ops) { return expr.ops; }
+    if (expr.each) {
+        const result = [];
+        const iter = expr.each();
+        if (iter) {
+            let next = iter.next();
+            while (next && !next.done) {
+                result.push(next.value);
+                next = iter.next();
+            }
+        }
+        return result;
+    }
+    return [];
+}
+
+export function getString(expr: any): string | null {
+    if (!expr) { return null; }
+    if (typeof expr.string === 'string') { return expr.string; }
+    if (typeof expr.value === 'string') { return expr.value; }
+    if (typeof expr.value === 'number') { return String(expr.value); }
+    if (typeof expr.symbol === 'string') { return expr.symbol; }
+    return null;
+}
+
+export function getNumber(expr: any): number {
+    if (!expr) { return 0; }
+    if (typeof expr.value === 'number') { return expr.value; }
+    return 0;
+}
+
+function lookupExtremum(
+    ops: ReadonlyArray<BoxedExpression>,
+    compare: (a: number, b: number) => boolean,
+    seed: number,
+    ce: ComputeEngine
+): BoxedExpression {
+    const vList = getList(ops[0]);
+    const kList = getList(ops[1]);
+    const sList = getList(ops[3]);
+    const idVal = getString(ops[2]);
+
+    let bestVal: BoxedExpression | null = null;
+    let bestSort = seed;
+
+    for (let n = 0; n < kList.length; n++) {
+        if (getString(kList[n]) !== idVal) { continue; }
+        const s = getNumber(sList[n]);
+        if (compare(s, bestSort)) {
+            bestSort = s;
+            bestVal = vList[n];
+        }
+    }
+
+    if (bestVal === null) { return ce.number(NaN); }
+    return typeof bestVal.value === 'number' ? ce.number(bestVal.value) : ce.number(NaN);
+}
+
+export function registerCEFunctions(ce: ComputeEngine): void {
+    ce.declare('Lookup', {
+        signature: '(value: list, keys: list, id: any) -> number',
+        evaluate: (ops: ReadonlyArray<any>) => {
+            const values = ops[0];
+            const keys = ops[1];
+            const id = ops[2];
+
+            const vList = getList(values);
+            const kList = getList(keys);
+            const idVal = getString(id);
+
+            for (let n = 0; n < kList.length; n++) {
+                const k = getString(kList[n]);
+                if (k === idVal) {
+                    const v = vList[n];
+                    const num = typeof v?.value === 'number' ? v.value : 0;
+                    return ce.number(num);
+                }
+            }
+            return ce.number(NaN);
+        }
+    });
+
+    ce.declare('LookupTwo', {
+        signature: '(value: list, keys1: list, id1: any, keys2: list, id2: any) -> number',
+        evaluate: (ops: ReadonlyArray<any>, options: any) => {
+            const values = ops[0];
+            const keys1  = ops[1];
+            const id1    = ops[2];
+            const keys2  = ops[3];
+            const id2    = ops[4];
+
+            const vList  = getList(values);
+            const k1List = getList(keys1);
+            const k2List = getList(keys2);
+
+            if (vList.length !== k1List.length || k1List.length !== k2List.length) {
+                return ce.number(NaN);
+            }
+
+            const id1Val = getString(id1);
+            const id2Val = getString(id2);
+
+            for (let n = 0; n < k1List.length; n++) {
+                if (getString(k1List[n]) !== id1Val) { continue; }
+                if (getString(k2List[n]) !== id2Val) { continue; }
+                const v = vList[n];
+                return ce.number(typeof v?.value === 'number' ? v.value : 0);
+            }
+            return ce.number(NaN);
+        }
+    });
+
+    ce.declare('LookupMin', {
+        signature: '(value: list, keys: list, id: any, sortKeys: list) -> number',
+        evaluate: (ops) => lookupExtremum(ops, (a, b) => a < b, Infinity, ce)
+    });
+
+    ce.declare('LookupMax', {
+        signature: '(value: list, keys: list, id: any, sortKeys: list) -> number',
+        evaluate: (ops) => lookupExtremum(ops, (a, b) => a > b, -Infinity, ce)
+    });
+
+    ce.declare('EqualString', {
+        signature: '(a: any, b: any) -> number',
+        evaluate: (ops) => {
+            return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
+        }
+    });
+}
 
 export class MathContext {
     private readonly list: (MathFormula | FieldLink)[];
@@ -122,238 +255,7 @@ export class MathContext {
             const ce = createComputeEngine();
 
             // Custom functions
-            ce.declare('Lookup', {
-                signature: '(value: any, keys: any, id: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values = ops[0];
-                    const keys = ops[1];
-                    const id = ops[2];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const idVal = getString(id);
-
-                    for (let n = 0; n < kList.length; n++) {
-                        const k = getString(kList[n]);
-                        if (k === idVal) {
-                            const v = vList[n];
-                            const num = typeof v?.value === 'number' ? v.value : 0;
-                            return ce.number(num);
-                        }
-                    }
-                    return ce.number(0);
-                }
-            });
-
-            ce.declare('LookupTwo', {
-                signature: '(value: any, keys1: any, id1: any, keys2: any, id2: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values = ops[0];
-                    const keys1  = ops[1];
-                    const id1    = ops[2];
-                    const keys2  = ops[3];
-                    const id2    = ops[4];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const vList  = getList(values);
-                    const k1List = getList(keys1);
-                    const k2List = getList(keys2);
-                    const id1Val = getString(id1);
-                    const id2Val = getString(id2);
-
-                    for (let n = 0; n < k1List.length; n++) {
-                        if (getString(k1List[n]) !== id1Val) { continue; }
-                        if (getString(k2List[n]) !== id2Val) { continue; }
-                        const v = vList[n];
-                        return ce.number(typeof v?.value === 'number' ? v.value : 0);
-                    }
-                    return ce.number(0);
-                }
-            });
-
-            ce.declare('LookupMin', {
-                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values   = ops[0];
-                    const keys     = ops[1];
-                    const id       = ops[2];
-                    const sortKeys = ops[3];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const getNumber = (expr: any): number => {
-                        if (!expr) { return 0; }
-                        if (typeof expr.value === 'number') { return expr.value; }
-                        return 0;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const sList = getList(sortKeys);
-                    const idVal = getString(id);
-
-                    let bestVal: any = null;
-                    let bestSort = Infinity;
-
-                    for (let n = 0; n < kList.length; n++) {
-                        if (getString(kList[n]) !== idVal) { continue; }
-                        const s = getNumber(sList[n]);
-                        if (s < bestSort) {
-                            bestSort = s;
-                            bestVal = vList[n];
-                        }
-                    }
-
-                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
-                }
-            });
-
-            ce.declare('LookupMax', {
-                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
-                evaluate: (ops: ReadonlyArray<any>, options: any) => {
-                    const values   = ops[0];
-                    const keys     = ops[1];
-                    const id       = ops[2];
-                    const sortKeys = ops[3];
-
-                    const getList = (expr: any): any[] => {
-                        if (!expr) { return []; }
-                        if (expr.ops) { return expr.ops; }
-                        if (expr.each) {
-                            const result = [];
-                            const iter = expr.each();
-                            if (iter) {
-                                let next = iter.next();
-                                while (next && !next.done) {
-                                    result.push(next.value);
-                                    next = iter.next();
-                                }
-                            }
-                            return result;
-                        }
-                        return [];
-                    };
-
-                    const getString = (expr: any): string | null => {
-                        if (!expr) { return null; }
-                        if (typeof expr.string === 'string') { return expr.string; }
-                        if (typeof expr.value === 'string') { return expr.value; }
-                        if (typeof expr.value === 'number') { return String(expr.value); }
-                        return null;
-                    };
-
-                    const getNumber = (expr: any): number => {
-                        if (!expr) { return 0; }
-                        if (typeof expr.value === 'number') { return expr.value; }
-                        return 0;
-                    };
-
-                    const vList = getList(values);
-                    const kList = getList(keys);
-                    const sList = getList(sortKeys);
-                    const idVal = getString(id);
-
-                    let bestVal: any = null;
-                    let bestSort = -Infinity;
-
-                    for (let n = 0; n < kList.length; n++) {
-                        if (getString(kList[n]) !== idVal) { continue; }
-                        const s = getNumber(sList[n]);
-                        if (s > bestSort) {
-                            bestSort = s;
-                            bestVal = vList[n];
-                        }
-                    }
-
-                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
-                }
-            });
-
-            ce.declare('EqualString', {
-                signature: '(a: any, b: any) -> number',
-                evaluate: (ops) => {
-                    const getString = (e: any) =>
-                        typeof e?.string === 'string' ? e.string :
-                            typeof e?.value  === 'string' ? e.value  :
-                                typeof e?.symbol === 'string' ? e.symbol : null;
-                    return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
-                }
-            });
+            registerCEFunctions(ce);
 
             const systemFunctions = MathFormula.createSystemFunctions();
             for (const systemFunction of systemFunctions) {
@@ -373,7 +275,7 @@ export class MathContext {
                     const value = item.value;
                     if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
                         const ceList = ['List', ...value.map((s: string) => `'${s}'`)];
-                        ce.assign(item.name, ce.box(ceList as any));
+                        ce.assign(item.name, ce.box(ceList as any)); // CE types don't accept string[] directly
                     } else if (typeof value === 'number') {
                         ce.assign(item.name, ce.number(value));
                     } else if (value !== null && value !== undefined && !Array.isArray(value)) {

--- a/policy-service/src/policy-engine/helpers/math-model/math-context.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/math-context.ts
@@ -120,6 +120,241 @@ export class MathContext {
         this.getField = this.__get.bind(doc);
         try {
             const ce = createComputeEngine();
+
+            // Custom functions
+            ce.declare('Lookup', {
+                signature: '(value: any, keys: any, id: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values = ops[0];
+                    const keys = ops[1];
+                    const id = ops[2];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const idVal = getString(id);
+
+                    for (let n = 0; n < kList.length; n++) {
+                        const k = getString(kList[n]);
+                        if (k === idVal) {
+                            const v = vList[n];
+                            const num = typeof v?.value === 'number' ? v.value : 0;
+                            return ce.number(num);
+                        }
+                    }
+                    return ce.number(0);
+                }
+            });
+
+            ce.declare('LookupTwo', {
+                signature: '(value: any, keys1: any, id1: any, keys2: any, id2: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values = ops[0];
+                    const keys1  = ops[1];
+                    const id1    = ops[2];
+                    const keys2  = ops[3];
+                    const id2    = ops[4];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const vList  = getList(values);
+                    const k1List = getList(keys1);
+                    const k2List = getList(keys2);
+                    const id1Val = getString(id1);
+                    const id2Val = getString(id2);
+
+                    for (let n = 0; n < k1List.length; n++) {
+                        if (getString(k1List[n]) !== id1Val) { continue; }
+                        if (getString(k2List[n]) !== id2Val) { continue; }
+                        const v = vList[n];
+                        return ce.number(typeof v?.value === 'number' ? v.value : 0);
+                    }
+                    return ce.number(0);
+                }
+            });
+
+            ce.declare('LookupMin', {
+                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values   = ops[0];
+                    const keys     = ops[1];
+                    const id       = ops[2];
+                    const sortKeys = ops[3];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const getNumber = (expr: any): number => {
+                        if (!expr) { return 0; }
+                        if (typeof expr.value === 'number') { return expr.value; }
+                        return 0;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const sList = getList(sortKeys);
+                    const idVal = getString(id);
+
+                    let bestVal: any = null;
+                    let bestSort = Infinity;
+
+                    for (let n = 0; n < kList.length; n++) {
+                        if (getString(kList[n]) !== idVal) { continue; }
+                        const s = getNumber(sList[n]);
+                        if (s < bestSort) {
+                            bestSort = s;
+                            bestVal = vList[n];
+                        }
+                    }
+
+                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
+                }
+            });
+
+            ce.declare('LookupMax', {
+                signature: '(value: any, keys: any, id: any, sortKeys: any) -> number',
+                evaluate: (ops: ReadonlyArray<any>, options: any) => {
+                    const values   = ops[0];
+                    const keys     = ops[1];
+                    const id       = ops[2];
+                    const sortKeys = ops[3];
+
+                    const getList = (expr: any): any[] => {
+                        if (!expr) { return []; }
+                        if (expr.ops) { return expr.ops; }
+                        if (expr.each) {
+                            const result = [];
+                            const iter = expr.each();
+                            if (iter) {
+                                let next = iter.next();
+                                while (next && !next.done) {
+                                    result.push(next.value);
+                                    next = iter.next();
+                                }
+                            }
+                            return result;
+                        }
+                        return [];
+                    };
+
+                    const getString = (expr: any): string | null => {
+                        if (!expr) { return null; }
+                        if (typeof expr.string === 'string') { return expr.string; }
+                        if (typeof expr.value === 'string') { return expr.value; }
+                        if (typeof expr.value === 'number') { return String(expr.value); }
+                        return null;
+                    };
+
+                    const getNumber = (expr: any): number => {
+                        if (!expr) { return 0; }
+                        if (typeof expr.value === 'number') { return expr.value; }
+                        return 0;
+                    };
+
+                    const vList = getList(values);
+                    const kList = getList(keys);
+                    const sList = getList(sortKeys);
+                    const idVal = getString(id);
+
+                    let bestVal: any = null;
+                    let bestSort = -Infinity;
+
+                    for (let n = 0; n < kList.length; n++) {
+                        if (getString(kList[n]) !== idVal) { continue; }
+                        const s = getNumber(sList[n]);
+                        if (s > bestSort) {
+                            bestSort = s;
+                            bestVal = vList[n];
+                        }
+                    }
+
+                    return ce.number(bestVal !== null && typeof bestVal.value === 'number' ? bestVal.value : 0);
+                }
+            });
+
+            ce.declare('EqualString', {
+                signature: '(a: any, b: any) -> number',
+                evaluate: (ops) => {
+                    const getString = (e: any) =>
+                        typeof e?.string === 'string' ? e.string :
+                            typeof e?.value  === 'string' ? e.value  :
+                                typeof e?.symbol === 'string' ? e.symbol : null;
+                    return ce.number(getString(ops[0]) === getString(ops[1]) ? 1 : 0);
+                }
+            });
+
             const systemFunctions = MathFormula.createSystemFunctions();
             for (const systemFunction of systemFunctions) {
                 const latex = systemFunction.getLatex();
@@ -135,9 +370,30 @@ export class MathContext {
             }
             for (const item of this.list) {
                 if (item.type === MathItemType.LINK) {
-                    const latex = item.getLatex();
-                    if (latex) {
-                        ce.assign(item.name, latex);
+                    const value = item.value;
+                    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+                        const ceList = ['List', ...value.map((s: string) => `'${s}'`)];
+                        ce.assign(item.name, ce.box(ceList as any));
+                    } else if (typeof value === 'number') {
+                        ce.assign(item.name, ce.number(value));
+                    } else if (value !== null && value !== undefined && !Array.isArray(value)) {
+                        if (typeof value === 'string') {
+                            ce.assign(item.name, ce.string(value));
+                        } else {
+                            const num = Number(value);
+                            if (!isNaN(num)) {
+                                ce.assign(item.name, ce.number(num));
+                            }
+                        }
+                    } else {
+                        const latex = item.getLatex();
+                        if (latex) {
+                            if (typeof latex === 'string') {
+                                ce.assign(item.name, ce.parse(latex));
+                            } else if (Array.isArray(latex)) {
+                                ce.assign(item.name, ce.box(latex as any));
+                            }
+                        }
                     }
                     this.variables[item.name] = item.value;
                     this.scope[item.name] = item.value;
@@ -149,8 +405,13 @@ export class MathContext {
                         item.value = parseValue(result);
                         this.variables[item.functionName] = item.value;
                         this.scope[item.functionName] = item.value;
-                        if (item.value) {
-                            ce.assign(item.functionName, convertValue(item.value));
+                        if (item.value !== null && item.value !== undefined) {
+                            const converted = convertValue(item.value);
+                            if (typeof converted === 'number') {
+                                ce.assign(item.functionName, ce.number(converted));
+                            } else if (Array.isArray(converted)) {
+                                ce.assign(item.functionName, ce.box(converted as any));
+                            }
                         }
                     }
                 }

--- a/policy-service/src/policy-engine/helpers/math-model/math-engine.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/math-engine.ts
@@ -102,6 +102,11 @@ export class MathEngine {
 
         list.set('_', new FieldLink('_'));
         list.set('index', new FieldLink('index'));
+        list.set('Lookup', new FieldLink('Lookup'));
+        list.set('LookupTwo', new FieldLink('LookupTwo'));
+        list.set('LookupMin', new FieldLink('LookupMin'));
+        list.set('LookupMax', new FieldLink('LookupMax'));
+        list.set('EqualString', new FieldLink('EqualString'));
 
         // Variables
         for (const page of this.variables.pages) {

--- a/policy-service/src/policy-engine/helpers/math-model/utils.ts
+++ b/policy-service/src/policy-engine/helpers/math-model/utils.ts
@@ -14,7 +14,7 @@ export function convertValue(value: any): any {
         const list: any = ['List'];
         for (const item of value) {
             const e = convertValue(item);
-            if (e) {
+            if (e !== null && e !== undefined) {
                 list.push(e);
             } else {
                 return null;

--- a/policy-service/src/policy-engine/helpers/workers/math-worker.ts
+++ b/policy-service/src/policy-engine/helpers/workers/math-worker.ts
@@ -31,11 +31,7 @@ function execute(): void {
     //Output
     const outputs = group.outputs.getItems();
     for (const link of outputs) {
-        try {
-            setDocumentValueByPath(schema, result, link.path, context.scope[link.name]);
-        } catch(e) {
-            throw e;
-        }
+        setDocumentValueByPath(schema, result, link.path, context.scope[link.name]);
     }
 
     //Code

--- a/policy-service/src/policy-engine/helpers/workers/math-worker.ts
+++ b/policy-service/src/policy-engine/helpers/workers/math-worker.ts
@@ -31,7 +31,11 @@ function execute(): void {
     //Output
     const outputs = group.outputs.getItems();
     for (const link of outputs) {
-        setDocumentValueByPath(schema, result, link.path, context.scope[link.name]);
+        try {
+            setDocumentValueByPath(schema, result, link.path, context.scope[link.name]);
+        } catch(e) {
+            throw e;
+        }
     }
 
     //Code

--- a/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
@@ -135,7 +135,7 @@ describe('Lookup (CE integration)', function () {
             ce.box(['List', ce.string('not-a-number')]),
             strList(ce, ['k']),
             ce.string('k'));
-        assert.strictEqual(result.value, 0);
+        assert.isNaN(result.value);
     });
 
     it('matches via numeric coercion: numeric key 5 matches id "5"', function () {

--- a/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
@@ -122,12 +122,12 @@ describe('Lookup (CE integration)', function () {
         assert.strictEqual(result.value, 20);
     });
 
-    it('returns NaN when key is not found', function () {
+    it('returns 0 when key is not found', function () {
         const result = call(ce, 'Lookup',
             numList(ce, [10, 20]),
             strList(ce, ['a', 'b']),
             ce.string('z'));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 
     it('returns 0 when matched value is not numeric', function () {
@@ -135,7 +135,7 @@ describe('Lookup (CE integration)', function () {
             ce.box(['List', ce.string('not-a-number')]),
             strList(ce, ['k']),
             ce.string('k'));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 
     it('matches via numeric coercion: numeric key 5 matches id "5"', function () {
@@ -160,20 +160,20 @@ describe('LookupTwo (CE integration)', function () {
         assert.strictEqual(result.value, 20);
     });
 
-    it('returns NaN when first key matches but second does not', function () {
+    it('returns 0 when first key matches but second does not', function () {
         const result = call(ce, 'LookupTwo',
             numList(ce, [10, 20]),
             strList(ce, ['a', 'a']), ce.string('a'),
             strList(ce, ['x', 'x']), ce.string('y'));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 
-    it('returns NaN when array lengths differ', function () {
+    it('returns 0 when array lengths differ', function () {
         const result = call(ce, 'LookupTwo',
             numList(ce, [10, 20]),
             strList(ce, ['a']),       ce.string('a'),
             strList(ce, ['x', 'y']), ce.string('x'));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 });
 
@@ -192,13 +192,13 @@ describe('LookupMin (CE integration)', function () {
         assert.strictEqual(result.value, 20);
     });
 
-    it('returns NaN when no key matches', function () {
+    it('returns 0 when no key matches', function () {
         const result = call(ce, 'LookupMin',
             numList(ce, [10]),
             strList(ce, ['a']),
             ce.string('z'),
             numList(ce, [1]));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 });
 
@@ -217,13 +217,13 @@ describe('LookupMax (CE integration)', function () {
         assert.strictEqual(result.value, 10);
     });
 
-    it('returns NaN when no key matches', function () {
+    it('returns 0 when no key matches', function () {
         const result = call(ce, 'LookupMax',
             numList(ce, [10]),
             strList(ce, ['a']),
             ce.string('z'),
             numList(ce, [1]));
-        assert.isNaN(result.value);
+        assert.strictEqual(result.value, 0);
     });
 });
 

--- a/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/math-model/math-context.test.mjs
@@ -1,0 +1,251 @@
+import 'module-alias/register.js';
+
+import { assert } from 'chai';
+import { ComputeEngine } from '@cortex-js/compute-engine';
+import {
+    getList,
+    getString,
+    getNumber,
+    registerCEFunctions,
+} from '../../../../dist/policy-engine/helpers/math-model/math-context.js';
+
+function makeTestCe() {
+    const ce = new ComputeEngine();
+    registerCEFunctions(ce);
+    return ce;
+}
+
+// ─── CE call helper ───────────────────────────────────────────────────────────
+function call(ce, name, ...args) {
+    return ce.box([name, ...args]).evaluate();
+}
+function numList(ce, nums) {
+    return ce.box(['List', ...nums.map(n => ce.number(n))]);
+}
+function strList(ce, strs) {
+    return ce.box(['List', ...strs.map(s => ce.string(s))]);
+}
+
+// ─── getList ──────────────────────────────────────────────────────────────────
+describe('getList', function () {
+    it('returns [] for undefined', function () {
+        assert.deepEqual(getList(undefined), []);
+    });
+
+    it('returns [] for null', function () {
+        assert.deepEqual(getList(null), []);
+    });
+
+    it('returns expr.ops when present', function () {
+        const ops = [1, 2, 3];
+        assert.strictEqual(getList({ ops }), ops);
+    });
+
+    it('collects items via expr.each() when ops is absent', function () {
+        const items = [10, 20, 30];
+        let i = 0;
+        const mock = {
+            each: () => ({
+                next: () => i < items.length
+                    ? { done: false, value: items[i++] }
+                    : { done: true,  value: undefined }
+            })
+        };
+        assert.deepEqual(getList(mock), [10, 20, 30]);
+    });
+
+    it('returns [] when each() returns null', function () {
+        assert.deepEqual(getList({ each: () => null }), []);
+    });
+});
+
+// ─── getString ────────────────────────────────────────────────────────────────
+describe('getString', function () {
+    it('returns null for undefined', function () {
+        assert.isNull(getString(undefined));
+    });
+
+    it('returns expr.string when present', function () {
+        assert.strictEqual(getString({ string: 'hello' }), 'hello');
+    });
+
+    it('returns expr.value when it is a string', function () {
+        assert.strictEqual(getString({ value: 'world' }), 'world');
+    });
+
+    it('coerces numeric value to string', function () {
+        assert.strictEqual(getString({ value: 5 }), '5');
+    });
+
+    it('returns expr.symbol when present', function () {
+        assert.strictEqual(getString({ symbol: 'x' }), 'x');
+    });
+
+    it('returns null when no recognised field', function () {
+        assert.isNull(getString({ ops: [] }));
+    });
+
+    it('string field takes precedence over value', function () {
+        assert.strictEqual(getString({ string: 'from-string', value: 'from-value' }), 'from-string');
+    });
+});
+
+// ─── getNumber ────────────────────────────────────────────────────────────────
+describe('getNumber', function () {
+    it('returns expr.value when numeric', function () {
+        assert.strictEqual(getNumber({ value: 42 }), 42);
+    });
+
+    it('returns 0 for undefined', function () {
+        assert.strictEqual(getNumber(undefined), 0);
+    });
+
+    it('returns 0 when value is not a number', function () {
+        assert.strictEqual(getNumber({ value: 'text' }), 0);
+    });
+
+    it('returns 0 for null', function () {
+        assert.strictEqual(getNumber(null), 0);
+    });
+});
+
+// ─── Lookup ───────────────────────────────────────────────────────────────────
+describe('Lookup (CE integration)', function () {
+    let ce;
+    beforeEach(function () { ce = makeTestCe(); });
+
+    it('returns the value at the matching key position', function () {
+        const result = call(ce, 'Lookup',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'b', 'c']),
+            ce.string('b'));
+        assert.strictEqual(result.value, 20);
+    });
+
+    it('returns NaN when key is not found', function () {
+        const result = call(ce, 'Lookup',
+            numList(ce, [10, 20]),
+            strList(ce, ['a', 'b']),
+            ce.string('z'));
+        assert.isNaN(result.value);
+    });
+
+    it('returns 0 when matched value is not numeric', function () {
+        const result = call(ce, 'Lookup',
+            ce.box(['List', ce.string('not-a-number')]),
+            strList(ce, ['k']),
+            ce.string('k'));
+        assert.strictEqual(result.value, 0);
+    });
+
+    it('matches via numeric coercion: numeric key 5 matches id "5"', function () {
+        const result = call(ce, 'Lookup',
+            numList(ce, [99]),
+            ce.box(['List', ce.number(5)]),
+            ce.string('5'));
+        assert.strictEqual(result.value, 99);
+    });
+});
+
+// ─── LookupTwo ────────────────────────────────────────────────────────────────
+describe('LookupTwo (CE integration)', function () {
+    let ce;
+    beforeEach(function () { ce = makeTestCe(); });
+
+    it('returns value when both keys match', function () {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'b']), ce.string('a'),
+            strList(ce, ['x', 'y', 'y']), ce.string('y'));
+        assert.strictEqual(result.value, 20);
+    });
+
+    it('returns NaN when first key matches but second does not', function () {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20]),
+            strList(ce, ['a', 'a']), ce.string('a'),
+            strList(ce, ['x', 'x']), ce.string('y'));
+        assert.isNaN(result.value);
+    });
+
+    it('returns NaN when array lengths differ', function () {
+        const result = call(ce, 'LookupTwo',
+            numList(ce, [10, 20]),
+            strList(ce, ['a']),       ce.string('a'),
+            strList(ce, ['x', 'y']), ce.string('x'));
+        assert.isNaN(result.value);
+    });
+});
+
+// ─── LookupMin ────────────────────────────────────────────────────────────────
+describe('LookupMin (CE integration)', function () {
+    let ce;
+    beforeEach(function () { ce = makeTestCe(); });
+
+    it('returns the value whose sortKey is smallest', function () {
+        // values [10,20,30], all keys 'a', sortKeys [3,1,2] → min sort=1 at index 1 → value 20
+        const result = call(ce, 'LookupMin',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'a']),
+            ce.string('a'),
+            numList(ce, [3, 1, 2]));
+        assert.strictEqual(result.value, 20);
+    });
+
+    it('returns NaN when no key matches', function () {
+        const result = call(ce, 'LookupMin',
+            numList(ce, [10]),
+            strList(ce, ['a']),
+            ce.string('z'),
+            numList(ce, [1]));
+        assert.isNaN(result.value);
+    });
+});
+
+// ─── LookupMax ────────────────────────────────────────────────────────────────
+describe('LookupMax (CE integration)', function () {
+    let ce;
+    beforeEach(function () { ce = makeTestCe(); });
+
+    it('returns the value whose sortKey is largest', function () {
+        // values [10,20,30], all keys 'a', sortKeys [3,1,2] → max sort=3 at index 0 → value 10
+        const result = call(ce, 'LookupMax',
+            numList(ce, [10, 20, 30]),
+            strList(ce, ['a', 'a', 'a']),
+            ce.string('a'),
+            numList(ce, [3, 1, 2]));
+        assert.strictEqual(result.value, 10);
+    });
+
+    it('returns NaN when no key matches', function () {
+        const result = call(ce, 'LookupMax',
+            numList(ce, [10]),
+            strList(ce, ['a']),
+            ce.string('z'),
+            numList(ce, [1]));
+        assert.isNaN(result.value);
+    });
+});
+
+// ─── EqualString ─────────────────────────────────────────────────────────────
+describe('EqualString (CE integration)', function () {
+    let ce;
+    beforeEach(function () { ce = makeTestCe(); });
+
+    it('returns 1 for equal strings', function () {
+        assert.strictEqual(call(ce, 'EqualString', ce.string('hello'), ce.string('hello')).value, 1);
+    });
+
+    it('returns 0 for unequal strings', function () {
+        assert.strictEqual(call(ce, 'EqualString', ce.string('foo'), ce.string('bar')).value, 0);
+    });
+
+    it('coerces numeric 5 to "5" — matches string "5"', function () {
+        assert.strictEqual(call(ce, 'EqualString', ce.number(5), ce.string('5')).value, 1);
+    });
+
+    it('returns 0 when one operand has no string representation', function () {
+        // An empty List has no string/value/symbol → getString returns null
+        assert.strictEqual(call(ce, 'EqualString', ce.box(['List']), ce.string('a')).value, 0);
+    });
+});


### PR DESCRIPTION
### Description
- Added Lookup, LookupTwo, LookupMin, LookupMax custom CE functions for array key-value resolution
- Added EqualString function for scalar string comparison
- Fixed scalar number assignment via ce.number() to resolve inside Map expressions
- Fixed string scalar assignment via ce.string() for non-numeric field values
- Fixed getLatex() return type
- Fixed VARIABLE type scalar assignment using ce.number()/ce.box() after evaluation

### Related issue(s)
Resolves [#5928](https://github.com/hashgraph/guardian/issues/5928)
