### PR TITLE
chore: update mongodb-github-action to latest main

### DIFF
--- a/.github/workflows/add-documentation-to-repo.yaml
+++ b/.github/workflows/add-documentation-to-repo.yaml
@@ -49,7 +49,7 @@ jobs:
           git checkout "${GITHUB_REF:11}"
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -81,7 +81,7 @@ jobs:
           port: '4222'
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -88,7 +88,7 @@ jobs:
           port: "4222"
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/api-schedule-all.yml
+++ b/.github/workflows/api-schedule-all.yml
@@ -82,7 +82,7 @@ jobs:
           port: '4222'
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/api-schedule-vm0033.yml
+++ b/.github/workflows/api-schedule-vm0033.yml
@@ -82,7 +82,7 @@ jobs:
           port: '4222'
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/ui-manual.yml
+++ b/.github/workflows/ui-manual.yml
@@ -82,7 +82,7 @@ jobs:
           port: "4222"
 
       - name: Start MongoDB
-        uses: step-security/mongodb-github-action@7263579321780efeb685cdd6a2a356aad687ebab # v1.12.3
+        uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 


### PR DESCRIPTION
Update step-security/mongodb-github-action from v1.12.3 to latest main (ca72004b9c8ad6d9ed996c3174edbe62f9f7424a) across workflow files. This resolves a CI/CD validation error related to unrecognized 'github' named-value in the action configuration.
