### PR TITLE
refactor: switch UUID and e2e random helpers to Web Crypto

### DIFF
--- a/e2e-tests/cypress/e2e/DR-test/recovery.cy.js
+++ b/e2e-tests/cypress/e2e/DR-test/recovery.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../support/random";
 
 const Locators = {
     createNew: "Create new",
@@ -14,7 +15,7 @@ const Locators = {
 };
 
 describe("Disaster Recovery Testing", { tags: "@recovery" }, () => {
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
     it("checks ", () => {
         cy.viewport(1440, 900);
 

--- a/e2e-tests/cypress/e2e/api-tests/000_accounts_tests/postRegister.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/000_accounts_tests/postRegister.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 
@@ -65,7 +66,7 @@ context("Register", { tags: ['accounts', 'firstPool', 'all'] }, () => {
     });
 
     it('Register with invalid input data - Negative', () => {
-        const randomName = `${Math.floor(Math.random() * 999)}test001`;
+        const randomName = `${randomInt(999)}test001`;
         postRegister({ username: randomName, name: 'test' }).then((response) => {
             expect(response.status).to.eq(STATUS_CODE.UNPROCESSABLE);
         });

--- a/e2e-tests/cypress/e2e/api-tests/003_ipfs/addAndGetFileIPFS.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/003_ipfs/addAndGetFileIPFS.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
@@ -10,9 +11,9 @@ context("IPFS", { tags: ['ipfs', 'secondPool', 'all'] }, () => {
     const ipfsFileUrl = `${API.ApiServer}${API.IPFSFile}`;
 
     let cid;
-    let firstRandom = Math.floor(Math.random() * 99999);
-    let secondRandom = Math.floor(Math.random() * 99999);
-    let thirdRandom = Math.floor(Math.random() * 99999);
+    let firstRandom = randomInt(99999);
+    let secondRandom = randomInt(99999);
+    let thirdRandom = randomInt(99999);
 
     const addFileWithAuth = (authorization, body) =>
         cy.request({

--- a/e2e-tests/cypress/e2e/api-tests/005_profiles/userCreateAndSetHederaCreds.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/005_profiles/userCreateAndSetHederaCreds.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -26,7 +27,7 @@ context('Profiles', { tags: ['profiles', 'thirdPool', 'all'] }, () => {
 
     it('Register a new user, login with it and set hedera credentials for it', () => {
         const userPassword = 'test'
-        const name = (Math.floor(Math.random() * 999) + 'testUser')
+        const name = (randomInt(999) + 'testUser')
         cy.request({
             method: METHOD.POST,
             url: API.ApiServer + 'accounts/register',
@@ -61,7 +62,7 @@ context('Profiles', { tags: ['profiles', 'thirdPool', 'all'] }, () => {
 
     it('Should attempt to register a new user, login with it and set invalid hedera credentials for it', () => {
         const userPassword = 'testTest'
-        const name = (Math.floor(Math.random() * 999) + 'testUser')
+        const name = (randomInt(999) + 'testUser')
         cy.request({
             method: METHOD.POST,
             url: API.ApiServer + 'accounts/register',

--- a/e2e-tests/cypress/e2e/api-tests/007_modules/03_editModule.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/007_modules/03_editModule.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
@@ -58,7 +59,7 @@ context("Edit Module", { tags: ['modules', 'thirdPool', 'all'] }, () => {
           delete lastModule.updateDate;
           delete lastModule._id;
           lastModule.config.description = lastModule.description;
-          lastModule.config.id = Math.floor(Math.random() * 99999);
+          lastModule.config.id = randomInt(99999);
           lastModule.config.name = lastModule.name;
           lastModule.config.tag = "Module";
           lastModule.config.children = [
@@ -68,7 +69,7 @@ context("Edit Module", { tags: ['modules', 'thirdPool', 'all'] }, () => {
               children: [],
               defaultActive: true,
               events: [],
-              id: Math.floor(Math.random() * 99999),
+              id: randomInt(99999),
               permissions: [],
               tag: tagBlock
             },
@@ -78,7 +79,7 @@ context("Edit Module", { tags: ['modules', 'thirdPool', 'all'] }, () => {
               children: [],
               defaultActive: true,
               events: [],
-              id: Math.floor(Math.random() * 99999),
+              id: randomInt(99999),
               permissions: [],
               tag: tagBlock2
             }

--- a/e2e-tests/cypress/e2e/api-tests/007_modules/09_deleteModule.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/007_modules/09_deleteModule.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
@@ -7,7 +8,7 @@ context("Delete Module", { tags: ['modules', 'thirdPool', 'all'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
     const UserUsername = Cypress.env('User');
-    const moduleName = Math.floor(Math.random() * 999) + "APIModule";
+    const moduleName = randomInt(999) + "APIModule";
 
     const modulesUrl = `${API.ApiServer}${API.ListOfAllModules}`;
 

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/getSchemaEntity.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/getSchemaEntity.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -15,7 +16,7 @@ context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
                 "WIPE_TOKEN",
                 "MINT_NFTOKEN",
             ];
-            let randomItem = items[Math.floor(Math.random() * items.length)];
+            let randomItem = items[randomInt(items.length)];
             cy.request({
                 method: METHOD.GET,
                 url:

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/putActiveSystemSchema.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/putActiveSystemSchema.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -5,7 +6,7 @@ import * as Authorization from "../../../support/authorization";
 context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
     const username = "StandartRegistry";
-    const schemaUUID = ("0000b23a-b1ea-408f-a573" + Math.floor(Math.random() * 999999) + "a2060a")
+    const schemaUUID = ("0000b23a-b1ea-408f-a573" + randomInt(999999) + "a2060a")
 
     it("Make the created scheme active", () => {
         //Create new schema
@@ -39,7 +40,7 @@ context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
 
                     let schemaId = response.body.at(0).id;
 
-                    const versionNum = "1." + Math.floor(Math.random() * 999);
+                    const versionNum = "1." + randomInt(999);
 
                     cy.request({
                         method: METHOD.PUT,

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/putPushSchemaPublish.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/putPushSchemaPublish.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
 
 context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
-    const schemaUUID = ("0000b23a-b1ea-408f-a573" + Math.floor(Math.random() * 999999) + "a2060a");
+    const schemaUUID = ("0000b23a-b1ea-408f-a573" + randomInt(999999) + "a2060a");
     let topicUid;
 
     it("Push publish the schema with the provided (internal) schema ID", () => {
@@ -106,7 +107,7 @@ context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
                 }).then((response) => {
                     expect(response.status).eql(STATUS_CODE.OK);
                     const schemaId = response.body.at(0).id;
-                    const versionNum = ("1." + Math.floor(Math.random() * 999))
+                    const versionNum = ("1." + randomInt(999))
                     //Publish schema
                     cy.request({
                         method: METHOD.PUT,

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/putSchemaPublish.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/putSchemaPublish.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
 
 context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
-    const schemaUUID = ("0000b23a-b1ea-408f-a573" + Math.floor(Math.random() * 999999) + "a2060a")
+    const schemaUUID = ("0000b23a-b1ea-408f-a573" + randomInt(999999) + "a2060a")
 
     before(() => {
         Authorization.getAccessToken(SRUsername).then((authorization) => {
@@ -110,7 +111,7 @@ context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
 
                 let schemaId = response.body.at(0).id;
 
-                const versionNum = "1." + Math.floor(Math.random() * 999);
+                const versionNum = "1." + randomInt(999);
                 //Publish schema
                 cy.request({
                     method: METHOD.PUT,

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/putUpdateSchema.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/putUpdateSchema.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
 
 context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
   const SRUsername = Cypress.env('SRUser');
-  const schemaUUID = ("0000b23a-b1ea-408f-a573" + Math.floor(Math.random() * 999999) + "a2060a");
+  const schemaUUID = ("0000b23a-b1ea-408f-a573" + randomInt(999999) + "a2060a");
   let topicUid;
 
   before(() => {

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/schemaManage.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/schemaManage.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
 
 context("Schemas", { tags: ['schema', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
-    const schemaUUID = ("0000b23a-b1ea-408f-a573" + Math.floor(Math.random() * 999999) + "a2060a");
+    const schemaUUID = ("0000b23a-b1ea-408f-a573" + randomInt(999999) + "a2060a");
     let topicUid;
     // const schemaUUID = "0000b23a-b1ea-408f-a573-6d8bd1a2060a";
     before(() => {

--- a/e2e-tests/cypress/e2e/api-tests/014_tags/01_synchronizationTag.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/014_tags/01_synchronizationTag.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { STATUS_CODE, METHOD } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -5,8 +6,8 @@ import * as Authorization from "../../../support/authorization";
 
 context("Tags", { tags: ['tags', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
-    const tagName = "contractTagAPI" + Math.floor(Math.random() * 999999);
-    const contactName = "contractNameAPI" + Math.floor(Math.random() * 999999);
+    const tagName = "contractTagAPI" + randomInt(999999);
+    const contactName = "contractNameAPI" + randomInt(999999);
     let contractId;
 
     before(() => {

--- a/e2e-tests/cypress/e2e/api-tests/014_tags/02_putTagSchema.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/014_tags/02_putTagSchema.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { STATUS_CODE, METHOD } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -6,7 +7,7 @@ import * as Authorization from "../../../support/authorization";
 context("Tags", { tags: ['tags', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
     const tagName = "tagSchemaAPI";
-    const tagId = "d0e99e70-3511-486668e-bf6f-10041e9a0cb7" + Math.floor(Math.random() * 999999);
+    const tagId = "d0e99e70-3511-486668e-bf6f-10041e9a0cb7" + randomInt(999999);
     let schemaId, schemaCreator, schemaUuid;
 
     before(() => {

--- a/e2e-tests/cypress/e2e/api-tests/024_formulas/01_updateFormulas.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/024_formulas/01_updateFormulas.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -25,7 +26,7 @@ context("Update formula", { tags: ['formulas', 'firstPool', 'all'] }, () => {
                             description: "testLink desc",
                             name: `testLink`,
                             type: "variable",
-                            uuid: Math.floor(Math.random() * 99999),
+                            uuid: randomInt(99999),
                             link: {
                                 item: "field0",
                                 type: "schema",

--- a/e2e-tests/cypress/e2e/api-tests/025_policy_labels/03_updatePolicyLabels.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/025_policy_labels/03_updatePolicyLabels.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
 
 context("Update policy labels", { tags: ['policy_labels', 'firstPool', 'all'] }, () => {
     const UserUsername = Cypress.env('User');
-    const labelConfigUUID = Math.floor(Math.random() * 99999).toString();
+    const labelConfigUUID = randomInt(99999).toString();
 
     let policyLabel, issueSchema;
 

--- a/e2e-tests/cypress/e2e/api-tests/029_tools/dryRunTools.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/029_tools/dryRunTools.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../support/random";
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
 import * as Authorization from "../../../support/authorization";
@@ -5,7 +6,7 @@ import * as Authorization from "../../../support/authorization";
 context("Tools", { tags: ['tools', 'thirdPool', 'all'] }, () => {
     const SRUsername = Cypress.env('SRUser');
     let toolId, policy, policyId;
-    const toolBlockConfigUUID = Math.floor(Math.random() * 99999).toString();
+    const toolBlockConfigUUID = randomInt(99999).toString();
 
     before("Import tool", () => {
         Authorization.getAccessToken(SRUsername).then((authorization) => {

--- a/e2e-tests/cypress/e2e/irec.cy.js
+++ b/e2e-tests/cypress/e2e/irec.cy.js
@@ -1,10 +1,11 @@
+import { randomInt } from "../support/random";
 import { METHOD, STATUS_CODE } from "../../support/api/api-const";
 import API from "../support/ApiUrls";
 
 context("IREC e2e test", { tags: "@e2e" }, () => {
     var accessToken;
     var rootUserDid;
-    const name = Math.floor(Math.random() * 99999) + "test001SR";
+    const name = randomInt(99999) + "test001SR";
 
     it("register a new root user and login with it", () => {
         cy.request("POST", API.ApiServer + "accounts/register", {
@@ -130,7 +131,7 @@ context("IREC e2e test", { tags: "@e2e" }, () => {
     });
 
     it("Tokens", () => {
-        const installer = Math.floor(Math.random() * 99999) + "test001User";
+        const installer = randomInt(99999) + "test001User";
 
         cy.request("POST", API.ApiServer + "accounts/register", {
             username: installer,

--- a/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_Generate.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_Generate.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -6,7 +7,7 @@ const configpage = new ConfigPage();
 
 context("Create User Accounts", { tags: ['ui'] }, () => {
 
-    const SRName = "TestSRUI" + Math.floor(Math.random() * 9999);
+    const SRName = "TestSRUI" + randomInt(9999);
     const SRUsername = Cypress.env('SRUser');
     const userName = "User2";
 

--- a/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_NonHappyFlows.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_NonHappyFlows.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -5,8 +6,8 @@ context("Create User Accounts_Non Happy Scenarios", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
     const userUsername = Cypress.env('User');
-    const SRNameNew = "TestSRUI" + Math.floor(Math.random() * 9999);
-    const userNameNew = "TestUserUI" + Math.floor(Math.random() * 9999);
+    const SRNameNew = "TestSRUI" + randomInt(9999);
+    const userNameNew = "TestUserUI" + randomInt(9999);
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_ProvideCredentials.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/00_account_registration/createAccount_ProvideCredentials.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -6,8 +7,8 @@ const configpage = new ConfigPage();
 
 context("Create User Accounts", { tags: ['ui'] }, () => {
 
-    const SRName = "TestSRUI" + Math.floor(Math.random() * 9999);
-    const userName = "TestUserUI" + Math.floor(Math.random() * 9999);
+    const SRName = "TestSRUI" + randomInt(9999);
+    const userName = "TestUserUI" + randomInt(9999);
     //rofiw
     const HederaIDSR = "0.0.3567105";
     const HederaKeySR = "3030020100300706052b8104000a04220420075cb7e3ec00a9429d4a1a17eb87814fac4cf0a073e374c770aa0df6c4e3e6e4";

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/deletePolicy.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/deletePolicy.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Workflow Policy Deletion", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/dryRunMode.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/dryRunMode.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Dry run Policy", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicy.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicy.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
     let newName;
 
     beforeEach(() => {

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicyFavorites.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicyFavorites.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy. Favorites flow", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySearch.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySearch.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy. Search flow", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySettings.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySettings.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy. Settings flow", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySwitchMode.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicySwitchMode.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy. Switch mode flow", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicyValidation.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/editPolicyValidation.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Edit Policy. Validation flow", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/exportPolicy.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/exportPolicy.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homepage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Export Policy", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/policyCreateFromScratch.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/policyCreateFromScratch.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Workflow  Policy", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/tagsPolicy.cy.js
+++ b/e2e-tests/cypress/e2e/ui-tests/specs/02_policies/tagsPolicy.cy.js
@@ -1,3 +1,4 @@
+import { randomInt } from "../../../../support/random";
 import { HomePage } from "../../pages/homePage";
 const homePage = new HomePage();
 
@@ -7,7 +8,7 @@ const policiesPage = new PoliciesPage();
 context("Tags Policy", { tags: ['ui'] }, () => {
 
     const SRUsername = Cypress.env('SRUser');
-    const name = Math.floor(Math.random() * 999) + "testName";
+    const name = randomInt(999) + "testName";
 
     beforeEach(() => {
         cy.viewport(1920, 1080);

--- a/e2e-tests/cypress/support/random.js
+++ b/e2e-tests/cypress/support/random.js
@@ -1,0 +1,13 @@
+/**
+ * Cryptographically random integer in [0, maxExclusive).
+ * Use this in place of `Math.floor(Math.random() * N)` for generating
+ * non-conflicting test names, IDs, and similar values in Cypress specs.
+ */
+export function randomInt(maxExclusive) {
+    if (!Number.isFinite(maxExclusive) || maxExclusive <= 0) {
+        return 0;
+    }
+    const buf = new Uint32Array(1);
+    globalThis.crypto.getRandomValues(buf);
+    return Math.floor((buf[0] / 0x100000000) * maxExclusive);
+}

--- a/indexer-common/src/utils/utils.ts
+++ b/indexer-common/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { FormulaEngine } from '@indexer/interfaces';
+
 export class Utils {
     public static async wait(delay: number) {
         return new Promise<void>(resolve => {
@@ -20,18 +22,11 @@ export class Utils {
     }
 
     public static GenerateUUIDv4(limit?: number): string {
-        const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-            // tslint:disable-next-line:no-bitwise
-            const r = Math.random() * 16 | 0;
-            // tslint:disable-next-line:no-bitwise
-            const v = c === 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
-        if (Number.isFinite(limit) && limit > 0) {
-            return uuid.substring(limit);
-        } else {
-            return uuid;
+        const uuid = FormulaEngine.GenerateUUIDv4();
+        if (Number.isFinite(limit) && (limit as number) > 0) {
+            return uuid.substring(limit as number);
         }
+        return uuid;
     }
 
     public static getIntParm(param: string, defaultValue: number): number {

--- a/indexer-interfaces/src/validators/utils/formula.ts
+++ b/indexer-interfaces/src/validators/utils/formula.ts
@@ -25,13 +25,7 @@ export abstract class FormulaEngine {
         }).call(null, FormulaEngine.mathjs, ex, scope);
     }
 
-    public static GenerateUUIDv4() {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-            // tslint:disable-next-line:no-bitwise
-            const r = Math.random() * 16 | 0;
-            // tslint:disable-next-line:no-bitwise
-            const v = c === 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
+    public static GenerateUUIDv4(): string {
+        return globalThis.crypto.randomUUID();
     }
 }

--- a/interfaces/src/helpers/generate-uuid-v4.ts
+++ b/interfaces/src/helpers/generate-uuid-v4.ts
@@ -1,23 +1,14 @@
 /**
- * Generate random UUID
+ * Generate a random RFC 4122 v4 UUID using the Web Crypto API.
  */
-export function GenerateUUIDv4() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-        // tslint:disable-next-line:no-bitwise
-        const r = Math.random() * 16 | 0;
-        // tslint:disable-next-line:no-bitwise
-        const v = c === 'x' ? r : (r & 0x3 | 0x8);
-        return v.toString(16);
-    });
+export function GenerateUUIDv4(): string {
+    return globalThis.crypto.randomUUID();
 }
 
 /**
- * Generate random UUID
+ * Generate a 32-character random hex identifier using the Web Crypto API.
  */
-export function GenerateID() {
-    return 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'.replace(/[x]/g, (c) => {
-        // tslint:disable-next-line:no-bitwise
-        const v = Math.random() * 16 | 0;
-        return v.toString(16);
-    });
+export function GenerateID(): string {
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 }


### PR DESCRIPTION
### Description

- Reimplement `GenerateUUIDv4` and `GenerateID` in `@guardian/interfaces` using `globalThis.crypto.randomUUID()` and `globalThis.crypto.getRandomValues()`. Output format and signatures are unchanged, so the ~446 backend and frontend call sites work without edits.
- Apply the same `globalThis.crypto.randomUUID()` rewrite to `FormulaEngine.GenerateUUIDv4` in `@indexer/interfaces`.
- Refactor `@indexer/common`'s `Utils.GenerateUUIDv4(limit?)` to delegate to `FormulaEngine.GenerateUUIDv4`, preserving the optional `substring(limit)` trim used for NATS channel-name suffixes. Removes the duplicated UUID implementation from the indexer packages.
- Add a `randomInt(maxExclusive)` helper in `e2e-tests/cypress/support/random.js`, backed by `globalThis.crypto.getRandomValues`.
- Replace `Math.floor(Math.random() * N)` (and the `* items.length` index variant) across 32 Cypress specs to route through the new helper. Output range and uniqueness behavior are unchanged.