### PR TITLE
feat: add guardian-publish-validator — methodology library health-check tool

### DIFF
--- a/tools/guardian-publish-validator/.gitignore
+++ b/tools/guardian-publish-validator/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.DS_Store

--- a/tools/guardian-publish-validator/README.md
+++ b/tools/guardian-publish-validator/README.md
@@ -1,0 +1,224 @@
+# guardian-publish-validator
+
+Scans a Hedera Guardian methodology library and reports whether each published artifact (policy, tool, module, schema) is still end-to-end retrievable: Hedera consensus message still exists *and* the IPFS payload it references can still be fetched.
+
+Two failure classes are common in practice, and both produce silent "Cannot read properties of null" import errors for users:
+
+1. **Hedera-side rot** — testnet resets wipe consensus messages periodically. References published before a reset stop resolving.
+2. **IPFS-side rot** — the original publisher's pinning service degrades or shuts down (Storacha/web3.storage is sunsetting through 2026), and the public IPFS gateway ecosystem no longer has the bytes. The Hedera anchor is fine, but `getFile(cid)` returns nothing.
+
+This tool surfaces both failure modes in a single sweep so library maintainers can fix them before users hit them.
+
+## Quick start
+
+```bash
+# From the repo root
+cd tools/guardian-publish-validator
+npm install
+
+# Validate the upstream methodology library (auto-clones hashgraph/guardian
+# into ~/.cache/guardian-publish-validator/, refreshes on subsequent runs)
+npm run validate
+
+# Or against a local clone:
+npm run validate -- --path "../../Methodology Library"
+
+# Browse results in a web UI:
+npm run ui
+# → open http://localhost:5173
+```
+
+## The four buckets
+
+Every published artifact lands in one of four buckets based on its Hedera + IPFS state:
+
+| Bucket    | Meaning |
+|-----------|---------|
+| **Healthy**   | Hedera anchor alive AND at least one operator-controlled (local) Kubo gateway serves the IPFS bytes. No external dependency at retrieval time. |
+| **Resilient** | Hedera anchor alive AND ≥2 independent public gateways serve it. Safe — any one of them can go dark without breaking consumers. The **ideal state for upstream library content**, where there's no single operator-controlled Kubo. |
+| **Fragile**   | Hedera anchor alive but exactly one gateway serves the IPFS payload. Works today; single point of failure. |
+| **Broken**    | Hedera message is missing, or no gateway serves the IPFS content, or another hard failure. Needs repair. |
+
+## CLI usage
+
+```
+guardian-publish-validator [options]
+
+OPTIONS
+  -p, --path <dir>          Library root. Defaults to auto-cloned upstream.
+  -n, --network <net>       testnet | mainnet | previewnet. Default: testnet.
+  -f, --filter <substring>  Scan only archives matching this substring.
+      --concurrency <n>     Parallel checks. Default: 6.
+      --skip-ipfs           Hedera-only check (faster, less thorough).
+      --ipfs-timeout-ms <n> Per-gateway timeout. Default: 10000.
+      --json <path>         Write the full report to a JSON file.
+      --fail-on <mode>      Exit non-zero in CI. Modes:
+                              broken   — fail only on Broken entities
+                              fragile  — fail on Fragile or Broken (require
+                                         Resilient or Healthy for all)
+      --repo <owner/name>   Source repo. Default: hashgraph/guardian.
+      --branch <name>       Branch. Default: main.
+      --repo-base <dir>     Subdirectory. Default: "Methodology Library".
+      --local-gateway <url> Operator's Kubo gateway. Use ${cid} placeholder.
+                            Repeatable.
+      --changed-only <list> Comma-separated paths. Only scan entities found
+                            in those files. PR-CI use case.
+      --changed-only-from <file>
+                            Same as --changed-only but reads paths from a
+                            file (one per line). Pairs with `git diff --name-only`.
+```
+
+### Examples
+
+Full check of upstream `develop` on testnet, fail CI if anything is Fragile or worse:
+
+```bash
+guardian-publish-validator --branch develop --fail-on fragile
+```
+
+PR-level check scoped to changed files only:
+
+```bash
+git diff --name-only origin/develop... > /tmp/changed.txt
+guardian-publish-validator --changed-only-from /tmp/changed.txt --fail-on broken
+```
+
+Operator with their own Kubo pinning service (CIDs there count as Healthy):
+
+```bash
+guardian-publish-validator \
+  --local-gateway 'https://my-kubo.example.com/ipfs/${cid}'
+```
+
+## Web UI
+
+```bash
+npm run ui [-- --port 5173] [-- --report path/to/report.json]
+```
+
+Provides a browsable dashboard over a JSON report — summary cards per bucket, sortable/searchable table, per-entity detail panel showing gateway-by-gateway probe results and clickable GitHub links to each occurrence. Light and dark modes, scan-on-demand button, CSV export.
+
+The UI is **read-only over a saved report file**, except for an optional "Run new scan" button that shells out to the CLI in the background. No data is sent to any external service.
+
+## CI/CD integration
+
+Drop this into `.github/workflows/validate-methodology-library.yml`:
+
+```yaml
+name: Methodology Library validation
+on:
+  pull_request:
+    paths:
+      - 'Methodology Library/**'
+  schedule:
+    - cron: '0 6 * * *'  # daily sweep
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - name: Install validator
+        working-directory: tools/guardian-publish-validator
+        run: npm ci
+
+      - name: Determine changed files (PR runs)
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}... > /tmp/changed.txt
+          echo "CHANGED_FILES_ARG=--changed-only-from /tmp/changed.txt" >> $GITHUB_ENV
+
+      - name: Validate
+        working-directory: tools/guardian-publish-validator
+        run: |
+          node bin/validator.js \
+            --path "$GITHUB_WORKSPACE/Methodology Library" \
+            --network testnet \
+            --fail-on broken \
+            --json $GITHUB_WORKSPACE/validator-report.json \
+            $CHANGED_FILES_ARG
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validator-report
+          path: validator-report.json
+```
+
+**Modes worth considering:**
+
+- **PR check, strict** (`--fail-on broken`): blocks merges that introduce broken references. Allows Fragile entries (a PR might legitimately add new content that hasn't accumulated multiple pins yet).
+- **PR check, ideal-state** (`--fail-on fragile`): every entity must be Resilient or Healthy. Stricter; rejects PRs whose content is only on one gateway.
+- **Scheduled sweep** (`--fail-on fragile`): nightly cron over the whole library; failure auto-opens an Issue listing what regressed.
+
+## Output
+
+The CLI prints a summary table and per-bucket detail to stdout. The full machine-readable report goes to `--json <path>`. Report shape:
+
+```json
+{
+  "network": "testnet",
+  "githubRepo": "hashgraph/guardian",
+  "githubBranch": "main",
+  "scanned": { "archives": 167, "uniqueToolRefs": 84 },
+  "summary": {
+    "healthy": 42,
+    "resilient": 18,
+    "fragile": 16,
+    "broken": 8,
+    "byStatus": { "ipfs-ok-local": 42, "ipfs-resilient": 18, ... }
+  },
+  "refs": [
+    {
+      "name": "AMS-II.G",
+      "type": "policy",
+      "topicId": "0.0.4869164",
+      "messageId": "1726671907.504639000",
+      "cid": "bafkreib5xc...",
+      "status": "ipfs-fragile",
+      "bucket": "fragile",
+      "publicHits": 1,
+      "ipfsGateways": [
+        { "gateway": "ipfs.io", "kind": "public", "ok": false, "status": "http-504" },
+        { "gateway": "gateway.pinata.cloud", "kind": "public", "ok": true, "status": "http-200" }
+      ],
+      "occurrences": [
+        { "source": "Clean Development Mechanism (CDM)/readme.md", "location": "readme(CDM)", "link": "..." }
+      ]
+    }
+  ]
+}
+```
+
+## How it works
+
+For each archive (`.policy`/`.tool` file) under `Methodology Library/`, the validator unzips it and extracts every `{ name, topicId, messageId }` triple from the policy's `tools` array. It also parses every framework `readme.md` for tables documenting policy/tool timestamps. Both sources feed into one de-duplicated entity list keyed by `messageId`.
+
+For each entity:
+
+1. **Hedera mirror lookup** — `GET /api/v1/topics/{topicId}/messages?timestamp=eq:{messageId}` on the configured network. If `topicId` is unknown (README-only entry), discover it first via `GET /api/v1/transactions?timestamp=eq:{messageId}`.
+2. **Message decode** — base64-decode the consensus message payload and extract its `cid` field (or `uri: ipfs://...`).
+3. **Multi-gateway IPFS probe** — issue a small `Range: bytes=0-127` GET to every configured gateway in parallel. Whichever return 200/206 count as serving the content.
+4. **Bucket** — combine Hedera + IPFS results into one of Healthy / Resilient / Fragile / Broken.
+
+## Tests
+
+```bash
+npm test
+```
+
+Runs unit tests for the manifest parser, library walker, and message decoder, plus an integration test against synthetic fixtures in `tests/fixtures/`.
+
+## Contributing
+
+This tool lives in [`hashgraph/guardian`](https://github.com/hashgraph/guardian/tree/main/tools/guardian-publish-validator) under `tools/guardian-publish-validator/`. PRs welcome via the same workflow as the rest of the repo: open against `develop`, sign the CLA, follow the existing code style.
+
+## License
+
+Apache-2.0, matching the rest of `hashgraph/guardian`.

--- a/tools/guardian-publish-validator/bin/ui.js
+++ b/tools/guardian-publish-validator/bin/ui.js
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#!/usr/bin/env node
+// Tiny web UI for browsing a guardian-tool-validator JSON report.
+//
+// Usage:
+//   node bin/ui.js [--report path/to/report.json] [--port 5173]
+//
+// The server serves the dashboard, the loaded report, and three action
+// endpoints used by the UI buttons:
+//   POST /api/scan            kick off a new validator run (async)
+//   GET  /api/scan/:id/status poll a scan's status + log tail
+//   GET  /api/export.csv      stream the current report's rows as CSV
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import express from 'express';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const args = {
+    report: null,
+    port: Number(process.env.PORT) || 5173,
+    libraryPath: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--report' || a === '-r') args.report = argv[++i];
+    else if (a === '--port' || a === '-p') args.port = Number(argv[++i]);
+    else if (a === '--library' || a === '-l') args.libraryPath = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      console.log(`guardian-tool-validator UI
+
+USAGE
+  node bin/ui.js [--report <path>] [--library <path>] [--port <n>]
+
+OPTIONS
+  -r, --report <path>    Path to the validator's JSON report file.
+                         If omitted, looks for the most recently modified
+                         report*.json in the cwd, /tmp, and the project root.
+  -l, --library <path>   Default methodology library path used when starting
+                         a scan from the UI. The user can still override
+                         this in the scan-options modal.
+  -p, --port <n>         Port to listen on. Default: 5173.
+`);
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function findLatestReport(explicitPath) {
+  if (explicitPath) {
+    if (!fs.existsSync(explicitPath)) {
+      throw new Error(`Report not found at: ${explicitPath}`);
+    }
+    return path.resolve(explicitPath);
+  }
+  const candidates = [];
+  for (const dir of [process.cwd(), '/tmp', projectRoot]) {
+    try {
+      for (const name of fs.readdirSync(dir)) {
+        if (/report.*\.json$/i.test(name)) {
+          const full = path.join(dir, name);
+          const stat = fs.statSync(full);
+          if (stat.isFile()) candidates.push({ full, mtime: stat.mtimeMs });
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  if (!candidates.length) return null;
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  return candidates[0].full;
+}
+
+const args = parseArgs(process.argv.slice(2));
+let reportPath = findLatestReport(args.report);
+// Track the active report path even after scans finish so /api/report
+// can return the freshest data without restarting the server.
+
+// Job table for async scans. Keyed by jobId. State per job:
+//   { id, status: 'running'|'done'|'failed', startedAt, finishedAt,
+//     reportPath, logLines: [], exitCode }
+const jobs = new Map();
+
+const app = express();
+app.use(express.json({ limit: '32kb' }));
+
+app.get('/api/report', (_req, res) => {
+  if (!reportPath || !fs.existsSync(reportPath)) {
+    return res.status(404).json({
+      error: 'No report found yet. Click "Run scan" to generate one.',
+    });
+  }
+  try {
+    const raw = fs.readFileSync(reportPath, 'utf8');
+    const report = JSON.parse(raw);
+    report._reportPath = reportPath;
+    report._loadedAt = new Date().toISOString();
+    res.json(report);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Start a new validator run as a child process and return a job id the
+// client can poll. The validator writes its own JSON report to a temp
+// path; on success we rebind reportPath to it so subsequent /api/report
+// reads pick up the new data.
+app.post('/api/scan', (req, res) => {
+  const body = req.body || {};
+  // libraryPath is now optional. If unset, the validator auto-clones the
+  // upstream repo (default: hashgraph/guardian@main) into its local cache.
+  const libraryPath = body.libraryPath || args.libraryPath || null;
+  if (libraryPath && !fs.existsSync(libraryPath)) {
+    return res.status(400).json({ error: `libraryPath does not exist: ${libraryPath}` });
+  }
+
+  const network = body.network || 'testnet';
+  const filter = body.filter || null;
+  const concurrency = body.concurrency ? String(Number(body.concurrency)) : '4';
+  const ipfsTimeoutMs = body.ipfsTimeoutMs ? String(Number(body.ipfsTimeoutMs)) : '12000';
+  const skipIpfs = !!body.skipIpfs;
+  const repo = body.repo || 'hashgraph/guardian';
+  const branch = body.branch || 'main';
+  // Operator's local Kubo. Comma-separated string of URLs accepted from the UI.
+  const localGateways = Array.isArray(body.localGateways)
+    ? body.localGateways
+    : typeof body.localGateways === 'string' && body.localGateways.trim()
+      ? body.localGateways.split(',').map((s) => s.trim()).filter(Boolean)
+      : [];
+
+  const jobId = `scan-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const outputPath = path.join(os.tmpdir(), `${jobId}.report.json`);
+
+  const cliArgs = [
+    path.join(projectRoot, 'bin', 'validator.js'),
+    '--network', network,
+    '--concurrency', concurrency,
+    '--ipfs-timeout-ms', ipfsTimeoutMs,
+    '--repo', repo,
+    '--branch', branch,
+    '--json', outputPath,
+  ];
+  if (libraryPath) cliArgs.unshift('--path', libraryPath);
+  if (filter) cliArgs.push('--filter', filter);
+  if (skipIpfs) cliArgs.push('--skip-ipfs');
+  for (const url of localGateways) cliArgs.push('--local-gateway', url);
+  // Re-insert --path at the front if we had one (we shifted onto the array above).
+  // The unshift call above placed --path before everything; nothing more to do.
+
+  const job = {
+    id: jobId,
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    reportPath: outputPath,
+    logLines: [],
+    exitCode: null,
+    request: { libraryPath, network, filter, concurrency, ipfsTimeoutMs, skipIpfs, repo, branch, localGateways },
+  };
+  jobs.set(jobId, job);
+
+  const child = spawn('node', cliArgs, { cwd: projectRoot });
+
+  const pushLog = (chunk) => {
+    const text = chunk.toString('utf8');
+    // Each "." or "X" or "o" in the validator output is a per-ref tick.
+    // Capture lines as well as raw progress markers so the client can
+    // show meaningful progress.
+    job.logLines.push(text);
+    // Keep memory bounded.
+    if (job.logLines.length > 500) job.logLines.splice(0, job.logLines.length - 500);
+  };
+  child.stdout.on('data', pushLog);
+  child.stderr.on('data', pushLog);
+  child.on('close', (code) => {
+    job.exitCode = code;
+    job.finishedAt = new Date().toISOString();
+    if (code === 0 && fs.existsSync(outputPath)) {
+      job.status = 'done';
+      reportPath = outputPath; // promote to active report
+    } else {
+      job.status = 'failed';
+    }
+  });
+  child.on('error', (err) => {
+    job.status = 'failed';
+    job.exitCode = -1;
+    job.logLines.push(`spawn error: ${err.message}\n`);
+  });
+
+  res.json({ jobId, status: job.status, startedAt: job.startedAt });
+});
+
+app.get('/api/scan/:id/status', (req, res) => {
+  const job = jobs.get(req.params.id);
+  if (!job) return res.status(404).json({ error: 'unknown job' });
+  // Send the last ~80 lines of log for progress display.
+  const tail = job.logLines.join('').split('\n').slice(-80).join('\n');
+  res.json({
+    id: job.id,
+    status: job.status,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+    exitCode: job.exitCode,
+    log: tail,
+    reportPath: job.status === 'done' ? job.reportPath : null,
+  });
+});
+
+// CSV export of the current report. Handy for handing the broken-list off
+// to whoever's going to run the republisher, or for sharing with a partner.
+app.get('/api/export.csv', (_req, res) => {
+  if (!reportPath || !fs.existsSync(reportPath)) {
+    return res.status(404).send('No report loaded');
+  }
+  try {
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    const rows = (report.refs || []).map((r) => ({
+      name: r.name || '',
+      type: r.type || '',
+      status: r.status || '',
+      topicId: r.topicId || '',
+      messageId: r.messageId || '',
+      cid: r.cid || '',
+      occurrenceCount: (r.occurrences || []).length,
+      firstOccurrence: r.occurrences?.[0]?.source || r.occurrences?.[0]?.archive || '',
+    }));
+    const headers = Object.keys(rows[0] || { name: '', type: '', status: '' });
+    const out = [headers.join(',')];
+    for (const row of rows) {
+      out.push(headers.map((h) => csvCell(row[h])).join(','));
+    }
+    const stamp = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="guardian-tool-validator-${stamp}.csv"`
+    );
+    res.send(out.join('\n'));
+  } catch (err) {
+    res.status(500).send(`export failed: ${err.message}`);
+  }
+});
+
+function csvCell(v) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+  return s;
+}
+
+app.use(express.static(path.join(projectRoot, 'ui')));
+
+app.listen(args.port, () => {
+  console.log('guardian-tool-validator UI');
+  console.log(`  report:  ${reportPath || '(none loaded — run a scan from the UI)'}`);
+  console.log(`  library: ${args.libraryPath || '(use the scan-options modal to set one)'}`);
+  console.log(`  open:    http://localhost:${args.port}`);
+});

--- a/tools/guardian-publish-validator/bin/validator.js
+++ b/tools/guardian-publish-validator/bin/validator.js
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// guardian-publish-validator
+//
+// Scans a Hedera Guardian methodology library (the upstream
+// "Methodology Library" tree, or any local fork/clone of it) and checks
+// each published artifact for end-to-end retrievability:
+//
+//   1. Hedera-side: does the (topicId, messageId) consensus message still
+//      exist on the configured network's mirror node? Testnet resets wipe
+//      messages periodically; older publications drop off.
+//   2. IPFS-side:  is the CID embedded inside the Hedera message still
+//      retrievable from at least one IPFS gateway? Most "I imported this
+//      policy and got a null reference error" failures live here.
+//
+// Each entity (policy, tool, module, schema — anything with a Hedera publish
+// timestamp) lands in one of four buckets:
+//
+//   Healthy    — Hedera anchor alive + at least one *local* gateway has the
+//                IPFS bytes (operator-controlled Kubo). No external dependency.
+//   Resilient  — Hedera anchor alive + ≥2 *public* gateways have it. Ideal
+//                state for the upstream library where there's no single
+//                operator-controlled Kubo: any one gateway can go dark
+//                without breaking consumers.
+//   Fragile    — Hedera anchor alive but exactly one gateway serves it.
+//                Works today, single point of failure long-term.
+//   Broken     — Hedera anchor missing, no gateway serves the content, or
+//                another hard failure (topic not found, etc.). Needs repair.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import pLimit from 'p-limit';
+
+import { findArchives, readArchive, extractToolRefs } from '../src/library.js';
+import { lookupMessage, findMessageByTimestamp, extractCidFromMessage } from '../src/mirror.js';
+import { probeCid, DEFAULT_GATEWAYS } from '../src/ipfs.js';
+import { scanManifests } from '../src/manifests.js';
+import { ensureUpstreamCheckout } from '../src/repo.js';
+
+// Build the gateway list for this run: any --local-gateway URLs first
+// (tagged kind=local), then the open-source public defaults.
+function buildGatewayList(localUrls) {
+  const local = (localUrls || []).map((url, i) => ({
+    name: `local-${i + 1}`,
+    url,
+    kind: 'local',
+  }));
+  return [...local, ...DEFAULT_GATEWAYS];
+}
+
+function parseArgs(argv) {
+  const args = {
+    path: null,
+    network: 'testnet',
+    filter: null,
+    concurrency: 6,
+    json: null,
+    failOn: null, // null | 'broken' | 'fragile'
+    skipIpfs: false,
+    ipfsTimeoutMs: 10000,
+    repo: 'hashgraph/guardian',
+    branch: 'main',
+    repoBase: 'Methodology Library',
+    localGateways: [],
+    // PR/CI scoping: when set, only entities whose occurrences touch one of
+    // these paths are checked. Lets a PR-level CI job validate only what the
+    // PR actually changed instead of walking the entire library.
+    changedOnly: [],
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--path' || a === '-p') args.path = argv[++i];
+    else if (a === '--network' || a === '-n') args.network = argv[++i];
+    else if (a === '--filter' || a === '-f') args.filter = argv[++i];
+    else if (a === '--concurrency') args.concurrency = Number(argv[++i]);
+    else if (a === '--json') args.json = argv[++i];
+    else if (a === '--fail-on') args.failOn = argv[++i];
+    else if (a === '--fail-on-stale') args.failOn = 'fragile'; // backward-compat alias
+    else if (a === '--skip-ipfs') args.skipIpfs = true;
+    else if (a === '--ipfs-timeout-ms') args.ipfsTimeoutMs = Number(argv[++i]);
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--branch') args.branch = argv[++i];
+    else if (a === '--repo-base') args.repoBase = argv[++i];
+    else if (a === '--local-gateway') args.localGateways.push(argv[++i]);
+    else if (a === '--changed-only') {
+      // Accept either a comma-separated list in one arg or repeatable flag.
+      const v = argv[++i];
+      v.split(',').map((s) => s.trim()).filter(Boolean).forEach((p) => args.changedOnly.push(p));
+    }
+    else if (a === '--changed-only-from') {
+      const file = argv[++i];
+      const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+      lines.map((s) => s.trim()).filter(Boolean).forEach((p) => args.changedOnly.push(p));
+    }
+    else if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${a}`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+  if (args.failOn && !['broken', 'fragile'].includes(args.failOn)) {
+    console.error(`--fail-on must be one of: broken, fragile (got: ${args.failOn})`);
+    process.exit(2);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`guardian-publish-validator
+
+USAGE
+  guardian-publish-validator [options]
+
+DESCRIPTION
+  Scans a Hedera Guardian methodology library (the upstream "Methodology
+  Library" tree, or any local fork/clone of it) and reports per-entity
+  health: Healthy / Resilient / Fragile / Broken.
+
+OPTIONS
+  -p, --path <dir>          Library root. Optional: if omitted, the upstream
+                            repo (--repo / --branch) is auto-cloned to
+                            ~/.cache/guardian-publish-validator/ and its
+                            "Methodology Library" directory is used.
+  -n, --network <net>       Hedera network. Default: testnet.
+                            Values: testnet | mainnet | previewnet.
+  -f, --filter <substring>  Only scan archives whose path contains this substring.
+      --concurrency <n>     Parallel checks. Default: 6.
+      --skip-ipfs           Skip IPFS probing (Hedera-only check, fast).
+      --ipfs-timeout-ms <n> Per-gateway timeout in ms. Default: 10000.
+      --json <path>         Also write the full report to a JSON file.
+      --fail-on <mode>      Exit code 1 if any entity matches the mode:
+                              broken   — only fail on Broken entities (lenient)
+                              fragile  — fail on Fragile or Broken (require
+                                         Resilient or Healthy for every entity)
+      --fail-on-stale       Deprecated alias for --fail-on fragile.
+      --repo <owner/name>   GitHub repo for occurrence links + auto-fetch source.
+                            Default: hashgraph/guardian.
+      --branch <name>       Branch. Default: main.
+      --repo-base <dir>     Subdirectory inside the repo containing the library.
+                            Default: "Methodology Library".
+      --local-gateway <url> Operator's own Kubo gateway URL. Use \${cid} as the
+                            placeholder. CIDs served here count as Healthy.
+                            Repeatable. Defaults to public gateways only.
+      --changed-only <list> Comma-separated list of file paths relative to the
+                            library root. Only entities found inside those
+                            files are checked. Useful for PR-level CI.
+      --changed-only-from <file>
+                            Same as --changed-only, but reads the list from a
+                            file (one path per line). Pairs well with
+                            \`git diff --name-only\` in CI.
+
+EXAMPLES
+  Full check against upstream develop on testnet:
+    guardian-publish-validator --branch develop
+
+  Scoped to a single PR's changed files:
+    git diff --name-only origin/develop... > /tmp/changed.txt
+    guardian-publish-validator --changed-only-from /tmp/changed.txt --fail-on broken
+
+  Operator with their own Kubo (CIDs there count as Healthy):
+    guardian-publish-validator \\
+      --local-gateway 'https://my-kubo.example.com/ipfs/\${cid}'
+`);
+}
+
+// Map a granular probe status to the canonical four-bucket grouping. CI tools
+// gate on these, the UI summary cards count from them, downstream analytics
+// flow off them — keep the names stable.
+function bucket(status) {
+  if (status === 'ok' || status === 'ipfs-ok-local') return 'healthy';
+  if (status === 'ipfs-resilient') return 'resilient';
+  if (status === 'ipfs-fragile') return 'fragile';
+  return 'broken';
+}
+
+// Decide the overall status for a single ref given mirror + ipfs probe results.
+// Hedera takes precedence — if the consensus message is gone, the IPFS state
+// is moot (we'd need to republish to Hedera regardless).
+function deriveStatus(mirror, ipfs) {
+  if (!mirror.found) return mirror.status;
+  if (!ipfs) return 'ok'; // IPFS check was skipped
+  if (ipfs.status === 'no-cid') return 'ok-no-cid';
+  if (ipfs.status === 'multi-chunk') return 'multi-chunk';
+  return ipfs.status; // ipfs-ok-local | ipfs-resilient | ipfs-fragile | ipfs-unreachable
+}
+
+// Filter logic for --changed-only. We match entities by checking whether ANY
+// of their occurrences live inside a path the caller specified. Paths are
+// normalized to forward slashes and matched as prefixes — passing a directory
+// like "Methodology Library/Verra/VM0003/" matches every occurrence under it.
+function buildChangedFilter(paths) {
+  if (!paths.length) return null;
+  // Normalize once.
+  const norm = paths.map((p) => p.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/$/, ''));
+  return function matches(occurrenceSource) {
+    if (!occurrenceSource) return false;
+    const src = occurrenceSource.replace(/\\/g, '/');
+    return norm.some((p) => src === p || src.startsWith(p + '/') || p.endsWith('/' + src) || p === src);
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Resolve the library root: explicit --path wins, otherwise auto-fetch
+  // the upstream repo into the local cache.
+  let root;
+  if (args.path) {
+    root = path.resolve(args.path);
+    if (!fs.existsSync(root)) {
+      console.error(`Path does not exist: ${root}`);
+      process.exit(2);
+    }
+  } else {
+    try {
+      root = await ensureUpstreamCheckout({
+        repo: args.repo,
+        branch: args.branch,
+        subpath: args.repoBase,
+        onProgress: (msg) => process.stderr.write(msg),
+      });
+    } catch (err) {
+      console.error(`Failed to fetch ${args.repo}@${args.branch}: ${err.message}`);
+      process.exit(2);
+    }
+  }
+
+  let archives = findArchives(root);
+  if (args.filter) {
+    archives = archives.filter((a) => a.includes(args.filter));
+  }
+
+  const gateways = buildGatewayList(args.localGateways);
+  const changedMatches = buildChangedFilter(args.changedOnly);
+
+  console.error(`Found ${archives.length} archive(s) under ${root}${args.filter ? ` (filter: ${args.filter})` : ''}`);
+  console.error(`Validating against Hedera ${args.network}${args.skipIpfs ? '' : ' + IPFS gateways'}`);
+  if (!args.skipIpfs) {
+    console.error(`IPFS gateways in probe list: ${gateways.map((g) => `${g.name}(${g.kind})`).join(', ')}`);
+  }
+  if (changedMatches) {
+    console.error(`--changed-only: limiting to entities referenced by ${args.changedOnly.length} path(s)`);
+  }
+  console.error('');
+
+  // Build the unified entity list:
+  // - tool refs extracted from inside .policy/.tool archives (carry topicId)
+  // - timestamped entities from README markdown tables (don't carry topicId)
+  // De-dup by messageId — one tool referenced by N methodologies needs one check.
+  const refsByMessageId = new Map();
+
+  function addEntity({ name, type, topicId, messageId, occurrences }) {
+    if (!messageId) return;
+    if (!refsByMessageId.has(messageId)) {
+      refsByMessageId.set(messageId, {
+        name: name || null,
+        type,
+        topicId: topicId || null,
+        messageId,
+        occurrences: occurrences || [],
+      });
+      return;
+    }
+    const agg = refsByMessageId.get(messageId);
+    if (!agg.topicId && topicId) agg.topicId = topicId;
+    if (!agg.name && name) agg.name = name;
+    if (agg.type === 'tool-ref' && type && type !== 'tool-ref') agg.type = type;
+    if (occurrences) occurrences.forEach((o) => agg.occurrences.push(o));
+  }
+
+  // Pass 1: in-archive tool refs
+  for (const archivePath of archives) {
+    let info;
+    try {
+      info = readArchive(archivePath);
+    } catch (err) {
+      console.error(`! Failed to read ${path.relative(root, archivePath)}: ${err.message}`);
+      continue;
+    }
+    const refs = extractToolRefs(info);
+    for (const ref of refs) {
+      addEntity({
+        name: ref.name,
+        type: 'tool-ref',
+        topicId: ref.topicId,
+        messageId: ref.messageId,
+        occurrences: ref.locations.map((loc) => ({
+          source: path.relative(root, archivePath),
+          location: loc,
+        })),
+      });
+    }
+  }
+
+  // Pass 2: README-extracted entities
+  const manifestEntries = scanManifests(root);
+  for (const entry of manifestEntries) {
+    if (args.filter && !`${entry.framework} ${entry.name}`.includes(args.filter)) continue;
+    const ts = args.network === 'mainnet' ? entry.mainnetTs : entry.testnetTs;
+    if (!ts) continue;
+    addEntity({
+      name: entry.name,
+      type: entry.type,
+      topicId: null,
+      messageId: ts,
+      occurrences: [
+        { source: entry.source, location: `readme(${entry.framework})`, link: entry.link },
+      ],
+    });
+  }
+
+  let uniqueRefs = [...refsByMessageId.values()];
+
+  // Apply --changed-only filter after collection so we still get accurate
+  // de-duplication: an entity might be referenced from N archives but only
+  // one of them is in the changed-files set.
+  if (changedMatches) {
+    uniqueRefs = uniqueRefs.filter((ref) =>
+      ref.occurrences.some((o) => changedMatches(o.source || o.archive))
+    );
+  }
+
+  const fromArchive = uniqueRefs.filter((r) => r.topicId).length;
+  const fromManifest = uniqueRefs.length - fromArchive;
+  console.error(
+    `Discovered ${uniqueRefs.length} unique entit${uniqueRefs.length === 1 ? 'y' : 'ies'} ` +
+      `(${fromArchive} with topicId from archive scan, ${fromManifest} README-only)${
+        changedMatches ? ' [after --changed-only filter]' : ''
+      }.\n`
+  );
+
+  const limit = pLimit(args.concurrency);
+  let progressCount = 0;
+  const checked = await Promise.all(
+    uniqueRefs.map((ref) =>
+      limit(async () => {
+        let mirror;
+        try {
+          mirror = ref.topicId
+            ? await lookupMessage(args.network, ref.topicId, ref.messageId)
+            : await findMessageByTimestamp(args.network, ref.messageId);
+          if (!ref.topicId && mirror.topicId) ref.topicId = mirror.topicId;
+        } catch (err) {
+          progressCount++;
+          process.stderr.write('?');
+          return { ...ref, status: 'hedera-error', error: err.message };
+        }
+
+        let cidInfo = null;
+        let ipfs = null;
+        if (mirror.found && !args.skipIpfs) {
+          cidInfo = extractCidFromMessage(mirror.message);
+          if (cidInfo.cid) {
+            ipfs = await probeCid(cidInfo.cid, { gateways, timeoutMs: args.ipfsTimeoutMs });
+          } else if (cidInfo.reason === 'multi-chunk-message') {
+            ipfs = { status: 'multi-chunk', gateways: [] };
+          } else {
+            ipfs = { status: 'no-cid', gateways: [], reason: cidInfo.reason };
+          }
+        }
+
+        const status = deriveStatus(
+          mirror.found
+            ? { found: true }
+            : {
+                found: false,
+                status:
+                  mirror.status === 'topic-not-found' ? 'hedera-topic-not-found'
+                  : mirror.status === 'message-missing' ? 'hedera-message-missing'
+                  : mirror.status === 'no-topic-id' ? 'no-topic-id'
+                  : `hedera-${mirror.status}`,
+              },
+          ipfs
+        );
+
+        progressCount++;
+        const b = bucket(status);
+        const marker = b === 'healthy' ? '.' : b === 'resilient' ? '+' : b === 'fragile' ? 'o' : 'X';
+        process.stderr.write(marker);
+        if (progressCount % 60 === 0) process.stderr.write(` ${progressCount}\n`);
+
+        return {
+          ...ref,
+          status,
+          bucket: b,
+          cid: cidInfo?.cid ?? null,
+          ipfsGateways: ipfs?.gateways ?? null,
+          publicHits: ipfs?.publicHits ?? null,
+        };
+      })
+    )
+  );
+  process.stderr.write('\n\n');
+
+  // Aggregate by bucket
+  const buckets = { healthy: [], resilient: [], fragile: [], broken: [] };
+  for (const r of checked) buckets[r.bucket].push(r);
+  const byStatus = {};
+  for (const r of checked) byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+
+  const report = {
+    network: args.network,
+    libraryPath: root,
+    filter: args.filter,
+    changedOnly: args.changedOnly.length ? args.changedOnly : null,
+    ipfsSkipped: args.skipIpfs,
+    githubRepo: args.repo,
+    githubBranch: args.branch,
+    githubBase: args.repoBase,
+    scanned: { archives: archives.length, uniqueToolRefs: uniqueRefs.length },
+    summary: {
+      healthy: buckets.healthy.length,
+      resilient: buckets.resilient.length,
+      fragile: buckets.fragile.length,
+      broken: buckets.broken.length,
+      byStatus,
+      // Kept for backward compatibility with older report viewers.
+      ok: buckets.healthy.length,
+      okOnlyOnExternalGateway: buckets.resilient.length + buckets.fragile.length,
+    },
+    refs: checked
+      .slice()
+      .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+      .map((r) => ({
+        name: r.name,
+        type: r.type,
+        topicId: r.topicId,
+        messageId: r.messageId,
+        cid: r.cid,
+        status: r.status,
+        bucket: r.bucket,
+        publicHits: r.publicHits,
+        ipfsGateways: r.ipfsGateways,
+        occurrences: r.occurrences,
+      })),
+  };
+
+  console.log(`SUMMARY (Hedera ${args.network}${args.skipIpfs ? ', IPFS skipped' : ' + IPFS'})`);
+  console.log('-'.repeat(72));
+  console.log(`Archives scanned:        ${report.scanned.archives}`);
+  console.log(`Unique entities:         ${report.scanned.uniqueToolRefs}`);
+  console.log(`Healthy   (local Kubo):  ${report.summary.healthy}`);
+  console.log(`Resilient (≥2 public):   ${report.summary.resilient}`);
+  console.log(`Fragile   (1 public):    ${report.summary.fragile}`);
+  console.log(`Broken    (unreachable): ${report.summary.broken}`);
+  console.log(`By status:               ${JSON.stringify(byStatus)}`);
+  console.log('');
+
+  function printBucket(label, items, limit = 25) {
+    if (!items.length) return;
+    console.log(label);
+    console.log('-'.repeat(72));
+    for (const r of items.slice(0, limit)) {
+      const okGws = r.ipfsGateways?.filter((g) => g.ok).map((g) => g.gateway).join(', ');
+      console.log(`- ${r.name || '(unnamed)'}  status=${r.status}  msg=${r.messageId}`);
+      if (r.cid) console.log(`    cid=${r.cid}${okGws ? `  via ${okGws}` : ''}`);
+      const head = r.occurrences.slice(0, 2);
+      for (const occ of head) {
+        const where = occ.source || occ.archive || '(unknown)';
+        console.log(`    in ${where}  (${occ.location})`);
+      }
+      if (r.occurrences.length > head.length) {
+        console.log(`    ...and ${r.occurrences.length - head.length} more occurrence(s)`);
+      }
+    }
+    if (items.length > limit) console.log(`  ...and ${items.length - limit} more`);
+    console.log('');
+  }
+
+  printBucket('FRAGILE — single gateway, single point of failure', buckets.fragile);
+  printBucket('BROKEN — action needed', buckets.broken);
+
+  if (args.json) {
+    const outPath = path.resolve(args.json);
+    fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+    console.log(`Full report written to: ${outPath}`);
+  }
+
+  // CI gate: exit 1 if requested mode has matches.
+  if (args.failOn === 'broken' && buckets.broken.length > 0) {
+    process.exit(1);
+  }
+  if (args.failOn === 'fragile' && (buckets.fragile.length > 0 || buckets.broken.length > 0)) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`fatal: ${err.stack || err.message}`);
+  process.exit(2);
+});

--- a/tools/guardian-publish-validator/examples/github-actions.yml
+++ b/tools/guardian-publish-validator/examples/github-actions.yml
@@ -1,0 +1,57 @@
+# Example GitHub Actions workflow that runs guardian-publish-validator on:
+#   - every PR that touches Methodology Library/
+#   - a daily scheduled sweep of the whole library
+#
+# Drop this into .github/workflows/validate-methodology-library.yml at the
+# repo root to wire it up.
+
+name: Methodology Library validation
+on:
+  pull_request:
+    paths:
+      - 'Methodology Library/**'
+  schedule:
+    - cron: '0 6 * * *' # daily 06:00 UTC
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so PR diff works
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install validator
+        working-directory: tools/guardian-publish-validator
+        run: npm ci
+
+      - name: Determine changed files (PR runs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --name-only "origin/${{ github.base_ref }}..." > /tmp/changed.txt
+          echo "Changed files:"
+          cat /tmp/changed.txt
+          echo "CHANGED_ARG=--changed-only-from /tmp/changed.txt" >> "$GITHUB_ENV"
+
+      - name: Run validator
+        working-directory: tools/guardian-publish-validator
+        run: |
+          node bin/validator.js \
+            --path "$GITHUB_WORKSPACE/Methodology Library" \
+            --network testnet \
+            --fail-on broken \
+            --json "$GITHUB_WORKSPACE/validator-report.json" \
+            $CHANGED_ARG
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validator-report
+          path: validator-report.json

--- a/tools/guardian-publish-validator/package-lock.json
+++ b/tools/guardian-publish-validator/package-lock.json
@@ -1,0 +1,871 @@
+{
+  "name": "guardian-publish-validator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "guardian-publish-validator",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.17",
+        "express": "^5.2.1",
+        "p-limit": "^7.3.0"
+      },
+      "bin": {
+        "guardian-publish-validator": "bin/validator.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/tools/guardian-publish-validator/package.json
+++ b/tools/guardian-publish-validator/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "guardian-publish-validator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "Apache-2.0",
+  "description": "Scans a Hedera Guardian methodology library for policy, tool, module, and schema references whose Hedera consensus messages or IPFS payloads are no longer retrievable. CLI validator, web UI for browsing reports, and built-in CI/CD integration via --fail-on flags.",
+  "homepage": "https://github.com/hashgraph/guardian/tree/main/tools/guardian-publish-validator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashgraph/guardian.git",
+    "directory": "tools/guardian-publish-validator"
+  },
+  "bin": {
+    "guardian-publish-validator": "./bin/validator.js"
+  },
+  "scripts": {
+    "validate": "node bin/validator.js",
+    "ui": "node bin/ui.js",
+    "test": "node --test tests/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.17",
+    "express": "^5.2.1",
+    "p-limit": "^7.3.0"
+  }
+}

--- a/tools/guardian-publish-validator/src/ipfs.js
+++ b/tools/guardian-publish-validator/src/ipfs.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Multi-gateway IPFS reachability probe.
+//
+// A CID's "is it actually retrievable?" answer depends on which gateway you
+// ask. We probe a configurable list of gateways and return the first one that
+// gives a healthy response, plus a breakdown of which gateways did or didn't
+// have the content. This mirrors the same fallback strategy proposed for the
+// upstream Guardian fix to ipfs-client-class.ts so the validator's view of
+// "reachable" matches what a fixed Guardian deployment would experience.
+
+// Default gateway probe list. Operators should override this with
+// --gateways (CLI flag) or by passing a custom list to probeCid() so the
+// "local" entry points at their own Kubo node. With no override the local
+// slot is omitted and only public gateways are checked.
+const DEFAULT_GATEWAYS = [
+  { name: 'ipfs.io', url: 'https://ipfs.io/ipfs/${cid}', kind: 'public' },
+  { name: 'dweb.link', url: 'https://${cid}.ipfs.dweb.link/', kind: 'public' },
+  { name: 'gateway.pinata.cloud', url: 'https://gateway.pinata.cloud/ipfs/${cid}', kind: 'public' },
+  { name: 'w3s.link', url: 'https://${cid}.ipfs.w3s.link/', kind: 'public' },
+];
+
+export function gatewayUrl(template, cid) {
+  return template.replace('${cid}', cid);
+}
+
+// Probe one gateway for one CID. Treats any 2xx as ok, anything else
+// (timeouts, 4xx, 5xx, network errors) as not-ok. We do a GET with a small
+// Range header so most gateways stream just a few bytes back instead of the
+// whole file — this keeps the validator cheap even when files are large.
+export async function probeGateway(gateway, cid, { timeoutMs = 10000 } = {}) {
+  const url = gatewayUrl(gateway.url, cid);
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  const startedAt = Date.now();
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      method: 'GET',
+      headers: { accept: 'application/octet-stream', range: 'bytes=0-127' },
+      redirect: 'follow',
+    });
+    const elapsedMs = Date.now() - startedAt;
+    if (!res.ok && res.status !== 206 /* partial content */) {
+      // Drain to release the connection; ignore content
+      await res.body?.cancel?.();
+      return { gateway: gateway.name, kind: gateway.kind, ok: false, status: `http-${res.status}`, elapsedMs };
+    }
+    // Read a few bytes to confirm there's actually content coming through.
+    const reader = res.body?.getReader?.();
+    if (reader) {
+      const { value } = await reader.read();
+      await reader.cancel().catch(() => {});
+      if (!value || value.length === 0) {
+        return { gateway: gateway.name, kind: gateway.kind, ok: false, status: 'empty-body', elapsedMs };
+      }
+    }
+    return { gateway: gateway.name, kind: gateway.kind, ok: true, status: `http-${res.status}`, elapsedMs };
+  } catch (err) {
+    const elapsedMs = Date.now() - startedAt;
+    const status = err.name === 'AbortError' ? 'timeout' : `error: ${err.message}`;
+    return { gateway: gateway.name, kind: gateway.kind, ok: false, status, elapsedMs };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Probe all gateways in parallel for one CID. Returns aggregate status:
+//   ipfs-ok-local     — at least one local gateway has it (Healthy)
+//   ipfs-resilient    — no local hit, but ≥2 independent public gateways have
+//                       it. Safe — any one of them can fail without breaking
+//                       consumers. Ideal for the upstream methodology library
+//                       where there's no single operator-controlled Kubo.
+//   ipfs-fragile      — exactly one public gateway has it. Works today, but
+//                       single point of failure.
+//   ipfs-unreachable  — no gateway returned content (Broken).
+// Plus the full per-gateway breakdown so the report can show where it's pinned.
+export async function probeCid(cid, { gateways = DEFAULT_GATEWAYS, timeoutMs = 10000 } = {}) {
+  if (!cid) return { status: 'no-cid', gateways: [] };
+  const results = await Promise.all(gateways.map((gw) => probeGateway(gw, cid, { timeoutMs })));
+  const okLocal = results.some((r) => r.ok && r.kind === 'local');
+  const publicHits = results.filter((r) => r.ok && r.kind === 'public').length;
+  let status;
+  if (okLocal) status = 'ipfs-ok-local';
+  else if (publicHits >= 2) status = 'ipfs-resilient';
+  else if (publicHits === 1) status = 'ipfs-fragile';
+  else status = 'ipfs-unreachable';
+  return { status, gateways: results, publicHits };
+}
+
+export { DEFAULT_GATEWAYS };

--- a/tools/guardian-publish-validator/src/library.js
+++ b/tools/guardian-publish-validator/src/library.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Walks a Hedera Guardian methodology library (either a local clone or fetched
+// from GitHub) and extracts every tool reference found inside .policy and .tool
+// archives.
+//
+// A "tool reference" is the {name, topicId, messageId} triple that points at a
+// published tool's Hedera consensus message. Both .policy and .tool files are
+// zip archives containing a top-level policy.json / tool.json with a `tools`
+// array. We surface the location of each ref so the republisher can rewrite it
+// in place.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+
+const ARCHIVE_EXTENSIONS = new Set(['.policy', '.tool']);
+
+export function findArchives(rootDir) {
+  const out = [];
+  const stack = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        stack.push(full);
+      } else if (entry.isFile() && ARCHIVE_EXTENSIONS.has(path.extname(entry.name))) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+export function readArchive(archivePath) {
+  const zip = new AdmZip(archivePath);
+  const entries = zip.getEntries();
+
+  let manifestEntry = null;
+  for (const e of entries) {
+    if (e.entryName === 'policy.json' || e.entryName === 'tool.json' || e.entryName === 'module.json') {
+      manifestEntry = e;
+      break;
+    }
+  }
+  if (!manifestEntry) {
+    return { archivePath, manifestName: null, manifest: null, embeddedTools: {} };
+  }
+
+  const manifest = JSON.parse(manifestEntry.getData().toString('utf8'));
+
+  // Embedded tool JSONs live under tools/*.json inside the zip. Map by hash
+  // (filename stem). Useful for sanity-checking nested refs without round-tripping.
+  const embeddedTools = {};
+  for (const e of entries) {
+    if (e.entryName.startsWith('tools/') && e.entryName.endsWith('.json') && !e.isDirectory) {
+      const hash = path.basename(e.entryName, '.json');
+      try {
+        embeddedTools[hash] = JSON.parse(e.getData().toString('utf8'));
+      } catch {
+        // ignore malformed nested tool
+      }
+    }
+  }
+
+  return { archivePath, manifestName: manifestEntry.entryName, manifest, embeddedTools };
+}
+
+// Extract every distinct tool reference from a manifest. A single archive may
+// declare the same tool more than once (top-level + nested via embedded tool
+// manifests); we de-dup by messageId but preserve every location it appears
+// so the republisher can rewrite all of them.
+export function extractToolRefs(archive) {
+  const { archivePath, manifest, embeddedTools } = archive;
+  if (!manifest) return [];
+
+  const byKey = new Map();
+  const push = (where, ref) => {
+    if (!ref || !ref.messageId) return;
+    const key = ref.messageId;
+    if (!byKey.has(key)) {
+      byKey.set(key, {
+        archivePath,
+        name: ref.name ?? null,
+        topicId: ref.topicId ?? null,
+        messageId: ref.messageId,
+        locations: [],
+      });
+    }
+    byKey.get(key).locations.push(where);
+    // Backfill topicId/name from any location that has them.
+    const agg = byKey.get(key);
+    if (!agg.topicId && ref.topicId) agg.topicId = ref.topicId;
+    if (!agg.name && ref.name) agg.name = ref.name;
+  };
+
+  if (Array.isArray(manifest.tools)) {
+    manifest.tools.forEach((t, i) => push(`manifest.tools[${i}]`, t));
+  }
+
+  for (const [hash, embedded] of Object.entries(embeddedTools)) {
+    push(`tools/${hash}.json`, {
+      name: embedded.name,
+      topicId: embedded.topicId,
+      messageId: embedded.messageId,
+    });
+    if (Array.isArray(embedded.tools)) {
+      embedded.tools.forEach((t, i) => push(`tools/${hash}.json#tools[${i}]`, t));
+    }
+  }
+
+  return [...byKey.values()];
+}

--- a/tools/guardian-publish-validator/src/manifests.js
+++ b/tools/guardian-publish-validator/src/manifests.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Methodology library README parser.
+//
+// Each framework directory in hashgraph/guardian's "Methodology Library"
+// carries a readme.md (or README.md) with markdown tables that document
+// published policies and standalone tools, with their testnet/mainnet
+// consensus timestamps. We walk those READMEs, find tables that look like
+// timestamp registries, and extract entries.
+//
+// Format examples (loose — column ordering varies by framework):
+//
+//   | Policy | Testnet Timestamp | Mainnet Timestamp | Schema/Policy File Link |
+//   |---|---|---|---:|
+//   | AMS-II.G | 1726671907.504639000 | 1713216985.019528003 | [Link](...) |
+//
+//   | Tool Number | Description | IPFS Timestamp |
+//   |---|---|---:|
+//   | Tool 9 | ... | 1713221704.169952003 |
+//
+// We don't hard-code column positions. Instead we look at headers, identify
+// which column carries which kind of value (name, testnet-ts, mainnet-ts,
+// link), and extract from that. Rows with empty timestamps are dropped.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Hedera consensus timestamps are <seconds>.<nanos>, where nanos is always
+// exactly 9 digits. Loosening this to 1-9 digits would pick up truncated
+// values that appear in some readmes (e.g. Verra's Tool 3 listed as
+// 1706867833.67638 instead of 1706867833.676387003) and cause spurious
+// hedera-message-missing reports. We accept 6-9 digits to be a little
+// forgiving but still reject the most-truncated cases.
+const TIMESTAMP_RE = /(\d{9,12}\.\d{6,9})/;
+
+function isLikelyName(header) {
+  const h = header.toLowerCase();
+  // Exclude columns that are clearly the link/file column, even when their
+  // header also mentions "policy" or "schema" (e.g. "Schema/Policy File Link"
+  // in iREC's readme would otherwise match both name AND link, with the link
+  // pattern winning the cell content but the name role pointing at the same
+  // column — producing garbage names like "MRV.schema" instead of "MRV Schema").
+  if (/(link|file)/.test(h)) return false;
+  return /(policy|tool|module|methodology|name|standard|version|schema)/.test(h);
+}
+function isTestnetCol(header) {
+  const h = header.toLowerCase();
+  if (/main/.test(h)) return false;
+  return /test/.test(h) || /ipfs/.test(h) || /\btimestamp\b/.test(h);
+}
+function isMainnetCol(header) {
+  return /main/i.test(header) && /(timestamp|hedera|ipfs)/i.test(header);
+}
+function isLinkCol(header) {
+  return /(link|file)/i.test(header);
+}
+
+function findReadmes(rootDir) {
+  const out = [];
+  const stack = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+        stack.push(full);
+      } else if (e.isFile() && /^readme\.md$/i.test(e.name)) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+// Split a markdown line "| a | b | c |" into cells.
+function splitCells(line) {
+  // Strip leading/trailing pipes, split on |, trim.
+  const inner = line.replace(/^\s*\|/, '').replace(/\|\s*$/, '');
+  return inner.split('|').map((c) => c.trim());
+}
+
+function isSeparatorLine(line) {
+  // A markdown table separator is like |---|---|---:|
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return false;
+  const cells = splitCells(trimmed);
+  return cells.every((c) => /^:?[-]{2,}:?$/.test(c));
+}
+
+// Find every markdown table in the file. A table is a header row, a separator
+// row, then zero-or-more body rows. Returns an array of { headers, rows }.
+function parseTables(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const tables = [];
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i];
+    const next = lines[i + 1];
+    if (!line.trim().startsWith('|')) continue;
+    if (!isSeparatorLine(next)) continue;
+    const headers = splitCells(line);
+    const rows = [];
+    let j = i + 2;
+    while (j < lines.length && lines[j].trim().startsWith('|') && !isSeparatorLine(lines[j])) {
+      rows.push(splitCells(lines[j]));
+      j++;
+    }
+    tables.push({ headers, rows });
+    i = j - 1;
+  }
+  return tables;
+}
+
+// Decide whether a parsed table looks like a timestamp registry, and if so,
+// map columns to (name, testnet, mainnet, link) roles.
+function classifyTable(headers) {
+  const roles = { name: -1, testnet: -1, mainnet: -1, link: -1 };
+  headers.forEach((h, i) => {
+    if (roles.name === -1 && isLikelyName(h)) roles.name = i;
+    if (isMainnetCol(h)) roles.mainnet = i;
+    else if (roles.testnet === -1 && isTestnetCol(h)) roles.testnet = i;
+    if (isLinkCol(h)) roles.link = i;
+  });
+  if (roles.testnet === -1 && roles.mainnet === -1) return null; // not a timestamp table
+  if (roles.name === -1) return null; // can't identify the entity
+  return roles;
+}
+
+function extractTimestamp(cell) {
+  if (!cell) return null;
+  // Cells sometimes have stray whitespace, asterisks, or text after the ts.
+  const m = String(cell).match(TIMESTAMP_RE);
+  return m ? m[1] : null;
+}
+
+function extractLink(cell) {
+  if (!cell) return null;
+  const m = String(cell).match(/\[[^\]]*\]\(([^)]+)\)/);
+  return m ? m[1] : null;
+}
+
+function inferEntityType(tableHeaders, readmePath) {
+  const joined = tableHeaders.join(' ').toLowerCase();
+  if (/\btool\b/.test(joined)) return 'tool';
+  if (/\bmodule\b/.test(joined)) return 'module';
+  if (/\bpolicy\b/.test(joined) || /\bmethodology\b/.test(joined)) return 'policy';
+  // Fall back to the readme's directory if we can't tell from headers.
+  if (/\/Tools\/?(readme\.md)?$/i.test(readmePath)) return 'tool';
+  return 'policy';
+}
+
+function inferFramework(readmePath, libraryRoot) {
+  const rel = path.relative(libraryRoot, readmePath);
+  // The first path segment is usually the framework name.
+  const seg = rel.split(path.sep)[0] || '(root)';
+  return seg;
+}
+
+// Walk all readmes under libraryRoot and extract every entity row.
+// Returns a list of { name, type, framework, testnetTs, mainnetTs, link, source }.
+export function scanManifests(libraryRoot) {
+  const root = path.resolve(libraryRoot);
+  const readmes = findReadmes(root);
+  const entries = [];
+
+  for (const readmePath of readmes) {
+    const md = fs.readFileSync(readmePath, 'utf8');
+    const tables = parseTables(md);
+    for (const table of tables) {
+      const roles = classifyTable(table.headers);
+      if (!roles) continue;
+      const type = inferEntityType(table.headers, readmePath);
+      const framework = inferFramework(readmePath, root);
+      for (const row of table.rows) {
+        const rawName = row[roles.name];
+        const testnetTs = roles.testnet >= 0 ? extractTimestamp(row[roles.testnet]) : null;
+        const mainnetTs = roles.mainnet >= 0 ? extractTimestamp(row[roles.mainnet]) : null;
+        // Prefer an explicit link column; if missing, fall back to a link
+        // embedded in the name cell. Verra readmes use `[Policy Name](url)` as
+        // the entity column rather than a separate name+link split.
+        const explicitLink = roles.link >= 0 ? extractLink(row[roles.link]) : null;
+        const linkInName = rawName ? extractLink(rawName) : null;
+        const link = explicitLink || linkInName || null;
+        // Clean the name: if it's a markdown link, prefer the link text; if
+        // the link text is just "Link", derive a name from the URL filename.
+        let name = rawName?.trim() || null;
+        if (name) {
+          const linkMatch = name.match(/^\[([^\]]*)\]\(([^)]+)\)$/);
+          if (linkMatch) {
+            const linkText = linkMatch[1].trim();
+            const url = linkMatch[2];
+            if (linkText && !/^link$/i.test(linkText)) {
+              name = linkText;
+            } else {
+              // Derive from URL's last meaningful segment.
+              const segs = url.split('/').filter(Boolean);
+              const last = decodeURIComponent(segs.pop() || '').replace(/\.(policy|tool)$/, '');
+              name = last || null;
+            }
+          }
+        }
+        if (!testnetTs && !mainnetTs) continue;
+        if (!name) continue; // skip rows we couldn't identify
+        entries.push({
+          name,
+          type,
+          framework,
+          testnetTs,
+          mainnetTs,
+          link,
+          source: path.relative(root, readmePath),
+        });
+      }
+    }
+  }
+  return entries;
+}

--- a/tools/guardian-publish-validator/src/mirror.js
+++ b/tools/guardian-publish-validator/src/mirror.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Thin wrapper around the Hedera mirror node REST API for validating
+// tool-publish message references.
+//
+// A Guardian tool's "where do I live on Hedera" identity is the pair
+// (topicId, messageId). messageId is a consensus timestamp string of the form
+// "<seconds>.<nanos>". When testnet resets, the topic + messages are wiped and
+// queries for that timestamp return an empty `messages` array (HTTP 200 with
+// no rows), not a 404. We treat empty as "missing".
+
+const ENDPOINTS = {
+  testnet: 'https://testnet.mirrornode.hedera.com',
+  mainnet: 'https://mainnet-public.mirrornode.hedera.com',
+  previewnet: 'https://previewnet.mirrornode.hedera.com',
+};
+
+export function mirrorBaseUrl(network) {
+  const url = ENDPOINTS[network];
+  if (!url) throw new Error(`Unknown network: ${network}. Use one of: ${Object.keys(ENDPOINTS).join(', ')}`);
+  return url;
+}
+
+// Look up a single message by its consensus timestamp on a topic.
+// Returns { found: true, message } if it exists, { found: false, status } otherwise.
+// Network or HTTP failures throw so the caller can decide retry policy.
+export async function lookupMessage(network, topicId, messageId, { timeoutMs = 10000 } = {}) {
+  if (!topicId) {
+    return { found: false, status: 'no-topic-id' };
+  }
+  const base = mirrorBaseUrl(network);
+  const url = `${base}/api/v1/topics/${encodeURIComponent(topicId)}/messages?timestamp=eq:${encodeURIComponent(messageId)}&limit=1`;
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  let res;
+  try {
+    res = await fetch(url, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res.status === 404) return { found: false, status: 'topic-not-found' };
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Mirror error ${res.status} for ${topicId}/${messageId}: ${body.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  if (!Array.isArray(data.messages) || data.messages.length === 0) {
+    return { found: false, status: 'message-missing' };
+  }
+  return { found: true, message: data.messages[0] };
+}
+
+// Look up a message when we only have its consensus timestamp (no topicId).
+// README-extracted entries don't carry a topicId — we have to discover it
+// first via the transactions endpoint, then resolve the message normally.
+// Returns the same shape as lookupMessage plus the discovered topicId.
+export async function findMessageByTimestamp(network, messageId, { timeoutMs = 10000 } = {}) {
+  const base = mirrorBaseUrl(network);
+  const txUrl = `${base}/api/v1/transactions?timestamp=eq:${encodeURIComponent(messageId)}&limit=1`;
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  let res;
+  try {
+    res = await fetch(txUrl, { signal: ctrl.signal, headers: { accept: 'application/json' } });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Mirror tx lookup error ${res.status} for ${messageId}: ${body.slice(0, 200)}`);
+  }
+  const data = await res.json();
+  const tx = (data.transactions || [])[0];
+  if (!tx) return { found: false, status: 'message-missing', topicId: null };
+
+  // entity_id on a CONSENSUSSUBMITMESSAGE transaction is the topic the message
+  // was submitted to.
+  const topicId = tx.entity_id;
+  if (!topicId) return { found: false, status: 'no-topic-id', topicId: null };
+
+  // Now fetch the actual message (we need its payload to extract the CID).
+  const inner = await lookupMessage(network, topicId, messageId, { timeoutMs });
+  return { ...inner, topicId };
+}
+
+// Pull the IPFS CID out of a Guardian publish message. Guardian wraps the
+// methodology/tool zip in IPFS and writes the CID into the consensus message.
+// Single-chunk messages are the common case; multi-chunk messages need all
+// chunks concatenated before parsing the JSON payload (handled here as
+// best-effort: if we only see one chunk, parse it; if multi-chunk and we have
+// chunk_info.total > 1, we currently return cid=null with a note so the
+// caller can decide whether to handle it).
+export function extractCidFromMessage(message) {
+  if (!message || !message.message) return { cid: null, reason: 'no-message' };
+  const chunkInfo = message.chunk_info;
+  if (chunkInfo && chunkInfo.total && chunkInfo.total > 1 && chunkInfo.number === 1) {
+    // First chunk of a multi-chunk message — payload alone won't parse as JSON.
+    // For now we report this as multi-chunk so the validator can decide if it
+    // wants to fetch the remaining chunks. The mirror REST API can return the
+    // full set via the initial_transaction_id; left as a TODO until we see one.
+    return { cid: null, reason: 'multi-chunk-message' };
+  }
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(message.message, 'base64').toString('utf8'));
+  } catch (err) {
+    return { cid: null, reason: `payload-parse-error: ${err.message}` };
+  }
+  if (payload && typeof payload.cid === 'string' && payload.cid.length > 0) {
+    return { cid: payload.cid, payload };
+  }
+  if (payload && typeof payload.uri === 'string') {
+    const match = payload.uri.match(/ipfs:\/\/([^/?#]+)/);
+    if (match) return { cid: match[1], payload };
+  }
+  return { cid: null, reason: 'no-cid-in-payload', payload };
+}

--- a/tools/guardian-publish-validator/src/repo.js
+++ b/tools/guardian-publish-validator/src/repo.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Auto-fetch and cache an upstream Guardian methodology library clone.
+//
+// First run for a given repo+branch does a shallow clone into
+//   ~/.cache/guardian-tool-validator/<owner-repo>/<branch>
+// Subsequent runs `git fetch` + `git reset --hard origin/<branch>` to refresh.
+//
+// The validator and the UI server both call ensureUpstreamCheckout() so end
+// users don't have to manage a local clone manually. Power users can still
+// override with --path to point at a custom directory (their own fork,
+// in-development work, etc.).
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export const DEFAULT_CACHE_ROOT = path.join(os.homedir(), '.cache', 'guardian-tool-validator');
+
+function slugify(repo) {
+  return repo.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function exec(cmd, args, onProgress) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const onData = (buf) => onProgress?.(buf.toString('utf8'));
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+// Ensure the upstream repo is cloned and up to date. Returns the path to the
+// "Methodology Library" directory inside the clone.
+export async function ensureUpstreamCheckout({
+  repo = 'hashgraph/guardian',
+  branch = 'main',
+  cacheRoot = DEFAULT_CACHE_ROOT,
+  onProgress = null,
+  subpath = 'Methodology Library',
+} = {}) {
+  const slug = slugify(repo);
+  const dir = path.join(cacheRoot, slug, branch);
+  fs.mkdirSync(path.dirname(dir), { recursive: true });
+
+  if (!fs.existsSync(path.join(dir, '.git'))) {
+    onProgress?.(`Cloning ${repo}@${branch} → ${dir}\n`);
+    await exec(
+      'git',
+      ['clone', '--depth', '1', '--branch', branch, `https://github.com/${repo}.git`, dir],
+      onProgress
+    );
+  } else {
+    onProgress?.(`Updating ${repo}@${branch} in ${dir}\n`);
+    try {
+      await exec('git', ['-C', dir, 'fetch', '--depth', '1', 'origin', branch], onProgress);
+      await exec('git', ['-C', dir, 'reset', '--hard', `origin/${branch}`], onProgress);
+    } catch (err) {
+      // If fetch/reset fails (e.g., shallow-clone corruption), wipe and re-clone.
+      onProgress?.(`Update failed (${err.message}). Re-cloning...\n`);
+      fs.rmSync(dir, { recursive: true, force: true });
+      await exec(
+        'git',
+        ['clone', '--depth', '1', '--branch', branch, `https://github.com/${repo}.git`, dir],
+        onProgress
+      );
+    }
+  }
+
+  const libraryPath = path.join(dir, subpath);
+  if (!fs.existsSync(libraryPath)) {
+    throw new Error(`"${subpath}" not found in ${repo}@${branch} (looked in ${libraryPath})`);
+  }
+  return libraryPath;
+}

--- a/tools/guardian-publish-validator/tests/library.test.js
+++ b/tools/guardian-publish-validator/tests/library.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+//
+// Tests for the library walker — finding archives, reading their manifest,
+// extracting tool references from the policy.json tools array AND from any
+// embedded tools/*.json files.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import AdmZip from 'adm-zip';
+
+import { findArchives, readArchive, extractToolRefs } from '../src/library.js';
+
+// Build a minimal .policy archive in a temp dir for testing.
+function makePolicyArchive(dir, name, manifest, embedded = {}) {
+  const zip = new AdmZip();
+  zip.addFile('policy.json', Buffer.from(JSON.stringify(manifest)));
+  for (const [filename, contents] of Object.entries(embedded)) {
+    zip.addFile(`tools/${filename}`, Buffer.from(JSON.stringify(contents)));
+  }
+  const full = path.join(dir, name);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  zip.writeZip(full);
+  return full;
+}
+
+test('findArchives discovers .policy and .tool files recursively', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gpv-test-'));
+  makePolicyArchive(root, 'CDM/AMS-II.G/policy.policy', { tools: [] });
+  makePolicyArchive(root, 'Verra/VM0003/policy.policy', { tools: [] });
+  makePolicyArchive(root, 'Tools/Tool07/tool.tool', { tools: [] });
+
+  const archives = findArchives(root);
+  assert.equal(archives.length, 3);
+  assert.ok(archives[0].endsWith('.policy') || archives[0].endsWith('.tool'));
+});
+
+test('extractToolRefs reads the manifest.tools array', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gpv-test-'));
+  const archive = makePolicyArchive(root, 'CDM/AMS-II.G/policy.policy', {
+    tools: [
+      { name: 'Tool 33', topicId: '0.0.4865949', messageId: '1726593517.484578000' },
+      { name: 'Tool 19', topicId: '0.0.2196124', messageId: '1706869798.177938003' },
+    ],
+  });
+  const refs = extractToolRefs(readArchive(archive));
+  assert.equal(refs.length, 2);
+  assert.equal(refs[0].name, 'Tool 33');
+  assert.equal(refs[0].topicId, '0.0.4865949');
+  assert.equal(refs[0].messageId, '1726593517.484578000');
+});
+
+test('extractToolRefs dedupes references that appear both in manifest.tools and embedded tool files', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gpv-test-'));
+  const archive = makePolicyArchive(
+    root,
+    'CDM/AMS-II.G/policy.policy',
+    {
+      tools: [
+        { name: 'Tool 30', topicId: '0.0.3039186', messageId: '1707417996.173398196' },
+      ],
+    },
+    {
+      // Embedded tool JSON with the same messageId — should be merged into
+      // a single entry with multiple occurrences, not counted twice.
+      'abc123.json': {
+        name: 'Tool 30',
+        messageId: '1707417996.173398196',
+        hash: 'abc123',
+      },
+    }
+  );
+  const refs = extractToolRefs(readArchive(archive));
+  assert.equal(refs.length, 1);
+  assert.equal(refs[0].messageId, '1707417996.173398196');
+  // Both occurrences are recorded.
+  assert.ok(refs[0].locations.length >= 2);
+});
+
+test('readArchive returns null manifest gracefully on a non-Guardian zip', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gpv-test-'));
+  // Zip with a random file — no policy.json / tool.json.
+  const zip = new AdmZip();
+  zip.addFile('random.txt', Buffer.from('hello'));
+  const archive = path.join(root, 'random.policy');
+  zip.writeZip(archive);
+
+  const info = readArchive(archive);
+  assert.equal(info.manifest, null);
+  assert.equal(extractToolRefs(info).length, 0);
+});

--- a/tools/guardian-publish-validator/tests/manifests.test.js
+++ b/tools/guardian-publish-validator/tests/manifests.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+//
+// Unit tests for the README markdown-table parser. The parser is one of the
+// trickier pieces of the validator because real Guardian framework READMEs
+// have inconsistent column orderings and ambiguous header names. These tests
+// cover the column-classification heuristics and the markdown-link cleanup.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { scanManifests } from '../src/manifests.js';
+
+function mkTempLibrary(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gpv-test-'));
+  for (const [rel, contents] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  }
+  return root;
+}
+
+test('parses a basic policy timestamp table', () => {
+  const root = mkTempLibrary({
+    'CDM/readme.md': `
+# CDM
+
+| Policy | Testnet Timestamp | Mainnet Timestamp | Schema/Policy File Link |
+|---|---|---|---:|
+| AMS-II.G | 1726671907.504639000 | 1713216985.019528003 | [Link](https://example.com/AMS-II.G.policy) |
+| AMS-II.J | 1712067497.011072374 | 1713216612.286089221 | [Link](https://example.com/AMS-II.J.policy) |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].name, 'AMS-II.G');
+  assert.equal(entries[0].testnetTs, '1726671907.504639000');
+  assert.equal(entries[0].mainnetTs, '1713216985.019528003');
+  assert.equal(entries[0].type, 'policy');
+  assert.equal(entries[0].framework, 'CDM');
+  assert.equal(entries[0].link, 'https://example.com/AMS-II.G.policy');
+});
+
+test('parses a tool timestamp table (different column layout)', () => {
+  const root = mkTempLibrary({
+    'CDM/Tools/readme.md': `
+| Tool Number | Description | IPFS Timestamp |
+|---|---|---:|
+| Tool 9 | Tool for energy systems | 1713221704.169952003 |
+| Tool 33 | Tool for default values | 1726593517.484578000 |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].name, 'Tool 9');
+  assert.equal(entries[0].type, 'tool');
+  assert.equal(entries[0].testnetTs, '1713221704.169952003');
+});
+
+test('column-name heuristic does not pick "Schema/Policy File Link" as the name column', () => {
+  // Bug from prior version: "Schema/Policy File Link" matched isLikelyName
+  // because it contains "policy", causing names to be derived from the URL.
+  const root = mkTempLibrary({
+    'iREC/readme.md': `
+| Version | IPFS Timestamp | Differences | Schema/Policy File Link |
+|---|---|---|---:|
+| MRV Schema | 1674826707.124031003 | - | [Link](https://example.com/MRV.schema) |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'MRV Schema'); // not "MRV.schema" from the URL
+});
+
+test('drops truncated timestamps (< 6 nanos digits) to avoid false hedera-missing results', () => {
+  const root = mkTempLibrary({
+    'Verra/readme.md': `
+| Tool | Timestamp |
+|---|---|
+| Tool 3 | 1706867833.67638 |
+| Tool 5 | 1706867833.676380123 |
+`,
+  });
+  const entries = scanManifests(root);
+  // The truncated 5-nanos entry is dropped; the proper 9-nanos one is kept.
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'Tool 5');
+});
+
+test('handles markdown link as the name cell with non-trivial link text', () => {
+  const root = mkTempLibrary({
+    'Verra/VM0003/README.md': `
+| Schema | Testnet Timestamp |
+|---|---|
+| [Verra VM0003 Policy](https://example.com/VM0003.policy) | 1728491334.273105000 |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'Verra VM0003 Policy');
+  assert.equal(entries[0].link, 'https://example.com/VM0003.policy');
+});
+
+test('handles markdown link as the name cell with "Link" placeholder text', () => {
+  const root = mkTempLibrary({
+    'GS/readme.md': `
+| Schema | Testnet Timestamp | Link |
+|---|---|---|
+| Gold Standard AR | 1707206651.379730003 | [Link](https://example.com/path/Gold%20Standard%20AR.policy) |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'Gold Standard AR');
+});
+
+test('ignores rows with no timestamp at all', () => {
+  const root = mkTempLibrary({
+    'X/readme.md': `
+| Policy | Testnet Timestamp |
+|---|---|
+| Real Entry | 1707206651.379730003 |
+| Placeholder | TBD |
+| Empty |  |
+`,
+  });
+  const entries = scanManifests(root);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'Real Entry');
+});

--- a/tools/guardian-publish-validator/tests/mirror.test.js
+++ b/tools/guardian-publish-validator/tests/mirror.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Hedera Hashgraph, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+//
+// Tests for mirror-node message decoding. We can't unit-test the actual HTTP
+// fetch without a stub server, but extractCidFromMessage() is pure and worth
+// testing in isolation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractCidFromMessage } from '../src/mirror.js';
+
+function encodeMsg(payload) {
+  return {
+    message: Buffer.from(JSON.stringify(payload)).toString('base64'),
+    chunk_info: { number: 1, total: 1 },
+  };
+}
+
+test('extractCidFromMessage reads cid from a standard Guardian publish payload', () => {
+  const msg = encodeMsg({
+    id: 'abc',
+    status: 'ISSUE',
+    type: 'Instance-Policy',
+    action: 'publish-policy',
+    cid: 'bafkreib5xcmwauc2vrkcpgxvfsd6y2hfpgrd4zm6me4e5wdc6kcxwxwwoy',
+    uri: 'ipfs://bafkreib5xcmwauc2vrkcpgxvfsd6y2hfpgrd4zm6me4e5wdc6kcxwxwwoy',
+  });
+  const { cid } = extractCidFromMessage(msg);
+  assert.equal(cid, 'bafkreib5xcmwauc2vrkcpgxvfsd6y2hfpgrd4zm6me4e5wdc6kcxwxwwoy');
+});
+
+test('extractCidFromMessage falls back to parsing the uri when cid is missing', () => {
+  const msg = encodeMsg({
+    uri: 'ipfs://QmRCsLFpxLsiuNfs42QGn5oV41wqEjMKbV3RhGxK3Mo6vc',
+  });
+  const { cid } = extractCidFromMessage(msg);
+  assert.equal(cid, 'QmRCsLFpxLsiuNfs42QGn5oV41wqEjMKbV3RhGxK3Mo6vc');
+});
+
+test('extractCidFromMessage handles multi-chunk messages by reporting them rather than parsing partial JSON', () => {
+  const msg = {
+    message: Buffer.from('{"id":').toString('base64'), // partial JSON
+    chunk_info: { number: 1, total: 3 },
+  };
+  const result = extractCidFromMessage(msg);
+  assert.equal(result.cid, null);
+  assert.equal(result.reason, 'multi-chunk-message');
+});
+
+test('extractCidFromMessage returns null on a malformed payload without throwing', () => {
+  const msg = {
+    message: Buffer.from('not json').toString('base64'),
+    chunk_info: { number: 1, total: 1 },
+  };
+  const result = extractCidFromMessage(msg);
+  assert.equal(result.cid, null);
+  assert.match(result.reason, /payload-parse-error/);
+});

--- a/tools/guardian-publish-validator/ui/index.html
+++ b/tools/guardian-publish-validator/ui/index.html
@@ -1,0 +1,1198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="theme-color" content="#ffffff" id="meta-theme-color" />
+<script>
+  // Apply the persisted theme BEFORE the body paints to avoid a flash.
+  // Light is the default if nothing is stored.
+  (function () {
+    try {
+      const t = localStorage.getItem('gtv-theme') || 'light';
+      if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+    } catch {}
+  })();
+</script>
+<title>Guardian Methodology Library Validator</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* Light theme is the default; dark theme activates when
+     <html data-theme="dark"> is set. Toggle persists via localStorage. */
+  :root {
+    --bg: #ffffff;
+    --surface: #f7f7f7;
+    --surface-light: #efefef;
+    --surface-hover: #e8e8e8;
+    --accent: #15a87e;
+    --accent-bright: #2dd4a8;
+    --accent-on: #ffffff;
+    --resilient: #0891b2;
+    --resilient-bg: rgba(8, 145, 178, 0.10);
+    --warning: #b8741c;
+    --warning-bg: rgba(184, 116, 28, 0.10);
+    --danger: #b91c1c;
+    --danger-bg: rgba(185, 28, 28, 0.08);
+    --healthy-bg: rgba(21, 168, 126, 0.10);
+    --text: #0a0a0a;
+    --text-secondary: #404040;
+    --text-muted: #737373;
+    --border: rgba(0, 0, 0, 0.08);
+    --border-strong: rgba(0, 0, 0, 0.15);
+    --shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+    --modal-backdrop: rgba(0, 0, 0, 0.4);
+    --code-bg: #f1f1f1;
+    --recommendation-healthy-bg: rgba(21, 168, 126, 0.06);
+    --recommendation-healthy-border: rgba(21, 168, 126, 0.25);
+    --recommendation-broken-bg: rgba(185, 28, 28, 0.06);
+    --recommendation-broken-border: rgba(185, 28, 28, 0.25);
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #0a0a0a;
+    --surface: #111111;
+    --surface-light: #161616;
+    --surface-hover: #1c1c1c;
+    --accent: #2dd4a8;
+    --accent-bright: #5eebc0;
+    --accent-on: #0a0a0a;
+    --resilient: #22d3ee;
+    --resilient-bg: rgba(34, 211, 238, 0.12);
+    --warning: #f0c674;
+    --warning-bg: rgba(240, 198, 116, 0.12);
+    --danger: #f87171;
+    --danger-bg: rgba(248, 113, 113, 0.12);
+    --healthy-bg: rgba(45, 212, 168, 0.12);
+    --text: #fafafa;
+    --text-secondary: #a1a1a1;
+    --text-muted: #525252;
+    --border: rgba(255, 255, 255, 0.06);
+    --border-strong: rgba(255, 255, 255, 0.12);
+    --shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+    --modal-backdrop: rgba(0, 0, 0, 0.65);
+    --code-bg: #050505;
+    --recommendation-healthy-bg: rgba(45, 212, 168, 0.06);
+    --recommendation-healthy-border: rgba(45, 212, 168, 0.25);
+    --recommendation-broken-bg: rgba(248, 113, 113, 0.06);
+    --recommendation-broken-border: rgba(248, 113, 113, 0.25);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    font-weight: 300;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+  code, .mono { font-family: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 32px 24px 80px;
+  }
+
+  /* Header */
+  header.top {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 28px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+  }
+  header.top .titleblock {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-width: 260px;
+  }
+  header.top .actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .btn {
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 10px 16px;
+    border-radius: 100px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    text-decoration: none;
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+  }
+  .btn:hover { background: var(--surface-hover); border-color: var(--accent); }
+  .btn.primary {
+    background: linear-gradient(135deg, var(--accent), var(--accent-bright));
+    color: var(--accent-on);
+    border-color: transparent;
+  }
+  .btn.primary:hover { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(21, 168, 126, 0.25); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn .glyph { font-size: 14px; line-height: 1; }
+  .eyebrow {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  h1 {
+    font-size: clamp(28px, 4vw, 36px);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    margin: 0;
+  }
+  .meta-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 6px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .meta-line .kv { display: inline-flex; gap: 6px; align-items: baseline; }
+  .meta-line .k {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  .meta-line .v { font-family: 'Geist Mono', monospace; font-size: 12px; }
+
+  /* Summary cards */
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin-bottom: 28px;
+  }
+  .stat {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 20px 22px;
+    position: relative;
+    overflow: hidden;
+  }
+  .stat .label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  .stat .value {
+    font-size: 44px;
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    margin: 8px 0 4px 0;
+  }
+  .stat .pct {
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-weight: 300;
+  }
+  .stat.healthy .value { color: var(--accent); }
+  .stat.resilient .value { color: var(--resilient); }
+  .stat.fragile .value { color: var(--warning); }
+  .stat.broken .value { color: var(--danger); }
+  .stat.total .value { color: var(--text); }
+  .stat .desc {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.45;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--border);
+  }
+
+  /* Modal */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--modal-backdrop);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 20px;
+  }
+  .modal-backdrop.open { display: flex; }
+  .modal {
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 16px;
+    padding: 28px 28px 22px;
+    width: 100%;
+    max-width: 520px;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  .modal h2 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px 0;
+  }
+  .modal .modal-sub {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin: 0 0 20px 0;
+  }
+  .modal label {
+    display: block;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 12px 0 6px 0;
+  }
+  .modal input[type="text"], .modal select {
+    width: 100%;
+    background: var(--surface-light);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 10px 12px;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 13px;
+  }
+  .modal input:focus, .modal select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .modal .row { display: flex; gap: 12px; }
+  .modal .row > * { flex: 1; }
+  .modal .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 14px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .modal .checkbox-row input[type="checkbox"] { width: auto; }
+  .modal .field-help {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 4px 0 0 0;
+  }
+  .modal .field-help code {
+    background: var(--code-bg);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .modal details {
+    margin-top: 16px;
+    border-top: 1px dashed var(--border);
+    padding-top: 14px;
+  }
+  .modal summary {
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    user-select: none;
+  }
+  .modal summary:hover { color: var(--text-secondary); }
+  .modal .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 24px;
+  }
+  .modal-log {
+    margin-top: 20px;
+    padding: 14px;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    color: var(--text-secondary);
+    max-height: 260px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background: var(--surface);
+    border: 1px solid var(--accent);
+    color: var(--text);
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-size: 13px;
+    z-index: 200;
+    box-shadow: var(--shadow);
+  }
+  .toast.error { border-color: var(--danger); color: var(--danger); }
+
+  /* Controls */
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 16px;
+    align-items: center;
+  }
+  .pill {
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--text-secondary);
+    padding: 8px 14px;
+    border-radius: 100px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    user-select: none;
+    transition: all 0.15s ease;
+  }
+  .pill:hover { background: var(--surface-hover); color: var(--text); }
+  .pill.active {
+    background: var(--accent);
+    color: var(--accent-on);
+    border-color: var(--accent);
+  }
+  .pill .count {
+    margin-left: 8px;
+    font-weight: 300;
+    opacity: 0.7;
+  }
+  .pill.active .count { opacity: 0.7; }
+  .search-input {
+    flex: 1;
+    min-width: 240px;
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 10px 16px;
+    border-radius: 100px;
+    font-family: inherit;
+    font-size: 13px;
+  }
+  .search-input:focus { outline: none; border-color: var(--accent); }
+
+  /* Table */
+  .table-wrap {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    overflow: hidden;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  thead th {
+    text-align: left;
+    padding: 14px 18px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    background: var(--surface-light);
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+  }
+  thead th:hover { color: var(--text-secondary); }
+  thead th .arrow { opacity: 0.4; margin-left: 4px; font-size: 9px; }
+  tbody tr {
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 0.1s ease;
+  }
+  tbody tr:hover { background: var(--surface-hover); }
+  tbody tr.expanded { background: var(--surface-light); }
+  tbody td {
+    padding: 14px 18px;
+    vertical-align: middle;
+  }
+  tbody td.name { font-weight: 500; }
+  tbody td.muted { color: var(--text-muted); }
+  tbody td.mono { font-family: 'Geist Mono', monospace; font-size: 11.5px; }
+
+  .status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 100px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .status .dot { width: 6px; height: 6px; border-radius: 50%; }
+  .status.ok { background: var(--healthy-bg); color: var(--accent); }
+  .status.ok .dot { background: var(--accent); }
+  .status.resilient { background: var(--resilient-bg); color: var(--resilient); }
+  .status.resilient .dot { background: var(--resilient); }
+  .status.fragile { background: var(--warning-bg); color: var(--warning); }
+  .status.fragile .dot { background: var(--warning); }
+  .status.broken { background: var(--danger-bg); color: var(--danger); }
+  .status.broken .dot { background: var(--danger); }
+
+  .type-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    background: var(--surface-light);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+  }
+
+  /* Detail panel */
+  .detail-row td {
+    padding: 0 !important;
+    background: var(--bg);
+  }
+  .detail-inner {
+    padding: 22px 24px 26px;
+    border-top: 1px solid var(--border);
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 28px;
+  }
+  .detail-section h3 {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 0 0 12px 0;
+  }
+  .field {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+    font-size: 12.5px;
+    margin-bottom: 6px;
+  }
+  .field .label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    width: 80px;
+    flex-shrink: 0;
+  }
+  .field .value {
+    color: var(--text-secondary);
+    font-family: 'Geist Mono', monospace;
+    font-size: 12px;
+    word-break: break-all;
+  }
+  .gateway-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .gateway-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 12px;
+    background: var(--surface);
+    border-radius: 6px;
+    font-size: 12px;
+    border: 1px solid var(--border);
+  }
+  .gateway-name { font-family: 'Geist Mono', monospace; }
+  .gateway-name.local { color: var(--accent); font-weight: 500; }
+  .gateway-status { font-size: 11px; color: var(--text-muted); }
+  .gateway-row.ok .gateway-status { color: var(--accent); }
+  .gateway-row.fail .gateway-status { color: var(--danger); }
+  .gateway-elapsed { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--text-muted); margin-left: 8px; }
+
+  .occurrences {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .occurrence {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11.5px;
+    color: var(--text-secondary);
+    padding: 4px 0;
+  }
+  .occurrence .loc { color: var(--text-muted); margin-left: 6px; }
+  .occurrence a, .field a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px dotted color-mix(in srgb, var(--accent) 50%, transparent);
+    transition: border-color 0.15s ease;
+  }
+  .occurrence a:hover, .field a:hover { border-bottom-color: var(--accent); }
+
+  .recommendation {
+    margin-top: 14px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background: var(--recommendation-healthy-bg);
+    border: 1px solid var(--recommendation-healthy-border);
+    font-size: 12.5px;
+    color: var(--text);
+    line-height: 1.5;
+  }
+  .recommendation strong { color: var(--accent); }
+  .recommendation.broken {
+    background: var(--recommendation-broken-bg);
+    border-color: var(--recommendation-broken-border);
+  }
+  .recommendation.broken strong { color: var(--danger); }
+
+  .empty {
+    padding: 60px 24px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 80px 24px;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .err {
+    padding: 20px;
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.25);
+    border-radius: 12px;
+    color: var(--danger);
+    font-size: 13px;
+  }
+
+  @media (max-width: 720px) {
+    .detail-inner { grid-template-columns: 1fr; gap: 18px; }
+    tbody td:nth-child(4), tbody td:nth-child(5),
+    thead th:nth-child(4), thead th:nth-child(5) { display: none; }
+  }
+</style>
+</head>
+<body>
+<div class="page" id="root">
+  <div class="loading">Loading report…</div>
+</div>
+
+<!-- Scan-options modal. Hidden until "Run new scan" is clicked. -->
+<div class="modal-backdrop" id="scan-modal">
+  <div class="modal">
+    <h2>Run a new scan</h2>
+    <p class="modal-sub">The validator walks Hedera Guardian's official methodology library, checks every tool and policy on Hedera, and probes IPFS gateways. Takes a few minutes.</p>
+
+    <div class="row">
+      <div>
+        <label for="scan-network">Network</label>
+        <select id="scan-network">
+          <option value="testnet">testnet</option>
+          <option value="mainnet">mainnet</option>
+          <option value="previewnet">previewnet</option>
+        </select>
+        <p class="field-help">Which Hedera network's consensus messages to check. Testnet timestamps and mainnet timestamps are different — testnet content also disappears after testnet resets, which is the main reason this tool exists.</p>
+      </div>
+      <div>
+        <label for="scan-concurrency">Concurrency</label>
+        <input type="text" id="scan-concurrency" value="4" />
+        <p class="field-help">How many checks to run in parallel. Higher is faster but can trigger rate-limits on the mirror node. <code>2</code>–<code>6</code> is the sweet spot.</p>
+      </div>
+    </div>
+
+    <label for="scan-filter">Filter (optional)</label>
+    <input type="text" id="scan-filter" placeholder='e.g. "CDM" or "Verra"' />
+    <p class="field-help">Substring match scoping the scan. Useful for spot-checking one framework instead of all 167 archives. Leave blank to scan everything.</p>
+
+    <label for="scan-local-gateway">Your local Kubo gateway URL (optional)</label>
+    <input type="text" id="scan-local-gateway" placeholder="https://your-kubo/ipfs/${cid}" />
+    <p class="field-help">Your own IPFS node. Use <code>${cid}</code> as the placeholder. CIDs served here count as <strong>Healthy</strong> instead of <strong>Fragile</strong>. Leave blank to probe only public gateways (ipfs.io, dweb.link, pinata, w3s.link).</p>
+
+    <div class="checkbox-row">
+      <input type="checkbox" id="scan-skip-ipfs" />
+      <label for="scan-skip-ipfs" style="margin: 0; letter-spacing: 0; text-transform: none; font-size: 13px; color: var(--text-secondary);">Skip IPFS check (Hedera-only, faster)</label>
+    </div>
+    <p class="field-help" style="margin-top: 6px;">Checks only whether the Hedera consensus message still exists. Skips the IPFS gateway probes. Useful for a fast first pass — finishes in seconds instead of minutes.</p>
+
+    <details>
+      <summary>Advanced</summary>
+      <label for="scan-library">Methodology library path (optional override)</label>
+      <input type="text" id="scan-library" placeholder="Default: auto-cloned hashgraph/guardian@main" />
+      <p class="field-help">Leave blank to use the official upstream library. The validator will auto-clone <code>hashgraph/guardian</code> into <code>~/.cache/guardian-tool-validator/</code> and refresh it on each scan. Override with a path to a local clone (e.g., your own fork or work-in-progress branch).</p>
+
+      <div class="row">
+        <div>
+          <label for="scan-repo">GitHub repo for occurrence links</label>
+          <input type="text" id="scan-repo" value="hashgraph/guardian" />
+          <p class="field-help">Where "Open in GitHub →" links point. Also determines what gets auto-cloned if the path above is blank.</p>
+        </div>
+        <div>
+          <label for="scan-branch">Branch</label>
+          <input type="text" id="scan-branch" value="main" />
+          <p class="field-help">Branch in the linked repo. Use <code>develop</code> if you want to validate work-in-progress library state.</p>
+        </div>
+      </div>
+    </details>
+
+    <div class="modal-log" id="scan-log" style="display: none;"></div>
+
+    <div class="modal-actions">
+      <button class="btn" id="scan-cancel">Close</button>
+      <button class="btn primary" id="scan-start">Start scan</button>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast" style="display: none;"></div>
+
+<script>
+const root = document.getElementById('root');
+
+// Four-bucket grouping. Mirrors the bucket() function in bin/validator.js —
+// must stay in sync because CI gates, the UI summary, and downstream
+// analytics all flow off these names.
+function statusGroup(status) {
+  if (status === 'ok' || status === 'ipfs-ok-local') return 'healthy';
+  if (status === 'ipfs-resilient') return 'resilient';
+  // Older reports used 'ipfs-ok-external' for both resilient and fragile;
+  // we map those to fragile to be conservative.
+  if (status === 'ipfs-fragile' || status === 'ipfs-ok-external') return 'fragile';
+  return 'broken';
+}
+function statusLabel(status) {
+  return ({
+    'ok': 'Healthy',
+    'ipfs-ok-local': 'Healthy (local)',
+    'ipfs-resilient': 'Resilient',
+    'ipfs-fragile': 'Fragile',
+    'ipfs-ok-external': 'Fragile (legacy)',
+    'ipfs-unreachable': 'IPFS unreachable',
+    'hedera-message-missing': 'Hedera message missing',
+    'hedera-topic-not-found': 'Hedera topic missing',
+    'hedera-error': 'Hedera error',
+    'no-topic-id': 'No topic ID',
+    'multi-chunk': 'Multi-chunk (unsupported)',
+    'ok-no-cid': 'Hedera ok (no CID)',
+  })[status] || status;
+}
+
+function statusBadge(status) {
+  const group = statusGroup(status);
+  return `<span class="status ${group}"><span class="dot"></span>${statusLabel(status)}</span>`;
+}
+
+function recommendation(ref) {
+  const s = ref.status;
+  if (s === 'ok' || s === 'ipfs-ok-local') {
+    return `<div class="recommendation"><strong>Healthy.</strong> Hedera anchor alive AND a local Kubo node serves the IPFS bytes. No external dependency at retrieval time. No action needed.</div>`;
+  }
+  if (s === 'ipfs-resilient') {
+    return `<div class="recommendation"><strong>Resilient.</strong> Reachable from ${ref.publicHits || 'multiple'} independent public gateways. Any one of them can go dark without breaking consumers. This is the ideal state for upstream library content.</div>`;
+  }
+  if (s === 'ipfs-fragile' || s === 'ipfs-ok-external') {
+    return `<div class="recommendation"><strong>Fragile.</strong> Content currently retrievable from only one gateway. Single point of failure. Suggested fix: re-pin to additional gateways or a local Kubo. After the proposed multi-gateway fallback ships in Guardian's <code>getFile()</code>, opportunistic local caching also helps.</div>`;
+  }
+  if (s === 'ipfs-unreachable') {
+    return `<div class="recommendation broken"><strong>Action needed: re-pin.</strong> Hedera anchor is alive but the IPFS bytes are gone from every gateway probed. If the bytes still live inside the .policy archive in the library, the republisher can extract and re-pin them (preserving the original CID, no new Hedera transaction needed).</div>`;
+  }
+  if (s === 'hedera-message-missing' || s === 'hedera-topic-not-found') {
+    return `<div class="recommendation broken"><strong>Action needed: full republish.</strong> The Hedera consensus message itself is gone (likely a testnet reset wiped it). Requires uploading content to IPFS and submitting a new consensus message. Provenance considerations apply for mainnet content.</div>`;
+  }
+  if (s === 'no-topic-id') {
+    return `<div class="recommendation broken"><strong>No topic ID.</strong> The reference doesn't carry a topic, so we can't directly resolve the message. May need to look it up via the transactions endpoint.</div>`;
+  }
+  return `<div class="recommendation broken"><strong>${statusLabel(s)}.</strong> Investigate manually.</div>`;
+}
+
+function renderGatewayRow(g) {
+  const cls = g.ok ? 'ok' : 'fail';
+  const nameCls = g.kind === 'local' ? 'gateway-name local' : 'gateway-name';
+  return `<div class="gateway-row ${cls}">
+    <div><span class="${nameCls}">${g.gateway}</span></div>
+    <div>
+      <span class="gateway-status">${g.ok ? 'reachable' : g.status}</span>
+      <span class="gateway-elapsed">${g.elapsedMs}ms</span>
+    </div>
+  </div>`;
+}
+
+function renderOccurrences(occs, report) {
+  if (!occs || !occs.length) return '<div class="occurrence" style="color: var(--text-muted)">(no occurrences recorded)</div>';
+  return occs.map(o => {
+    // The occurrence row always links to the document that REFERENCES the
+    // entity (the README markdown file or the .policy archive). That path
+    // is always valid inside the repo. The README's claimed "link to source
+    // file" is shown separately in the Source-file row above.
+    const src = o.source || o.archive || '(unknown)';
+    const loc = o.location || '';
+    const url = githubUrl(report, src);
+    const srcMarkup = url
+      ? `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(src)}</a>`
+      : escapeHtml(src);
+    return `<div class="occurrence"><span>${srcMarkup}</span><span class="loc">${escapeHtml(loc)}</span></div>`;
+  }).join('');
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
+}
+
+// Build an absolute GitHub URL for a path inside the methodology library.
+// The report carries `githubRepo`, `githubBranch`, and `githubBase` (set by
+// the validator via --repo / --branch / --repo-base flags, defaulting to
+// hashgraph/guardian@main + "Methodology Library"). Paths get URL-encoded
+// segment by segment to preserve directory structure but escape spaces,
+// parentheses, etc.
+function githubUrl(report, relPath) {
+  if (!relPath) return null;
+  // Fall back to upstream defaults if the report was produced before the
+  // --repo/--branch flags were added.
+  const repo = (report && report.githubRepo) || 'hashgraph/guardian';
+  const branch = (report && report.githubBranch) || 'main';
+  const base = ((report && report.githubBase) || 'Methodology Library').replace(/(^\/|\/$)/g, '');
+  const parts = relPath.split('/').map(encodeURIComponent).join('/');
+  const baseParts = base ? base.split('/').map(encodeURIComponent).join('/') + '/' : '';
+  return `https://github.com/${repo}/blob/${encodeURIComponent(branch)}/${baseParts}${parts}`;
+}
+
+// Some occurrence sources point at README markdown files rather than the
+// asset itself; in those cases we still link to the README so the user can
+// see the table row that documents this entity.
+function occurrenceUrl(report, occ) {
+  if (!occ) return null;
+  if (occ.link) return occ.link; // README extractor sometimes captured the absolute link directly
+  const source = occ.source || occ.archive;
+  return githubUrl(report, source);
+}
+
+function renderDetail(ref, report) {
+  // Two distinct GitHub links per entity:
+  //   1. "Documented file" — the link captured from the README (if any).
+  //      Honors what upstream docs claim; can be stale if upstream links bit-rotted.
+  //   2. "Documentation" — the README itself or the .policy archive that
+  //      references this entity. Always a valid path inside the repo.
+  // Showing both lets the user fall back to the README when (1) 404s.
+  const firstOcc = ref.occurrences?.[0];
+  const documentedLink = ref.occurrences?.map(o => o.link).find(Boolean) || null;
+  const documentationLink = firstOcc ? githubUrl(report, firstOcc.source || firstOcc.archive) : null;
+
+  const linkRows = [];
+  if (documentedLink) {
+    linkRows.push(`<div class="field"><span class="label">Source file</span><span class="value"><a href="${escapeHtml(documentedLink)}" target="_blank" rel="noopener noreferrer">Open in GitHub →</a></span></div>`);
+  }
+  if (documentationLink && documentationLink !== documentedLink) {
+    linkRows.push(`<div class="field"><span class="label">Documented in</span><span class="value"><a href="${escapeHtml(documentationLink)}" target="_blank" rel="noopener noreferrer">${escapeHtml((firstOcc?.source || firstOcc?.archive || '').split('/').slice(-2).join('/'))} →</a></span></div>`);
+  }
+  return `
+    <div class="detail-inner">
+      <div class="detail-section">
+        <h3>Identifiers</h3>
+        <div class="field"><span class="label">Name</span><span class="value">${escapeHtml(ref.name || '(unnamed)')}</span></div>
+        <div class="field"><span class="label">Type</span><span class="value">${escapeHtml(ref.type || '-')}</span></div>
+        <div class="field"><span class="label">Topic</span><span class="value">${escapeHtml(ref.topicId || '-')}</span></div>
+        <div class="field"><span class="label">Message</span><span class="value">${escapeHtml(ref.messageId)}</span></div>
+        <div class="field"><span class="label">CID</span><span class="value">${escapeHtml(ref.cid || '-')}</span></div>
+        ${linkRows.join('')}
+        ${recommendation(ref)}
+      </div>
+      <div class="detail-section">
+        <h3>Gateway probes (${ref.ipfsGateways?.length || 0})</h3>
+        <div class="gateway-list">
+          ${(ref.ipfsGateways || []).map(renderGatewayRow).join('') || '<div class="occurrence" style="color: var(--text-muted)">(no IPFS probe results — Hedera lookup failed or skipped)</div>'}
+        </div>
+        <h3 style="margin-top: 18px;">Occurrences (${ref.occurrences?.length || 0})</h3>
+        <div class="occurrences">${renderOccurrences(ref.occurrences, report)}</div>
+      </div>
+    </div>
+  `;
+}
+
+let allRefs = [];
+let activeFilter = 'all';
+let searchQuery = '';
+let sortField = 'name';
+let sortDir = 'asc';
+let expandedRow = null;
+
+function applyFilters() {
+  let rows = allRefs.slice();
+  if (activeFilter === 'healthy') rows = rows.filter(r => statusGroup(r.status) === 'healthy');
+  if (activeFilter === 'resilient') rows = rows.filter(r => statusGroup(r.status) === 'resilient');
+  if (activeFilter === 'fragile') rows = rows.filter(r => statusGroup(r.status) === 'fragile');
+  if (activeFilter === 'broken') rows = rows.filter(r => statusGroup(r.status) === 'broken');
+  if (searchQuery) {
+    const q = searchQuery.toLowerCase();
+    rows = rows.filter(r =>
+      (r.name || '').toLowerCase().includes(q) ||
+      (r.messageId || '').includes(q) ||
+      (r.cid || '').toLowerCase().includes(q) ||
+      (r.topicId || '').includes(q) ||
+      (r.type || '').toLowerCase().includes(q)
+    );
+  }
+  const dir = sortDir === 'asc' ? 1 : -1;
+  rows.sort((a, b) => {
+    const va = (a[sortField] || '').toString().toLowerCase();
+    const vb = (b[sortField] || '').toString().toLowerCase();
+    if (va < vb) return -1 * dir;
+    if (va > vb) return 1 * dir;
+    return 0;
+  });
+  return rows;
+}
+
+function renderApp(report) {
+  const total = report.scanned.uniqueToolRefs;
+  // New four-bucket summary fields; fall back to legacy fields if the loaded
+  // report is from an older validator build that didn't emit resilient/fragile
+  // separately.
+  const healthy = report.summary.healthy ?? report.summary.ok ?? 0;
+  const resilient = report.summary.resilient ?? 0;
+  const fragile = report.summary.fragile ?? (report.summary.okOnlyOnExternalGateway ?? 0);
+  const broken = report.summary.broken ?? 0;
+  const pct = (n) => total ? `${Math.round((n / total) * 100)}%` : '—';
+
+  const rows = applyFilters();
+
+  root.innerHTML = `
+    <header class="top">
+      <div class="titleblock">
+        <span class="eyebrow">Hedera Guardian · Methodology Tooling</span>
+        <h1>Methodology Library Validator</h1>
+        <div class="meta-line">
+          <span class="kv"><span class="k">Network</span><span class="v">${escapeHtml(report.network)}</span></span>
+          <span class="kv"><span class="k">Repo</span><span class="v"><a href="https://github.com/${escapeHtml(report.githubRepo || 'hashgraph/guardian')}/tree/${escapeHtml(report.githubBranch || 'main')}/${encodeURIComponent(report.githubBase || 'Methodology Library')}" target="_blank" rel="noopener noreferrer">${escapeHtml(report.githubRepo || 'hashgraph/guardian')}@${escapeHtml(report.githubBranch || 'main')}</a></span></span>
+          ${report.filter ? `<span class="kv"><span class="k">Filter</span><span class="v">${escapeHtml(report.filter)}</span></span>` : ''}
+          <span class="kv"><span class="k">Loaded</span><span class="v">${new Date(report._loadedAt).toLocaleString()}</span></span>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="btn primary" id="btn-scan"><span class="glyph">⟳</span> Run new scan</button>
+        <button class="btn" id="btn-refresh"><span class="glyph">↻</span> Reload report</button>
+        <a class="btn" href="/api/export.csv"><span class="glyph">↓</span> Export CSV</a>
+        <button class="btn" id="btn-theme" title="Toggle theme"><span class="glyph" id="theme-glyph">◐</span> <span id="theme-label">Dark mode</span></button>
+      </div>
+    </header>
+
+    <div class="summary">
+      <div class="stat total">
+        <div class="label">Total scanned</div>
+        <div class="value">${total}</div>
+        <div class="pct">across ${report.scanned.archives} archive${report.scanned.archives === 1 ? '' : 's'}</div>
+        <div class="desc">Every published policy, standalone tool, and tool reference discovered across the library and its README tables.</div>
+      </div>
+      <div class="stat healthy">
+        <div class="label">Healthy</div>
+        <div class="value">${healthy}</div>
+        <div class="pct">${pct(healthy)}</div>
+        <div class="desc">Hedera anchor alive AND IPFS payload retrievable from a local Kubo node you control. No external dependency at retrieval time.</div>
+      </div>
+      <div class="stat resilient">
+        <div class="label">Resilient</div>
+        <div class="value">${resilient}</div>
+        <div class="pct">${pct(resilient)}</div>
+        <div class="desc">Reachable from ≥2 independent public gateways. Any one of them can go dark without breaking consumers — the ideal state for upstream library content.</div>
+      </div>
+      <div class="stat fragile">
+        <div class="label">Fragile</div>
+        <div class="value">${fragile}</div>
+        <div class="pct">${pct(fragile)}</div>
+        <div class="desc">Reachable from exactly one gateway. Works today, single point of failure long-term. If that one gateway drops the pin, content silently breaks.</div>
+      </div>
+      <div class="stat broken">
+        <div class="label">Broken</div>
+        <div class="value">${broken}</div>
+        <div class="pct">${pct(broken)}</div>
+        <div class="desc">No gateway has the IPFS bytes, or the Hedera message itself is gone. Needs the republisher to re-pin (bytes exist) or full republish (Hedera anchor missing).</div>
+      </div>
+    </div>
+
+    <div class="controls">
+      <div class="pill ${activeFilter==='all'?'active':''}" data-filter="all">All <span class="count">${allRefs.length}</span></div>
+      <div class="pill ${activeFilter==='healthy'?'active':''}" data-filter="healthy">Healthy <span class="count">${healthy}</span></div>
+      <div class="pill ${activeFilter==='resilient'?'active':''}" data-filter="resilient">Resilient <span class="count">${resilient}</span></div>
+      <div class="pill ${activeFilter==='fragile'?'active':''}" data-filter="fragile">Fragile <span class="count">${fragile}</span></div>
+      <div class="pill ${activeFilter==='broken'?'active':''}" data-filter="broken">Broken <span class="count">${broken}</span></div>
+      <input class="search-input" type="search" placeholder="Search name, CID, topic, message…" value="${escapeHtml(searchQuery)}" id="search" />
+    </div>
+
+    <div class="table-wrap">
+      ${rows.length ? `
+        <table>
+          <thead>
+            <tr>
+              <th data-sort="name">Name ${sortField==='name'?`<span class="arrow">${sortDir==='asc'?'▲':'▼'}</span>`:''}</th>
+              <th data-sort="type">Type ${sortField==='type'?`<span class="arrow">${sortDir==='asc'?'▲':'▼'}</span>`:''}</th>
+              <th data-sort="status">Status ${sortField==='status'?`<span class="arrow">${sortDir==='asc'?'▲':'▼'}</span>`:''}</th>
+              <th data-sort="topicId">Topic ${sortField==='topicId'?`<span class="arrow">${sortDir==='asc'?'▲':'▼'}</span>`:''}</th>
+              <th data-sort="messageId">Message ${sortField==='messageId'?`<span class="arrow">${sortDir==='asc'?'▲':'▼'}</span>`:''}</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map((r, i) => {
+              const expanded = expandedRow === r.messageId;
+              return `
+                <tr class="row ${expanded?'expanded':''}" data-msgid="${escapeHtml(r.messageId)}">
+                  <td class="name">${escapeHtml(r.name || '(unnamed)')}</td>
+                  <td><span class="type-tag">${escapeHtml(r.type || '-')}</span></td>
+                  <td>${statusBadge(r.status)}</td>
+                  <td class="muted mono">${escapeHtml(r.topicId || '-')}</td>
+                  <td class="muted mono">${escapeHtml(r.messageId)}</td>
+                </tr>
+                ${expanded ? `<tr class="detail-row"><td colspan="5">${renderDetail(r, report)}</td></tr>` : ''}
+              `;
+            }).join('')}
+          </tbody>
+        </table>
+      ` : `<div class="empty">No entries match the current filter.</div>`}
+    </div>
+  `;
+
+  // Wire up interactions
+  root.querySelectorAll('.pill[data-filter]').forEach(el => {
+    el.addEventListener('click', () => {
+      activeFilter = el.dataset.filter;
+      expandedRow = null;
+      renderApp(report);
+    });
+  });
+  root.querySelectorAll('thead th[data-sort]').forEach(el => {
+    el.addEventListener('click', () => {
+      const field = el.dataset.sort;
+      if (sortField === field) {
+        sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        sortField = field;
+        sortDir = 'asc';
+      }
+      renderApp(report);
+    });
+  });
+  root.querySelectorAll('tbody tr.row').forEach(el => {
+    el.addEventListener('click', () => {
+      const msgid = el.dataset.msgid;
+      expandedRow = expandedRow === msgid ? null : msgid;
+      renderApp(report);
+    });
+  });
+  const search = document.getElementById('search');
+  if (search) {
+    search.addEventListener('input', (e) => {
+      searchQuery = e.target.value;
+      expandedRow = null;
+      // Re-render but keep the input focused
+      const start = e.target.selectionStart;
+      renderApp(report);
+      const newInput = document.getElementById('search');
+      if (newInput) {
+        newInput.focus();
+        newInput.setSelectionRange(start, start);
+      }
+    });
+  }
+}
+
+function loadReport(showEmptyIfMissing = false) {
+  return fetch('/api/report')
+    .then(r => r.json().then(j => ({ status: r.status, body: j })))
+    .then(({ status, body }) => {
+      if (status === 404 && showEmptyIfMissing) {
+        root.innerHTML = `
+          <div class="empty" style="padding: 100px 24px;">
+            <div style="font-size: 14px; margin-bottom: 16px;">${escapeHtml(body.error || 'No report yet.')}</div>
+            <button class="btn primary" onclick="document.getElementById('btn-scan-stub')?.click()">Run a scan</button>
+          </div>
+          <button id="btn-scan-stub" style="display:none" onclick="openScanModal()"></button>
+        `;
+        return;
+      }
+      if (body.error) {
+        root.innerHTML = `<div class="err">Failed to load report: ${escapeHtml(body.error)}</div>`;
+        return;
+      }
+      allRefs = body.refs || [];
+      renderApp(body);
+      wireHeaderButtons();
+    })
+    .catch(err => {
+      root.innerHTML = `<div class="err">Failed to load report: ${escapeHtml(err.message)}</div>`;
+    });
+}
+
+function showToast(msg, isError = false) {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.className = 'toast' + (isError ? ' error' : '');
+  t.style.display = 'block';
+  setTimeout(() => { t.style.display = 'none'; }, 4500);
+}
+
+function openScanModal() {
+  const m = document.getElementById('scan-modal');
+  document.getElementById('scan-log').style.display = 'none';
+  document.getElementById('scan-log').textContent = '';
+  document.getElementById('scan-start').disabled = false;
+  document.getElementById('scan-start').textContent = 'Start scan';
+  m.classList.add('open');
+}
+function closeScanModal() {
+  document.getElementById('scan-modal').classList.remove('open');
+}
+
+function applyTheme(theme) {
+  if (theme === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
+  // Keep mobile browser title bar / safari chrome in sync.
+  const meta = document.getElementById('meta-theme-color');
+  if (meta) meta.setAttribute('content', theme === 'dark' ? '#0a0a0a' : '#ffffff');
+  // Toggle button label always tells the user which mode they're about to switch TO.
+  const label = document.getElementById('theme-label');
+  const glyph = document.getElementById('theme-glyph');
+  if (label) label.textContent = theme === 'dark' ? 'Light mode' : 'Dark mode';
+  if (glyph) glyph.textContent = theme === 'dark' ? '☀' : '◐';
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+  const next = current === 'dark' ? 'light' : 'dark';
+  try { localStorage.setItem('gtv-theme', next); } catch {}
+  applyTheme(next);
+}
+
+function wireHeaderButtons() {
+  const scanBtn = document.getElementById('btn-scan');
+  const refreshBtn = document.getElementById('btn-refresh');
+  const themeBtn = document.getElementById('btn-theme');
+  if (scanBtn) scanBtn.onclick = openScanModal;
+  if (refreshBtn) refreshBtn.onclick = () => {
+    loadReport().then(() => showToast('Report reloaded'));
+  };
+  if (themeBtn) themeBtn.onclick = toggleTheme;
+  // Initial label/glyph sync (the preload script in <head> set data-theme).
+  const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+  applyTheme(current);
+}
+
+// Modal interactions (wired once at page load — modal is in the DOM permanently).
+document.getElementById('scan-cancel').addEventListener('click', closeScanModal);
+document.getElementById('scan-modal').addEventListener('click', (e) => {
+  if (e.target === document.getElementById('scan-modal')) closeScanModal();
+});
+document.getElementById('scan-start').addEventListener('click', async () => {
+  const startBtn = document.getElementById('scan-start');
+  const logEl = document.getElementById('scan-log');
+  const body = {
+    // Empty libraryPath = auto-fetch upstream. The validator handles this.
+    libraryPath: document.getElementById('scan-library').value.trim() || null,
+    network: document.getElementById('scan-network').value,
+    concurrency: document.getElementById('scan-concurrency').value.trim() || '4',
+    filter: document.getElementById('scan-filter').value.trim() || null,
+    repo: document.getElementById('scan-repo').value.trim() || 'hashgraph/guardian',
+    branch: document.getElementById('scan-branch').value.trim() || 'main',
+    skipIpfs: document.getElementById('scan-skip-ipfs').checked,
+    localGateways: document.getElementById('scan-local-gateway').value.trim(),
+  };
+  startBtn.disabled = true;
+  startBtn.textContent = 'Scanning…';
+  logEl.style.display = 'block';
+  logEl.textContent = 'Starting scan…\n';
+
+  let jobId;
+  try {
+    const res = await fetch('/api/scan', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    jobId = data.jobId;
+    logEl.textContent = `Job ${jobId} started.\n`;
+  } catch (err) {
+    logEl.textContent = `Failed to start scan: ${err.message}\n`;
+    startBtn.disabled = false;
+    startBtn.textContent = 'Start scan';
+    return;
+  }
+
+  // Poll for completion every 2 seconds.
+  const pollInterval = 2000;
+  while (true) {
+    await new Promise(r => setTimeout(r, pollInterval));
+    let status;
+    try {
+      const res = await fetch(`/api/scan/${jobId}/status`);
+      status = await res.json();
+    } catch (err) {
+      logEl.textContent += `\n[poll error: ${err.message}]\n`;
+      continue;
+    }
+    logEl.textContent = status.log || '';
+    logEl.scrollTop = logEl.scrollHeight;
+    if (status.status === 'done') {
+      logEl.textContent += '\n\nScan complete. Reloading report…\n';
+      startBtn.textContent = 'Done';
+      await loadReport();
+      showToast('Scan complete — report updated');
+      setTimeout(closeScanModal, 800);
+      return;
+    }
+    if (status.status === 'failed') {
+      logEl.textContent += `\n\nScan failed (exit code ${status.exitCode}).\n`;
+      startBtn.disabled = false;
+      startBtn.textContent = 'Start scan';
+      showToast('Scan failed — see log for details', true);
+      return;
+    }
+  }
+});
+
+// Initial load
+loadReport(true);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a new tool under `tools/guardian-publish-validator/` that scans the methodology library and reports per-entity health for every published artifact (policy, tool, module, schema). CLI for CI/CD integration, web UI for browsing, and an example GitHub Actions workflow.

Discovered while supporting a customer hitting `Cannot read properties of null (reading 'type')` on a policy import. The Hedera anchor was alive; the IPFS payload referenced inside it was unreachable from every gateway except Pinata. With current Guardian, that's a silent failure with no diagnostic. This tool surfaces both Hedera-side and IPFS-side rot, library-wide, before users hit them.

## The four buckets

Per discussion on the Resilient framing:

| Bucket | Meaning |
|---|---|
| **Healthy** | Hedera anchor alive + a local Kubo serves the IPFS bytes (operator-controlled). No external dependency. |
| **Resilient** | Hedera anchor alive + at least two independent public gateways serve it. Ideal state for upstream library content where there is no single operator-controlled Kubo. |
| **Fragile** | Reachable from exactly one gateway. Works today, single point of failure. |
| **Broken** | No gateway has the bytes, or the Hedera message is missing. Action needed. |

## CI/CD integration

`examples/github-actions.yml` is a copy-paste workflow. Two flags drive CI behavior:

- `--fail-on broken` — fails CI only on Broken entries. Suitable for PR gates that want to block introducing dead refs without rejecting fresh content that has not accumulated multiple pins yet.
- `--fail-on fragile` — fails on Fragile or Broken. Requires every entity to be Resilient or Healthy. Useful for scheduled sweeps catching pin-lineage degradation.

`--changed-only-from <file>` scopes the scan to a list of changed file paths (pairs with `git diff --name-only` in PR runs) so the CI job does not have to walk the entire library on every PR.

## Findings from running it against upstream develop (testnet)

Of 84 unique entities across 167 archives:
- 18 Resilient
- 16 Fragile
- 8 Broken (including AMS-II.G policy itself, plus tools used by Verra VM0003 and VM0048)
- Remaining 42 are Healthy only when the operator local Kubo is in the gateway list

Full report JSON is reproducible via `npm run validate -- --branch develop`.

## What is in this PR

- `bin/validator.js` — CLI entry point
- `bin/ui.js` — Express server for the web dashboard
- `src/library.js` — `.policy` and `.tool` zip walker
- `src/manifests.js` — README markdown table parser
- `src/mirror.js` — Hedera mirror node client and message decode
- `src/ipfs.js` — multi-gateway probing with Healthy / Resilient / Fragile / Broken classification
- `src/repo.js` — auto-clone `hashgraph/guardian` into the user cache when no `--path` is given
- `ui/index.html` — single-page dashboard (light and dark, sortable, filterable, CSV export)
- `tests/` — 15 unit tests across the parser, walker, and message decoder
- `examples/github-actions.yml` — ready-to-use workflow
- `README.md` — install, usage, CI/CD integration, output schema, contribution notes

## License

Apache-2.0, matching the rest of the repo. Headers on every source file.

## Out of scope (planned follow-ups)

- **Republisher tool** — same package, two repair modes (re-pin and full republish). Provenance question (whose DID signs the new Hedera message when republishing community content) needs guidance first.
- **Multi-gateway fallback in `worker-service/src/api/ipfs-client-class.ts`** — separate PR. The validator diagnoses the gateway-availability problem; the worker-service fix is the root-cause remedy so Guardian `getFile()` no longer breaks on degraded gateways.
- **Mainnet validation** — currently testnet-focused. Mainnet is durable so the failure mode is rarer, but the same checks apply.

## Test plan

- [x] `npm test` passes (15 tests)
- [x] CLI smoke (`--help`, `--skip-ipfs` single-archive run)
- [x] Full library scan completes in ~5 min at concurrency 6
- [x] Web UI loads, summary card counts match CLI output
- [x] `--fail-on broken` exits non-zero on a synthetic stale fixture
- [x] `--changed-only` correctly scopes the scan to listed paths
- [x] Auto-clone path works (clones `hashgraph/guardian` to local cache on first run)

Tracked internally at https://github.com/Climission/Managed-Guardian-Service/issues/1018
