### PR TITLE
fix: emit RFC 5987 Content-Disposition on exports

### DIFF
--- a/api-gateway/src/api/service/artifact.ts
+++ b/api-gateway/src/api/service/artifact.ts
@@ -444,7 +444,7 @@ export class ArtifactApi {
             res.header('X-Content-Type-Options', 'nosniff');
             res.header(
                 'Content-Disposition',
-                `attachment; filename="${FilenameSanitizer.sanitize(filename || fileId)}"`
+                FilenameSanitizer.contentDisposition(filename || fileId)
             );
 
             return res.send(Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer));

--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -3147,7 +3147,7 @@ export class PolicyApi {
             const downloadResult = await engineService.downloadPolicyData(policyId, owner);
             res.header(
                 'Content-Disposition',
-                `attachment; filename=${FilenameSanitizer.sanitize(policy.name)}.data`
+                FilenameSanitizer.contentDisposition(policy.name, '.data')
             );
             res.header('Content-Type', 'application/policy-data');
             return res.send(downloadResult);
@@ -3261,7 +3261,7 @@ export class PolicyApi {
             const downloadResult = await engineService.downloadVirtualKeys(policyId, owner);
             res.header(
                 'Content-Disposition',
-                `attachment; filename=${FilenameSanitizer.sanitize(policy.name)}.vk`
+                FilenameSanitizer.contentDisposition(policy.name, '.vk')
             );
             res.header('Content-Type', 'application/virtual-keys');
             return res.send(downloadResult);
@@ -4494,7 +4494,7 @@ export class PolicyApi {
             const owner = new EntityOwner(user);
             const policy = await engineService.accessPolicy(policyId, owner, 'read');
             const policyFile: any = await engineService.exportFile(policyId, owner);
-            res.header('Content-disposition', `attachment; filename=${FilenameSanitizer.sanitize(policy.name)}`);
+            res.header('Content-Disposition', FilenameSanitizer.contentDisposition(policy.name));
             res.header('Content-type', 'application/zip');
             return res.send(policyFile);
         } catch (error) {
@@ -4602,7 +4602,7 @@ export class PolicyApi {
             const owner = new EntityOwner(user);
             const policy = await engineService.accessPolicy(policyId, owner, 'read');
             const policyFile: any = await engineService.exportXlsx(policyId, owner);
-            res.header('Content-disposition', `attachment; filename=${FilenameSanitizer.sanitize(policy.name)}`);
+            res.header('Content-Disposition', FilenameSanitizer.contentDisposition(policy.name));
             res.header('Content-type', 'application/zip');
             return res.send(policyFile);
         } catch (error) {

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -2546,7 +2546,7 @@ export class SchemaApi {
                 },
                 platform: 'UNIX',
             });
-            res.header('Content-disposition', `attachment; filename=${FilenameSanitizer.sanitize(name)}`);
+            res.header('Content-Disposition', FilenameSanitizer.contentDisposition(name));
             res.header('Content-type', 'application/zip');
             return res.send(arcStream);
         } catch (error) {
@@ -3218,8 +3218,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const file: any = await guardians.exportSchemasXlsx(owner, [schemaId]);
             const schema: any = await guardians.getSchemaById(user, schemaId);
-            const filename = FilenameSanitizer.sanitize(schema.name || '');
-            res.header('Content-disposition', `attachment; filename=${filename}`);
+            res.header('Content-Disposition', FilenameSanitizer.contentDisposition(schema.name || ''));
             res.header('Content-type', 'application/zip');
             return res.send(file);
         } catch (error) {
@@ -3505,7 +3504,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const file = await guardians.getFileTemplate(owner, filename);
             const fileBuffer = Buffer.from(file, 'base64');
-            res.header('Content-disposition', `attachment; filename=` + FilenameSanitizer.sanitize(filename));
+            res.header('Content-Disposition', FilenameSanitizer.contentDisposition(filename));
             res.header('Content-type', 'application/zip');
 
             req.locals = fileBuffer

--- a/api-gateway/src/helpers/filename-sanitizer.ts
+++ b/api-gateway/src/helpers/filename-sanitizer.ts
@@ -1,6 +1,6 @@
 export class FilenameSanitizer {
     private static readonly DANGEROUS_CHARS_REGEX = /[/\\?%*:|"<>,\s.]/g;
-    private static readonly CONTROL_REGEX = /[\x00-\x1f\x80-\x9f]/g;
+    private static readonly NON_PRINTABLE_ASCII_REGEX = /[^\x20-\x7e]/g;
     private static readonly RESERVED_REGEX = /^\.+$/;
     private static readonly WINDOWS_RESERVED_REGEX = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
     private static readonly WINDOWS_TRAILING_REGEX = /[\. ]+$/;
@@ -8,10 +8,22 @@ export class FilenameSanitizer {
 
     public static sanitize(fileName: string): string {
         return fileName.replace(FilenameSanitizer.DANGEROUS_CHARS_REGEX, '_')
-            .replace(FilenameSanitizer.CONTROL_REGEX, '_')
+            .replace(FilenameSanitizer.NON_PRINTABLE_ASCII_REGEX, '_')
             .replace(FilenameSanitizer.RESERVED_REGEX, '_')
             .replace(FilenameSanitizer.WINDOWS_RESERVED_REGEX, '_')
             .replace(FilenameSanitizer.WINDOWS_TRAILING_REGEX, '_')
             .replace(FilenameSanitizer.MULTIPLE_UNDERSCORES_REGEX, '_');
+    }
+
+    /**
+     * Build an RFC 6266 / RFC 5987 Content-Disposition value that survives
+     * non-ASCII characters in `name`. The ASCII `filename=` parameter is the
+     * sanitized fallback; `filename*=UTF-8''<percent-encoded>` preserves the
+     * original name for clients that understand it.
+     */
+    public static contentDisposition(name: string, extension = ''): string {
+        const ascii = `${FilenameSanitizer.sanitize(name)}${extension}`;
+        const utf8 = `${encodeURIComponent(name).replace(/'/g, '%27')}${extension}`;
+        return `attachment; filename="${ascii}"; filename*=UTF-8''${utf8}`;
     }
 }


### PR DESCRIPTION
### Description

Export endpoints returned HTTP 500 whenever a policy/schema name contained a non-ASCII character (em-dash, accented Latin, Cyrillic, NBSP, emoji, etc.) because the `Content-Disposition` header was emitted with the raw name and Node's HTTP layer rejects non-ASCII header bytes.

1. Added `FilenameSanitizer.contentDisposition(name, extension?)` which returns the RFC 6266 + RFC 5987 dual-parameter form `attachment; filename="<ascii>"; filename*=UTF-8''<percent-encoded>` so clients that support RFC 5987 keep the original name and clients that don't fall back to the sanitized ASCII form.
2. Tightened `FilenameSanitizer.sanitize()` to strip everything outside printable ASCII (`[^\x20-\x7e]`) instead of only C0/C1 control bytes, so the ASCII fallback is guaranteed header-safe even if a future caller bypasses the new helper.
3. Switched all 8 user-name-driven export endpoints to the new helper:

    - policy file/XLSX/data/virtual-keys exports in `api-gateway/src/api/service/policy.ts`
    - schema ZIP/XLSX/template exports in `api-gateway/src/api/service/schema.ts`
    -  the CSV download in `api-gateway/src/api/service/artifact.ts`.

Closes #6121