### PR TITLE
fix: worker-service Blob/Buffer TS build error

### DIFF
--- a/worker-service/src/api/ipfs-client-class.ts
+++ b/worker-service/src/api/ipfs-client-class.ts
@@ -135,14 +135,14 @@ export class IpfsClientClass {
         let cid: string;
         switch (this.IPFS_PROVIDER) {
             case IpfsProvider.WEB3STORAGE: {
-                const result = await this.client.uploadFile(new Blob([file]));
+                const result = await this.client.uploadFile(new Blob([new Uint8Array(file)]));
 
                 cid = result.toString()
                 break;
             }
 
             case IpfsProvider.FILEBASE: {
-                cid = await this.client.storeBlob(new Blob([file]))
+                cid = await this.client.storeBlob(new Blob([new Uint8Array(file)]))
                 break;
             }
 


### PR DESCRIPTION
### Description

- Wrap the `Buffer` in `new Uint8Array(...)` before passing it to the `Blob` constructor at the two call sites in `IpfsClientClass.addFile` (`WEB3STORAGE` and `FILEBASE` branches).
- Resolves two `TS2322` errors that broke `worker-service` `tsc` under `@types/node` v22, where `Buffer.buffer` resolves to `ArrayBufferLike` (incl. `SharedArrayBuffer`) and is not assignable to `BlobPart`.
- Behavior is unchanged at runtime — matches the existing pattern already used across the frontend.