### PR TITLE
fix: prompt for mock before policy Dry-Run

### DIFF
--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -938,50 +938,72 @@ export class PoliciesComponent implements OnInit {
     }
 
     private dryRun(element: any) {
-        this.loading = true;
-        this.policyEngineService
-            .dryRun(element.id, {
-                enableMock: true
-            })
-            .pipe(takeUntil(this._destroy$))
-            .subscribe(
-                (data: any) => {
-                    const { policies, isValid, errors } = data;
-                    if (!isValid) {
-                        let text = [];
-                        const blocks = errors.blocks;
-                        const invalidBlocks = blocks.filter(
-                            (block: any) => !block.isValid
-                        );
-                        for (let i = 0; i < invalidBlocks.length; i++) {
-                            const block = invalidBlocks[i];
-                            for (let j = 0; j < block.errors.length; j++) {
-                                const error = block.errors[j];
-                                if (block.id) {
-                                    text.push(`<div>${block.id}: ${error}</div>`);
-                                } else {
-                                    text.push(`<div>${error}</div>`);
+        const dialogRef = this.dialogService.open(CustomConfirmDialogComponent, {
+            showHeader: false,
+            width: '640px',
+            styleClass: 'guardian-dialog',
+            data: {
+                header: 'Enable Mock',
+                texts: [
+                    `Mock Data intercepts all external service calls (IPFS, Topics, Tokens, and API requests) and returns pre-configured test responses instead of making real network calls. This lets you run and test your policy in a fully self-contained offline environment.`,
+                    `You can change this setting and configure individual blocks at any time from the 'Mock Config' panel.`,
+                    `Note: enabling Mock pre-records responses for every schema in the policy, so moving to Dry-Run may take several minutes.`
+                ],
+                buttons: [{
+                    name: 'Disable',
+                    class: 'secondary'
+                }, {
+                    name: 'Enable',
+                    class: 'primary'
+                }]
+            },
+        });
+        dialogRef.onClose.pipe(takeUntil(this._destroy$)).subscribe((result: string) => {
+            this.loading = true;
+            this.policyEngineService
+                .dryRun(element.id, {
+                    enableMock: result === 'Enable'
+                })
+                .pipe(takeUntil(this._destroy$))
+                .subscribe(
+                    (data: any) => {
+                        const { policies, isValid, errors } = data;
+                        if (!isValid) {
+                            let text = [];
+                            const blocks = errors.blocks;
+                            const invalidBlocks = blocks.filter(
+                                (block: any) => !block.isValid
+                            );
+                            for (let i = 0; i < invalidBlocks.length; i++) {
+                                const block = invalidBlocks[i];
+                                for (let j = 0; j < block.errors.length; j++) {
+                                    const error = block.errors[j];
+                                    if (block.id) {
+                                        text.push(`<div>${block.id}: ${error}</div>`);
+                                    } else {
+                                        text.push(`<div>${error}</div>`);
+                                    }
                                 }
                             }
+                            this.informService.errorMessage(
+                                text.join(''),
+                                'The policy is invalid'
+                            );
+                            this._configurationErrors.set(element.id, errors);
+                            this.router.navigate(['policy-configuration'], {
+                                queryParams: {
+                                    policyId: element.id,
+                                },
+                                replaceUrl: true,
+                            });
                         }
-                        this.informService.errorMessage(
-                            text.join(''),
-                            'The policy is invalid'
-                        );
-                        this._configurationErrors.set(element.id, errors);
-                        this.router.navigate(['policy-configuration'], {
-                            queryParams: {
-                                policyId: element.id,
-                            },
-                            replaceUrl: true,
-                        });
+                        this.loadAllPolicy();
+                    },
+                    (e) => {
+                        this.loading = false;
                     }
-                    this.loadAllPolicy();
-                },
-                (e) => {
-                    this.loading = false;
-                }
-            );
+                );
+        });
     }
 
     private draft(element: any) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -1235,7 +1235,8 @@ export class PolicyConfigurationComponent implements OnInit {
                 header: 'Enable Mock',
                 texts: [
                     `Mock Data intercepts all external service calls (IPFS, Topics, Tokens, and API requests) and returns pre-configured test responses instead of making real network calls. This lets you run and test your policy in a fully self-contained offline environment.`,
-                    `You can change this setting and configure individual blocks at any time from the 'Mock Config' panel.`
+                    `You can change this setting and configure individual blocks at any time from the 'Mock Config' panel.`,
+                    `Note: enabling Mock pre-records responses for every schema in the policy, so moving to Dry-Run may take several minutes.`
                 ],
                 buttons: [{
                     name: 'Disable',


### PR DESCRIPTION
### Description
- Replaced the hard-coded `enableMock: true` on the policies-list "Dry Run" action with the same "Enable Mock" confirmation dialog used by the policy editor, so mock external services are only activated when the user opts in.
- Closing the dialog or choosing "Disable" sends `enableMock: false`, which skips the per-schema `PublishSchema` message that was making the Dry-Run transition take 5-10 minutes on policies with many schemas.
- Added a note to the dialog (in both entry points) warning that enabling mock will make the Dry-Run transition take several minutes, since the policy engine pre-records mock responses for every schema.