### PR TITLE
fix: match cypress base image to npm v15.15.0

### DIFF
--- a/e2e-tests/Dockerfile
+++ b/e2e-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/included:14.5.4
+FROM cypress/included:15.15.0
 WORKDIR /e2e
 ENV CYPRESS_INSTALL_BINARY=0
 

--- a/e2e-tests/cypress.config.js
+++ b/e2e-tests/cypress.config.js
@@ -67,7 +67,7 @@ module.exports = defineConfig({
                 config.env.grepFilterSpecs = config.env.grepFilterSpecs.toLowerCase() === 'true';
             }
 
-            require('@cypress/grep/src/plugin')(config);
+            require('@cypress/grep/plugin').plugin(config);
             require('cypress-mochawesome-reporter/plugin')(on);
             on('task', verifyDownloadTasks);
             on('task', {

--- a/e2e-tests/cypress/support/e2e.js
+++ b/e2e-tests/cypress/support/e2e.js
@@ -24,7 +24,7 @@ import "cypress-mochawesome-reporter/register";
 // load and register the grep feature using "require" function
 // https://github.com/cypress-io/cypress-grep
 
-const registerCypressGrep = require('@cypress/grep')
+const { register: registerCypressGrep } = require('@cypress/grep')
 
 registerCypressGrep()
 


### PR DESCRIPTION
### Description

- Bump `e2e-tests/Dockerfile` base image from `cypress/included:14.5.4` to `cypress/included:15.15.0` so the prebaked Cypress binary matches the npm package version introduced in 6ae9375ba. Fixes `The cypress npm package is installed, but the Cypress binary is missing` in `api-after-commit.yml` (and the 4 other workflows sharing this Dockerfile: `api-manual.yml`, `api-schedule-all.yml`, `api-schedule-vm0033.yml`, `ui-manual.yml`).
- Update `@cypress/grep` v6 import paths so `setupNodeEvents` no longer throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. v6 restricts subpath imports via the `exports` field and exposes named functions:
  - `cypress.config.js`: `require('@cypress/grep/src/plugin')(config)` → `require('@cypress/grep/plugin').plugin(config)`
  - `cypress/support/e2e.js`: `require('@cypress/grep')` (called directly) → `const { register } = require('@cypress/grep')`