### PR TITLE
fix: tslint array-type violations

### DIFF
--- a/interfaces/src/interface/messages/socket.message.ts
+++ b/interfaces/src/interface/messages/socket.message.ts
@@ -74,7 +74,7 @@ export interface IBlockCompleteEvent {
     /** Human-readable description of the first error (when status === 'failure') */
     error?: string;
     /** All errors collected across the downstream async chain */
-    errorDetails?: Array<{ message: string; stack?: string }>;
+    errorDetails?: { message: string; stack?: string }[];
     /** Unix ms timestamp when completion was determined */
     timestamp: number;
 }

--- a/policy-service/src/policy-engine/record-action-step.ts
+++ b/policy-service/src/policy-engine/record-action-step.ts
@@ -1,7 +1,7 @@
 import { GenerateUUIDv4 } from '@guardian/interfaces';
 import { PolicyLink } from './interfaces';
 
-type Callback = (id: string, timestamp: number, errors: Array<{ message: string; stack?: string }>) => void;
+type Callback = (id: string, timestamp: number, errors: { message: string; stack?: string }[]) => void;
 
 export class RecordActionStep {
     public readonly id: string;
@@ -9,7 +9,7 @@ export class RecordActionStep {
     public readonly syncActions: boolean;
     public readonly withHistory: boolean;
     private readonly results: any[] = [];
-    private readonly errors: Array<{ message: string; stack?: string }> = [];
+    private readonly errors: { message: string; stack?: string }[] = [];
     private readonly actionsMap: Set<string> = new Set();
     public counter: number;
     private callbackFired = false;
@@ -56,7 +56,7 @@ export class RecordActionStep {
         this.errors.push({ message, stack });
     }
 
-    public getErrors(): Array<{ message: string; stack?: string }> {
+    public getErrors(): { message: string; stack?: string }[] {
         return [...this.errors];
     }
 


### PR DESCRIPTION
### Description
- Replace `Array<{ message: string; stack?: string }>` with `{ message: string; stack?: string }[]` in `interfaces/src/interface/messages/socket.message.ts` and `policy-service/src/policy-engine/record-action-step.ts` to satisfy the `array-type` rule from `tslint:recommended`.
- Unblocks CI; no runtime behaviour change.