### PR TITLE
chore: Bump Node to 20.20.2; update Nginx & IPFS

### DIFF
--- a/.github/workflows/add-documentation-to-repo.yaml
+++ b/.github/workflows/add-documentation-to-repo.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: guardian-linux-medium
     strategy:
       matrix:
-        node-version: [ 20.19.5 ]
+        node-version: [ 20.20.2 ]
         mongodb-version: [ 7.0.21 ]
     steps:
       - name: Harden Runner

--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -15,7 +15,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 20.19.5 ]
+        node-version: [ 20.20.2 ]
         mongodb-version: [ 7.0.21 ]
     steps:
       - name: Harden Runner

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -23,7 +23,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [20.19.5]
+        node-version: [20.20.2]
         mongodb-version: [7.0.21]
     steps:
       - name: Harden Runner

--- a/.github/workflows/api-schedule-all.yml
+++ b/.github/workflows/api-schedule-all.yml
@@ -14,7 +14,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 20.19.5 ]
+        node-version: [ 20.20.2 ]
         mongodb-version: [ 7.0.21 ]
     steps:
       - name: Harden Runner

--- a/.github/workflows/api-schedule-vm0033.yml
+++ b/.github/workflows/api-schedule-vm0033.yml
@@ -14,7 +14,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 20.19.5 ]
+        node-version: [ 20.20.2 ]
         mongodb-version: [ 7.0.21 ]
     steps:
       - name: Harden Runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: guardian-linux-medium
     strategy:
       matrix:
-        node-version: [ 20.19.5 ]
+        node-version: [ 20.20.2 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/ui-manual.yml
+++ b/.github/workflows/ui-manual.yml
@@ -14,7 +14,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [20.19.5]
+        node-version: [20.20.2]
         mongodb-version: [7.0.21]
     steps:
       - name: Harden Runner

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/analytics-service/Dockerfile
+++ b/analytics-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/api-gateway/Dockerfile.demo
+++ b/api-gateway/Dockerfile.demo
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/application-events/Dockerfile
+++ b/application-events/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/auth-service/Dockerfile.demo
+++ b/auth-service/Dockerfile.demo
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -124,7 +124,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/docker-compose-indexer-build.yml
+++ b/docker-compose-indexer-build.yml
@@ -81,7 +81,7 @@ services:
       - '3333'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     environment:
       IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
     init: true

--- a/docker-compose-indexer.yml
+++ b/docker-compose-indexer.yml
@@ -73,7 +73,7 @@ services:
       - '3333'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     environment:
       IPFS_TELEMETRY: off # valid options: 'on' (default), 'off', 'auto' (https://github.com/ipfs/kubo/blob/master/docs/telemetry.md)
     init: true

--- a/docker-compose-production-build.yml
+++ b/docker-compose-production-build.yml
@@ -128,7 +128,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -117,7 +117,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/docker-compose-quickstart-build.yml
+++ b/docker-compose-quickstart-build.yml
@@ -79,7 +79,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -73,7 +73,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - '5007'
 
   ipfs-node:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ipfs_data:/data/ipfs:rw
       - ipfs_export:/export:rw

--- a/guardian-service/Dockerfile
+++ b/guardian-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/indexer-api-gateway/Dockerfile
+++ b/indexer-api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/indexer-service/Dockerfile
+++ b/indexer-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/indexer-web-proxy/Dockerfile
+++ b/indexer-web-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=20.19.5-alpine
-ARG NGINX_VERSION=1.27.4-alpine
+ARG NODE_VERSION=20.20.2-alpine
+ARG NGINX_VERSION=1.27.5-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/indexer-worker-service/Dockerfile
+++ b/indexer-worker-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/logger-service/Dockerfile
+++ b/logger-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/mrv-sender/Dockerfile
+++ b/mrv-sender/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/policy-service/Dockerfile
+++ b/policy-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/queue-service/Dockerfile
+++ b/queue-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/topic-listener-service/Dockerfile
+++ b/topic-listener-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/topic-viewer/Dockerfile
+++ b/topic-viewer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/tree-viewer/Dockerfile
+++ b/tree-viewer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory

--- a/web-proxy/Dockerfile
+++ b/web-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=20.19.5-alpine
-ARG NGINX_VERSION=1.27.4-alpine
+ARG NODE_VERSION=20.20.2-alpine
+ARG NGINX_VERSION=1.27.5-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/web-proxy/Dockerfile.ci
+++ b/web-proxy/Dockerfile.ci
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=20.19.5-alpine
-ARG NGINX_VERSION=1.27.4-alpine
+ARG NODE_VERSION=20.20.2-alpine
+ARG NGINX_VERSION=1.27.5-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/web-proxy/Dockerfile.demo
+++ b/web-proxy/Dockerfile.demo
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=20.19.5-alpine
-ARG NGINX_VERSION=1.27.4-alpine
+ARG NODE_VERSION=20.20.2-alpine
+ARG NGINX_VERSION=1.27.5-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/worker-service/Dockerfile
+++ b/worker-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=20.19.5-alpine
+ARG NODE_VERSION=20.20.2-alpine
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 # Define an argument `YARN_CACHE_FOLDER` for the Yarn cache directory


### PR DESCRIPTION
### Description
Upgrade runtime and base images across the repo: 

- bump Node from 20.19.5 to 20.20.2 in GitHub workflow matrices and numerous service Dockerfiles; 
- bump NGINX from 1.27.4 to 1.27.5 in web-proxy and indexer-web-proxy Dockerfiles; 
- update ipfs/kubo from v0.39.0 to v0.41.0 in docker-compose files.
