### PR TITLE
chore: Run IPFS offline and bump to v0.42.0

### DIFF
--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -90,8 +90,17 @@ jobs:
       - name: Set up IPFS
         uses: oduwsdl/setup-ipfs@678755ac20f92d2dfca7e16138e40ae75f7a0f6f # v0.8.0
         with:
-          ipfs_version: 0.41.0
-          run_daemon: true
+          ipfs_version: 0.42.0
+          run_daemon: false
+      
+      - name: Start IPFS offline
+        shell: bash
+        run: |
+          ipfs config profile apply test    # Routing.Type=none, no bootstrap, mDNS off, localhost-only
+          ipfs bootstrap rm --all
+          ipfs config --json Discovery.MDNS.Enabled false
+          ipfs daemon --offline &
+          until ipfs id >/dev/null 2>&1; do sleep 0.5; done
 
       - name: Start MongoDB
         uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -98,8 +98,17 @@ jobs:
       - name: Set up IPFS
         uses: oduwsdl/setup-ipfs@678755ac20f92d2dfca7e16138e40ae75f7a0f6f # v0.8.0
         with:
-          ipfs_version: 0.41.0
-          run_daemon: true
+          ipfs_version: 0.42.0
+          run_daemon: false
+      
+      - name: Start IPFS offline
+        shell: bash
+        run: |
+          ipfs config profile apply test    # Routing.Type=none, no bootstrap, mDNS off, localhost-only
+          ipfs bootstrap rm --all
+          ipfs config --json Discovery.MDNS.Enabled false
+          ipfs daemon --offline &
+          until ipfs id >/dev/null 2>&1; do sleep 0.5; done
 
       - name: Start MongoDB
         uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a

--- a/.github/workflows/api-schedule-all.yml
+++ b/.github/workflows/api-schedule-all.yml
@@ -91,8 +91,17 @@ jobs:
       - name: Set up IPFS
         uses: oduwsdl/setup-ipfs@678755ac20f92d2dfca7e16138e40ae75f7a0f6f # v0.8.0
         with:
-          ipfs_version: 0.41.0
-          run_daemon: true
+          ipfs_version: 0.42.0
+          run_daemon: false
+      
+      - name: Start IPFS offline
+        shell: bash
+        run: |
+          ipfs config profile apply test    # Routing.Type=none, no bootstrap, mDNS off, localhost-only
+          ipfs bootstrap rm --all
+          ipfs config --json Discovery.MDNS.Enabled false
+          ipfs daemon --offline &
+          until ipfs id >/dev/null 2>&1; do sleep 0.5; done
 
       - name: Start MongoDB
         uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a

--- a/.github/workflows/api-schedule-vm0033.yml
+++ b/.github/workflows/api-schedule-vm0033.yml
@@ -91,8 +91,17 @@ jobs:
       - name: Set up IPFS
         uses: oduwsdl/setup-ipfs@678755ac20f92d2dfca7e16138e40ae75f7a0f6f # v0.8.0
         with:
-          ipfs_version: 0.41.0
-          run_daemon: true
+          ipfs_version: 0.42.0
+          run_daemon: false
+      
+      - name: Start IPFS offline
+        shell: bash
+        run: |
+          ipfs config profile apply test    # Routing.Type=none, no bootstrap, mDNS off, localhost-only
+          ipfs bootstrap rm --all
+          ipfs config --json Discovery.MDNS.Enabled false
+          ipfs daemon --offline &
+          until ipfs id >/dev/null 2>&1; do sleep 0.5; done
 
       - name: Start MongoDB
         uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a

--- a/.github/workflows/ui-manual.yml
+++ b/.github/workflows/ui-manual.yml
@@ -91,8 +91,17 @@ jobs:
       - name: Set up IPFS
         uses: oduwsdl/setup-ipfs@678755ac20f92d2dfca7e16138e40ae75f7a0f6f # v0.8.0
         with:
-          ipfs_version: 0.41.0
-          run_daemon: true
+          ipfs_version: 0.42.0
+          run_daemon: false
+      
+      - name: Start IPFS offline
+        shell: bash
+        run: |
+          ipfs config profile apply test    # Routing.Type=none, no bootstrap, mDNS off, localhost-only
+          ipfs bootstrap rm --all
+          ipfs config --json Discovery.MDNS.Enabled false
+          ipfs daemon --offline &
+          until ipfs id >/dev/null 2>&1; do sleep 0.5; done
 
       - name: Start MongoDB
         uses: step-security/mongodb-github-action@ca72004b9c8ad6d9ed996c3174edbe62f9f7424a


### PR DESCRIPTION
Update IPFS setup across CI workflows:
- bump ipfs_version from 0.41.0 to 0.42.0 and set run_daemon to false for oduwsdl/setup-ipfs.
- add an explicit "Start IPFS offline" step that applies the test profile, removes bootstrap peers, disables mDNS, starts the IPFS daemon in offline mode, and waits for ipfs id to succeed.

Changes applied to GitHub Actions workflows to ensure a local, isolated IPFS instance for CI runs and reduce network-related flakiness.