### PR TITLE
fix: require authentication on GET /demo/registered-users (CVE-2026-45248)

### DIFF
--- a/api-gateway/src/api/service/demo.ts
+++ b/api-gateway/src/api/service/demo.ts
@@ -16,6 +16,9 @@ export class DemoApi {
      * Returns list of registered users
      */
     @Get('/registered-users')
+    @Auth(
+        Permissions.DEMO_KEY_CREATE,
+    )
     @ApiOperation({
         summary: 'Returns list of registered users.',
         description: 'Returns list of registered users.',
@@ -30,7 +33,9 @@ export class DemoApi {
     })
     @ApiExtraModels(RegisteredUsersDTO, InternalServerErrorDTO)
     @HttpCode(HttpStatus.OK)
-    async registeredUsers(): Promise<RegisteredUsersDTO> {
+    async registeredUsers(
+        @AuthUser() user: any
+    ): Promise<RegisteredUsersDTO> {
         const users = new Users();
         const guardians = new Guardians();
         try {
@@ -46,7 +51,7 @@ export class DemoApi {
 
             return demoUsers
         } catch (error) {
-            await InternalException(error, this.logger, null);
+            await InternalException(error, this.logger, user.id);
         }
     }
 

--- a/e2e-tests/cypress/e2e/api-tests/001_demo/getRegisteredUsers.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/001_demo/getRegisteredUsers.cy.js
@@ -1,17 +1,54 @@
 import { METHOD, STATUS_CODE } from "../../../support/api/api-const";
 import API from "../../../support/ApiUrls";
+import * as Authorization from "../../../support/authorization";
 
 context("Demo", { tags: ['demo', 'secondPool', 'all'] }, () => {
-    
-    it("Returns list of registered users", () => {
+
+    const SRUsername = Cypress.env('SRUser');
+    const regUsersUrl = `${API.ApiServer}${API.RegUsers}`;
+
+    const getRegisteredUsersWithAuth = (authorization) =>
         cy.request({
             method: METHOD.GET,
-            url: API.ApiServer + API.RegUsers,
-        }).then((response) => {
-            expect(response.status).eql(STATUS_CODE.OK);
-            expect(response.body.at(0)).to.have.property("username");
-            expect(response.body.at(0)).to.have.property("role");
-            expect(response.body.at(0)).to.have.property("policyRoles");
+            url: regUsersUrl,
+            headers: { authorization },
+        });
+
+    const getRegisteredUsersWithoutAuth = (headers = {}) =>
+        cy.request({
+            method: METHOD.GET,
+            url: regUsersUrl,
+            headers,
+            failOnStatusCode: false,
+        });
+
+    it("Returns list of registered users", () => {
+        Authorization.getAccessToken(SRUsername).then((authorization) => {
+            getRegisteredUsersWithAuth(authorization).then((response) => {
+                expect(response.status).eql(STATUS_CODE.OK);
+                expect(response.body.at(0)).to.have.property("username");
+                expect(response.body.at(0)).to.have.property("role");
+                expect(response.body.at(0)).to.have.property("policyRoles");
+            });
         });
     });
+
+    it("Returns list of registered users without auth token - Negative", () => {
+        getRegisteredUsersWithoutAuth().then((response) => {
+            expect(response.status).eql(STATUS_CODE.UNAUTHORIZED);
+        });
+    });
+
+    it("Returns list of registered users with invalid auth token - Negative", () => {
+        getRegisteredUsersWithoutAuth({ authorization: "Bearer wqe" }).then((response) => {
+            expect(response.status).eql(STATUS_CODE.UNAUTHORIZED);
+        });
+    });
+
+    it("Returns list of registered users with empty auth token - Negative", () => {
+        getRegisteredUsersWithoutAuth({ authorization: "" }).then((response) => {
+            expect(response.status).eql(STATUS_CODE.UNAUTHORIZED);
+        });
+    });
+
 });


### PR DESCRIPTION
The `GET /api/v1/demo/registered-users` endpoint was publicly accessible without authentication, exposing all registered user accounts (usernames, DIDs, roles, policy assignments).

## Changes

**`api-gateway/src/api/service/demo.ts`**
- Added `@Auth(Permissions.DEMO_KEY_CREATE)` guard to `registeredUsers()`, matching the sibling `/random-key` and `/push/random-key` endpoints
- Injected `@AuthUser()` to pass authenticated user context
- Updated `InternalException` call to use `user.id` instead of `null`

**`e2e-tests/cypress/e2e/api-tests/001_demo/getRegisteredUsers.cy.js`**
- Updated positive test to authenticate via `Authorization.getAccessToken()`
- Added negative tests: no token, invalid token, empty token → expect `401 UNAUTHORIZED`

## References
-  CVE-2026-45248
- CWE-306 (Missing Authentication for Critical Function)