### PR TITLE
fix: add missing policy-service env vars

### DIFF
--- a/policy-service/configs/.env.policy
+++ b/policy-service/configs/.env.policy
@@ -12,11 +12,21 @@ PREUSED_HEDERA_NET="testnet"
 MQ_ADDRESS="localhost"
 DB_HOST="localhost"
 MESSAGE_LANG="en-US"
-BBS_SIGNATURES_MODE="WASM"
 MQ_MAX_PAYLOAD="1048576"
 MULTI_POLICY_SCHEDULER="0 0 * * *"
 EXTERNAL_DOCUMENTS_SCHEDULER="0 0 * * *"
 #LOG_LEVEL="2"
+
+# FEATURES
+# --------------
+BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
+PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
+DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+# Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):
+# PYTHON_SANDBOX_MEMORY="512m" # Container memory limit (default 512m). Same value used for --memory-swap (no swap).
+# PYTHON_SANDBOX_CPUS="1.0"    # Container CPU limit (default 1.0)
+# PYTHON_SANDBOX_PIDS="128"    # Container PID limit (default 128)
 
 OVERRIDE_NETWORK_CONFIGURATION="false" # if true, the OVERRIDE configurations will be applied on top of the base configuration defined by the HEDERA_NET value
 OVERRIDE_HEDERA_CONSENSUS_NODES={"0.testnet.hedera.com:50211":"0.0.3"}  # object list: {"10.0.2.15:50211":"0.0.3", "10.0.2.16:50211":"0.0.3", ...}

--- a/policy-service/configs/.env.policy.develop
+++ b/policy-service/configs/.env.policy.develop
@@ -12,11 +12,21 @@ PREUSED_HEDERA_NET="testnet"
 MQ_ADDRESS="localhost"
 DB_HOST="localhost"
 MESSAGE_LANG="en-US"
-BBS_SIGNATURES_MODE="WASM"
 MQ_MAX_PAYLOAD="1048576"
 MULTI_POLICY_SCHEDULER="0 0 * * *"
 EXTERNAL_DOCUMENTS_SCHEDULER="0 0 * * *"
 #LOG_LEVEL="2"
+
+# FEATURES
+# --------------
+BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
+PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
+DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+# Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):
+# PYTHON_SANDBOX_MEMORY="512m" # Container memory limit (default 512m). Same value used for --memory-swap (no swap).
+# PYTHON_SANDBOX_CPUS="1.0"    # Container CPU limit (default 1.0)
+# PYTHON_SANDBOX_PIDS="128"    # Container PID limit (default 128)
 
 OVERRIDE_NETWORK_CONFIGURATION="false" # if true, the OVERRIDE configurations will be applied on top of the base configuration defined by the HEDERA_NET value
 OVERRIDE_HEDERA_CONSENSUS_NODES={"0.testnet.hedera.com:50211":"0.0.3"}  # object list: {"10.0.2.15:50211":"0.0.3", "10.0.2.16:50211":"0.0.3", ...}

--- a/policy-service/configs/.env.policy.template
+++ b/policy-service/configs/.env.policy.template
@@ -12,11 +12,21 @@ PREUSED_HEDERA_NET=""
 MQ_ADDRESS=""
 DB_HOST=""
 MESSAGE_LANG="en-US"
-BBS_SIGNATURES_MODE="WASM"
 MQ_MAX_PAYLOAD=""
 MULTI_POLICY_SCHEDULER=""
 EXTERNAL_DOCUMENTS_SCHEDULER=""
 #LOG_LEVEL="2"
+
+# FEATURES
+# --------------
+BBS_SIGNATURES_MODE="WASM"
+# PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
+PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
+DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+# Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):
+# PYTHON_SANDBOX_MEMORY="512m" # Container memory limit (default 512m). Same value used for --memory-swap (no swap).
+# PYTHON_SANDBOX_CPUS="1.0"    # Container CPU limit (default 1.0)
+# PYTHON_SANDBOX_PIDS="128"    # Container PID limit (default 128)
 
 OVERRIDE_NETWORK_CONFIGURATION="false" # if true, the OVERRIDE configurations will be applied on top of the base configuration defined by the HEDERA_NET value
 OVERRIDE_HEDERA_CONSENSUS_NODES={"0.testnet.hedera.com:50211":"0.0.3"}  # object list: {"10.0.2.15:50211":"0.0.3", "10.0.2.16:50211":"0.0.3", ...}


### PR DESCRIPTION
The application was throwing a startup error when PYTHON_SANDBOX_TIMEOUT_MS and DRY_RUN_BLOCK_TIMEOUT_MS were not defined in the environment, due to strict validation requiring a positive integer.

- Add PYTHON_SANDBOX_TIMEOUT_MS (default 120000) and DRY_RUN_BLOCK_TIMEOUT_MS (default 120000) with sensible defaults.
- Ensure the variables are included in all relevant .env example/template files