### PR TITLE
fix: prevent stored XSS in branding company name (CVE-2026-22674)

### DIFF
--- a/frontend/src/app/services/branding.service.ts
+++ b/frontend/src/app/services/branding.service.ts
@@ -99,7 +99,7 @@ export class BrandingService {
             }
             if (brandingData.companyName) {
                 if (companyName) {
-                    companyName.innerHTML = brandingData.companyName;
+                    companyName.textContent = brandingData.companyName;
                 }
                 document.title = brandingData.companyName;
             }

--- a/frontend/src/app/views/branding/branding.component.ts
+++ b/frontend/src/app/views/branding/branding.component.ts
@@ -220,7 +220,7 @@ export class BrandingComponent implements OnInit, OnDestroy {
             document.body.style.setProperty('--linear-gradient', gradientData);
             // document.body.style.setProperty('--header-color-shadow', shadow);
             document.body.style.setProperty('--color-primary', this.primaryHexColorControl.value);
-            companyName.innerHTML = brandingData.companyName;
+            companyName.textContent = brandingData.companyName;
             document.title = brandingData.companyName;
 
             if (brandingData.companyLogoUrl) {
@@ -242,7 +242,7 @@ export class BrandingComponent implements OnInit, OnDestroy {
         document.body.style.setProperty('--color-primary', primaryColor);
         //document.documentElement.style.setProperty('--button-primary-color', primaryColor);
         if (this.companyNameControl.value) {
-            companyName.innerHTML = this.companyNameControl.value;
+            companyName.textContent = this.companyNameControl.value;
             document.title = this.companyNameControl.value;
         }
         if (this.companyLogoUrl) {


### PR DESCRIPTION
## Summary

The branding company name is assigned to the DOM using `innerHTML` at three
locations. A Standard Registry user can store an HTML or script payload in the
company name field. Because the branding service runs from the root app
component, the payload renders on every page load for every authenticated user
on the instance, with no interaction beyond logging in. This is a stored XSS.

Tracked as CVE-2026-22674.

## Root cause

`companyName.innerHTML = <user-controlled value>` at:
- `frontend/src/app/services/branding.service.ts:102`
- `frontend/src/app/views/branding/branding.component.ts:222`
- `frontend/src/app/views/branding/branding.component.ts:244`

Angular's built-in XSS protection only covers template bindings. Direct DOM
manipulation via `innerHTML` bypasses it. No `DomSanitizer` is used in this path.

## Fix

Replace `innerHTML` with `textContent` at all three locations. The company name
is never intended to contain markup, so the value is always treated as plain
text. This is a behavior preserving change.

## Impact

- Affected versions: <= 3.6.0
- Input vector: POST /api/v1/branding, companyName field (requires
  Permissions.BRANDING_CONFIG_UPDATE, STANDARD_REGISTRY role)
- CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N (4.8 Medium)

## Testing

Verified on a local quickstart instance. A Standard Registry account stored a
payload in the company name field. A separate account logging in afterwards
executed the payload on next page load with no further interaction. After the
fix the value renders as inert text.