### PR TITLE
fix: strip IPv6 brackets from hostname

### DIFF
--- a/policy-service/src/policy-engine/block-validators/blocks/http-request-block.ts
+++ b/policy-service/src/policy-engine/block-validators/blocks/http-request-block.ts
@@ -92,7 +92,10 @@ export class HttpRequestBlock {
         }
 
         const parsedUrl = new URL(url);
-        const hostname = parsedUrl.hostname;
+        const rawHostname = parsedUrl.hostname;
+        const hostname = rawHostname.startsWith('[') && rawHostname.endsWith(']')
+            ? rawHostname.slice(1, -1)
+            : rawHostname;
 
         const directFamily = net.isIP(hostname);
         if (directFamily) {


### PR DESCRIPTION
**Description**:
- Added strip brackets from IPv6 hostname before net.isIP check in http-request-block validator

**Related issue(s)**:
#6102
