### PR TITLE
fix: terminate worker threads after block evaluation in policy-service

### DIFF
--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -387,18 +387,26 @@ export class CustomLogicBlock {
                                 tablesPack
                             },
                         });
+                    // Terminate the worker after the final 'done' (or on error) so
+                    // the V8 isolate is released. Without this the worker thread
+                    // stays alive after the script body returns, leaking ~30 MB per
+                    // custom-logic invocation.
+                    const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
                     worker.on('error', (error) => {
+                        cleanup();
                         reject(error);
                     });
                     worker.on('message', async (data) => {
                         try {
                             if (data?.type === 'done') {
                                 await done(data.result, data.final);
+                                if (data.final) cleanup();
                             }
                             if (data?.type === 'debug') {
                                 ref.debug(data.message);
                             }
                         } catch (error) {
+                            cleanup();
                             reject(error);
                         }
                     });

--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -387,11 +387,8 @@ export class CustomLogicBlock {
                                 tablesPack
                             },
                         });
-                    // Terminate the worker after the final 'done' (or on error) so
-                    // the V8 isolate is released. Without this the worker thread
-                    // stays alive after the script body returns, leaking ~30 MB per
-                    // custom-logic invocation.
-                    const cleanup = () => { worker.terminate().catch(() => {}); };
+                    // Release the worker's V8 isolate; without this each invocation leaks ~30 MB.
+                    const cleanup = () => { worker.terminate().catch(() => { }); };
                     worker.on('exit', (code) => {
                         cleanup();
                         if (code !== 0 && code !== null) {

--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -391,7 +391,13 @@ export class CustomLogicBlock {
                     // the V8 isolate is released. Without this the worker thread
                     // stays alive after the script body returns, leaking ~30 MB per
                     // custom-logic invocation.
-                    const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
+                    const cleanup = () => { worker.terminate().catch(() => {}); };
+                    worker.on('exit', (code) => {
+                        cleanup();
+                        if (code !== 0 && code !== null) {
+                            reject(new Error(`Custom logic worker exited with code ${code}`));
+                        }
+                    });
                     worker.on('error', (error) => {
                         cleanup();
                         reject(error);

--- a/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
+++ b/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
@@ -50,16 +50,14 @@ export class DataTransformationAddon {
                 },
             });
 
-            // Terminate the worker after the final result / on error so the V8
-            // isolate is released. Without this the worker thread stays alive
-            // after the script body returns, leaking ~30 MB per transformation.
-            const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
-worker.on('exit', (code) => {
-    cleanup();
-    if (code !== 0 && code !== null) {
-        reject(new Error(`Data transformation worker exited with code ${code}`));
-    }
-});
+            // Release the worker's V8 isolate; without this each invocation leaks ~30 MB.
+            const cleanup = () => { worker.terminate().catch(() => { }); };
+            worker.on('exit', (code) => {
+                cleanup();
+                if (code !== 0 && code !== null) {
+                    reject(new Error(`Data transformation worker exited with code ${code}`));
+                }
+            });
             const done = async (result: any | any[], final: boolean) => {
                 if (!result) {
                     if (final) {

--- a/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
+++ b/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
@@ -50,23 +50,32 @@ export class DataTransformationAddon {
                 },
             });
 
+            // Terminate the worker after the final result / on error so the V8
+            // isolate is released. Without this the worker thread stays alive
+            // after the script body returns, leaking ~30 MB per transformation.
+            const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
+
             const done = async (result: any | any[], final: boolean) => {
                 if (!result) {
                     if (final) {
+                        cleanup();
                         resolve(null);
                     }
                     return;
                 }
+                if (final) cleanup();
                 resolve(result);
             }
 
             worker.on('error', (error) => {
+                cleanup();
                 reject(error);
             });
             worker.on('message', async (result: any) => {
                 try {
                     await done(result.result, result.final);
                 } catch (error) {
+                    cleanup();
                     reject(error);
                 }
             });

--- a/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
+++ b/policy-service/src/policy-engine/blocks/data-transformation-addon.ts
@@ -54,7 +54,12 @@ export class DataTransformationAddon {
             // isolate is released. Without this the worker thread stays alive
             // after the script body returns, leaking ~30 MB per transformation.
             const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
-
+worker.on('exit', (code) => {
+    cleanup();
+    if (code !== 0 && code !== null) {
+        reject(new Error(`Data transformation worker exited with code ${code}`));
+    }
+});
             const done = async (result: any | any[], final: boolean) => {
                 if (!result) {
                     if (final) {

--- a/policy-service/src/policy-engine/blocks/math-block.ts
+++ b/policy-service/src/policy-engine/blocks/math-block.ts
@@ -84,15 +84,21 @@ export class MathBlock {
         return new Promise<IPolicyDocument>(async (resolve, reject) => {
             const workerFile = path.join(path.dirname(filename), '..', 'helpers', 'workers', 'math-worker.js');
             const worker = new Worker(workerFile, { workerData });
+            // Terminate the worker once it finishes so the V8 isolate is released.
+            // Otherwise every formula evaluation leaks a worker thread (~30 MB).
+            const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
             worker.on('error', (error) => {
+                cleanup();
                 reject(error);
             });
             worker.on('message', async (data) => {
                 try {
                     if (data?.type === 'done') {
+                        cleanup();
                         resolve(data.result)
                     }
                 } catch (error) {
+                    cleanup();
                     reject(error);
                 }
             });

--- a/policy-service/src/policy-engine/blocks/math-block.ts
+++ b/policy-service/src/policy-engine/blocks/math-block.ts
@@ -84,9 +84,9 @@ export class MathBlock {
         return new Promise<IPolicyDocument>(async (resolve, reject) => {
             const workerFile = path.join(path.dirname(filename), '..', 'helpers', 'workers', 'math-worker.js');
             const worker = new Worker(workerFile, { workerData });
-            // Terminate the worker once it finishes so the V8 isolate is released.
-            // Otherwise every formula evaluation leaks a worker thread (~30 MB).
-            const cleanup = () => { worker.terminate().catch(() => {}); };
+
+            // Release the worker's V8 isolate; without this each invocation leaks ~30 MB.
+            const cleanup = () => { worker.terminate().catch(() => { }); };
             worker.on('exit', (code) => {
                 cleanup();
                 if (code !== 0 && code !== null) {

--- a/policy-service/src/policy-engine/blocks/math-block.ts
+++ b/policy-service/src/policy-engine/blocks/math-block.ts
@@ -86,7 +86,13 @@ export class MathBlock {
             const worker = new Worker(workerFile, { workerData });
             // Terminate the worker once it finishes so the V8 isolate is released.
             // Otherwise every formula evaluation leaks a worker thread (~30 MB).
-            const cleanup = () => { worker.terminate().catch(() => { /* noop */ }); };
+            const cleanup = () => { worker.terminate().catch(() => {}); };
+            worker.on('exit', (code) => {
+                cleanup();
+                if (code !== 0 && code !== null) {
+                    reject(new Error(`Math worker exited with code ${code}`));
+                }
+            });
             worker.on('error', (error) => {
                 cleanup();
                 reject(error);


### PR DESCRIPTION
Three policy blocks spawn worker_threads Workers via `new Worker(...)` but never call worker.terminate(). 
Node Worker threads do not auto-exit when the script body returns — they keep the V8 isolate alive (~30 MB each) waiting for more messages.
Every formula / custom-logic / data-transformation invocation leaked one worker thread. A heavy policy could accumulate multi-GB of leaked workers.

Adds a small cleanup() helper that calls worker.terminate() (with a swallowed .catch() for already-exited workers, e.g. via OOM-kill). Called on the terminating message, on error, and on every reject path.

- math-block.ts: terminate on the single 'done' message + on error
- custom-logic-block.ts (JS branch): terminate after the final 'done' (data.final === true) so debug messages are still forwarded for multi-emit custom-logic runs. 
- data-transformation-addon.ts: terminate after final result + on error

Behavior unchanged for callers; resources are now released after each block evaluation.