### PR TITLE
fix(carbon-atlas): APX latin-1 encoding + GS file-date bump + verify-link policy scope

### DIFF
--- a/carbon-atlas/components/device-map.tsx
+++ b/carbon-atlas/components/device-map.tsx
@@ -18,6 +18,7 @@ import {
 import type { LatLngExpression } from "leaflet"
 import { useDashboardStats } from "@/hooks/useDashboardStats"
 import { useAllPolicyVcs } from "@/hooks/usePolicyVcDocuments"
+import { usePolicyNetwork } from "@/providers/PolicyNetworkProvider"
 
 // Known project deployment locations with approximate coordinates
 // These are derived from PDD host country fields in the Guardian VC data
@@ -55,6 +56,7 @@ function PulsingDot({ count }: { count: number | null }) {
 }
 
 export function DeviceMap() {
+  const { policy } = usePolicyNetwork()
   const { totalDevices, isLoading } = useDashboardStats()
   const { data: mrvReports } = useAllPolicyVcs("daily_mrv_report")
 
@@ -82,7 +84,7 @@ export function DeviceMap() {
           </div>
           {latestMrvTs && (
             <Link
-              href={`/verify?ts=${encodeURIComponent(latestMrvTs)}`}
+              href={`/policy/${policy.slug}/verify?ts=${encodeURIComponent(latestMrvTs)}`}
               className="text-xs text-primary hover:underline whitespace-nowrap"
             >
               View all devices &rarr;

--- a/carbon-atlas/pipeline/extended_schema.py
+++ b/carbon-atlas/pipeline/extended_schema.py
@@ -138,7 +138,7 @@ def extract_apx_project_extras(raw_path: Path, registry: str) -> pd.DataFrame:
     - crediting_period_end (ACR)
     - registration_date (CAR)
     """
-    df = pd.read_csv(raw_path)
+    df = pd.read_csv(raw_path, encoding="latin-1", engine="python", on_bad_lines="warn")
 
     extras = pd.DataFrame()
 

--- a/carbon-atlas/pipeline/process.py
+++ b/carbon-atlas/pipeline/process.py
@@ -76,8 +76,8 @@ REGISTRY_CONFIG = {
     "gold-standard": {
         "projects": "projects.csv",
         "credits": [
-            {"file": "GSF Registry Credits Export 2026-03-31-issuances.csv", "type": "issuance"},
-            {"file": "GSF Registry Credits Export 2026-03-31-retirements.csv", "type": "retirement"},
+            {"file": "GSF Registry Credits Export 2026-05-21-issuances.csv", "type": "issuance"},
+            {"file": "GSF Registry Credits Export 2026-05-21-retirements.csv", "type": "retirement"},
         ],
     },
     "american-carbon-registry": {

--- a/carbon-atlas/pipeline/process.py
+++ b/carbon-atlas/pipeline/process.py
@@ -220,7 +220,7 @@ def process_credits(registry: str) -> pd.DataFrame | None:
             if not credit_path.exists():
                 print(f"  Credit file not found: {credit_path.name}")
                 continue
-            df = pd.read_csv(credit_path)
+            df = pd.read_csv(credit_path, encoding="latin-1", engine="python", on_bad_lines="warn")
             print(f"  Read {credit_path.name}: {len(df)} rows")
             # Normalize column names to match the expected mapping
             df = _normalize_apx_credit_columns(df, registry, entry["type"])
@@ -254,7 +254,10 @@ def process_projects(registry: str, credits: pd.DataFrame) -> pd.DataFrame | Non
     if not project_path.exists():
         return None
 
-    df = pd.read_csv(project_path)
+    if registry in APX_REGISTRIES:
+        df = pd.read_csv(project_path, encoding="latin-1", engine="python", on_bad_lines="warn")
+    else:
+        df = pd.read_csv(project_path)
     print(f"  Raw project rows: {len(df)}")
 
     if registry == "verra":
@@ -314,7 +317,14 @@ def _apply_corsia_eligible(df: pd.DataFrame, registry: str) -> pd.DataFrame:
             if not credit_path.exists():
                 continue
             try:
-                raw = pd.read_csv(credit_path, dtype=str, usecols=[pid_col, "CORSIA Eligible"])
+                raw = pd.read_csv(
+                    credit_path,
+                    dtype=str,
+                    usecols=[pid_col, "CORSIA Eligible"],
+                    encoding="latin-1",
+                    engine="python",
+                    on_bad_lines="warn",
+                )
             except (ValueError, KeyError):
                 continue
             eligible = raw[raw["CORSIA Eligible"].str.strip().str.lower() == "yes"]


### PR DESCRIPTION
## Summary

Three small carbon-atlas fixes against `develop`:

1. **`carbon-atlas: Fix the broken device verification doc link`** (`fc72daec`) — the "View all devices →" link on the Device Map card pointed at the unscoped `/verify?ts=...` path, which 404s. The verify route only exists at `app/policy/[slug]/verify/page.tsx`, so the link now resolves to `/policy/{slug}/verify?ts=...` and correctly scopes to whichever methodology (MECD / VM0033 / future) is selected in the sidebar. The verify page already consumes `?ts=` to prefill the lookup form, so the deep-link behaviour is preserved.

2. **`carbon-atlas: read APX registry CSVs as latin-1, tolerate bad lines`** (`15c31ee5`) — the APX-based registries (ACR, CAR, ART TREES) export their CSVs in latin-1/cp1252, not UTF-8. The pipeline previously called `pd.read_csv` without an encoding hint, so any non-ASCII byte in a project name, proponent, or beneficiary field crashed the run with `UnicodeDecodeError`. CAR's retirements export also occasionally emits `""`-wrapped fields that confuse the C tokenizer; switching to `engine="python"` with `on_bad_lines="warn"` lets the run proceed (loses ~30 rows out of ~10K, acceptable until the upstream quoting bug is fixed). Updates all four APX read sites:
   - `pipeline/process.py`: APX credit reads, APX project reads, CORSIA helper
   - `pipeline/extended_schema.py`: `extract_apx_project_extras`

3. **`carbon-atlas: bump Gold Standard credit file dates to 2026-05-21`** (`b0abe5d4`) — Gold Standard's portal stamps the export date into the filename, so `REGISTRY_CONFIG` has to track the most recent refresh date. Points the pipeline at the 2026-05-21 issuances + retirements exports.

## Why now

Pipeline run on 2026-05-21 against fresh registry exports surfaced the encoding crash on the very first APX file (`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdc`). Without the encoding fix the pipeline can't ingest ACR/CAR/ART data at all once any registry record contains a non-ASCII character (e.g. accented project names from Mexican or European projects). The Device Map link was a separate user-visible bug noticed during the same sweep.

## Test plan

- [x] Verify-link fix: clicked "View all devices →" on the MECD dashboard and confirmed it navigates to `/policy/mecd/verify?ts=…` with the timestamp pre-filled in the lookup form
- [x] Ran `python -m pipeline.process` on the tracker5 VM end-to-end with all 5 registries — completed successfully
- [x] Verified post-run DB counts vs baseline: +142 projects, +7,170 credits, +76 developers
- [x] Confirmed APX-specific counts grew sanely (ACR 996→1,011, CAR 1,240→1,272, ART 20→28)
- [x] Verified `/api/v1/stats` returns `last_synced_at: 2026-05-21` and `atlas.carbonmarketshq.com/market` shows the new totals