### PR TITLE
fix: 6103 6104 6105 6106 Top Level API dialog bugs

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.html
@@ -53,7 +53,7 @@
                     </div>
                     <div class="field-group field-alias">
                         <label>Alias</label>
-                        <input type="text" pInputText [(ngModel)]="entry.alias" (input)="onAliasChange(i)" placeholder="url-friendly-alias or path/with/segments" />
+                        <input type="text" pInputText [(ngModel)]="entry.alias" (ngModelChange)="onAliasChange(i)" placeholder="url-friendly-alias or path/with/segments" />
                     </div>
                 </div>
                 <div class="field-group field-description-full">

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { IPolicyDocumentationEntry, POLICY_ALIAS_REGEX } from '@guardian/interfaces';
+import { InformService } from 'src/app/services/inform.service';
 import { RegisteredService } from '../../services/registered.service';
 import { IBlockAbout, PolicyFolder, PolicyItem } from '../../structures';
 
@@ -47,7 +48,8 @@ export class PolicyApiConfigDialogComponent {
     constructor(
         public ref: DynamicDialogRef,
         public config: DynamicDialogConfig,
-        private registeredService: RegisteredService
+        private registeredService: RegisteredService,
+        private informService: InformService
     ) {
         this.policyId = this.config.data?.policyId ?? '';
         this.blocks = this.config.data?.blocks ?? [];
@@ -278,24 +280,40 @@ export class PolicyApiConfigDialogComponent {
         const file = input.files[0];
         const reader = new FileReader();
         reader.onload = () => {
+            let imported: unknown;
             try {
-                const imported = JSON.parse(reader.result as string);
-                if (Array.isArray(imported)) {
-                    this.entries = imported.map((e: any) => ({
-                        name: e.name || '',
-                        description: e.description || '',
-                        target: e.target || '',
-                        method: e.method || 'GET',
-                        alias: e.alias || '',
-                        url: e.url || '',
-                        dmrvUrl: e.dmrvUrl || '',
-                        blockType: e.blockType || '',
-                    }));
-                    this.revalidate();
-                }
+                imported = JSON.parse(reader.result as string);
             } catch {
-                // invalid JSON — ignore
+                this.informService.errorShortMessage(
+                    'Could not parse the selected file. Expected a JSON array exported from this dialog.',
+                    'Import failed'
+                );
+                return;
             }
+            if (!Array.isArray(imported)) {
+                this.informService.errorShortMessage(
+                    'Unexpected file contents. Expected a JSON array of API entries.',
+                    'Import failed'
+                );
+                return;
+            }
+            this.entries = imported.map((e: any) => ({
+                name: e.name || '',
+                description: e.description || '',
+                target: e.target || '',
+                method: e.method || 'GET',
+                alias: e.alias || '',
+                url: e.url || '',
+                dmrvUrl: e.dmrvUrl || '',
+                blockType: e.blockType || '',
+            }));
+            this.revalidate();
+        };
+        reader.onerror = () => {
+            this.informService.errorShortMessage(
+                'Could not read the selected file.',
+                'Import failed'
+            );
         };
         reader.readAsText(file);
         input.value = '';

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ContractType, IContract, LocationType, PolicyAvailability, PolicyCategoryType, PolicyStatus, Schema, SchemaHelper, TagType, Token, UserPermissions } from '@guardian/interfaces';
 import * as yaml from 'js-yaml';
 import { DialogService } from 'primeng/dynamicdialog';
-import { forkJoin, Observable, Subject } from 'rxjs';
+import { forkJoin, Observable, of, Subject } from 'rxjs';
 import { WizardMode, WizardService } from 'src/app/modules/policy-engine/services/wizard.service';
 import { AnalyticsService } from 'src/app/services/analytics.service';
 import { ContractService } from 'src/app/services/contract.service';
@@ -29,7 +29,7 @@ import { OrderOption } from '../../structures/interfaces/order-option.interface'
 import { PolicyFolder, PolicyItem, PolicyRoot } from '../../structures/policy-models/interfaces/types';
 import { PolicyPropertiesComponent } from '../policy-properties/policy-properties.component';
 import { PolicyTreeComponent } from '../policy-tree/policy-tree.component';
-import { takeUntil } from 'rxjs/operators';
+import { catchError, takeUntil, tap } from 'rxjs/operators';
 import { TestCodeDialog } from '../../dialogs/test-code-dialog/test-code-dialog.component';
 import { CustomConfirmDialogComponent } from 'src/app/modules/common/custom-confirm-dialog/custom-confirm-dialog.component';
 import { IndexedDbRegistryService } from 'src/app/services/indexed-db-registry.service';
@@ -445,7 +445,7 @@ export class PolicyConfigurationComponent implements OnInit {
                 return;
             }
 
-            this.loadTagsData();
+            const tags$ = this.loadTagsData();
 
             if (this.user.POLICIES_POLICY_UPDATE) {
                 forkJoin([
@@ -456,6 +456,7 @@ export class PolicyConfigurationComponent implements OnInit {
                     this.toolsService.menuList(),
                     this.policyEngineService.getPolicyCategories(),
                     this.contractService.getContracts({ type: ContractType.WIPE }),
+                    tags$,
                 ]).pipe(takeUntil(this._destroy$)).subscribe(async (data) => {
                     const tokens = data[0] || [];
                     const blockInformation = data[1] || {};
@@ -511,6 +512,10 @@ export class PolicyConfigurationComponent implements OnInit {
                     this.loading = false;
                     console.error(message);
                 });
+            } else {
+                tags$.pipe(takeUntil(this._destroy$)).subscribe(() => {
+                    this.loading = false;
+                });
             }
         }, ({ message }) => {
             this.loading = false;
@@ -518,61 +523,53 @@ export class PolicyConfigurationComponent implements OnInit {
         });
     }
 
-    private loadTagsData() {
-        if (this.user.TAGS_TAG_READ) {
-            const blockIds = this.allBlocks?.map(block => block.id) || [];
-
-            this.tagsService.search(TagType.PolicyBlock, [this.policy.id], blockIds).subscribe((data) => {
-                const policyBlockTags = data[this.policy.id];
-                if (this.allBlocks) {
-                    for (const block of this.allBlocks) {
-                        (block as any)._tags = policyBlockTags?.tags.filter((tag: any) => tag.linkedItems.includes(block.id));
-
-                        policyBlockTags?.tags.forEach((tag: any) => {
-                            const totalTagOptions = [
-                                ...this.tagOptions,
-                                tag.name,
-                            ];
-                            this.tagOptions = [
-                                ...new Set(totalTagOptions),
-                            ];
-                        });
-
-                        let history: TagsHistory;
-                        if ((block as any)._tags) {
-                            history = new TagsHistory(
-                                policyBlockTags.entity || TagType.PolicyBlock,
-                                policyBlockTags.target || this.policy.id,
-                                this.owner,
-                                this.policy.location || LocationType.LOCAL,
-                                [block.id]
-                            );
-                            history.setData((block as any)._tags);
-                            history.setDate(policyBlockTags.refreshDate);
-                        } else {
-                            history = new TagsHistory(
-                                TagType.PolicyBlock,
-                                this.policy.id,
-                                this.owner,
-                                this.policy.location || LocationType.LOCAL,
-                                [block.id]
-                            );
-                        }
-                        this.blockTagHistories.set(block.id, history);
-                    }
-                }
-                setTimeout(() => {
-                    this.loading = false;
-                }, 500);
-            }, (e) => {
-                console.error(e.error);
-                this.loading = false;
-            });
-        } else {
-            setTimeout(() => {
-                this.loading = false;
-            }, 500);
+    private loadTagsData(): Observable<unknown> {
+        if (!this.user.TAGS_TAG_READ) {
+            return of(null);
         }
+        const blockIds = this.allBlocks?.map(block => block.id) || [];
+
+        return this.tagsService.search(TagType.PolicyBlock, [this.policy.id], blockIds).pipe(
+            tap((data) => {
+                const policyBlockTags = data[this.policy.id];
+                if (!this.allBlocks?.length) {
+                    return;
+                }
+                const tagNames: string[] = policyBlockTags?.tags?.map((tag: any) => tag.name) ?? [];
+                if (tagNames.length > 0) {
+                    this.tagOptions = [...new Set([...this.tagOptions, ...tagNames])];
+                }
+                for (const block of this.allBlocks) {
+                    (block as any)._tags = policyBlockTags?.tags.filter((tag: any) => tag.linkedItems.includes(block.id));
+
+                    let history: TagsHistory;
+                    if ((block as any)._tags) {
+                        history = new TagsHistory(
+                            policyBlockTags.entity || TagType.PolicyBlock,
+                            policyBlockTags.target || this.policy.id,
+                            this.owner,
+                            this.policy.location || LocationType.LOCAL,
+                            [block.id]
+                        );
+                        history.setData((block as any)._tags);
+                        history.setDate(policyBlockTags.refreshDate);
+                    } else {
+                        history = new TagsHistory(
+                            TagType.PolicyBlock,
+                            this.policy.id,
+                            this.owner,
+                            this.policy.location || LocationType.LOCAL,
+                            [block.id]
+                        );
+                    }
+                    this.blockTagHistories.set(block.id, history);
+                }
+            }),
+            catchError((e) => {
+                console.error(e?.error ?? e);
+                return of(null);
+            }),
+        );
     }
 
     private loadModule(): void {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -2351,8 +2351,42 @@ export class PolicyConfigurationComponent implements OnInit {
         });
     }
 
-    public backToPolicies() {
-        this.router.navigateByUrl('/policy-viewer');
+    public async backToPolicies() {
+        const isPolicyStorage = await this.storage.getPolicyById(this.policyId);
+
+        if (!isPolicyStorage) {
+            this.router.navigateByUrl('/policy-viewer');
+            return;
+        }
+
+        const dialogRef = this.dialogService.open(CustomConfirmDialogComponent, {
+            showHeader: false,
+            width: '640px',
+            styleClass: 'guardian-dialog',
+            data: {
+                header: 'Unsaved Changes',
+                text: 'You have unsaved changes. Save to the server, or leave — your edits will be available the next time you open this policy.',
+                buttons: [{
+                    name: 'Cancel',
+                    class: 'secondary'
+                }, {
+                    name: 'Leave for now',
+                    class: 'secondary'
+                }, {
+                    name: 'Save',
+                    class: 'primary'
+                }]
+            },
+        });
+        dialogRef.onClose.pipe(takeUntil(this._destroy$)).subscribe((result: string) => {
+            if (result === 'Save') {
+                this.asyncUpdatePolicy().pipe(takeUntil(this._destroy$)).subscribe(() => {
+                    this.router.navigateByUrl('/policy-viewer');
+                });
+            } else if (result === 'Leave for now') {
+                this.router.navigateByUrl('/policy-viewer');
+            }
+        });
     }
 
     public backToModules() {


### PR DESCRIPTION
### Description

- **#6103 — false "Selected block does not support API aliases" errors.** `loadTagsData` ran in parallel with the `forkJoin` that calls `registeredService.registerConfig(...)` and cleared the loader after the tag request returned. When tags were faster than `getBlockInformation`, the toolbar (including the API button) became interactive before block metadata was registered, and every row failed the API-support check. Refactored `loadTagsData` to return an Observable and folded it into the policy-update `forkJoin` so the loader stays up until `registerConfig` + `finishedLoad` have run. While there, hoisted the per-block tag dedup out of the loop (`O(N*M)` spread/Set rebuilds → one pass). For users without `POLICIES_POLICY_UPDATE`, the tag observable still drives the spinner.
- **#6104 — silent malformed imports.** `onImport` caught all parse errors with an empty `catch` and ignored non-array payloads with no `else`. Routed parse failures, non-array shapes, and `FileReader` errors through `InformService.errorShortMessage` so the user sees a toast.
- **#6105 — alias `/` characters intermittently disappearing.** The field used `(input)` alongside `[(ngModel)]`, so the DOM input event raced with NgModel's own input listener. When NgModel committed the raw keystroke after the sanitizer wrote the cleaned value, the raw value won. Switched to `(ngModelChange)`, which fires after NgModel commits the model write, so the sanitizer always runs against (and overwrites) the committed value.
- **#6106 — no warning when leaving with unsaved changes.** `backToPolicies()` navigated unconditionally, so users who edited the API documentation (or anything else cached in `PolicyStorage`) had no signal that the toolbar `Save` was a separate step. Mirrored the `tryPublishPolicy` pattern: check storage for dirty state, prompt with `Cancel` / `Leave for now` / `Save`. `Save` runs `asyncUpdatePolicy` then navigates; `Leave for now` navigates and leaves the local edit in IndexedDB so the existing `checkState()` flow can offer to restore it on the next open.