### PR TITLE
fix: restore @cypress/grep v6 spec filtering

### DIFF
--- a/e2e-tests/cypress.config.js
+++ b/e2e-tests/cypress.config.js
@@ -49,7 +49,6 @@ module.exports = defineConfig({
             "cypress/e2e/ui-tests/specs/08_tag_schemas/*.cy.js",
             "cypress/e2e/ui-tests/specs/09_tokens/*.cy.js",
             "cypress/e2e/ui-tests/specs/10_schema_validation/*.cy.js",
-            "**/*.cy.js",
         ],
         reporter: 'cypress-multi-reporters',
         reporterOptions: {
@@ -66,6 +65,15 @@ module.exports = defineConfig({
             if (typeof config.env.grepFilterSpecs === 'string') {
                 config.env.grepFilterSpecs = config.env.grepFilterSpecs.toLowerCase() === 'true';
             }
+
+            // @cypress/grep v6 reads its options from `config.expose`, not `config.env`.
+            // CI/Docker still pass them via CYPRESS_grepTags/--env, so forward them here.
+            config.expose = {
+                ...config.expose,
+                grepTags: config.env.grepTags,
+                grepFilterSpecs: config.env.grepFilterSpecs,
+                grepOmitFiltered: config.env.grepOmitFiltered,
+            };
 
             require('@cypress/grep/plugin').plugin(config);
             require('cypress-mochawesome-reporter/plugin')(on);


### PR DESCRIPTION
### Description

- After bumping Cypress to 15.15.0 and `@cypress/grep` to 6.0.0, a regular CI run grew from ~20 min to over 90 min: every spec (284) ran instead of the tag-filtered subset (~32).
- Root cause: `@cypress/grep` v6 reads its options from `Cypress.expose()` instead of `Cypress.env()`. CI/Docker still pass them via `CYPRESS_grepTags`/`--env`, so `grepFilterSpecs` was never enabled and no spec pre-filtering occurred.
- Forward the normalized grep options from `config.env` into `config.expose` in `setupNodeEvents`, re-enabling tag-based spec filtering without touching `entrypoint.sh` or CI variables.
- Remove the redundant `**/*.cy.js` catch-all from `specPattern`, which matched every spec file and defeated the explicit allow-list.