### PR TITLE
feat: collapse dry-run view tabs into dropdown

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.html
@@ -187,37 +187,13 @@
           <span>Run</span>
         </div>
         <div class="delimiter"></div>
-        <div
-          (click)="onView('policy')"
-          [attr.action]="view === 'policy'"
-          class="dry-run-btn"
-        >Policy View</div>
-        <div
-          (click)="onView('transactions')"
-          [attr.action]="view === 'transactions'"
-          class="dry-run-btn"
-        >Transactions</div>
-        <div
-          (click)="onView('artifacts')"
-          [attr.action]="view === 'artifacts'"
-          class="dry-run-btn"
-        >Artifacts</div>
-        <div
-          (click)="onView('ipfs')"
-          [attr.action]="view === 'ipfs'"
-          class="dry-run-btn"
-        >IPFS</div>
-        <div class="delimiter"></div>
-        <div
-          (click)="onView('mock_config')"
-          [attr.action]="view === 'mock_config'"
-          class="dry-run-btn"
-        >Mock Config</div>
-        <div
-          (click)="onView('mock_data')"
-          [attr.action]="view === 'mock_data'"
-          class="dry-run-btn"
-        >Mock Data</div>
+        <div (click)="viewMenu.toggle($event)" class="dry-run-group-btn dry-run-view-btn">
+          <i class="pi pi-eye"></i>
+          <span>{{ viewLabels[view] }}</span>
+          <div class="expand-group">
+            <i class="pi pi-sort-down-fill"></i>
+          </div>
+        </div>
       </div>
     }
     <div
@@ -822,6 +798,15 @@
     ></app-record-controller>
   }
 </div>
+
+<p-popover #viewMenu>
+  <div (click)="onView('policy', viewMenu)"       [attr.active]="view === 'policy'"       class="view-menu-item">Policy View</div>
+  <div (click)="onView('transactions', viewMenu)" [attr.active]="view === 'transactions'" class="view-menu-item">Transactions</div>
+  <div (click)="onView('artifacts', viewMenu)"    [attr.active]="view === 'artifacts'"    class="view-menu-item">Artifacts</div>
+  <div (click)="onView('ipfs', viewMenu)"         [attr.active]="view === 'ipfs'"         class="view-menu-item">IPFS</div>
+  <div (click)="onView('mock_config', viewMenu)"  [attr.active]="view === 'mock_config'"  class="view-menu-item">Mock Config</div>
+  <div (click)="onView('mock_data', viewMenu)"    [attr.active]="view === 'mock_data'"    class="view-menu-item">Mock Data</div>
+</p-popover>
 
 <p-popover #menu>
   @for (item of virtualUsers; track item) {

--- a/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.scss
@@ -495,6 +495,31 @@ a.go-back-link svg {
     left: 2px;
 }
 
+.dry-run-view-btn span {
+    max-width: 90px;
+    min-width: 70px;
+}
+
+.view-menu-item {
+    padding: 8px 16px;
+    cursor: pointer;
+    font-size: 13px;
+    min-width: 160px;
+    color: #3f51b5;
+    border-radius: 4px;
+    user-select: none;
+
+    &:hover {
+        background: #3f51b50d;
+    }
+
+    &[active="true"] {
+        background: #3f51b5;
+        color: #fff;
+        font-weight: 500;
+    }
+}
+
 .record-btn {
     color: #ff0000;
 }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/policy-viewer/policy-viewer.component.ts
@@ -57,6 +57,14 @@ export class PolicyViewerComponent implements OnInit, OnDestroy {
         artifacts: ['createDate', 'type', 'owner', 'document'],
         ipfs: ['createDate', 'size', 'url', 'document'],
     };
+    public viewLabels: any = {
+        policy: 'Policy View',
+        transactions: 'Transactions',
+        artifacts: 'Artifacts',
+        ipfs: 'IPFS',
+        mock_config: 'Mock Config',
+        mock_data: 'Mock Data',
+    };
     public pageIndex: number;
     public pageSize: number;
     public documentCount: any;
@@ -464,7 +472,8 @@ export class PolicyViewerComponent implements OnInit, OnDestroy {
         this.policyTest.reset();
     }
 
-    onView(view: string) {
+    onView(view: string, menu?: any) {
+        if (menu) { menu.hide(); }
         this.view = view;
         this.columns = this.columnsMap[this.view];
         if (this.view === 'mock_config' || this.view === 'mock_data') {


### PR DESCRIPTION
### Description

- Replaced 6 navigation tabs (Policy View, Transactions, Artifacts, IPFS, Mock Config, Mock Data) in the dry-run toolbar with a single dropdown button
- Dropdown is styled like the existing Users button; shows the currently selected view as its label
- Active view is highlighted in the expanded menu