### PR TITLE
perf: sign GeoJSON geometry as @json literal to fix pathological VC canonicalization

### DIFF
--- a/common/src/helpers/schemas-to-context.ts
+++ b/common/src/helpers/schemas-to-context.ts
@@ -15,6 +15,11 @@ export function schemasToContext(
         type?: string | undefined;
         // tslint:disable-next-line:completed-docs
         rootTerms?: any;
+        // Map GeoJSON `coordinates`/`bbox` to a single `@type: @json` literal instead of
+        // expanding them per-coordinate into RDF (huge JSON-LD canonicalization cost on sign).
+        // MUST be false for EVC schemas: BBS+ selective-disclosure derive flattens @json values.
+        // tslint:disable-next-line:completed-docs
+        geoJsonCoordinatesAsJson?: boolean;
     }
 ): {
     // tslint:disable-next-line:completed-docs
@@ -31,6 +36,17 @@ export function schemasToContext(
         for (const contextEntry of additionalContexts) {
             replacedContext['@context'][contextEntry[0]] = contextEntry[1];
         }
+    }
+    if (contextSettings?.geoJsonCoordinatesAsJson && additionalContexts && additionalContexts.has('#GeoJSON')) {
+        // GeoJSON `coordinates`/`bbox` are deeply-nested numeric arrays. Expanding them into
+        // RDF (per-coordinate) makes JSON-LD canonicalization super-linear — a large MultiPolygon
+        // takes tens of seconds and tens-to-hundreds of MB to sign. Map them to a single @json
+        // literal (root-level, so it applies at every nesting depth) so the geometry is signed as
+        // an opaque JCS value instead of exploded into RDF lists. Requires JSON-LD 1.1 (set above).
+        // Gated by the caller: EVC schemas must NOT use this — BBS+ selective-disclosure derive
+        // flattens nested arrays inside an @json literal, corrupting the revealed geometry.
+        replacedContext['@context'].coordinates = { '@id': 'https://purl.org/geojson/vocab#coordinates', '@type': '@json' };
+        replacedContext['@context'].bbox = { '@id': 'https://purl.org/geojson/vocab#bbox', '@type': '@json' };
     }
     return replacedContext;
 }

--- a/common/tests/unit-tests/schemas-to-context/geojson-coordinates-json.test.mjs
+++ b/common/tests/unit-tests/schemas-to-context/geojson-coordinates-json.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import esmock from 'esmock';
+
+const COORDS_ID = 'https://purl.org/geojson/vocab#coordinates';
+const BBOX_ID = 'https://purl.org/geojson/vocab#bbox';
+
+const { schemasToContext } = await esmock('../../../dist/helpers/schemas-to-context.js', {
+    '@transmute/jsonld-schema': {
+        schemasToContext: () => ({
+            '@context': {
+                place: { '@id': 'https://example.org/place' },
+            },
+        }),
+    },
+});
+
+const withGeoJson = (extra = []) => new Map([['#GeoJSON', { geo: true }], ...extra]);
+
+describe('@unit schemasToContext (GeoJSON coordinates as @json)', () => {
+    it('maps root coordinates to an @json literal when enabled and #GeoJSON is present', () => {
+        const out = schemasToContext([], withGeoJson(), { geoJsonCoordinatesAsJson: true });
+        assert.deepEqual(out['@context'].coordinates, { '@id': COORDS_ID, '@type': '@json' });
+    });
+
+    it('maps root bbox to an @json literal when enabled and #GeoJSON is present', () => {
+        const out = schemasToContext([], withGeoJson(), { geoJsonCoordinatesAsJson: true });
+        assert.deepEqual(out['@context'].bbox, { '@id': BBOX_ID, '@type': '@json' });
+    });
+
+    it('still merges the #GeoJSON additional context alongside the @json terms', () => {
+        const out = schemasToContext([], withGeoJson(), { geoJsonCoordinatesAsJson: true });
+        assert.deepEqual(out['@context']['#GeoJSON'], { geo: true });
+        assert.equal(out['@context'].coordinates['@type'], '@json');
+    });
+
+    it('does NOT add the @json terms when the flag is false', () => {
+        const out = schemasToContext([], withGeoJson(), { geoJsonCoordinatesAsJson: false });
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+
+    it('does NOT add the @json terms when the flag is omitted', () => {
+        const out = schemasToContext([], withGeoJson(), {});
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+
+    it('does NOT add the @json terms when contextSettings is absent', () => {
+        const out = schemasToContext([], withGeoJson());
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+
+    it('does NOT add the @json terms when #GeoJSON is not among the additional contexts', () => {
+        const additional = new Map([['#SentinelHUB', { hub: true }]]);
+        const out = schemasToContext([], additional, { geoJsonCoordinatesAsJson: true });
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+
+    it('does NOT add the @json terms when there are no additional contexts', () => {
+        const out = schemasToContext([], undefined, { geoJsonCoordinatesAsJson: true });
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+
+    it('does NOT add the @json terms for an empty additional contexts map', () => {
+        const out = schemasToContext([], new Map(), { geoJsonCoordinatesAsJson: true });
+        assert.equal(out['@context'].coordinates, undefined);
+        assert.equal(out['@context'].bbox, undefined);
+    });
+});

--- a/guardian-service/src/helpers/import-helpers/schema/schema-publish-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/schema/schema-publish-helper.ts
@@ -6,6 +6,7 @@ import {
     ISchemaDocument,
     ModuleStatus,
     Schema,
+    SchemaEntity,
     SchemaHelper,
     SchemaStatus,
     SentinelHubContext
@@ -52,7 +53,11 @@ export function generateSchemaContext(item: SchemaCollection) {
     checkSchemaProps(item, itemDocument);
     const defsArray = itemDocument.$defs ? Object.values(itemDocument.$defs) : [];
     const additionalContexts = getAdditionalContexts(itemDocument);
-    return schemasToContext([...defsArray, itemDocument], additionalContexts);
+    return schemasToContext([...defsArray, itemDocument], additionalContexts, {
+        // Sign GeoJSON geometry as an opaque @json literal (fast canonicalization) — but NOT for
+        // EVC schemas, where BBS+ selective-disclosure derive would flatten the revealed geometry.
+        geoJsonCoordinatesAsJson: item.entity !== SchemaEntity.EVC,
+    });
 }
 
 export function generatePackage(options: {
@@ -96,7 +101,10 @@ export function generatePackage(options: {
         Array.from(defsArray.values()),
         additionalContexts,
         {
-            vocab: 'https://w3id.org/traceability/#undefinedTerm'
+            vocab: 'https://w3id.org/traceability/#undefinedTerm',
+            // Only optimize GeoJSON-as-@json when NO packaged schema is EVC (selective disclosure),
+            // since the package shares one context and @json breaks BBS+ derive of geometry.
+            geoJsonCoordinatesAsJson: schemas.every((s) => s.entity !== SchemaEntity.EVC)
         }
     );
 

--- a/guardian-service/tests/unit/schema-publish-geojson-context.test.mjs
+++ b/guardian-service/tests/unit/schema-publish-geojson-context.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { SchemaEntity } from '@guardian/interfaces';
+import { generateSchemaContext, generatePackage } from '../../dist/helpers/import-helpers/schema/schema-publish-helper.js';
+
+const COORDS_ID = 'https://purl.org/geojson/vocab#coordinates';
+const BBOX_ID = 'https://purl.org/geojson/vocab#bbox';
+
+const stringProp = (title = 'Field') => ({
+    type: 'string',
+    title,
+    description: title,
+    $comment: JSON.stringify({ term: title, '@id': `schema:${title}` })
+});
+
+const schemaDoc = (id, overrides = {}) => ({
+    $id: id,
+    title: id.replace('#', ''),
+    type: 'object',
+    $comment: JSON.stringify({ term: id.replace('#', ''), '@id': `schema:${id.replace('#', '')}` }),
+    properties: { amount: stringProp() },
+    ...overrides
+});
+
+const schemaItem = (iri, document, overrides = {}) => ({
+    uuid: `uuid-${iri}`,
+    iri,
+    document,
+    ...overrides
+});
+
+const geoDoc = (id) => schemaDoc(id, {
+    properties: { place: { $ref: '#GeoJSON', title: 'g', description: 'g' } },
+    $defs: { '#GeoJSON': schemaDoc('#GeoJSON') }
+});
+
+describe('generateSchemaContext (GeoJSON coordinates as @json)', () => {
+    it('signs coordinates/bbox as @json for a non-EVC schema that uses #GeoJSON', () => {
+        const context = generateSchemaContext(schemaItem('#A', geoDoc('#A'), { entity: SchemaEntity.VC }));
+        assert.deepEqual(context['@context'].coordinates, { '@id': COORDS_ID, '@type': '@json' });
+        assert.deepEqual(context['@context'].bbox, { '@id': BBOX_ID, '@type': '@json' });
+    });
+
+    it('signs coordinates/bbox as @json when the entity is undefined (still not EVC)', () => {
+        const context = generateSchemaContext(schemaItem('#A', geoDoc('#A')));
+        assert.equal(context['@context'].coordinates['@type'], '@json');
+    });
+
+    it('does NOT add @json terms for an EVC schema, even with #GeoJSON', () => {
+        const context = generateSchemaContext(schemaItem('#A', geoDoc('#A'), { entity: SchemaEntity.EVC }));
+        assert.equal(context['@context'].coordinates, undefined);
+        assert.equal(context['@context'].bbox, undefined);
+    });
+
+    it('does NOT add @json terms for a non-EVC schema without #GeoJSON', () => {
+        const context = generateSchemaContext(schemaItem('#A', schemaDoc('#A'), { entity: SchemaEntity.VC }));
+        assert.equal(context['@context'].coordinates, undefined);
+        assert.equal(context['@context'].bbox, undefined);
+    });
+});
+
+describe('generatePackage (GeoJSON coordinates as @json)', () => {
+    const owner = { owner: 'did:owner' };
+    const options = (schemas, overrides = {}) => ({
+        name: 'pkg',
+        version: '1.0.0',
+        type: 'publish',
+        schemas,
+        owner,
+        ...overrides
+    });
+
+    it('signs coordinates/bbox as @json when no packaged schema is EVC', () => {
+        const result = generatePackage(options([
+            schemaItem('#A', geoDoc('#A'), { entity: SchemaEntity.VC }),
+            schemaItem('#B', schemaDoc('#B'), { entity: SchemaEntity.VC })
+        ]));
+        assert.deepEqual(result.context['@context'].coordinates, { '@id': COORDS_ID, '@type': '@json' });
+        assert.deepEqual(result.context['@context'].bbox, { '@id': BBOX_ID, '@type': '@json' });
+    });
+
+    it('does NOT add @json terms when ANY packaged schema is EVC', () => {
+        const result = generatePackage(options([
+            schemaItem('#A', geoDoc('#A'), { entity: SchemaEntity.VC }),
+            schemaItem('#B', schemaDoc('#B'), { entity: SchemaEntity.EVC })
+        ]));
+        assert.equal(result.context['@context'].coordinates, undefined);
+        assert.equal(result.context['@context'].bbox, undefined);
+    });
+
+    it('does NOT add @json terms when no packaged schema uses #GeoJSON', () => {
+        const result = generatePackage(options([
+            schemaItem('#A', schemaDoc('#A'), { entity: SchemaEntity.VC })
+        ]));
+        assert.equal(result.context['@context'].coordinates, undefined);
+        assert.equal(result.context['@context'].bbox, undefined);
+    });
+});


### PR DESCRIPTION
## Problem
Signing a Verifiable Credential that embeds a GeoJSON geometry is dominated by JSON-LD canonicalization and is pathologically slow. For a large `MultiPolygon`, `jsonld` canonicalization runs **tens of seconds** and allocates **tens-to-hundreds of MB**; because policies sign concurrently, the cost stacks and can drive the policy process into multi-hundred-MB / GB memory spikes.

## Root cause
The generated schema `@context` **never activates** the geojson `@list` scoped context for the geometry field: `schemasToContext` emits the field as `{ "@id": … }` with no scoped `@context`, so the nested `coordinates` falls through to the default `@vocab` and **every coordinate is expanded per-value into RDF**. URDNA2015 over that graph is super-linear (~O(n²)) in the number of coordinates.

Bisecting `jsonld.toRDF` on a real document attributes ~93% of the RDF quads to a single `coordinates` field; `rdf-canonize` itself is fast (~0.1 s) — the cost is the JSON-LD expansion of the geometry. (Upgrading `jsonld`/`rdf-canonize` does not help.)

## Fix
When a schema context contains `#GeoJSON`, map the **root** `coordinates`/`bbox` terms to `@type: @json`, so the geometry is signed as a single opaque JCS literal instead of exploded into RDF lists. A root-level term applies at every nesting depth (the scoped geojson context is never activated, so this is what actually governs the geometry).

- `common/.../schemas-to-context.ts` — inject root `coordinates`/`bbox` = `@type: @json`, behind a new `geoJsonCoordinatesAsJson` option.
- `guardian-service/.../schema-publish-helper.ts` — pass `geoJsonCoordinatesAsJson: entity !== EVC` (and, for packages, only when no packaged schema is EVC).

## Why gated on `entity !== EVC`
For `EVC` schemas (BBS+ selective disclosure), the derive/reveal step flattens nested arrays inside an `@json` literal, corrupting the revealed geometry. EVC schemas therefore keep the existing context.

## Results (measured on a large real MultiPolygon schema)
| | before | after |
| --- | --- | --- |
| `jsonld.canonize` (real schema context) | ~22 s | ~1.5 s |
| Ed25519 issue + verify | tens of s | ~0.46 s, verify VALID |
| BBS+ issue (non-derive) | 54–75 s | ~0.6 s, valid proof |

## Compatibility
`@type: @json` changes only JSON-LD **canonicalization**, not the stored JSON document — so consumers that read the geometry as JSON (indexer project map, UI map, schema validation, credential hash) are unaffected, and the signed geometry is byte-identical. The change applies to **newly published** schema contexts; existing credentials keep verifying against their own published context (the `@context` is referenced by URL, not embedded), so it must be published at a new context URL/version — never overwrite an existing one in place.
