### PR TITLE
chore: update cache service image to Valkey

### DIFF
--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -12,7 +12,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     services:
       cache:
-        image: registry.redict.io/redict
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
     strategy:

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -20,7 +20,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     services:
       cache:
-        image: registry.redict.io/redict
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
     strategy:

--- a/.github/workflows/api-schedule-all.yml
+++ b/.github/workflows/api-schedule-all.yml
@@ -11,7 +11,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     services:
       cache:
-        image: registry.redict.io/redict
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
     strategy:

--- a/.github/workflows/api-schedule-vm0033.yml
+++ b/.github/workflows/api-schedule-vm0033.yml
@@ -11,7 +11,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     services:
       cache:
-        image: registry.redict.io/redict
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
     strategy:

--- a/.github/workflows/ui-manual.yml
+++ b/.github/workflows/ui-manual.yml
@@ -11,7 +11,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     services:
       cache:
-        image: registry.redict.io/redict
+        image: valkey/valkey:8.1-alpine
         ports:
           - 6379:6379
     strategy:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To get a local copy up and running quickly, follow the steps below. Please refer
    - **[Filebase account](https://filebase.com/)** – S3-compatible IPFS pinning
    - Local IPFS node (e.g., **[Kubo](https://github.com/ipfs/kubo)**) – auto-provisioned when using Docker Compose
 
-5. **[Redict](https://redict.io/)** – in-memory cache & message broker, independent fork of Redis® (auto-provisioned by the Docker stack)
+5. **[Valkey](https://valkey.io)** – in-memory cache & message broker (auto-provisioned by the Docker stack)
 
 When building the reference implementation, you can [manually build every component](#manual-installation) or run a single command with Docker.
 
@@ -410,7 +410,7 @@ If you want to manually build every component with debug information, then build
 - [Node.js v20.20](https://nodejs.org)
 - [Yarn](https://yarnpkg.com/getting-started/install)
 - [Nats 2.9.25](https://nats.io/)
-- [Redict](https://redict.io/)
+- [Valkey](https://valkey.io)
 - [Seq 2025.2 - optional for logging](https://datalust.co/seq)
 
 ### Build and start each component

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -81,7 +81,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docker-compose-production-build.yml
+++ b/docker-compose-production-build.yml
@@ -84,7 +84,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -76,7 +76,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docker-compose-quickstart-build.yml
+++ b/docker-compose-quickstart-build.yml
@@ -50,7 +50,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -46,7 +46,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - '5005'
 
   cache:
-    image: registry.redict.io/redict:7.3.6-alpine
+    image: valkey/valkey:8.1-alpine
     restart: always
     expose:
       - '6379'

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Below are the universal software prerequisites, followed by network-specific ite
 3. [MongoDB v6](https://www.mongodb.com/), [Node.js v16](https://nodejs.org/en), and [NATS 1.12.2](https://nats.io/) – auto-installed when using Docker-Compose
 4. [Web3.Storage account](https://web3.storage/) – IPFS pinning service
 5. [Filebase account](https://filebase.com/) – S3-compatible IPFS pinning
-6. [Redis 7.3.0](https://redict.io/) – in-memory cache & message broker (auto-provisioned by the Docker stack)
+6. [Valkey](https://valkey.io) – in-memory cache & message broker (auto-provisioned by the Docker stack)
 
 ### 2.2 Hedera network
 

--- a/docs/guardian/readme/getting-started/prerequisites.md
+++ b/docs/guardian/readme/getting-started/prerequisites.md
@@ -7,7 +7,7 @@
 * [MongoDB](https://www.mongodb.com/)[ V6](https://www.mongodb.com/) , [NodeJS](https://nodejs.org/)[ v16](https://nodejs.org/en) and [Nats](https://nats.io/)[ 1.12.2](https://nats.io/) (If you build with docker these components will be installed automatically)
 * [Web3.Storage Account](https://web3.storage/)
 * [Filebase Account](https://filebase.com/)
-* [Redict 7.3.0](https://redict.io/)
+* [Valkey](https://valkey.io)
 
 When building reference implementation, you can manually build every component or run a single command with Docker.
 


### PR DESCRIPTION
### Description

Replaces Redict with [Valkey](https://valkey.io) as the in-memory cache across the entire Guardian stack.

Resolve #6250 

### Changes

**Docker Compose** — updated the `cache` service image from `registry.redict.io/redict:7.3.6-alpine` to `valkey/valkey:8.1-alpine` in all six Compose files:
- `docker-compose.yml`
- `docker-compose-build.yml`
- `docker-compose-production.yml`
- `docker-compose-production-build.yml`
- `docker-compose-quickstart.yml`
- `docker-compose-quickstart-build.yml`

**CI workflows** — same image swap applied to the `cache` service in all five GitHub Actions workflow files:
- `api-after-commit.yml`
- `api-manual.yml`
- `api-schedule-all.yml`
- `api-schedule-vm0033.yml`
- `ui-manual.yml`

**Documentation** — updated all references from Redict/Redis to Valkey with links to `https://valkey.io`:
- `README.md`
- `docs/README.md`
- `docs/guardian/readme/getting-started/prerequisites.md`

### Notes

No application code or configuration changes – only the container image and documentation are affected. The Valkey service continues to expose port `6379` and is fully compatible with existing Guardian cache clients.