### PR TITLE
chore: version bump 3.6.0

### DIFF
--- a/ai-service/package.json
+++ b/ai-service/package.json
@@ -1,11 +1,11 @@
 {
     "name": "ai-service",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "main": "dist/app.js",
     "license": "Apache-2.0",
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@langchain/classic": "1.0.34",
         "@langchain/community": "1.1.28",
         "@langchain/core": "1.1.48",

--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -13,8 +13,8 @@
     },
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
@@ -64,5 +64,5 @@
         "test": "mocha tests/**/*.test.js --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/ui-service.xml"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -4,8 +4,8 @@
         "@fastify/formbody": "^8.0.2",
         "@fastify/multipart": "^9.0.3",
         "@fastify/static": "^8.1.1",
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
@@ -69,5 +69,5 @@
         "test": "mocha tests/**/*.test.js --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/ui-service.xml"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/application-events/package.json
+++ b/application-events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "application-events",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "description": "",
     "main": "index.js",
     "scripts": {
@@ -24,8 +24,8 @@
         "#constants": "./dist/constants/index.js"
     },
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@types/express": "^4.17.17",
         "@types/morgan": "1.9.10",
         "axios": "^1.16.1",

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -10,8 +10,8 @@
         "image-size": "1.0.2"
     },
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@meeco/cryppo": "^2.0.2",
         "@mikro-orm/core": "6.4.16",
         "@mikro-orm/mongodb": "6.4.16",
@@ -74,5 +74,5 @@
         "test": "mocha tests/**/*.test.js --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/ui-service.xml"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/common/package.json
+++ b/common/package.json
@@ -6,7 +6,7 @@
         "@azure/keyvault-secrets": "^4.9.0",
         "@formulajs/formulajs": "4.5.4",
         "@google-cloud/secret-manager": "^4.2.2",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/interfaces": "3.6.0",
         "@hiero-ledger/sdk": "2.84.0",
         "@mattrglobal/jsonld-signatures-bbs": "^1.1.2",
         "@meeco/cryppo": "^2.0.2",
@@ -91,5 +91,5 @@
         "test:stability": "mocha tests/stability.test.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "guardian-e2e-test",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "guardian-e2e-test",
-            "version": "3.6.0-rc",
+            "version": "3.6.0",
             "license": "ISC",
             "dependencies": {
                 "@bahmutov/cy-api": "2.3.0",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "guardian-e2e-test",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "description": "This a place for quardian e2e automation test suite",
     "main": "index.js",
     "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guardian",
-  "version": "3.6.0-rc",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guardian",
-      "version": "3.6.0-rc",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/animations": "^18.2.12",
@@ -88,7 +88,7 @@
     },
     "../interfaces": {
       "name": "@guardian/interfaces",
-      "version": "3.6.0-rc",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "reflect-metadata": "^0.1.13"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,5 +93,5 @@
     "test": "ng test",
     "watch": "ng build --watch --configuration development --output-path ../www-data"
   },
-  "version": "3.6.0-rc"
+  "version": "3.6.0"
 }

--- a/guardian-service/package.json
+++ b/guardian-service/package.json
@@ -17,8 +17,8 @@
     },
     "dependencies": {
         "@formulajs/formulajs": "4.5.4",
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@hiero-ledger/proto": "2.30.0",
         "@mikro-orm/core": "6.4.16",
         "@mikro-orm/mongodb": "6.4.16",
@@ -75,5 +75,5 @@
         "test:stability": "mocha tests/stability.test.mjs"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/indexer-api-gateway/package.json
+++ b/indexer-api-gateway/package.json
@@ -14,8 +14,8 @@
     },
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@indexer/interfaces": "3.6.0-rc",
-        "@indexer/common": "3.6.0-rc",
+        "@indexer/interfaces": "3.6.0",
+        "@indexer/common": "3.6.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
@@ -79,5 +79,5 @@
         "test": "mocha tests/**/*.test.js --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/ui-service.xml"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/indexer-common/package.json
+++ b/indexer-common/package.json
@@ -4,7 +4,7 @@
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
-        "@indexer/interfaces": "3.6.0-rc",
+        "@indexer/interfaces": "3.6.0",
         "cross-blob": "^2.0.1",
         "dotenv": "^16.0.0",
         "jszip": "^3.7.1",
@@ -52,5 +52,5 @@
         "test:stability": "mocha tests/stability.test.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/indexer-frontend/package-lock.json
+++ b/indexer-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "indexer-frontend",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "indexer-frontend",
-            "version": "3.6.0-rc",
+            "version": "3.6.0",
             "dependencies": {
                 "@angular/animations": "^17.3.0",
                 "@angular/cdk": "^17.3.2",
@@ -57,10 +57,10 @@
         },
         "../indexer-common": {
             "name": "@indexer/common",
-            "version": "3.6.0-rc",
+            "version": "3.6.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@indexer/interfaces": "3.6.0-rc",
+                "@indexer/interfaces": "3.6.0",
                 "@mikro-orm/core": "6.4.16",
                 "@mikro-orm/migrations-mongodb": "6.4.16",
                 "@mikro-orm/mongodb": "6.4.16",
@@ -86,7 +86,7 @@
         },
         "../indexer-interfaces": {
             "name": "@indexer/interfaces",
-            "version": "3.6.0-rc",
+            "version": "3.6.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/glob": "^8.1.0",

--- a/indexer-frontend/package.json
+++ b/indexer-frontend/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "name": "indexer-frontend",
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "scripts": {
         "ng": "ng",
         "start": "ng serve --proxy-config ./proxy.conf.json",

--- a/indexer-interfaces/package.json
+++ b/indexer-interfaces/package.json
@@ -22,5 +22,5 @@
         "prepack": "npm run build"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/indexer-service/package.json
+++ b/indexer-service/package.json
@@ -1,8 +1,8 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@indexer/common": "3.6.0-rc",
-        "@indexer/interfaces": "3.6.0-rc",
+        "@indexer/common": "3.6.0",
+        "@indexer/interfaces": "3.6.0",
         "mongodb": "6.16.0",
         "@mikro-orm/core": "6.4.16",
         "@mikro-orm/mongodb": "6.4.16",
@@ -54,5 +54,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/indexer-worker-service/package.json
+++ b/indexer-worker-service/package.json
@@ -1,8 +1,8 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@indexer/interfaces": "3.6.0-rc",
-        "@indexer/common": "3.6.0-rc",
+        "@indexer/interfaces": "3.6.0",
+        "@indexer/common": "3.6.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
@@ -50,5 +50,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -27,5 +27,5 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/logger-service/package.json
+++ b/logger-service/package.json
@@ -5,8 +5,8 @@
         "image-size": "1.0.2"
     },
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@mikro-orm/core": "6.4.16",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
@@ -41,5 +41,5 @@
         "watch": "nodemon src/index.ts"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/mrv-sender/package.json
+++ b/mrv-sender/package.json
@@ -33,5 +33,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/notification-service/package.json
+++ b/notification-service/package.json
@@ -5,8 +5,8 @@
         "image-size": "1.0.2"
     },
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@mikro-orm/core": "6.4.16",
         "@mikro-orm/mongodb": "6.4.16",
         "@nestjs/common": "^11.1.24",
@@ -42,5 +42,5 @@
         "watch": "nodemon src/index.ts"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "detect-secrets": "detect-secrets-launcher --word-list exclude-secrets.txt k8s-manifests/**/* */src/**.ts **/.env*",
         "publish-policies": "guardian-cli publish-policies \"Methodology Library\" -c \"configs/automatic-publish-policies.config.json\" -o \"published-policies.txt\""
     },
-    "version": "3.6.0-rc",
+    "version": "3.6.0",
     "workspaces": [
         "interfaces",
         "common",

--- a/policy-service/package.json
+++ b/policy-service/package.json
@@ -15,8 +15,8 @@
         "image-size": "1.0.2"
     },
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@mikro-orm/core": "6.4.16",
         "@mikro-orm/mongodb": "6.4.16",
         "@nestjs/common": "^11.1.24",
@@ -74,5 +74,5 @@
         "test:stability": "mocha tests/stability.test.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/queue-service/package.json
+++ b/queue-service/package.json
@@ -1,8 +1,8 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
         "@nestjs/microservices": "^11.1.24",
@@ -39,5 +39,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/swagger-analytics.yaml
+++ b/swagger-analytics.yaml
@@ -215,7 +215,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.6.0-rc
+  version: 3.6.0
   contact:
     name: API developer
     url: https://envisionblockchain.com

--- a/swagger-indexer.yaml
+++ b/swagger-indexer.yaml
@@ -3264,7 +3264,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.6.0-rc
+  version: 3.6.0
   contact:
     name: API developer
     url: https://envisionblockchain.com

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -49933,7 +49933,7 @@ info:
     the heart of the Guardian solution is a sophisticated Policy Workflow Engine
     (PWE) that enables applications to offer a requirements-based tokenization
     implementation.
-  version: 3.6.0-rc
+  version: 3.6.0
   contact:
     name: API developer
     url: https://envisionblockchain.com

--- a/topic-listener-service/package.json
+++ b/topic-listener-service/package.json
@@ -1,8 +1,8 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@hiero-ledger/sdk": "2.84.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
@@ -50,5 +50,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/topic-viewer/package.json
+++ b/topic-viewer/package.json
@@ -23,5 +23,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/tree-viewer/package.json
+++ b/tree-viewer/package.json
@@ -22,5 +22,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }

--- a/worker-service/package.json
+++ b/worker-service/package.json
@@ -2,8 +2,8 @@
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
         "@filebase/client": "^0.0.5",
-        "@guardian/common": "3.6.0-rc",
-        "@guardian/interfaces": "3.6.0-rc",
+        "@guardian/common": "3.6.0",
+        "@guardian/interfaces": "3.6.0",
         "@hiero-ledger/sdk": "2.84.0",
         "@nestjs/common": "^11.1.24",
         "@nestjs/core": "^11.1.24",
@@ -50,5 +50,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.6.0-rc"
+    "version": "3.6.0"
 }


### PR DESCRIPTION
Update package versions from 3.6.0-rc to 3.6.0 across the monorepo and align internal dependencies (e.g. @guardian/* and @indexer/* packages and interfaces) to the stable 3.6.0 release. Prepares repository for the 3.6.0 release.