### PR TITLE
chore: Nested aliases, DMRV GET routing fix, /about response cleanup

### DIFF
--- a/api-gateway/src/api/service/dmrv.ts
+++ b/api-gateway/src/api/service/dmrv.ts
@@ -2,7 +2,7 @@ import { Auth, AuthUser } from '#auth';
 import { PREFIXES } from '#constants';
 import { CacheService, EntityOwner, getCacheKey, InternalException, PolicyEngine } from '#helpers';
 import { IAuthUser, PinoLogger } from '@guardian/common';
-import { Permissions } from '@guardian/interfaces';
+import { Permissions, POLICY_ALIAS_REGEX } from '@guardian/interfaces';
 import {
     All,
     Body,
@@ -34,7 +34,7 @@ export class DmrvApi {
     /**
      * DMRV proxy: resolves alias to block and forwards request
      */
-    @All('/:policyId/:alias')
+    @All('/:policyId/*')
     @Auth(
         Permissions.POLICIES_POLICY_EXECUTE,
         Permissions.POLICIES_POLICY_MANAGE,
@@ -52,7 +52,8 @@ export class DmrvApi {
     @ApiParam({
         name: 'alias',
         type: String,
-        description: 'Human-readable alias for the block endpoint',
+        description: 'Alias path; one or more lowercase slug segments separated by `/`.',
+        example: 'monitoring-reports/create',
         required: true,
     })
     @ApiOkResponse({
@@ -66,12 +67,17 @@ export class DmrvApi {
     async proxyByAlias(
         @AuthUser() user: IAuthUser,
         @Param('policyId') policyId: string,
-        @Param('alias') alias: string,
         @Query() query: any,
         @Body() body: any,
         @Req() req: any
     ): Promise<any> {
         try {
+            const rawAlias = (req.params && req.params['*']) ?? '';
+            const alias = decodeURIComponent(String(rawAlias));
+            if (!alias || !POLICY_ALIAS_REGEX.test(alias)) {
+                throw new HttpException('Invalid alias path.', HttpStatus.BAD_REQUEST);
+            }
+
             const engineService = new PolicyEngine();
             const policy = await engineService.getPolicy(
                 { filters: policyId, userDid: user.did },

--- a/api-gateway/src/api/service/dmrv.ts
+++ b/api-gateway/src/api/service/dmrv.ts
@@ -115,19 +115,12 @@ export class DmrvApi {
                     user, policyId, tagName, body, false, false, timeout, waitRemotePolicy
                 );
             } else {
-                const hasQueryParams = Object.keys(query).length > 0;
-                if (hasQueryParams) {
-                    query.savepointIds = typeof query.savepointIds === 'string'
-                        ? JSON.parse(query.savepointIds)
-                        : query.savepointIds;
-                    return await engineService.getBlockDataByTag(
-                        user, policyId, tagName, query
-                    );
-                } else {
-                    return await engineService.getBlockByTagName(
-                        user, policyId, tagName
-                    );
-                }
+                query.savepointIds = typeof query.savepointIds === 'string'
+                    ? JSON.parse(query.savepointIds)
+                    : query.savepointIds;
+                return await engineService.getBlockDataByTag(
+                    user, policyId, tagName, query
+                );
             }
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -1494,7 +1494,10 @@ export class PolicyApi {
             );
             return entries.map((entry: any) => {
                 const getParams = getParamsByBlockType[entry.blockType] || [];
-                const schemaId = schemaByTag.get(entry.target);
+                const rawSchemaId = schemaByTag.get(entry.target);
+                const schemaId = rawSchemaId
+                    ? rawSchemaId.replace(/^#/, '')
+                    : undefined;
                 return {
                     ...entry,
                     ...(schemaId ? { schemaId } : {}),

--- a/api-gateway/src/middlewares/validation/schemas/policies.dto.ts
+++ b/api-gateway/src/middlewares/validation/schemas/policies.dto.ts
@@ -510,15 +510,15 @@ export class PolicyDTO {
         type: 'object',
         additionalProperties: true,
         isArray: true,
-        description: 'User-configured policy API documentation entries',
+        description: 'User-configured policy API documentation entries. The `alias` may be a single slug (`create-device`) or a path of slugs separated by `/` (`monitoring-reports/create`).',
         example: [{
             name: 'create_device',
             description: 'Send event to create_device',
             target: 'create_device',
             method: 'POST',
-            alias: 'create-device',
+            alias: 'monitoring-reports/create',
             url: '/api/v1/policies/{policyId}/tag/create_device/blocks',
-            dmrvUrl: '/api/v1/dmrv/{policyId}/create-device'
+            dmrvUrl: '/api/v1/dmrv/{policyId}/monitoring-reports/create'
         }]
     })
     @IsOptional()

--- a/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
+++ b/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
@@ -104,7 +104,7 @@ Request: POST /api/v1/dmrv/{policyId}/monitoring-reports/create
 
 ### 3.3. Method Routing
 
-<table><thead><tr><th width="130.65625">Request Method</th><th width="196.7578125">Internal Call</th><th>Equivalent Standard Endpoint</th></tr></thead><tbody><tr><td><code>GET</code></td><td><code>getBlockByTagName</code></td><td><code>GET /api/v1/policies/:id/tag/:tag</code></td></tr><tr><td><code>POST</code></td><td><code>setBlockDataByTag</code></td><td><code>POST /api/v1/policies/:id/tag/:tag/blocks</code></td></tr></tbody></table>
+<table><thead><tr><th width="130.65625">Request Method</th><th width="196.7578125">Internal Call</th><th>Equivalent Standard Endpoint</th></tr></thead><tbody><tr><td><code>GET</code></td><td><code>getBlockDataByTag</code></td><td><code>GET /api/v1/policies/:id/tag/:tag/blocks</code></td></tr><tr><td><code>POST</code></td><td><code>setBlockDataByTag</code></td><td><code>POST /api/v1/policies/:id/tag/:tag/blocks</code></td></tr></tbody></table>
 
 ### 3.4. Authentication
 
@@ -149,7 +149,7 @@ Content-Type: application/json
 
 Returns the configured documentation entries.
 
-When the target block references a schema (e.g. `requestVcDocumentBlock`, `documentValidatorBlock`), the entry includes a `schemaId` field with the schema's IRI. The field is omitted for blocks that don't reference a schema.
+When the target block references a schema (e.g. `requestVcDocumentBlock`, `documentValidatorBlock`), the entry includes a `schemaId` field with the schema's IRI (without the leading `#`). The field is omitted for blocks that don't reference a schema.
 
 **Response example:**
 
@@ -161,7 +161,7 @@ When the target block references a schema (e.g. `requestVcDocumentBlock`, `docum
     "target": "registrant_form_grid",
     "method": "GET",
     "alias": "reg",
-    "url": "/api/v1/policies/69c3dbe9a4d2ac84f75cdfc4/tag/registrant_form_grid",
+    "url": "/api/v1/policies/69c3dbe9a4d2ac84f75cdfc4/tag/registrant_form_grid/blocks",
     "dmrvUrl": "/api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/reg",
     "blockType": "interfaceDocumentsSourceBlock",
     "queryParams": [
@@ -182,7 +182,7 @@ When the target block references a schema (e.g. `requestVcDocumentBlock`, `docum
     "url": "/api/v1/policies/69c3dbe9a4d2ac84f75cdfc4/tag/create_application/blocks",
     "dmrvUrl": "/api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/applications/create",
     "blockType": "requestVcDocumentBlock",
-    "schemaId": "#9bd1c75b-76df-4d3c-8775-1f76d18d7d8c",
+    "schemaId": "9bd1c75b-76df-4d3c-8775-1f76d18d7d8c",
     "queryParams": []
   }
 ]

--- a/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
+++ b/docs/guardian/policy-api-documentation-and-dmrv-aliases.md
@@ -24,7 +24,7 @@ Policy authors can define clean, human-readable API endpoint aliases for their p
 1. Click **+ Add Endpoint**.
 2. Fill in the fields for each row:
 
-<table><thead><tr><th width="225.86328125">Field</th><th>Description</th></tr></thead><tbody><tr><td>Block</td><td>Select a block from the dropdown list</td></tr><tr><td>Method</td><td>Choose <code>BOTH</code>, <code>GET</code> or <code>POST</code></td></tr><tr><td>Name</td><td>Short name (auto-filled from block name)</td></tr><tr><td>Description</td><td>What the endpoint does</td></tr><tr><td>Alias</td><td>URL-friendly identifier, e.g. <code>new-device</code>, <code>create-application</code></td></tr><tr><td>Preview URL</td><td>Read-only: <code>/api/v1/dmrv/{policyId}/{alias}</code></td></tr></tbody></table>
+<table><thead><tr><th width="225.86328125">Field</th><th>Description</th></tr></thead><tbody><tr><td>Block</td><td>Select a block from the dropdown list</td></tr><tr><td>Method</td><td>Choose <code>BOTH</code>, <code>GET</code> or <code>POST</code></td></tr><tr><td>Name</td><td>Short name (auto-filled from block name)</td></tr><tr><td>Description</td><td>What the endpoint does</td></tr><tr><td>Alias</td><td>URL-friendly identifier. Either a single slug (<code>new-device</code>, <code>create-application</code>) or a path of slugs separated by <code>/</code> (<code>monitoring-reports/create</code>).</td></tr><tr><td>Preview URL</td><td>Read-only: <code>/api/v1/dmrv/{policyId}/{alias}</code></td></tr></tbody></table>
 
 <figure><img src="../.gitbook/assets/image (1).png" alt=""><figcaption></figcaption></figure>
 
@@ -39,11 +39,11 @@ Use the **Add All Endpoints** button at the top of the dialog (next to **+ Add E
 * Adds an entry for every eligible block in the current policy.
 * **Skips blocks that already have an entry** — no duplicates are created.
 * Generates a smart **Name** from the block name.
-* Generates a smart **Alias** (URL-friendly: lowercase, hyphenated) from the block name/tag.
+* Generates a smart **Alias** (URL-friendly: lowercase, hyphenated) from the block name/tag. The auto-generated alias is always a single segment; you can manually edit it into a path (e.g. `monitoring-reports/create`).
 
 ### 1.4. Validation Rules
 
-* **Alias:** only `a-z`, `0-9`, `-` allowed
+* **Alias:** one or more segments of `a-z`, `0-9`, `-`, separated by single `/`. No leading, trailing, or consecutive slashes; no empty segments. Examples: `new-device`, `monitoring-reports/create`.
 * **Block** and **Alias** must be unique
 * **Block** and **Alias** are required
 * **Method** must be supported by the selected **Block** (`GET`, `POST`, or both for `BOTH`)
@@ -82,20 +82,24 @@ Errors appear below the corresponding row.
 ### 3.1. Endpoint
 
 ```
-ANY /api/v1/dmrv/:policyId/:alias
+ANY /api/v1/dmrv/:policyId/<alias-path>
 ```
+
+`<alias-path>` is the configured alias as-is — a single segment (`new-device`) or a multi-segment path (`monitoring-reports/create`). The proxy captures everything after `:policyId` as the alias.
 
 ### 3.2. How It Works
 
 ```
-Request: GET /api/v1/dmrv/{policyId}/new-device
+Request: POST /api/v1/dmrv/{policyId}/monitoring-reports/create
             │
             ▼
-   1. Load policy by policyId
-   2. Find entry: alias="new-device", method="GET"
-   3. Resolve: target="new_device"
-   4. Forward → getBlockByTagName(user, policyId, "new_device")
-   5. Return block response
+   1. Capture alias path = "monitoring-reports/create"
+   2. Validate alias against the rule (lowercase slug segments separated by '/')
+   3. Load policy by policyId
+   4. Find entry: alias="monitoring-reports/create", method="POST"
+   5. Resolve: target="create_monitoring_report"
+   6. Forward → setBlockDataByTag(user, policyId, "create_monitoring_report", body, ...)
+   7. Return block response
 ```
 
 ### 3.3. Method Routing
@@ -108,15 +112,25 @@ Standard Bearer token. Required permissions: `POLICIES_POLICY_EXECUTE`, `POLICIE
 
 ### 3.5. Response Codes
 
-<table><thead><tr><th width="134.70703125">Code</th><th>Meaning</th></tr></thead><tbody><tr><td><code>200</code></td><td>Success</td></tr><tr><td><code>401</code></td><td>Unauthorized</td></tr><tr><td><code>404</code></td><td>Policy not found or alias not configured for this method</td></tr><tr><td><code>503</code></td><td>Block Unavailable (block exists but not accessible in current policy state)</td></tr></tbody></table>
+<table><thead><tr><th width="134.70703125">Code</th><th>Meaning</th></tr></thead><tbody><tr><td><code>200</code></td><td>Success</td></tr><tr><td><code>400</code></td><td>Invalid alias path (does not match the slug-segments rule)</td></tr><tr><td><code>401</code></td><td>Unauthorized</td></tr><tr><td><code>404</code></td><td>Policy not found or alias not configured for this method</td></tr><tr><td><code>503</code></td><td>Block Unavailable (block exists but not accessible in current policy state)</td></tr></tbody></table>
 
 ### 3.6. Example
 
-**Request:**
+**Request (single-segment alias):**
 
 ```http
 GET /api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/choose-role-alias
 Authorization: Bearer <token>
+```
+
+**Request (multi-segment alias):**
+
+```http
+POST /api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/monitoring-reports/create
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "field": "value" }
 ```
 
 **Response:**
@@ -164,9 +178,9 @@ When the target block references a schema (e.g. `requestVcDocumentBlock`, `docum
     "description": "Submit a new applicant registration",
     "target": "create_application",
     "method": "POST",
-    "alias": "create-application",
+    "alias": "applications/create",
     "url": "/api/v1/policies/69c3dbe9a4d2ac84f75cdfc4/tag/create_application/blocks",
-    "dmrvUrl": "/api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/create-application",
+    "dmrvUrl": "/api/v1/dmrv/69c3dbe9a4d2ac84f75cdfc4/applications/create",
     "blockType": "requestVcDocumentBlock",
     "schemaId": "#9bd1c75b-76df-4d3c-8775-1f76d18d7d8c",
     "queryParams": []

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.html
@@ -53,7 +53,7 @@
                     </div>
                     <div class="field-group field-alias">
                         <label>Alias</label>
-                        <input type="text" pInputText [(ngModel)]="entry.alias" (input)="onAliasChange(i)" placeholder="url-friendly-alias" />
+                        <input type="text" pInputText [(ngModel)]="entry.alias" (input)="onAliasChange(i)" placeholder="url-friendly-alias or path/with/segments" />
                     </div>
                 </div>
                 <div class="field-group field-description-full">

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { IPolicyDocumentationEntry } from '@guardian/interfaces';
+import { IPolicyDocumentationEntry, POLICY_ALIAS_REGEX } from '@guardian/interfaces';
 import { RegisteredService } from '../../services/registered.service';
 import { IBlockAbout, PolicyFolder, PolicyItem } from '../../structures';
 
@@ -139,7 +139,7 @@ export class PolicyApiConfigDialogComponent {
 
     onAliasChange(index: number): void {
         const entry = this.entries[index];
-        entry.alias = entry.alias.toLowerCase().replace(/[^a-z0-9-]/g, '');
+        entry.alias = entry.alias.toLowerCase().replace(/[^a-z0-9\-/]/g, '');
         this.revalidate();
     }
 
@@ -220,8 +220,8 @@ export class PolicyApiConfigDialogComponent {
         if (!entry.alias) {
             return 'Alias is required';
         }
-        if (!/^[a-z0-9-]+$/.test(entry.alias)) {
-            return 'Alias: only lowercase letters, digits and hyphens';
+        if (!POLICY_ALIAS_REGEX.test(entry.alias)) {
+            return "Alias: lowercase letters, digits, hyphens; use '/' to separate path segments";
         }
         if (!block || !about || (!about.get && !about.post)) {
             return 'Selected block does not support API aliases';

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-documentation-dialog/policy-documentation-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-documentation-dialog/policy-documentation-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
     selector: 'app-policy-documentation-dialog',
@@ -16,7 +17,8 @@ export class PolicyDocumentationDialogComponent implements OnInit {
 
     constructor(
         public ref: DynamicDialogRef,
-        public config: DynamicDialogConfig
+        public config: DynamicDialogConfig,
+        private toastr: ToastrService
     ) {
         this.title = this.config.header || 'API Documentation';
         this.entries = this.config.data?.entries || [];
@@ -43,7 +45,21 @@ export class PolicyDocumentationDialogComponent implements OnInit {
     }
 
     copyUrl(url: string): void {
-        navigator.clipboard.writeText(url);
+        navigator.clipboard.writeText(url).then(() => {
+            this.toastr.success('URL copied to clipboard', '', {
+                timeOut: 3000,
+                closeButton: true,
+                positionClass: 'toast-bottom-right',
+                enableHtml: true,
+            });
+        }, () => {
+            this.toastr.error('Failed to copy URL', '', {
+                timeOut: 3000,
+                closeButton: true,
+                positionClass: 'toast-bottom-right',
+                enableHtml: true,
+            });
+        });
     }
 
     toggleSize(): void {

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -67,7 +67,8 @@ import {
     MigrationConfig, MigrationRunStatus,
     MintTransactionStatus,
     TokenType,
-    IPolicyDocumentationEntry
+    IPolicyDocumentationEntry,
+    POLICY_ALIAS_REGEX
 } from '@guardian/interfaces';
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { NatsConnection } from 'nats';
@@ -100,6 +101,11 @@ function buildDocumentationUrls(
         const tag = entry.target;
         const alias = entry.alias;
         const method = entry.method;
+        if (!alias || !POLICY_ALIAS_REGEX.test(alias)) {
+            throw new Error(
+                `Invalid alias "${alias}" — only lowercase letters, digits, hyphens; segments separated by '/'.`
+            );
+        }
         const technicalUrl = method === 'POST'
             ? `/api/v1/policies/${policyId}/tag/${tag}/blocks`
             : `/api/v1/policies/${policyId}/tag/${tag}`;

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -100,15 +100,12 @@ function buildDocumentationUrls(
     return entries.map((entry) => {
         const tag = entry.target;
         const alias = entry.alias;
-        const method = entry.method;
         if (!alias || !POLICY_ALIAS_REGEX.test(alias)) {
             throw new Error(
                 `Invalid alias "${alias}" — only lowercase letters, digits, hyphens; segments separated by '/'.`
             );
         }
-        const technicalUrl = method === 'POST'
-            ? `/api/v1/policies/${policyId}/tag/${tag}/blocks`
-            : `/api/v1/policies/${policyId}/tag/${tag}`;
+        const technicalUrl = `/api/v1/policies/${policyId}/tag/${tag}/blocks`;
         const dmrvUrl = `/api/v1/dmrv/${policyId}/${alias}`;
         return {
             ...entry,

--- a/interfaces/src/interface/policy.interface.ts
+++ b/interfaces/src/interface/policy.interface.ts
@@ -1,4 +1,11 @@
 /**
+ * Allowed shape of a policy documentation alias.
+ * One or more `[a-z0-9-]+` segments separated by single `/`
+ * (no leading/trailing/double slashes, no empty segments).
+ */
+export const POLICY_ALIAS_REGEX = /^[a-z0-9-]+(?:\/[a-z0-9-]+)*$/;
+
+/**
  * Policy documentation entry
  */
 export interface IPolicyDocumentationEntry {
@@ -19,7 +26,8 @@ export interface IPolicyDocumentationEntry {
    */
   method: string;
   /**
-   * Human-readable alias for the DMRV URL (lowercase, alphanumeric, hyphens)
+   * Human-readable alias for the DMRV URL: lowercase letters, digits, hyphens;
+   * multiple segments may be separated by `/` (e.g. `monitoring-reports/create`).
    */
   alias: string;
   /**

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -24488,7 +24488,7 @@ paths:
       summary: Get all versions of a VC document.
       tags:
         - policies
-  /dmrv/{policyId}/{alias}:
+  /dmrv/{policyId}/{path}:
     get:
       description: >-
         Resolves a human-readable alias to a policy block and proxies the
@@ -24504,8 +24504,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24555,8 +24556,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24606,8 +24608,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24657,8 +24660,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24708,8 +24712,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24759,8 +24764,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24810,8 +24816,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -24861,8 +24868,9 @@ paths:
         - name: alias
           required: true
           in: path
-          description: Human-readable alias for the block endpoint
+          description: Alias path; one or more lowercase slug segments separated by `/`.
           schema:
+            example: monitoring-reports/create
             type: string
       responses:
         '200':
@@ -50270,15 +50278,18 @@ components:
             type: object
         policyDocumentation:
           additionalProperties: true
-          description: User-configured policy API documentation entries
+          description: >-
+            User-configured policy API documentation entries. The `alias` may be
+            a single slug (`create-device`) or a path of slugs separated by `/`
+            (`monitoring-reports/create`).
           example:
             - name: create_device
               description: Send event to create_device
               target: create_device
               method: POST
-              alias: create-device
+              alias: monitoring-reports/create
               url: /api/v1/policies/{policyId}/tag/create_device/blocks
-              dmrvUrl: /api/v1/dmrv/{policyId}/create-device
+              dmrvUrl: /api/v1/dmrv/{policyId}/monitoring-reports/create
           type: array
           items:
             type: object


### PR DESCRIPTION
### Description

- Allow `alias` values in policy documentation entries to be a single slug (`create-device`) or a path of slugs separated by `/` (`monitoring-reports/create`); the resulting `dmrvUrl` becomes `/api/v1/dmrv/{policyId}/monitoring-reports/create`.
- Add a shared `POLICY_ALIAS_REGEX` in `@guardian/interfaces` and enforce it in three places: the Angular API config dialog, `buildDocumentationUrls` (save-time), and the DMRV proxy (request-time).
- Switch the DMRV proxy route to a Fastify-compatible wildcard so multi-segment alias paths reach the controller; read the captured suffix from `req.params['*']`, decode it, and 400 on a malformed alias.
- Strip the leading `#` from `schemaId` returned by `GET /policies/{policyId}/about`.
- In `buildDocumentationUrls`, always emit `/blocks` as the technical URL suffix (previously only for `POST`).
- Route DMRV `GET` requests through `getBlockDataByTag` unconditionally so the proxy hits the same handler as the advertised `/tag/:tag/blocks` URL — previously, queryless GETs went to `getBlockByTagName` (`/tag/:tag`) and didn't match the documented technical URL.
- Frontend dialog: widen the alias input sanitization to accept `/`, update the validation message and placeholder. Show a `URL copied to clipboard` success toast (and an error toast on failure) when the user clicks the copy button on the API Documentation modal.
- Refresh `docs/guardian/policy-api-documentation-and-dmrv-aliases.md` and the OpenAPI example in `policies.dto.ts` to reflect the new alias shape, the always-`/blocks` URL, the unhashed `schemaId`, and the new `400` response code.