### PR TITLE
fix(policy-service): stop backup file parser from pinning full payload in memory

### DIFF
--- a/policy-service/src/policy-engine/db-restore/file-helper.ts
+++ b/policy-service/src/policy-engine/db-restore/file-helper.ts
@@ -318,15 +318,6 @@ export class FileHelper {
         }
     }
 
-    /**
-     * Force a flat, standalone copy of a string.
-     *
-     * `String.prototype.split`/`substring` return V8 `SlicedString`s that keep the
-     * ENTIRE parent string alive. The parsed diff only retains tiny header fields
-     * (uuid/type/hash), but as slices they pin the whole multi-MB source file for the
-     * lifetime of `PolicyRestore.lastDiff.file`. Round-tripping through a Buffer yields a
-     * fresh, flat string that does not reference the source, letting it be GC'd.
-     */
     private static _flat(value: string): string {
         return value == null ? value : Buffer.from(value, 'utf8').toString('utf8');
     }

--- a/policy-service/src/policy-engine/db-restore/file-helper.ts
+++ b/policy-service/src/policy-engine/db-restore/file-helper.ts
@@ -304,7 +304,7 @@ export class FileHelper {
 
     private static _decryptKey(line: string): string {
         if (line) {
-            return line;
+            return FileHelper._flat(line);
         } else {
             return null;
         }
@@ -318,9 +318,22 @@ export class FileHelper {
         }
     }
 
+    /**
+     * Force a flat, standalone copy of a string.
+     *
+     * `String.prototype.split`/`substring` return V8 `SlicedString`s that keep the
+     * ENTIRE parent string alive. The parsed diff only retains tiny header fields
+     * (uuid/type/hash), but as slices they pin the whole multi-MB source file for the
+     * lifetime of `PolicyRestore.lastDiff.file`. Round-tripping through a Buffer yields a
+     * fresh, flat string that does not reference the source, letting it be GC'd.
+     */
+    private static _flat(value: string): string {
+        return value == null ? value : Buffer.from(value, 'utf8').toString('utf8');
+    }
+
     private static _readString(header: FileHeaders, lines: string[], cursor: Cursor): string {
         if (lines[cursor.index] && lines[cursor.index].startsWith(header)) {
-            return lines[cursor.index++].substring(header.length);
+            return FileHelper._flat(lines[cursor.index++].substring(header.length));
         } else {
             return null;
         }


### PR DESCRIPTION
## Problem

`PolicyRestore` keeps its last backup/diff file resident for the policy's whole lifetime (rooted by the static `PolicyComponentsUtils.RestoreControllers` map), costing **O(full backup) RAM per running policy** — observed at ~82 MB for a VM0033-class methodology, doubled when a policy is double-spawned on one pod.

## Root cause

**V8 sliced-string retention, not a real payload cache.** The restore path already collapses every collection to hash-only (`restoreBackup` / `restoreDiff` return `actions: []`), so the parsed diff is tiny. But `FileHelper.decryptFile` parses the multi-MB source with `split('\n')` + `substring`, which return V8 `SlicedString`s. The tiny header fields the parser keeps (uuid, type, per-collection hash / fullHash) are slices that each pin the ENTIRE source string, so the whole file survives GC behind a few hundred bytes of header data.

Reference: `String.prototype.substring()` on V8 typically returns a `SlicedString` carrying a back-reference to the parent. Any escaping slice pins the parent indefinitely.

## Fix

Add `FileHelper._flat()` — a Buffer round-trip that yields a fresh, flat string with no parent reference — and apply it where header strings are extracted (`_readString`, `_decryptKey`). Action payloads were already fresh via `JSON.parse` and are unaffected; hash comparisons remain byte-identical. The multi-MB source becomes unreachable once parsing returns.

```ts
private static _flat(value: string): string {
    return value == null ? value : Buffer.from(value, 'utf8').toString('utf8');
}