### PR TITLE
fix: import-by-message failures (null-safe load, single error toast, 504 retry)

### DIFF
--- a/common/src/hedera-modules/message/message-server.ts
+++ b/common/src/hedera-modules/message/message-server.ts
@@ -841,6 +841,7 @@ export class MessageServer {
                 return message;
             }
         } catch (error) {
+            new PinoLogger().error(error, ['GUARDIAN_SERVICE'], options?.userId);
             return null;
         }
     }
@@ -874,6 +875,7 @@ export class MessageServer {
                 return message as T;
             }
         } catch (error) {
+            new PinoLogger().error(error, ['GUARDIAN_SERVICE'], options?.userId);
             return null;
         }
     }

--- a/common/src/notification/notification-events.ts
+++ b/common/src/notification/notification-events.ts
@@ -25,6 +25,11 @@ export const notificationActionMap = new Map<TaskAction, NotificationAction>([
     [TaskAction.PUBLISH_POLICY_LABEL, NotificationAction.POLICY_LABEL_PAGE],
 ]);
 
+export const previewActions = new Set<TaskAction>([
+    TaskAction.PREVIEW_POLICY_MESSAGE,
+    TaskAction.PREVIEW_SCHEMA_MESSAGE,
+]);
+
 export const taskResultTitleMap = new Map<TaskAction, string>([
     [TaskAction.CREATE_POLICY, 'Policy created'],
     [TaskAction.CREATE_TOOL, 'Tool created'],
@@ -236,10 +241,14 @@ export class NotificationEvents {
         code: string | number,
         message: string
     }): void {
-        this.notify.stop({
-            title: this.action,
-            message: error.message
-        });
+        if (previewActions.has(this.action)) {
+            this.notify.stop();
+        } else {
+            this.notify.stop({
+                title: this.action,
+                message: error.message
+            });
+        }
         NotificationEvents.service.publish(MessageAPI.UPDATE_TASK_STATUS, {
             taskId: this.taskId,
             error,

--- a/guardian-service/src/api/external-policies.service.ts
+++ b/guardian-service/src/api/external-policies.service.ts
@@ -72,6 +72,9 @@ async function preparePolicyPreviewMessage(
     });
     const message = await messageServer
         .getMessage<PolicyMessage>({ messageId, loadIPFS: true, userId, interception: userId });
+    if (!message) {
+        throw new Error('Invalid Message');
+    }
     if (message.type !== MessageType.InstancePolicy) {
         throw new Error('Invalid Message Type');
     }

--- a/guardian-service/src/api/module.service.ts
+++ b/guardian-service/src/api/module.service.ts
@@ -63,6 +63,9 @@ export async function preparePreviewMessage(
             userId: user.id,
             interception: null
         });
+    if (!message) {
+        throw new Error('Invalid Message');
+    }
     if (message.type !== MessageType.Module) {
         throw new Error('Invalid Message Type');
     }

--- a/guardian-service/src/helpers/import-helpers/common/load-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/common/load-helper.ts
@@ -70,6 +70,9 @@ export async function loadSchema(
             });
 
         log.info(`loadedSchema: ${messageId}`, ['GUARDIAN_SERVICE'], userId);
+        if (!response) {
+            return null;
+        }
         if (response.type === MessageType.Schema) {
             const message = response as SchemaMessage;
             const schemaToImport: any = {

--- a/guardian-service/src/helpers/import-helpers/policy/policy-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import-helper.ts
@@ -264,6 +264,9 @@ export class PolicyImportExportHelper {
                 userId,
                 interception: null
             });
+        if (!message) {
+            throw new Error('Invalid Message');
+        }
         if (message.type !== MessageType.InstancePolicy) {
             throw new Error('Invalid Message Type');
         }

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -2043,6 +2043,9 @@ export class PolicyEngine extends NatsService {
                 userId,
                 interception: null
             });
+        if (!message) {
+            throw new Error('Invalid Message');
+        }
         if (message.type !== MessageType.InstancePolicy) {
             throw new Error('Invalid Message Type');
         }

--- a/worker-service/src/api/helpers/hedera-sdk-helper.ts
+++ b/worker-service/src/api/helpers/hedera-sdk-helper.ts
@@ -46,7 +46,7 @@ import {
     TransactionRecordQuery,
     TransferTransaction
 } from '@hiero-ledger/sdk';
-import { HederaUtils, timeout } from './utils.js';
+import { axiosGetWithRetry, HederaUtils, timeout } from './utils.js';
 import axios, { AxiosResponse } from 'axios';
 import { ContractParamType, FireblocksCreds, GenerateUUIDv4, HederaResponseCode, ISignOptions, SignType } from '@guardian/interfaces';
 import Long from 'long';
@@ -1132,9 +1132,13 @@ export class HederaSDKHelper {
             }
         }
 
-        const res = await axios.get(
+        const res = await axiosGetWithRetry(
+            'Mirror node',
             `${Environment.HEDERA_MESSAGE_API}/${timeStamp}`,
-            { responseType: 'json' }
+            {
+                responseType: 'json',
+                timeout: process.env.REST_API_TIMEOUT ? parseInt(process.env.REST_API_TIMEOUT, 10) : 30000
+            }
         );
         if (!res || !res.data || !res.data.message) {
             throw new Error(`Invalid message '${timeStamp}'`);

--- a/worker-service/src/api/helpers/utils.ts
+++ b/worker-service/src/api/helpers/utils.ts
@@ -1,5 +1,56 @@
 import { TimeoutError } from '@guardian/interfaces';
 import { PrivateKey } from '@hiero-ledger/sdk';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+
+const TRANSIENT_STATUS_CODES = new Set<number>([502, 503, 504]);
+const TRANSIENT_ERROR_CODES = new Set<string>(['ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET']);
+
+// Retry 5xx gateway errors and network timeouts, but not 4xx (e.g. 404 must fail fast).
+function isTransientError(error: any): boolean {
+    const status = error?.response?.status;
+    if (typeof status === 'number') {
+        return TRANSIENT_STATUS_CODES.has(status);
+    }
+    return !error?.response || TRANSIENT_ERROR_CODES.has(error?.code);
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Axios GET with exponential-backoff retry on transient failures. On final
+ * failure rethrows an error prefixed with `source` so the failing fetch is
+ * unambiguous in logs (e.g. 'Mirror node', 'IPFS gateway').
+ */
+export async function axiosGetWithRetry(
+    source: string,
+    url: string,
+    config?: AxiosRequestConfig,
+    options?: { attempts?: number; delay?: number }
+): Promise<AxiosResponse> {
+    const attempts = options?.attempts ??
+        (process.env.REST_API_RETRY_COUNT ? parseInt(process.env.REST_API_RETRY_COUNT, 10) : 3);
+    const baseDelay = options?.delay ??
+        (process.env.REST_API_RETRY_DELAY ? parseInt(process.env.REST_API_RETRY_DELAY, 10) : 500);
+
+    let lastError: any;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            return await axios.get(url, config);
+        } catch (error) {
+            lastError = error;
+            if (attempt >= attempts || !isTransientError(error)) {
+                break;
+            }
+            await delay(baseDelay * Math.pow(2, attempt - 1));
+        }
+    }
+    const reason = lastError?.message || 'Unknown error';
+    const wrapped = new Error(`${source} request failed: ${reason}`);
+    (wrapped as any).isTimeoutError = lastError?.isTimeoutError;
+    throw wrapped;
+}
 
 /**
  * Timeout decorator

--- a/worker-service/src/api/ipfs-client-class.ts
+++ b/worker-service/src/api/ipfs-client-class.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { axiosGetWithRetry } from './helpers/utils.js';
 import { create } from 'kubo-rpc-client'
 import { FilebaseClient } from '@filebase/client';
 import { StoreMemory } from '@storacha/client/stores/memory';
@@ -201,7 +201,8 @@ export class IpfsClientClass {
      */
     public async getFile(cid: string): Promise<any> {
         const _cid = this.parseCID(cid);
-        const fileRes = await axios.get(
+        const fileRes = await axiosGetWithRetry(
+            'IPFS gateway',
             this.IPFS_PUBLIC_GATEWAY
                 ?.replace('${cid}', _cid)
                 ?.replace('{cid}', _cid),


### PR DESCRIPTION
### Description

- Guard against `MessageServer.getMessage()` returning `null` in the import-by-message preview paths (policy, module, external policy, and the policy/schema import helpers). A failed or invalid message fetch now returns a clear `Invalid Message` error instead of crashing with `Cannot read properties of null (reading 'type')`.
- Log the previously-swallowed error inside `getMessage` so the real cause of a failed fetch (network, IPFS, invalid type, not found) is visible instead of silently becoming `null`.
- Stop showing two notifications on a failed preview: preview actions now report only the task-status error, without an additional persistent notification (matching the success path).
- Retry transient mirror-node and IPFS gateway requests (502/503/504 and network timeouts) with exponential backoff, while failing fast on 4xx, and add a per-request timeout to the mirror-node fetch. On final failure the error names its source (`Mirror node` / `IPFS gateway`).

Closes #6167