### PR TITLE
feat: 4907 Implement cross-schema conditions

### DIFF
--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -378,6 +378,29 @@ export class VCJS {
         }
         const rootProperties = schema.properties || {};
         const conditionalByRef = new Map<string, Set<string>>();
+
+        const collectConditional = (constraint: any, refKey: string) => {
+            if (!constraint || typeof constraint !== 'object') { return; }
+            if (!conditionalByRef.has(refKey)) { conditionalByRef.set(refKey, new Set()); }
+            const fields = conditionalByRef.get(refKey)!;
+            if (Array.isArray(constraint.required)) {
+                for (const fn of constraint.required) { fields.add(fn); }
+            }
+            if (constraint.properties) {
+                const parentSchema = defsObj[refKey];
+                for (const [fieldName, val] of Object.entries(constraint.properties) as [string, any][]) {
+                    if (val === false) {
+                        fields.add(fieldName);
+                    } else if (val && typeof val === 'object') {
+                        const nestedRef = parentSchema?.properties?.[fieldName]?.$ref;
+                        if (nestedRef && defsObj[nestedRef]) {
+                            collectConditional(val, nestedRef);
+                        }
+                    }
+                }
+            }
+        };
+
         for (const condEntry of schema.allOf) {
             if (!condEntry?.if) { continue; }
             for (const branch of [condEntry.then, condEntry.else]) {
@@ -387,16 +410,7 @@ export class VCJS {
                     if (!constraint || typeof constraint !== 'object') { continue; }
                     const ref = rootProperties[propKey]?.$ref;
                     if (!ref || !defsObj[ref]) { continue; }
-                    if (!conditionalByRef.has(ref)) { conditionalByRef.set(ref, new Set()); }
-                    const conditionalFields = conditionalByRef.get(ref)!;
-                    if (Array.isArray(constraint.required)) {
-                        for (const fieldName of constraint.required) { conditionalFields.add(fieldName); }
-                    }
-                    if (constraint.properties) {
-                        for (const [fieldName, val] of Object.entries(constraint.properties)) {
-                            if (val === false) { conditionalFields.add(fieldName); }
-                        }
-                    }
+                    collectConditional(constraint, ref);
                 }
             }
         }

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -322,8 +322,9 @@ export class VCJS {
 
         const validate = await ajv.compileAsync(schema);
         const valid = validate(vcObject);
+        const errors = this.enhanceConditionErrors(validate.errors as any[], schema);
 
-        return new SchemaValidationResult(valid, 'JSON_SCHEMA_VALIDATION_ERROR', validate.errors as any);
+        return new SchemaValidationResult(valid, 'JSON_SCHEMA_VALIDATION_ERROR', errors as any);
     }
 
     /**
@@ -354,6 +355,8 @@ export class VCJS {
      * @param schema Schema
      */
     private prepareSchema(schema: any) {
+        this.stripIfOnly(schema);
+
         const defsObj = schema.$defs;
         if (!defsObj) {
             return;
@@ -362,12 +365,121 @@ export class VCJS {
         const defsKeys = Object.keys(defsObj);
         for (const key of defsKeys) {
             const nestedSchema = defsObj[key];
+            this.stripIfOnly(nestedSchema);
             const required = nestedSchema.required;
             if (!required || required.length === 0) {
                 continue;
             }
             nestedSchema.required = required.filter((field: any) => !nestedSchema.properties[field] || !nestedSchema.properties[field].readOnly);
         }
+
+        if (!Array.isArray(schema.allOf)) {
+            return;
+        }
+        const rootProperties = schema.properties || {};
+        const conditionalByRef = new Map<string, Set<string>>();
+        for (const condEntry of schema.allOf) {
+            if (!condEntry?.if) { continue; }
+            for (const branch of [condEntry.then, condEntry.else]) {
+                if (!branch?.properties) { continue; }
+                for (const propKey of Object.keys(branch.properties)) {
+                    const constraint = branch.properties[propKey];
+                    if (!constraint || typeof constraint !== 'object') { continue; }
+                    const ref = rootProperties[propKey]?.$ref;
+                    if (!ref || !defsObj[ref]) { continue; }
+                    if (!conditionalByRef.has(ref)) { conditionalByRef.set(ref, new Set()); }
+                    const conditionalFields = conditionalByRef.get(ref)!;
+                    if (Array.isArray(constraint.required)) {
+                        for (const fieldName of constraint.required) { conditionalFields.add(fieldName); }
+                    }
+                    if (constraint.properties) {
+                        for (const [fieldName, val] of Object.entries(constraint.properties)) {
+                            if (val === false) { conditionalFields.add(fieldName); }
+                        }
+                    }
+                }
+            }
+        }
+        for (const [ref, conditionalFields] of conditionalByRef) {
+            const defsEntry = defsObj[ref];
+            if (Array.isArray(defsEntry?.required) && conditionalFields.size) {
+                defsEntry.required = defsEntry.required.filter((r: string) => !conditionalFields.has(r));
+            }
+        }
+    }
+
+    private stripIfOnly(schema: any) {
+        if (!Array.isArray(schema?.allOf)) {
+            return;
+        }
+        schema.allOf = schema.allOf.filter(
+            (entry: any) => !entry?.if || entry.then !== undefined || entry.else !== undefined
+        );
+        if (schema.allOf.length === 0) {
+            delete schema.allOf;
+        }
+    }
+
+    /**
+     * Converts the nested JSON Schema `if` node into a readable condition string
+     */
+    private describeIfCondition(node: any): string {
+        if (!node) { return ''; }
+        if (Array.isArray(node.anyOf)) {
+            return node.anyOf.map((b: any) => this.describeIfCondition(b)).filter(Boolean).join(' OR ');
+        }
+        if (Array.isArray(node.allOf)) {
+            return node.allOf.map((b: any) => this.describeIfCondition(b)).filter(Boolean).join(' AND ');
+        }
+        if (node.properties) {
+            return Object.entries(node.properties as Record<string, any>)
+                .map(([key, val]) => this.describeIfConditionLeaf(val, key))
+                .filter(Boolean)
+                .join(', ');
+        }
+        return '';
+    }
+
+    private describeIfConditionLeaf(node: any, leafKey: string): string {
+        if (!node) { return ''; }
+        if (node.const !== undefined) {
+            return `${leafKey} = '${node.const}'`;
+        }
+        if (node.properties) {
+            return Object.entries(node.properties as Record<string, any>)
+                .map(([key, val]) => this.describeIfConditionLeaf(val, key))
+                .filter(Boolean)
+                .join(', ');
+        }
+        if (Array.isArray(node.anyOf)) {
+            return node.anyOf.map((b: any) => this.describeIfConditionLeaf(b, leafKey)).filter(Boolean).join(' OR ');
+        }
+        if (Array.isArray(node.allOf)) {
+            return node.allOf.map((b: any) => this.describeIfConditionLeaf(b, leafKey)).filter(Boolean).join(' AND ');
+        }
+        return '';
+    }
+
+    /**
+     * Replaces AJV messages with a human-readable description
+     */
+    private enhanceConditionErrors(errors: any[] | null | undefined, schema: any): any[] | null | undefined {
+        if (!errors?.length || !Array.isArray(schema?.allOf)) {
+            return errors;
+        }
+        return errors.map(error => {
+            if (error.keyword !== 'false schema') { return error; }
+            const match = (error.schemaPath as string)?.match(/^#\/allOf\/(\d+)\/(then|else)\//);
+            if (!match) { return error; }
+            const condEntry = schema.allOf[parseInt(match[1], 10)];
+            if (!condEntry?.if) { return error; }
+            const fieldName = (error.instancePath as string).split('/').filter(Boolean).pop() || 'field';
+            const condition = this.describeIfCondition(condEntry.if) || 'condition not met';
+            return {
+                ...error,
+                message: `Field '${fieldName}' is not allowed unless: ${condition}`,
+            };
+        });
     }
 
     /**
@@ -396,10 +508,10 @@ export class VCJS {
         this.prepareSchema(schema);
 
         const validate = await ajv.compileAsync(schema);
-
         const valid = validate(subject);
+        const errors = this.enhanceConditionErrors(validate.errors as any[], schema);
 
-        return new SchemaValidationResult(valid, 'JSON_SCHEMA_VALIDATION_ERROR', validate.errors as any);
+        return new SchemaValidationResult(valid, 'JSON_SCHEMA_VALIDATION_ERROR', errors as any);
     }
 
     /**

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -377,26 +377,31 @@ export class VCJS {
             return;
         }
         const rootProperties = schema.properties || {};
-        const conditionalByRef = new Map<string, Set<string>>();
 
-        const collectConditional = (constraint: any, refKey: string) => {
-            if (!constraint || typeof constraint !== 'object') { return; }
-            if (!conditionalByRef.has(refKey)) { conditionalByRef.set(refKey, new Set()); }
-            const fields = conditionalByRef.get(refKey)!;
-            if (Array.isArray(constraint.required)) {
-                for (const fn of constraint.required) { fields.add(fn); }
-            }
-            if (constraint.properties) {
-                const parentSchema = defsObj[refKey];
-                for (const [fieldName, val] of Object.entries(constraint.properties) as [string, any][]) {
-                    if (val === false) {
-                        fields.add(fieldName);
-                    } else if (val && typeof val === 'object') {
-                        const nestedRef = parentSchema?.properties?.[fieldName]?.$ref;
-                        if (nestedRef && defsObj[nestedRef]) {
-                            collectConditional(val, nestedRef);
+        // Collect fields to strip keyed by container dot-path (not by IRI).
+        // Multiple conditions targeting the same container accumulate into one Set.
+        const stripByPath = new Map<string, Set<string>>();
+
+        const collectPath = (constraint: any, pathSoFar: string[], currentProps: any) => {
+            if (!constraint?.properties) { return; }
+            for (const [propKey, val] of Object.entries(constraint.properties) as [string, any][]) {
+                if (!val || typeof val !== 'object') { continue; }
+                const ref = currentProps[propKey]?.$ref;
+                if (!ref || !defsObj[ref]) { continue; }
+                const containerPath = [...pathSoFar, propKey];
+                const pathKey = containerPath.join('.');
+                if (Array.isArray(val.required)) {
+                    if (!stripByPath.has(pathKey)) { stripByPath.set(pathKey, new Set()); }
+                    for (const f of val.required) { stripByPath.get(pathKey)!.add(f); }
+                }
+                if (val.properties) {
+                    for (const [fieldName, fieldVal] of Object.entries(val.properties) as [string, any][]) {
+                        if (fieldVal === false) {
+                            if (!stripByPath.has(pathKey)) { stripByPath.set(pathKey, new Set()); }
+                            stripByPath.get(pathKey)!.add(fieldName);
                         }
                     }
+                    collectPath(val, containerPath, defsObj[ref]?.properties || {});
                 }
             }
         };
@@ -404,20 +409,80 @@ export class VCJS {
         for (const condEntry of schema.allOf) {
             if (!condEntry?.if) { continue; }
             for (const branch of [condEntry.then, condEntry.else]) {
-                if (!branch?.properties) { continue; }
-                for (const propKey of Object.keys(branch.properties)) {
-                    const constraint = branch.properties[propKey];
-                    if (!constraint || typeof constraint !== 'object') { continue; }
-                    const ref = rootProperties[propKey]?.$ref;
-                    if (!ref || !defsObj[ref]) { continue; }
-                    collectConditional(constraint, ref);
-                }
+                collectPath(branch, [], rootProperties);
             }
         }
-        for (const [ref, conditionalFields] of conditionalByRef) {
-            const defsEntry = defsObj[ref];
-            if (Array.isArray(defsEntry?.required) && conditionalFields.size) {
-                defsEntry.required = defsEntry.required.filter((r: string) => !conditionalFields.has(r));
+
+        if (!stripByPath.size) { return; }
+
+        // Pre-compute original IRIs for every path and its ancestors before any $ref rewrite.
+        const originalIriByPath = new Map<string, string>();
+        const computeOriginalIri = (pathArr: string[]): string | undefined => {
+            let props = rootProperties;
+            for (let i = 0; i < pathArr.length; i++) {
+                const ref = props[pathArr[i]]?.$ref;
+                if (!ref || !defsObj[ref]) { return undefined; }
+                if (i === pathArr.length - 1) { return ref; }
+                props = defsObj[ref]?.properties || {};
+            }
+            return undefined;
+        };
+
+        // Include all ancestor paths so passthrough clones can be created for them.
+        const allPathsNeeded = new Set<string>();
+        for (const pathKey of stripByPath.keys()) {
+            const parts = pathKey.split('.');
+            for (let d = 1; d <= parts.length; d++) {
+                allPathsNeeded.add(parts.slice(0, d).join('.'));
+            }
+        }
+        for (const pathKey of allPathsNeeded) {
+            const iri = computeOriginalIri(pathKey.split('.'));
+            if (iri) { originalIriByPath.set(pathKey, iri); }
+        }
+
+        // Process shortest paths first so parent clones exist before children need them.
+        const cloneKeys = new Map<string, string>();
+        const sortedPaths = [...allPathsNeeded].sort(
+            (a, b) => a.split('.').length - b.split('.').length
+        );
+
+        for (const pathKey of sortedPaths) {
+            const iri = originalIriByPath.get(pathKey);
+            if (!iri) { continue; }
+            const pathArr = pathKey.split('.');
+            const fieldsToStrip = stripByPath.get(pathKey);
+            const cloneKey = `${iri}__${pathArr.join('__')}`;
+
+            // Deep-copy original def so the shared entry is never mutated.
+            const clone = JSON.parse(JSON.stringify(defsObj[iri]));
+            // Give the clone a unique $id so AJV can resolve the rewritten $ref to
+            // it, without conflicting with the original entry's $id anchor.
+            clone.$id = cloneKey;
+            delete clone.$anchor;
+            delete clone.$dynamicAnchor;
+            if (fieldsToStrip?.size && Array.isArray(clone.required)) {
+                clone.required = clone.required.filter((r: string) => !fieldsToStrip.has(r));
+                if (!clone.required.length) { delete clone.required; }
+            }
+            defsObj[cloneKey] = clone;
+            cloneKeys.set(pathKey, cloneKey);
+
+            // Rewrite the $ref on this specific container only.
+            if (pathArr.length === 1) {
+                if (rootProperties[pathArr[0]]) {
+                    rootProperties[pathArr[0]] = { ...rootProperties[pathArr[0]], $ref: cloneKey };
+                }
+            } else {
+                const parentPathKey = pathArr.slice(0, -1).join('.');
+                const parentCloneKey = cloneKeys.get(parentPathKey);
+                const leafProp = pathArr[pathArr.length - 1];
+                if (parentCloneKey && defsObj[parentCloneKey]?.properties?.[leafProp]) {
+                    defsObj[parentCloneKey].properties[leafProp] = {
+                        ...defsObj[parentCloneKey].properties[leafProp],
+                        $ref: cloneKey,
+                    };
+                }
             }
         }
     }

--- a/common/src/xlsx/json-to-xlsx.ts
+++ b/common/src/xlsx/json-to-xlsx.ts
@@ -276,7 +276,9 @@ export class JsonToXlsx {
                 schemaCache,
                 enumsCache,
                 row,
-                subSchemaNames
+                subSchemaNames,
+                fieldCache,
+                [field.name]
             );
         }
 
@@ -481,7 +483,9 @@ export class JsonToXlsx {
         schemaCache: Map<string, string>,
         enumsCache: Map<string, XlsxEnum>,
         row: number,
-        subSchemaNames: Map<string, string> = new Map()
+        subSchemaNames: Map<string, string> = new Map(),
+        rootFieldCache?: Map<string, IRowField>,
+        pathPrefix?: string[]
     ): number {
         if (!parent || !parent.isRef || !Array.isArray(parent.fields) || parent.fields.length === 0) {
             return row;
@@ -512,6 +516,13 @@ export class JsonToXlsx {
                 subSchemaNames,
                 parent
             );
+            if (rootFieldCache && pathPrefix) {
+                const dotPath = [...pathPrefix, field.name].join('.');
+                const rowField = fieldCache.get(field.name);
+                if (rowField) {
+                    rootFieldCache.set(dotPath, rowField);
+                }
+            }
             worksheet
                 .getRow(row)
                 .setOutline(lvl);
@@ -522,16 +533,29 @@ export class JsonToXlsx {
                 schemaCache,
                 enumsCache,
                 row,
-                subSchemaNames
+                subSchemaNames,
+                rootFieldCache,
+                pathPrefix ? [...pathPrefix, field.name] : undefined
             );
         }
 
+        // Extend local cache with relative dot-paths from rootFieldCache so nested fieldPath refs resolve.
+        let condCache = fieldCache;
+        if (rootFieldCache && pathPrefix) {
+            const prefix = pathPrefix.join('.') + '.';
+            condCache = new Map(fieldCache);
+            for (const [k, v] of rootFieldCache) {
+                if (k.startsWith(prefix)) {
+                    condCache.set(k.slice(prefix.length), v);
+                }
+            }
+        }
         for (const condition of parent.conditions) {
             JsonToXlsx.writeCondition(
                 worksheet,
                 table,
                 condition,
-                fieldCache
+                condCache
             );
         }
 
@@ -620,7 +644,10 @@ export class JsonToXlsx {
         fieldCache: Map<string, IRowField>
     ): string {
         const toExact = (sub: any): string => {
-            const f = fieldCache.get(sub.field.name);
+            const key = (sub.fieldPath?.length > 1)
+                ? (sub.fieldPath as string[]).join('.')
+                : sub.field.name;
+            const f = fieldCache.get(key) ?? fieldCache.get(sub.field.name);
             if (!f) {
                 throw new Error(`Condition refers to unknown field "${sub.field?.name}".`);
             }

--- a/common/src/xlsx/json-to-xlsx.ts
+++ b/common/src/xlsx/json-to-xlsx.ts
@@ -448,32 +448,20 @@ export class JsonToXlsx {
         fieldCache: Map<string, IRowField>,
     ) {
         const baseFormula = JsonToXlsx.buildIfFormula(condition.ifCondition, fieldCache);
-
         const thenFormula = baseFormula;
         const elseFormula = `NOT(${baseFormula})`;
 
-        if (Array.isArray(condition.thenFields)) {
-            for (const field of condition.thenFields) {
-                const thenField = fieldCache.get(field.name);
-                if (!thenField) {
-                    continue;
-                }
-                worksheet
-                    .getCell(table.getCol(Dictionary.VISIBILITY), thenField.row)
-                    .setFormulae(thenFormula);
+        const writeCell = (key: string, formula: string) => {
+            const rowField = fieldCache.get(key);
+            if (rowField) {
+                worksheet.getCell(table.getCol(Dictionary.VISIBILITY), rowField.row).setFormulae(formula);
             }
-        }
-        if (Array.isArray(condition.elseFields)) {
-            for (const field of condition.elseFields) {
-                const elseField = fieldCache.get(field.name);
-                if (!elseField) {
-                    continue;
-                }
-                worksheet
-                    .getCell(table.getCol(Dictionary.VISIBILITY), elseField.row)
-                    .setFormulae(elseFormula);
-            }
-        }
+        };
+
+        for (const field of condition.thenFields || []) { writeCell(field.name, thenFormula); }
+        for (const field of condition.elseFields || []) { writeCell(field.name, elseFormula); }
+        for (const t of condition.thenTargets || []) { writeCell(t.fieldPath.join('.'), thenFormula); }
+        for (const t of condition.elseTargets || []) { writeCell(t.fieldPath.join('.'), elseFormula); }
     }
 
     public static writeSubFields(

--- a/common/src/xlsx/models/schema-condition.ts
+++ b/common/src/xlsx/models/schema-condition.ts
@@ -54,7 +54,7 @@ export class XlsxSchemaConditions {
         return this.condition;
     }
 
-    public equal(otherFieldOrGroup: any, otherValue?: any): boolean {
+    public equal(otherFieldOrGroup: any, otherValue?: any, otherFieldPath?: string[]): boolean {
         if (this.group) {
             if (!(otherFieldOrGroup?.op && Array.isArray(otherFieldOrGroup.items))) {
                 return false
@@ -65,16 +65,18 @@ export class XlsxSchemaConditions {
             if (this.group.items.length !== otherFieldOrGroup.items.length) {
                 return false
             };
-            const norm = (arr: any[]) =>
+            const toKey = (arr: any[]) =>
                 arr
-                    .map(i => `${i.field?.name}::${JSON.stringify(i.value)}`)
+                    .map(i => `${i.field?.name}::${JSON.stringify(i.value)}::${JSON.stringify(normalizePath(i.fieldPath))}`)
                     .sort()
                     .join('|');
 
-            return norm(this.group.items) === norm(otherFieldOrGroup.items);
+            return toKey(this.group.items) === toKey(otherFieldOrGroup.items);
         } else {
             const of = otherFieldOrGroup as SchemaField;
-            return of?.name === this.single.field.name && sameValue(otherValue, this.single.value);
+            const pathA = JSON.stringify(normalizePath(this.single.fieldPath));
+            const pathB = JSON.stringify(normalizePath(otherFieldPath));
+            return of?.name === this.single.field.name && sameValue(otherValue, this.single.value) && pathA === pathB;
         }
     }
 

--- a/common/src/xlsx/models/schema-condition.ts
+++ b/common/src/xlsx/models/schema-condition.ts
@@ -1,38 +1,48 @@
 import { SchemaCondition, SchemaField } from '@guardian/interfaces';
 
-type SingleIf = { field: SchemaField; fieldValue: any };
+type SingleIf = { field: SchemaField; fieldValue: any; fieldPath?: string[] };
 type GroupIf = { OR: SingleIf[] } | { AND: SingleIf[] };
+
+function normalizePath(fieldPath?: string[]): string[] | undefined {
+    return Array.isArray(fieldPath) && fieldPath.length > 1 ? fieldPath : undefined;
+}
 
 function sameValue(a: any, b: any): boolean {
     return JSON.stringify(a) === JSON.stringify(b);
 }
 
 export class XlsxSchemaConditions {
-    private readonly single?: { field: SchemaField; value: any };
-    private readonly group?: { op: 'OR' | 'AND'; items: { field: SchemaField; value: any }[] };
+    private readonly single?: { field: SchemaField; value: any; fieldPath?: string[] };
+    private readonly group?: { op: 'OR' | 'AND'; items: { field: SchemaField; value: any; fieldPath?: string[] }[] };
 
     public readonly condition: SchemaCondition;
 
-    constructor(field: SchemaField, value: any);
-    constructor(group: { op: 'OR' | 'AND'; items: { field: SchemaField; value: any }[] });
-    constructor(arg1: any, value?: any) {
+    constructor(field: SchemaField, value: any, fieldPath?: string[]);
+    constructor(group: { op: 'OR' | 'AND'; items: { field: SchemaField; value: any; fieldPath?: string[] }[] });
+    constructor(arg1: any, value?: any, fieldPath?: string[]) {
         if (typeof arg1 === 'object' && value === undefined && arg1?.op && Array.isArray(arg1.items)) {
             this.group = { op: arg1.op, items: arg1.items };
+            const toPredicate = (i: any) => ({
+                field: i.field,
+                fieldValue: i.value,
+                fieldPath: normalizePath(i.fieldPath)
+            });
             const payload: GroupIf =
                 arg1.op === 'OR'
-                    ? { OR: arg1.items.map((i: any) => ({ field: i.field, fieldValue: i.value })) }
-                    : { AND: arg1.items.map((i: any) => ({ field: i.field, fieldValue: i.value })) };
+                    ? { OR: arg1.items.map(toPredicate) }
+                    : { AND: arg1.items.map(toPredicate) };
             this.condition = {
                 ifCondition: payload as any,
                 thenFields: [],
                 elseFields: []
             };
         } else {
-            this.single = { field: arg1 as SchemaField, value };
+            this.single = { field: arg1 as SchemaField, value, fieldPath: normalizePath(fieldPath) };
             this.condition = {
                 ifCondition: {
                     field: arg1 as SchemaField,
-                    fieldValue: value
+                    fieldValue: value,
+                    fieldPath: normalizePath(fieldPath)
                 } as any,
                 thenFields: [],
                 elseFields: []

--- a/common/src/xlsx/models/schema-condition.ts
+++ b/common/src/xlsx/models/schema-condition.ts
@@ -85,4 +85,15 @@ export class XlsxSchemaConditions {
             this.condition.thenFields.push(field);
         }
     }
+
+    public addTarget(field: SchemaField, targetFieldPath: string[], invert: boolean) {
+        const target = { field, fieldPath: targetFieldPath };
+        if (invert) {
+            if (!this.condition.elseTargets) { this.condition.elseTargets = []; }
+            this.condition.elseTargets.push(target);
+        } else {
+            if (!this.condition.thenTargets) { this.condition.thenTargets = []; }
+            this.condition.thenTargets.push(target);
+        }
+    }
 }

--- a/common/src/xlsx/xlsx-to-json.ts
+++ b/common/src/xlsx/xlsx-to-json.ts
@@ -407,6 +407,7 @@ export class XlsxToJson {
             row = table.end.r + 1;
             const fields: SchemaField[] = [];
             const allFields = new Map<string, SchemaField>();
+            const fieldPaths = new Map<string, string[]>();
 
             let parents: SchemaField[] = [];
             for (; row < range.e.r; row++) {
@@ -421,6 +422,7 @@ export class XlsxToJson {
                     allFields.set(field.title, field);
                     parents = parents.slice(0, groupIndex);
                     parents[groupIndex] = field;
+                    fieldPaths.set(field.title, parents.slice(0, groupIndex + 1).map(p => p.name));
                     if (groupIndex === 0) {
                         XlsxToJson.addFieldByName(worksheet, table, row, xlsxResult, fields, field);
                     } else {
@@ -475,6 +477,8 @@ export class XlsxToJson {
                     worksheet,
                     table,
                     fields,
+                    allFields,
+                    fieldPaths,
                     conditionCache,
                     row,
                     xlsxResult
@@ -865,6 +869,8 @@ export class XlsxToJson {
         worksheet: Worksheet,
         table: Table,
         fields: SchemaField[],
+        allFields: Map<string, SchemaField>,
+        fieldPaths: Map<string, string[]>,
         conditionCache: XlsxSchemaConditions[],
         row: number,
         xlsxResult: XlsxResult
@@ -922,11 +928,11 @@ export class XlsxToJson {
 
             if (result.op && Array.isArray(result.items)) {
                 const resolved = result.items.map(it => {
-                    const target = fields.find(f => f.title === it.fieldPath);
+                    const target = allFields.get(it.fieldPath) || fields.find(f => f.title === it.fieldPath);
                     if (!target) {
                         throw new Error(`Invalid target in ${result.op} condition: ${it.fieldPath}`);
                     }
-                    return { field: target, value: it.compareValue };
+                    return { field: target, value: it.compareValue, fieldPath: fieldPaths.get(it.fieldPath) };
                 });
 
                 const conditionKey = { op: result.op, items: resolved };
@@ -939,16 +945,17 @@ export class XlsxToJson {
                 }
                 return null;
             } else {
-                const target = fields.find((f) => f.title === result.fieldPath);
+                const target = allFields.get(result.fieldPath) || fields.find((f) => f.title === result.fieldPath);
                 if (!target) {
                     throw new Error('Invalid target');
                 }
+                const fieldPath = fieldPaths.get(result.fieldPath);
                 const condition = conditionCache.find(c => c.equal(target, result.compareValue));
                 if (condition) {
                     condition.addField(field, result.invert);
                     return null;
                 } else {
-                    const newCondition = new XlsxSchemaConditions(target, result.compareValue);
+                    const newCondition = new XlsxSchemaConditions(target, result.compareValue, fieldPath);
                     newCondition.addField(field, result.invert);
                     return newCondition;
                 }

--- a/common/src/xlsx/xlsx-to-json.ts
+++ b/common/src/xlsx/xlsx-to-json.ts
@@ -955,7 +955,7 @@ export class XlsxToJson {
                     throw new Error('Invalid trigger field');
                 }
                 const triggerPath = fieldPaths.get(result.fieldPath);
-                const condition = conditionCache.find(c => c.equal(trigger, result.compareValue));
+                const condition = conditionCache.find(c => c.equal(trigger, result.compareValue, triggerPath));
                 if (condition) {
                     addToCondition(condition, result.invert);
                     return null;

--- a/common/src/xlsx/xlsx-to-json.ts
+++ b/common/src/xlsx/xlsx-to-json.ts
@@ -487,7 +487,6 @@ export class XlsxToJson {
                     conditionCache.push(condition);
                 }
             }
-
             row = table.end.r + 1;
             const expressions: XlsxExpressions = new XlsxExpressions();
             for (; row < range.e.r; row++) {
@@ -878,15 +877,13 @@ export class XlsxToJson {
         if (worksheet.empty(table.start.c, table.end.c, row)) {
             return null;
         }
-        if (worksheet.getRow(row).getOutline()) {
-            return null;
-        }
 
         const key = XlsxToJson.getFieldKey(worksheet, table, row, xlsxResult);
-        const field = fields.find((f) => f.title === key.path);
+        const field = allFields.get(key.path) || fields.find((f) => f.title === key.path);
+        const targetPath = fieldPaths.get(key.path);
+        const isNested = targetPath && targetPath.length > 1;
 
         try {
-            //visibility
             if (worksheet.outColumnRange(table.getCol(Dictionary.VISIBILITY))) {
                 return;
             }
@@ -922,41 +919,49 @@ export class XlsxToJson {
             }
 
             if (result.type === 'const') {
-                field.hidden = field.hidden || !result.value;
+                if (field) { field.hidden = field.hidden || !result.value; }
                 return;
             }
 
+            const addToCondition = (holder: XlsxSchemaConditions, invert: boolean) => {
+                if (isNested && field) {
+                    holder.addTarget(field, targetPath, invert);
+                } else if (field) {
+                    holder.addField(field, invert);
+                }
+            };
+
             if (result.op && Array.isArray(result.items)) {
                 const resolved = result.items.map(it => {
-                    const target = allFields.get(it.fieldPath) || fields.find(f => f.title === it.fieldPath);
-                    if (!target) {
+                    const trigger = allFields.get(it.fieldPath) || fields.find(f => f.title === it.fieldPath);
+                    if (!trigger) {
                         throw new Error(`Invalid target in ${result.op} condition: ${it.fieldPath}`);
                     }
-                    return { field: target, value: it.compareValue, fieldPath: fieldPaths.get(it.fieldPath) };
+                    return { field: trigger, value: it.compareValue, fieldPath: fieldPaths.get(it.fieldPath) };
                 });
 
                 const conditionKey = { op: result.op, items: resolved };
                 const existed = conditionCache.find(c => (c as any).equal(conditionKey));
                 const holder = existed || new XlsxSchemaConditions(conditionKey as any);
 
-                holder.addField(field, !!result.invert);
+                addToCondition(holder, !!result.invert);
                 if (!existed) {
                     return holder;
                 }
                 return null;
             } else {
-                const target = allFields.get(result.fieldPath) || fields.find((f) => f.title === result.fieldPath);
-                if (!target) {
-                    throw new Error('Invalid target');
+                const trigger = allFields.get(result.fieldPath) || fields.find((f) => f.title === result.fieldPath);
+                if (!trigger) {
+                    throw new Error('Invalid trigger field');
                 }
-                const fieldPath = fieldPaths.get(result.fieldPath);
-                const condition = conditionCache.find(c => c.equal(target, result.compareValue));
+                const triggerPath = fieldPaths.get(result.fieldPath);
+                const condition = conditionCache.find(c => c.equal(trigger, result.compareValue));
                 if (condition) {
-                    condition.addField(field, result.invert);
+                    addToCondition(condition, result.invert);
                     return null;
                 } else {
-                    const newCondition = new XlsxSchemaConditions(target, result.compareValue, fieldPath);
-                    newCondition.addField(field, result.invert);
+                    const newCondition = new XlsxSchemaConditions(trigger, result.compareValue, triggerPath);
+                    addToCondition(newCondition, result.invert);
                     return newCondition;
                 }
             }
@@ -1095,6 +1100,15 @@ export class XlsxToJson {
                         items,
                         invert
                     };
+                }
+            }
+
+            if ((node as any).type === 'AssignmentNode') {
+                const assign = node as any;
+                const obj = assign.object;
+                const val = assign.value;
+                if (obj?.type === 'SymbolNode' && val?.type === 'ConstantNode') {
+                    return { type: 'formulae', fieldPath: obj.name, compareValue: val.value, invert };
                 }
             }
 

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
@@ -115,6 +115,133 @@ describe('VCJS coverage (offline paths)', function () {
             assert.deepEqual(schema.$defs.Foo.required, ['b']);
             assert.deepEqual(schema.$defs.Bar.required, []);
         });
+
+        describe('shared sub-schema sibling isolation', function () {
+            // Two root fields (`targeted` and `sibling`) both $ref the same #Sub entry.
+            // A condition in allOf targets only `targeted`. The fix must clone #Sub
+            // for `targeted` only — leaving `sibling` pointing at the unmodified original.
+            function makeSharedRefSchema() {
+                return {
+                    type: 'object',
+                    properties: {
+                        targeted: { $ref: '#Sub' },
+                        sibling:  { $ref: '#Sub' }
+                    },
+                    required: ['targeted', 'sibling'],
+                    allOf: [{
+                        if: {
+                            properties: { targeted: { properties: { a: { const: 1 } }, required: ['a'] } },
+                            required: ['targeted']
+                        },
+                        then: { properties: { targeted: { required: ['b'] } } },
+                        else: { properties: { targeted: { properties: { b: false } } } }
+                    }],
+                    $defs: {
+                        '#Sub': {
+                            $id: '#Sub',
+                            type: 'object',
+                            properties: {
+                                a: { type: 'number' },
+                                b: { type: 'number' }
+                            },
+                            required: ['a', 'b']
+                        }
+                    }
+                };
+            }
+
+            it('rewrites $ref only on the targeted container, not on sibling', function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.prepareSchema(schema);
+
+                assert.notEqual(schema.properties.targeted.$ref, '#Sub',
+                    'targeted $ref should point to a per-container clone');
+                assert.equal(schema.properties.sibling.$ref, '#Sub',
+                    'sibling $ref must remain on the original entry');
+            });
+
+            it('clone receives a unique $id; original entry is untouched', function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.prepareSchema(schema);
+
+                const cloneKey = schema.properties.targeted.$ref;
+                assert.exists(schema.$defs[cloneKey], 'clone must be present in $defs');
+                assert.equal(schema.$defs[cloneKey].$id, cloneKey,
+                    'clone $id must equal the clone key so AJV can resolve the rewritten $ref');
+                assert.equal(schema.$defs['#Sub'].$id, '#Sub',
+                    'original $id must not be changed');
+            });
+
+            it('strips conditional field from clone required without mutating the original', function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.prepareSchema(schema);
+
+                const cloneKey = schema.properties.targeted.$ref;
+                assert.notInclude(schema.$defs[cloneKey].required ?? [], 'b',
+                    'b should be stripped from the clone required array');
+                assert.include(schema.$defs['#Sub'].required, 'b',
+                    'original required must not be mutated — sibling still needs b');
+            });
+
+            it('condition TRUE: targeted.b required, sibling.b independently required', async function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.schemaLoader = async () => schema;
+
+                const result = await vcjs.verifySubject({
+                    type: 'T',
+                    targeted: { a: 1, b: 99 },
+                    sibling:  { a: 2, b: 7 }
+                });
+                assert.isTrue(result.ok, 'both fields provided — should be valid');
+            });
+
+            it('condition TRUE: missing targeted.b fails validation', async function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.schemaLoader = async () => schema;
+
+                const result = await vcjs.verifySubject({
+                    type: 'T',
+                    targeted: { a: 1 },
+                    sibling:  { a: 2, b: 7 }
+                });
+                assert.isFalse(result.ok, 'targeted.b is required when condition is true');
+            });
+
+            it('condition FALSE: targeted has no b, sibling.b still required from base schema', async function () {
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.schemaLoader = async () => schema;
+
+                const result = await vcjs.verifySubject({
+                    type: 'T',
+                    targeted: { a: 2 },
+                    sibling:  { a: 3, b: 5 }
+                });
+                assert.isTrue(result.ok, 'sibling.b provided — should be valid');
+            });
+
+            it('condition FALSE: missing sibling.b fails — strip must not leak to untargeted sibling', async function () {
+                // Regression guard: the old IRI-keyed approach mutated the shared $defs entry,
+                // making b optional on sibling too. With per-container cloning, the original
+                // entry is never modified, so sibling.b remains required.
+                const vcjs = makeVcjs();
+                const schema = makeSharedRefSchema();
+                vcjs.schemaLoader = async () => schema;
+
+                const result = await vcjs.verifySubject({
+                    type: 'T',
+                    targeted: { a: 2 },
+                    sibling:  { a: 3 }
+                });
+                assert.isFalse(result.ok,
+                    'sibling.b must still be required — the required-strip must not leak from targeted to sibling');
+            });
+        });
     });
 
     describe('verifySubject', function () {

--- a/frontend/src/app/modules/schema-engine/condition-control.ts
+++ b/frontend/src/app/modules/schema-engine/condition-control.ts
@@ -1,4 +1,3 @@
-// condition-control.ts
 import {
     UntypedFormArray,
     UntypedFormControl,
@@ -12,6 +11,21 @@ import { FieldControl } from './field-control';
 
 export type IfOperator = 'SINGLE' | 'AND' | 'OR';
 
+export interface ConditionFieldOption {
+    key: string;
+    label: string;
+    shortLabel?: string;
+    fieldPath: string[];
+    typeKey: string;
+    required: boolean;
+    fieldControl?: FieldControl;
+}
+
+export interface ConditionFieldGroup {
+    label: string;
+    items: ConditionFieldOption[];
+}
+
 export class ConditionControl {
     public readonly name: string;
 
@@ -20,6 +34,11 @@ export class ConditionControl {
     public readonly thenFieldControls: UntypedFormGroup;
     public readonly elseFieldControls: UntypedFormGroup;
 
+    public crossThenTargets: ConditionFieldOption[] = [];
+    public crossElseTargets: ConditionFieldOption[] = [];
+    public readonly crossThenCount: UntypedFormControl;
+    public readonly crossElseCount: UntypedFormControl;
+
     public readonly conditions: UntypedFormArray;
 
     public readonly operator: UntypedFormControl;
@@ -27,13 +46,15 @@ export class ConditionControl {
     public changeEvents: any[] | null = null;
     public fieldChange: Subscription | null = null;
 
-    constructor(field?: FieldControl, fieldValue: string = '', operator: IfOperator = 'SINGLE') {
+    constructor(field?: ConditionFieldOption, fieldValue: string = '', operator: IfOperator = 'SINGLE') {
         this.name = `condition${Date.now()}${Math.floor(Math.random() * 1000000)}`;
 
         this.thenControls = [];
         this.elseControls = [];
         this.thenFieldControls = new UntypedFormGroup({});
         this.elseFieldControls = new UntypedFormGroup({});
+        this.crossThenCount = new UntypedFormControl(0);
+        this.crossElseCount = new UntypedFormControl(0);
 
         this.operator = new UntypedFormControl(operator, Validators.required);
         this.conditions = new UntypedFormArray([], this.dynamicConditionsValidator());
@@ -45,7 +66,35 @@ export class ConditionControl {
         }
     }
 
-    public get fieldControl(): FieldControl | undefined {
+    public addCrossThenTarget(option: ConditionFieldOption): void {
+        const key = option.fieldPath.join('.');
+        if (!this.crossThenTargets.find(t => t.fieldPath.join('.') === key)) {
+            this.crossThenTargets = [...this.crossThenTargets, option];
+            this.crossThenCount.setValue(this.crossThenTargets.length);
+        }
+    }
+
+    public removeCrossThenTarget(option: ConditionFieldOption): void {
+        const key = option.fieldPath.join('.');
+        this.crossThenTargets = this.crossThenTargets.filter(t => t.fieldPath.join('.') !== key);
+        this.crossThenCount.setValue(this.crossThenTargets.length);
+    }
+
+    public addCrossElseTarget(option: ConditionFieldOption): void {
+        const key = option.fieldPath.join('.');
+        if (!this.crossElseTargets.find(t => t.fieldPath.join('.') === key)) {
+            this.crossElseTargets = [...this.crossElseTargets, option];
+            this.crossElseCount.setValue(this.crossElseTargets.length);
+        }
+    }
+
+    public removeCrossElseTarget(option: ConditionFieldOption): void {
+        const key = option.fieldPath.join('.');
+        this.crossElseTargets = this.crossElseTargets.filter(t => t.fieldPath.join('.') !== key);
+        this.crossElseCount.setValue(this.crossElseTargets.length);
+    }
+
+    public get fieldControl(): ConditionFieldOption | undefined {
         const g = this.conditions.at(0) as UntypedFormGroup;
         return g ? (g.get('field') as UntypedFormControl)?.value : undefined;
     }
@@ -65,7 +114,9 @@ export class ConditionControl {
                 conditions: this.conditions
             }),
             thenFieldControls: this.thenFieldControls,
-            elseFieldControls: this.elseFieldControls
+            elseFieldControls: this.elseFieldControls,
+            crossThenCount: this.crossThenCount,
+            crossElseCount: this.crossElseCount,
         }, this.countThenElseFieldsValidator());
     }
 
@@ -92,10 +143,11 @@ export class ConditionControl {
         type === 'then' ? this.removeThenControl(control) : this.removeElseControl(control);
     }
 
-    public addCondition(field?: FieldControl, fieldValue: string = '') {
+    public addCondition(option?: ConditionFieldOption, fieldValue: string = '') {
         const group = new UntypedFormGroup({
-            field: new UntypedFormControl(field, Validators.required),
-            fieldValue: new UntypedFormControl(fieldValue, Validators.required)
+            field: new UntypedFormControl(option, Validators.required),
+            fieldValue: new UntypedFormControl(fieldValue, Validators.required),
+            fieldPath: new UntypedFormControl(option?.fieldPath ?? null),
         });
         this.conditions.push(group);
         this.conditions.updateValueAndValidity();
@@ -122,16 +174,25 @@ export class ConditionControl {
     public normalizeByOperator() {
         const op = this.operator.value as IfOperator;
         if (op === 'SINGLE' && this.conditions.length > 1) {
-            while (this.conditions.length > 1) this.conditions.removeAt(this.conditions.length - 1);
+            while (this.conditions.length > 1) {
+                this.conditions.removeAt(this.conditions.length - 1);
+            }
         }
         this.conditions.updateValueAndValidity();
     }
 
     private countThenElseFieldsValidator(): ValidatorFn {
         return (group: any): ValidationErrors | null => {
-            const thenFieldControls = group.controls['thenFieldControls'] as UntypedFormGroup;
-            const elseFieldControls = group.controls['elseFieldControls'] as UntypedFormGroup;
-            if (Object.keys(thenFieldControls.controls).length > 0 || Object.keys(elseFieldControls.controls).length > 0) {
+            const thenFieldControls = group.controls.thenFieldControls as UntypedFormGroup;
+            const elseFieldControls = group.controls.elseFieldControls as UntypedFormGroup;
+            const crossThen: number = (group.controls.crossThenCount as UntypedFormControl)?.value || 0;
+            const crossElse: number = (group.controls.crossElseCount as UntypedFormControl)?.value || 0;
+            if (
+                Object.keys(thenFieldControls.controls).length > 0 ||
+                Object.keys(elseFieldControls.controls).length > 0 ||
+                crossThen > 0 ||
+                crossElse > 0
+            ) {
                 return null;
             }
             return { noConditionFields: { valid: false } };

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
@@ -229,11 +229,18 @@
                             appendTo="body"
                             placeholder="Field"
                             [formControl]="getRowFieldControl(row)"
+                            [ngClass]="{'ng-invalid ng-dirty': getRowFieldControl(row)?.invalid}"
                             (onChange)="onIfRowFieldChange(condition, i, $event)">
                             <ng-template let-group pTemplate="group">
                               <span class="if-field-group-label">{{ group.label }}</span>
                             </ng-template>
                           </p-select>
+                          @if (getRowFieldControl(row)?.hasError('staleOption')) {
+                            <small class="condition-field-error">Field no longer exists — please re-select.</small>
+                          }
+                          @if (getRowFieldControl(row)?.hasError('arrayRefTrigger')) {
+                            <small class="condition-field-error">Array-ref fields cannot be used as IF triggers.</small>
+                          }
                         </div>
                         @if (getRowField(row)) {
                           <div class="equal-label">=</div>

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
@@ -388,7 +388,10 @@
                 <div class="cross-targets-chips">
                   <span class="cross-targets-label">Sub-schema THEN:</span>
                   @for (target of condition.crossThenTargets; track target.fieldPath.join('>')) {
-                    <span class="cross-target-chip" [title]="target.fieldPath.join(' > ')">
+                    <span class="cross-target-chip"
+                          [class.cross-target-chip--stale]="isCrossTargetStale(condition, target)"
+                          [title]="isCrossTargetStale(condition, target) ? 'Field no longer available: ' + target.fieldPath.join(' > ') : target.fieldPath.join(' > ')"
+                    >
                       {{ target.label }}
                       <button class="chip-remove" (click)="onCrossTargetRemove(condition, 'then', target)">×</button>
                     </span>
@@ -469,7 +472,10 @@
                 <div class="cross-targets-chips">
                   <span class="cross-targets-label">Sub-schema ELSE:</span>
                   @for (target of condition.crossElseTargets; track target.fieldPath.join('>')) {
-                    <span class="cross-target-chip" [title]="target.fieldPath.join(' > ')">
+                    <span class="cross-target-chip"
+                          [class.cross-target-chip--stale]="isCrossTargetStale(condition, target)"
+                          [title]="isCrossTargetStale(condition, target) ? 'Field no longer available: ' + target.fieldPath.join(' > ') : target.fieldPath.join(' > ')"
+                    >
                       {{ target.label }}
                       <button class="chip-remove" (click)="onCrossTargetRemove(condition, 'else', target)">×</button>
                     </span>

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.html
@@ -218,19 +218,28 @@
                           <p-select
                             class="guardian-dropdown"
                             panelStyleClass="guardian-dropdown-panel"
-                            [options]="getFieldsForCondition(condition)"
+                            [options]="getFieldOptionGroupsForCondition(condition)"
+                            [group]="true"
+                            optionGroupLabel="label"
+                            optionGroupChildren="items"
+                            optionLabel="label"
+                            dataKey="key"
+                            [filter]="true"
+                            filterBy="label"
                             appendTo="body"
-                            optionLabel="controlDescription.value"
                             placeholder="Field"
                             [formControl]="getRowFieldControl(row)"
                             (onChange)="onIfRowFieldChange(condition, i, $event)">
+                            <ng-template let-group pTemplate="group">
+                              <span class="if-field-group-label">{{ group.label }}</span>
+                            </ng-template>
                           </p-select>
                         </div>
                         @if (getRowField(row)) {
                           <div class="equal-label">=</div>
                         }
                         @switch (true) {
-                          @case (isFieldType1(getRowField(row))) {
+                          @case (isFieldType1(getRowOption(row))) {
                             <div
                               class="input-field-container guardian-input-container"
                               style="margin-bottom: unset"
@@ -244,7 +253,7 @@
                                 />
                             </div>
                           }
-                          @case (isFieldType2(getRowField(row))) {
+                          @case (isFieldType2(getRowOption(row))) {
                             <div
                               class="input-field-container guardian-input-container"
                               style="margin-bottom: unset"
@@ -259,7 +268,7 @@
                                 />
                             </div>
                           }
-                          @case (isFieldType3(getRowField(row))) {
+                          @case (isFieldType3(getRowOption(row))) {
                             <div
                               class="form-group required-form-field guardian-input-container">
                               <label class="form-label">Choose a date &amp; time</label>
@@ -271,7 +280,7 @@
                               appendTo="body"></p-datepicker>
                             </div>
                           }
-                          @case (isFieldType4(getRowField(row))) {
+                          @case (isFieldType4(getRowOption(row))) {
                             <div
                               class="form-group example-full-width required-form-field">
                               <label class="form-label">Choose a date</label>
@@ -282,7 +291,7 @@
                               appendTo="body"></p-datepicker>
                             </div>
                           }
-                          @case (isFieldType5(getRowField(row))) {
+                          @case (isFieldType5(getRowOption(row))) {
                             <div
                               class="radio-button-container">
                               <div>
@@ -375,6 +384,41 @@
                 </div>
                 <div class="guardian-button-label">Add THEN Field</div>
               </button>
+              @if (condition.crossThenTargets.length) {
+                <div class="cross-targets-chips">
+                  <span class="cross-targets-label">Sub-schema THEN:</span>
+                  @for (target of condition.crossThenTargets; track target.fieldPath.join('>')) {
+                    <span class="cross-target-chip" [title]="target.fieldPath.join(' > ')">
+                      {{ target.label }}
+                      <button class="chip-remove" (click)="onCrossTargetRemove(condition, 'then', target)">×</button>
+                    </span>
+                  }
+                </div>
+              }
+              <div class="cross-target-add-row">
+                <p-select
+                  class="guardian-dropdown cross-target-dropdown"
+                  panelStyleClass="guardian-dropdown-panel"
+                  [options]="getCrossTargetGroupsForCondition(condition, 'then')"
+                  [group]="true"
+                  optionGroupLabel="label"
+                  optionGroupChildren="items"
+                  optionLabel="label"
+                  dataKey="key"
+                  [filter]="true"
+                  filterBy="label"
+                  [resetFilterOnHide]="true"
+                  appendTo="body"
+                  placeholder="Add sub-schema THEN field…"
+                  (onChange)="onCrossTargetAdd(condition, 'then', $event)">
+                  <ng-template let-group pTemplate="group">
+                    <span class="if-field-group-label">{{ group.label }}</span>
+                  </ng-template>
+                  <ng-template let-option pTemplate="item">
+                    <span class="if-field-item-label" [title]="option.label">{{ option.shortLabel || option.label }}</span>
+                  </ng-template>
+                </p-select>
+              </div>
               <p class="condition-label">ELSE</p>
               @if (condition.elseControls) {
                 <div
@@ -421,6 +465,41 @@
                 </div>
                 <div class="guardian-button-label">Add ELSE Field</div>
               </button>
+              @if (condition.crossElseTargets.length) {
+                <div class="cross-targets-chips">
+                  <span class="cross-targets-label">Sub-schema ELSE:</span>
+                  @for (target of condition.crossElseTargets; track target.fieldPath.join('>')) {
+                    <span class="cross-target-chip" [title]="target.fieldPath.join(' > ')">
+                      {{ target.label }}
+                      <button class="chip-remove" (click)="onCrossTargetRemove(condition, 'else', target)">×</button>
+                    </span>
+                  }
+                </div>
+              }
+              <div class="cross-target-add-row">
+                <p-select
+                  class="guardian-dropdown cross-target-dropdown"
+                  panelStyleClass="guardian-dropdown-panel"
+                  [options]="getCrossTargetGroupsForCondition(condition, 'else')"
+                  [group]="true"
+                  optionGroupLabel="label"
+                  optionGroupChildren="items"
+                  optionLabel="label"
+                  dataKey="key"
+                  [filter]="true"
+                  filterBy="label"
+                  [resetFilterOnHide]="true"
+                  appendTo="body"
+                  placeholder="Add sub-schema ELSE field…"
+                  (onChange)="onCrossTargetAdd(condition, 'else', $event)">
+                  <ng-template let-group pTemplate="group">
+                    <span class="if-field-group-label">{{ group.label }}</span>
+                  </ng-template>
+                  <ng-template let-option pTemplate="item">
+                    <span class="if-field-item-label" [title]="option.label">{{ option.shortLabel || option.label }}</span>
+                  </ng-template>
+                </p-select>
+              </div>
               <button
                 (click)="onConditionRemove(condition)"
                 class="guardian-button guardian-button-delete rmv-btn">

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
@@ -372,6 +372,12 @@ form {
     }
 }
 
+.condition-field-error {
+    color: var(--red-500, #ef4444);
+    font-size: 0.75rem;
+    margin-top: 2px;
+}
+
 .if-field-group-label {
     display: block;
     font-weight: 600;

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
@@ -495,6 +495,12 @@ form {
     font-size: 12px;
     color: #1a56db;
 
+    &--stale {
+        background: #fef2f2;
+        border-color: #fca5a5;
+        color: #dc2626;
+    }
+
     .chip-remove {
         background: none;
         border: none;

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.scss
@@ -372,6 +372,29 @@ form {
     }
 }
 
+.if-field-group-label {
+    display: block;
+    font-weight: 600;
+    color: var(--color-grey-6, #3f4756);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.if-field-item-label {
+    display: block;
+    padding-left: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.if-field-selected-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .input-field-container {
     display: flex;
     flex-direction: column;
@@ -445,4 +468,53 @@ form {
 
 .if-label-mode {
     color: #848FA9;
+}
+
+.cross-targets-chips {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin: 8px 0 4px;
+}
+
+.cross-targets-label {
+    font-size: 12px;
+    color: #848FA9;
+    margin-right: 4px;
+}
+
+.cross-target-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: #e8f0fe;
+    border: 1px solid #a8c4f8;
+    border-radius: 12px;
+    padding: 2px 8px;
+    font-size: 12px;
+    color: #1a56db;
+
+    .chip-remove {
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: #6b7280;
+        font-size: 14px;
+        line-height: 1;
+        padding: 0 0 0 2px;
+
+        &:hover {
+            color: #dc2626;
+        }
+    }
+}
+
+.cross-target-add-row {
+    margin: 6px 0 12px;
+
+    .cross-target-dropdown {
+        width: 100%;
+        max-width: 420px;
+    }
 }

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -20,7 +20,7 @@ import {
     UnitSystem,
 } from '@guardian/interfaces';
 import moment from 'moment';
-import { Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ConditionControl, ConditionFieldGroup, ConditionFieldOption, IfOperator } from '../condition-control';
 import { FieldControl } from '../field-control';
@@ -380,6 +380,7 @@ export class SchemaConfigurationComponent implements OnInit {
             control.append(this.fieldsForm);
             control.refreshType(this.types);
             this.fields.push(control);
+            this.watchFieldControl(control);
         }
     }
 
@@ -407,6 +408,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 );
                 fc.refreshType(this.types);
                 cc.addThenControl(fc);
+                this.watchFieldControl(fc);
             });
 
             condition.elseFields?.forEach(field => {
@@ -417,6 +419,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 );
                 fc.refreshType(this.types);
                 cc.addElseControl(fc);
+                this.watchFieldControl(fc);
             });
 
             (condition.thenTargets || []).forEach(target => {
@@ -758,6 +761,7 @@ export class SchemaConfigurationComponent implements OnInit {
             this.getFieldName()
         );
         condition.addControl(type, field);
+        this.watchFieldControl(field);
         this.rebuildOptionCaches();
     }
 
@@ -787,6 +791,7 @@ export class SchemaConfigurationComponent implements OnInit {
         control.append(this.fieldsForm);
         this.fields.push(control);
         this.fields = this.fields.slice();
+        this.watchFieldControl(control);
         this.rebuildOptionCaches();
     }
 
@@ -1028,8 +1033,25 @@ export class SchemaConfigurationComponent implements OnInit {
             return current;
         };
 
+        const startsWithArrayRefContainer = (path: string[]): boolean => {
+            if (path.length <= 1) { return false; }
+            const key = path[0];
+            const isArrayRef = (fc: FieldControl) =>
+                fc.controlKey?.value === key &&
+                !!fc.controlArray?.value &&
+                !!this.schemaTypeMap[fc.controlType?.value]?.isRef;
+            if (this.fields.some(isArrayRef)) { return true; }
+            for (const cond of this.conditions) {
+                if ([...(cond.thenControls || []), ...(cond.elseControls || [])].some(isArrayRef)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         const resolveIfField = (opt: ConditionFieldOption | undefined): { field: SchemaField; fieldPath?: string[] } | null => {
             if (!opt?.fieldPath?.length) { return null; }
+            if (startsWithArrayRefContainer(opt.fieldPath)) { return null; }
             const leaf = traverseFieldPath(opt.fieldPath);
             if (!leaf) { return null; }
             return opt.fieldPath.length === 1
@@ -1039,6 +1061,7 @@ export class SchemaConfigurationComponent implements OnInit {
 
         const buildCrossTargets = (targets: ConditionFieldOption[]): SchemaConditionTarget[] =>
             targets.map(opt => {
+                if (startsWithArrayRefContainer(opt.fieldPath)) { return null; }
                 const leaf = traverseFieldPath(opt.fieldPath);
                 if (!leaf) { return null; }
                 return { fieldPath: opt.fieldPath, field: leaf } as SchemaConditionTarget;
@@ -1531,6 +1554,7 @@ export class SchemaConfigurationComponent implements OnInit {
                     maxDepth,
                 ));
             } else {
+                if (f.isArray) { continue; }
                 const leafTypeKey = this.getType(f);
                 if (!leafTypeKey || !this.schemaTypeMap[leafTypeKey]) { continue; }
                 const path = [...prefix, f.name];
@@ -1620,6 +1644,12 @@ export class SchemaConfigurationComponent implements OnInit {
             ));
         }
         return groups;
+    }
+
+    private watchFieldControl(fc: FieldControl): void {
+        merge(fc.controlType.valueChanges, fc.controlArray.valueChanges)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.rebuildOptionCaches());
     }
 
     private rebuildOptionCaches(): void {

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1008,25 +1008,29 @@ export class SchemaConfigurationComponent implements OnInit {
                 (typeof r?.field === 'string' ? r.field : undefined);
         };
 
+        const traverseFieldPath = (path: string[]): SchemaField | undefined => {
+            let current: SchemaField | undefined = fieldsBySchemaName.get(path[0]);
+            for (let i = 1; i < path.length; i++) {
+                if (!current?.fields) { return undefined; }
+                current = current.fields.find(f => f.name === path[i]);
+            }
+            return current;
+        };
+
         const resolveIfField = (opt: ConditionFieldOption | undefined): { field: SchemaField; fieldPath?: string[] } | null => {
             if (!opt?.fieldPath?.length) { return null; }
-            if (opt.fieldPath.length === 1) {
-                const sf = fieldsBySchemaName.get(opt.fieldPath[0]);
-                return sf ? { field: sf } : null;
-            }
-            const containerField = fieldsBySchemaName.get(opt.fieldPath[0]);
-            if (!containerField) { return null; }
-            const leafField = containerField.fields?.find(f => f.name === opt.fieldPath[opt.fieldPath.length - 1]);
-            return leafField ? { field: leafField, fieldPath: opt.fieldPath } : null;
+            const leaf = traverseFieldPath(opt.fieldPath);
+            if (!leaf) { return null; }
+            return opt.fieldPath.length === 1
+                ? { field: leaf }
+                : { field: leaf, fieldPath: opt.fieldPath };
         };
 
         const buildCrossTargets = (targets: ConditionFieldOption[]): SchemaConditionTarget[] =>
             targets.map(opt => {
-                const containerField = fieldsBySchemaName.get(opt.fieldPath[0]);
-                if (!containerField) { return null; }
-                const leafField = containerField.fields?.find(f => f.name === opt.fieldPath[opt.fieldPath.length - 1]);
-                if (!leafField) { return null; }
-                return { fieldPath: opt.fieldPath, field: leafField } as SchemaConditionTarget;
+                const leaf = traverseFieldPath(opt.fieldPath);
+                if (!leaf) { return null; }
+                return { fieldPath: opt.fieldPath, field: leaf } as SchemaConditionTarget;
             }).filter(Boolean) as SchemaConditionTarget[];
 
         const conditions: SchemaCondition[] = [];

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -14,6 +14,7 @@ import {
     Schema,
     SchemaCategory,
     SchemaCondition,
+    SchemaConditionTarget,
     SchemaEntity,
     SchemaField,
     UnitSystem,
@@ -21,7 +22,7 @@ import {
 import moment from 'moment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { ConditionControl, IfOperator } from '../condition-control';
+import { ConditionControl, ConditionFieldGroup, ConditionFieldOption, IfOperator } from '../condition-control';
 import { FieldControl } from '../field-control';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { SchemaService } from 'src/app/services/schema.service';
@@ -246,6 +247,7 @@ export class SchemaConfigurationComponent implements OnInit {
                     format: undefined,
                     pattern: undefined,
                     isRef: true,
+                    customType: schema.topicId === this._topicId ? 'subSchema' : undefined,
                 }
             }
         }
@@ -269,7 +271,7 @@ export class SchemaConfigurationComponent implements OnInit {
         this.fieldsForm = this.fb.group({});
         this.conditionsForm = new UntypedFormGroup({});
 
-        let props: any = {
+        const props: any = {
             name: ['', Validators.required],
             description: [''],
             fields: this.fieldsForm,
@@ -412,6 +414,25 @@ export class SchemaConfigurationComponent implements OnInit {
                 cc.addElseControl(fc);
             });
 
+            (condition.thenTargets || []).forEach(target => {
+                cc.addCrossThenTarget({
+                    key: target.fieldPath.join('.'),
+                    label: target.fieldPath.join(' > '),
+                    fieldPath: target.fieldPath,
+                    typeKey: this.getType(target.field),
+                    required: target.field.required,
+                });
+            });
+            (condition.elseTargets || []).forEach(target => {
+                cc.addCrossElseTarget({
+                    key: target.fieldPath.join('.'),
+                    label: target.fieldPath.join(' > '),
+                    fieldPath: target.fieldPath,
+                    typeKey: this.getType(target.field),
+                    required: target.field.required,
+                });
+            });
+
             this.conditions.push(cc);
             this.conditionsForm.addControl(cc.name, cc.createGroup());
         }
@@ -438,38 +459,54 @@ export class SchemaConfigurationComponent implements OnInit {
             }
             (ifGroup.get('operator') as UntypedFormControl).setValue(operator, { emitEvent: false });
 
-            const available = new Map<string, FieldControl>();
+            const availableByKey = new Map<string, FieldControl>();
             for (const f of this.fields) {
                 const key = f.controlKey?.value;
                 if (key && f.isCondition(this.schemaTypeMap)) {
-                    available.set(key, f);
+                    availableByKey.set(key, f);
                 }
             }
             this.conditions.forEach(other => {
                 if (other === cc) return;
-                for (const f of other.thenControls || []) {
+                for (const f of [...(other.thenControls || []), ...(other.elseControls || [])]) {
                     const key = f.controlKey?.value;
-                    if (key) {
-                        available.set(key, f);
-                    }
-                }
-                for (const f of other.elseControls || []) {
-                    const key = f.controlKey?.value;
-                    if (key) {
-                        available.set(key, f);
-                    }
+                    if (key) { availableByKey.set(key, f); }
                 }
             });
 
+            const buildOptionFromPredicate = (p: any): ConditionFieldOption | undefined => {
+                const fp: string[] | undefined = p.fieldPath;
+                if (fp != null && fp.length > 1) {
+                    const leafField: SchemaField = p.field;
+                    return {
+                        key: fp.join('.'),
+                        label: fp.join(' > '),
+                        fieldPath: fp,
+                        typeKey: this.getType(leafField),
+                        required: leafField.required,
+                    };
+                }
+                const fieldName = pickName(p.field);
+                const fc = fieldName ? availableByKey.get(fieldName) : undefined;
+                if (!fc) { return undefined; }
+                return {
+                    key: fc.controlKey.value,
+                    label: fc.controlTitle.value || fc.controlKey.value,
+                    fieldPath: [fc.controlKey.value],
+                    typeKey: fc.controlType.value,
+                    required: fc.controlRequired.value,
+                    fieldControl: fc,
+                };
+            };
+
             cc.clearConditions(false);
             pairs.forEach(p => {
-                const fieldName = pickName(p.field);
-                const fc = fieldName ? available.get(fieldName) : undefined;
-                cc.addCondition(fc, p.fieldValue);
+                const opt = buildOptionFromPredicate(p);
+                cc.addCondition(opt, p.fieldValue);
                 const row = cc.conditions.at(cc.conditions.length - 1) as UntypedFormGroup;
                 const valueCtrl = row.get('fieldValue') as UntypedFormControl;
-                if (fc) {
-                    this.ifFormatValueFor(valueCtrl, fc);
+                if (opt) {
+                    this.ifFormatValueForOption(valueCtrl, opt);
                 }
             });
         });
@@ -498,8 +535,9 @@ export class SchemaConfigurationComponent implements OnInit {
         const row = condition.conditions.at(idx) as UntypedFormGroup;
         const fieldCtrl = row.get('field') as UntypedFormControl;
         const valueCtrl = row.get('fieldValue') as UntypedFormControl;
-        fieldCtrl.setValue(event.value);
-        this.ifFormatValueFor(valueCtrl, event.value);
+        const opt: ConditionFieldOption = event.value;
+        fieldCtrl.setValue(opt);
+        this.ifFormatValueForOption(valueCtrl, opt);
     }
 
     private ifFormatValueFor(valueCtrl: UntypedFormControl, field: FieldControl) {
@@ -553,24 +591,33 @@ export class SchemaConfigurationComponent implements OnInit {
         return typeKey ? this.schemaTypeMap[typeKey] : null;
     }
 
-    public isFieldType1(fc: FieldControl | null): boolean {
-        const t = this.getTypeByField(fc);
+    private getTypeByOption(opt: ConditionFieldOption | null | undefined) {
+        if (!opt) { return null; }
+        return opt.typeKey ? this.schemaTypeMap[opt.typeKey] : null;
+    }
+
+    public getRowOption(row: UntypedFormGroup): ConditionFieldOption | null {
+        return (row.get('field') as UntypedFormControl)?.value || null;
+    }
+
+    public isFieldType1(opt: ConditionFieldOption | null): boolean {
+        const t = this.getTypeByOption(opt);
         return !!t && t.type !== 'boolean' && !['time', 'date-time', 'date'].includes(t.format);
     }
-    public isFieldType2(fc: FieldControl | null): boolean {
-        const t = this.getTypeByField(fc);
+    public isFieldType2(opt: ConditionFieldOption | null): boolean {
+        const t = this.getTypeByOption(opt);
         return !!t && t.type === 'string' && t.format === 'time';
     }
-    public isFieldType3(fc: FieldControl | null): boolean {
-        const t = this.getTypeByField(fc);
+    public isFieldType3(opt: ConditionFieldOption | null): boolean {
+        const t = this.getTypeByOption(opt);
         return !!t && t.type === 'string' && t.format === 'date-time';
     }
-    public isFieldType4(fc: FieldControl | null): boolean {
-        const t = this.getTypeByField(fc);
+    public isFieldType4(opt: ConditionFieldOption | null): boolean {
+        const t = this.getTypeByOption(opt);
         return !!t && t.type === 'string' && t.format === 'date';
     }
-    public isFieldType5(fc: FieldControl | null): boolean {
-        const t = this.getTypeByField(fc);
+    public isFieldType5(opt: ConditionFieldOption | null): boolean {
+        const t = this.getTypeByOption(opt);
         return !!t && t.type === 'boolean';
     }
     private checkDependencies(currentSchemaId: any, schema: Schema): boolean {
@@ -961,6 +1008,27 @@ export class SchemaConfigurationComponent implements OnInit {
                 (typeof r?.field === 'string' ? r.field : undefined);
         };
 
+        const resolveIfField = (opt: ConditionFieldOption | undefined): { field: SchemaField; fieldPath?: string[] } | null => {
+            if (!opt?.fieldPath?.length) { return null; }
+            if (opt.fieldPath.length === 1) {
+                const sf = fieldsBySchemaName.get(opt.fieldPath[0]);
+                return sf ? { field: sf } : null;
+            }
+            const containerField = fieldsBySchemaName.get(opt.fieldPath[0]);
+            if (!containerField) { return null; }
+            const leafField = containerField.fields?.find(f => f.name === opt.fieldPath[opt.fieldPath.length - 1]);
+            return leafField ? { field: leafField, fieldPath: opt.fieldPath } : null;
+        };
+
+        const buildCrossTargets = (targets: ConditionFieldOption[]): SchemaConditionTarget[] =>
+            targets.map(opt => {
+                const containerField = fieldsBySchemaName.get(opt.fieldPath[0]);
+                if (!containerField) { return null; }
+                const leafField = containerField.fields?.find(f => f.name === opt.fieldPath[opt.fieldPath.length - 1]);
+                if (!leafField) { return null; }
+                return { fieldPath: opt.fieldPath, field: leafField } as SchemaConditionTarget;
+            }).filter(Boolean) as SchemaConditionTarget[];
+
         const conditions: SchemaCondition[] = [];
         for (const element of this.conditions) {
             const conditionValue = value.conditions[element.name];
@@ -984,6 +1052,9 @@ export class SchemaConfigurationComponent implements OnInit {
                 }
             }
 
+            const thenTargets = buildCrossTargets(element.crossThenTargets || []);
+            const elseTargets = buildCrossTargets(element.crossElseTargets || []);
+
             const op: IfOperator = conditionValue.ifCondition?.operator || 'SINGLE';
             const rows = (conditionValue.ifCondition?.conditions as any[]) || [];
             if (!rows.length) {
@@ -992,31 +1063,31 @@ export class SchemaConfigurationComponent implements OnInit {
 
             if (op === 'SINGLE') {
                 const row = rows[0];
-                const name = getPickedName(row);
-                const sf = name ? fieldsBySchemaName.get(name) : undefined;
-                if (!sf) {
+                const resolved = resolveIfField(row?.field);
+                if (!resolved) {
                     continue;
                 }
-
                 conditions.push({
                     ifCondition: {
-                        field: sf,
-                        fieldValue: row.fieldValue
-                    },
+                        field: resolved.field,
+                        fieldValue: row.fieldValue,
+                        ...(resolved.fieldPath ? { fieldPath: resolved.fieldPath } : {})
+                    } as any,
                     thenFields,
-                    elseFields
+                    elseFields,
+                    thenTargets: thenTargets.length ? thenTargets : undefined,
+                    elseTargets: elseTargets.length ? elseTargets : undefined,
                 });
             } else {
                 const arr = rows
                     .map(r => {
-                        const name = getPickedName(r);
-                        const sf = name ? fieldsBySchemaName.get(name) : undefined;
-                        if (!sf) {
-                            return null;
-                        }
-                        return { field: sf, fieldValue: r.fieldValue };
+                        const resolved = resolveIfField(r?.field);
+                        if (!resolved) { return null; }
+                        const pred: any = { field: resolved.field, fieldValue: r.fieldValue };
+                        if (resolved.fieldPath) { pred.fieldPath = resolved.fieldPath; }
+                        return pred;
                     })
-                    .filter(Boolean) as { field: SchemaField; fieldValue: any }[];
+                    .filter(Boolean);
 
                 if (!arr.length) {
                     continue;
@@ -1025,7 +1096,9 @@ export class SchemaConfigurationComponent implements OnInit {
                 conditions.push({
                     ifCondition: op === 'AND' ? { AND: arr } : { OR: arr },
                     thenFields,
-                    elseFields
+                    elseFields,
+                    thenTargets: thenTargets.length ? thenTargets : undefined,
+                    elseTargets: elseTargets.length ? elseTargets : undefined,
                 });
             }
         }
@@ -1293,44 +1366,44 @@ export class SchemaConfigurationComponent implements OnInit {
     }
 
     public isConditionType1(condition: ConditionControl): boolean {
-        const type = condition.fieldControl?.type;
+        const type = condition.fieldControl?.typeKey;
         return (
             !!type &&
-            'boolean' !== this.schemaTypeMap[type].type &&
-            !['time', 'date-time', 'date'].includes(this.schemaTypeMap[type].format)
+            'boolean' !== this.schemaTypeMap[type]?.type &&
+            !['time', 'date-time', 'date'].includes(this.schemaTypeMap[type]?.format)
         );
     }
 
     public isConditionType2(condition: ConditionControl): boolean {
-        const type = condition.fieldControl?.type;
+        const type = condition.fieldControl?.typeKey;
         return (
             !!type &&
-            this.schemaTypeMap[type].type === 'string' &&
-            this.schemaTypeMap[type].format === 'time'
+            this.schemaTypeMap[type]?.type === 'string' &&
+            this.schemaTypeMap[type]?.format === 'time'
         );
     }
 
     public isConditionType3(condition: ConditionControl): boolean {
-        const type = condition.fieldControl?.type;
+        const type = condition.fieldControl?.typeKey;
         return (
             !!type &&
-            this.schemaTypeMap[type].type === 'string' &&
-            this.schemaTypeMap[type].format === 'date-time'
+            this.schemaTypeMap[type]?.type === 'string' &&
+            this.schemaTypeMap[type]?.format === 'date-time'
         );
     }
 
     public isConditionType4(condition: ConditionControl): boolean {
-        const type = condition.fieldControl?.type;
+        const type = condition.fieldControl?.typeKey;
         return (
             !!type &&
-            this.schemaTypeMap[type].type === 'string' &&
-            this.schemaTypeMap[type].format === 'date'
+            this.schemaTypeMap[type]?.type === 'string' &&
+            this.schemaTypeMap[type]?.format === 'date'
         );
     }
 
     public isConditionType5(condition: ConditionControl): boolean {
-        const type = condition.fieldControl?.type;
-        return !!type && this.schemaTypeMap[type].type === 'boolean';
+        const type = condition.fieldControl?.typeKey;
+        return !!type && this.schemaTypeMap[type]?.type === 'boolean';
     }
 
     private fieldNameValidator(): ValidatorFn {
@@ -1376,6 +1449,177 @@ export class SchemaConfigurationComponent implements OnInit {
 
             return error;
         };
+    }
+
+    private ifFormatValueForOption(valueCtrl: UntypedFormControl, opt: ConditionFieldOption | null) {
+        if (!opt?.typeKey) { return; }
+        const type = this.schemaTypeMap[opt.typeKey];
+        if (!type) { return; }
+        const isNumber = ['number', 'integer'].includes(type.type) || type.format === 'duration';
+        const validators = [];
+        if (opt.required) { validators.push(Validators.required); }
+        if (isNumber) { validators.push(this.isNumberOrEmptyValidator()); }
+        valueCtrl.clearValidators();
+        valueCtrl.setValidators(validators);
+        if (['date', 'date-time'].includes(type.format)) {
+            this.subscribeFormatDateValue(valueCtrl, type.format);
+        }
+        if (isNumber) {
+            this.subscribeFormatNumberValue(valueCtrl, type.format || type.type);
+        }
+        valueCtrl.updateValueAndValidity();
+    }
+
+    private getAllRefControls(): FieldControl[] {
+        const seen = new Set<string>();
+        const result: FieldControl[] = [];
+        const add = (fc: FieldControl) => {
+            const typeKey = fc.controlType?.value;
+            if (!this.schemaTypeMap[typeKey]?.isRef) { return; }
+            const key = fc.controlKey?.value;
+            if (!key || seen.has(key)) { return; }
+            seen.add(key);
+            result.push(fc);
+        };
+        for (const fc of this.fields) { add(fc); }
+        for (const cond of this.conditions) {
+            for (const fc of [...(cond.thenControls || []), ...(cond.elseControls || [])]) {
+                add(fc);
+            }
+        }
+        return result;
+    }
+
+    private collectNestedFieldOptions(
+        fields: SchemaField[],
+        prefix: string[],
+        labelPrefix: string,
+        alreadySelected?: Set<string>,
+        maxDepth: number = 12,
+    ): ConditionFieldOption[] {
+        if (prefix.length > maxDepth) { return []; }
+        const result: ConditionFieldOption[] = [];
+        for (const f of fields) {
+            if (f.readOnly) { continue; }
+            if (f.isRef) {
+                const nestedSchema = this.subSchemas?.find(s => s.iri === f.type);
+                if (!nestedSchema?.fields?.length) { continue; }
+                result.push(...this.collectNestedFieldOptions(
+                    nestedSchema.fields,
+                    [...prefix, f.name],
+                    `${labelPrefix} > ${f.title || f.name}`,
+                    alreadySelected,
+                    maxDepth,
+                ));
+            } else {
+                const leafTypeKey = this.getType(f);
+                if (!leafTypeKey || !this.schemaTypeMap[leafTypeKey]) { continue; }
+                const path = [...prefix, f.name];
+                if (alreadySelected?.has(path.join('.'))) { continue; }
+                result.push({
+                    key: path.join('.'),
+                    label: `${labelPrefix} > ${f.title || f.name}`,
+                    shortLabel: f.title || f.name,
+                    fieldPath: path,
+                    typeKey: leafTypeKey,
+                    required: f.required,
+                });
+            }
+        }
+        return result;
+    }
+
+    public getFieldOptionGroupsForCondition(condition: ConditionControl): ConditionFieldGroup[] {
+        const groups: ConditionFieldGroup[] = [];
+
+        const topItems: ConditionFieldOption[] = [];
+        for (const fc of this.fields) {
+            if (!fc.isCondition(this.schemaTypeMap)) { continue; }
+            topItems.push({
+                key: fc.controlKey.value,
+                label: fc.controlTitle.value || fc.controlKey.value,
+                fieldPath: [fc.controlKey.value],
+                typeKey: fc.controlType.value,
+                required: fc.controlRequired.value,
+                fieldControl: fc,
+            });
+        }
+        for (const cond of this.conditions) {
+            if (cond === condition) { continue; }
+            for (const fc of [...(cond.thenControls || []), ...(cond.elseControls || [])]) {
+                if (!fc.isCondition(this.schemaTypeMap)) { continue; }
+                topItems.push({
+                    key: fc.controlKey.value,
+                    label: fc.controlTitle.value || fc.controlKey.value,
+                    fieldPath: [fc.controlKey.value],
+                    typeKey: fc.controlType.value,
+                    required: fc.controlRequired.value,
+                    fieldControl: fc,
+                });
+            }
+        }
+        if (topItems.length) { groups.push({ label: 'This Schema', items: topItems }); }
+
+        for (const fc of this.getAllRefControls()) {
+            const typeKey = fc.controlType?.value;
+            const type = this.schemaTypeMap[typeKey];
+            const subSchema = this.subSchemas?.find(s => s.iri === type.type);
+            if (!subSchema?.fields?.length) { continue; }
+            const groupLabel = fc.controlTitle.value || fc.controlKey.value;
+            const nestedItems = this.collectNestedFieldOptions(
+                subSchema.fields,
+                [fc.controlKey.value],
+                groupLabel,
+            );
+            if (nestedItems.length) {
+                groups.push({ label: groupLabel, items: nestedItems });
+            }
+        }
+
+        return groups;
+    }
+
+    public getCrossTargetGroupsForCondition(condition: ConditionControl, type: 'then' | 'else'): ConditionFieldGroup[] {
+        const alreadySelected = new Set<string>(
+            (type === 'then' ? condition.crossThenTargets : condition.crossElseTargets)
+                .map(t => t.fieldPath.join('.'))
+        );
+
+        const groups: ConditionFieldGroup[] = [];
+        for (const fc of this.getAllRefControls()) {
+            const typeKey = fc.controlType?.value;
+            const schemaType = this.schemaTypeMap[typeKey];
+            const subSchema = this.subSchemas?.find(s => s.iri === schemaType.type);
+            if (!subSchema?.fields?.length) { continue; }
+            const groupLabel = fc.controlTitle.value || fc.controlKey.value;
+            const items = this.collectNestedFieldOptions(
+                subSchema.fields,
+                [fc.controlKey.value],
+                groupLabel,
+                alreadySelected,
+            );
+            if (items.length) {
+                groups.push({ label: groupLabel, items });
+            }
+        }
+        return groups;
+    }
+
+    public onCrossTargetAdd(condition: ConditionControl, type: 'then' | 'else', event: any): void {
+        if (!event?.value) { return; }
+        if (type === 'then') {
+            condition.addCrossThenTarget(event.value);
+        } else {
+            condition.addCrossElseTarget(event.value);
+        }
+    }
+
+    public onCrossTargetRemove(condition: ConditionControl, type: 'then' | 'else', target: ConditionFieldOption): void {
+        if (type === 'then') {
+            condition.removeCrossThenTarget(target);
+        } else {
+            condition.removeCrossElseTarget(target);
+        }
     }
 
     public drop(event: CdkDragDrop<any[]>) {

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1454,6 +1454,14 @@ export class SchemaConfigurationComponent implements OnInit {
         return false;
     }
 
+    private _isIfControlLive(fc: FieldControl, currentCondition: ConditionControl): boolean {
+        if (this.fields.some(f => f === fc)) { return true; }
+        return this.conditions.some(c =>
+            c !== currentCondition &&
+            (c.thenControls?.some(tc => tc === fc) || c.elseControls?.some(ec => ec === fc))
+        );
+    }
+
     private _hasStaleConditionSelections(): boolean {
         const validRefKeys = new Set(
             this.getAllRefControls().map(fc => fc.controlKey?.value).filter(Boolean)
@@ -1468,6 +1476,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 if (opt.fieldPath?.length > 0 && this.startsWithArrayRefContainer(opt.fieldPath)) { return true; }
                 const isStale = opt.fieldControl
                     ? opt.fieldControl.controlKey?.value !== opt.key
+                        || !this._isIfControlLive(opt.fieldControl, condition)
                     : (opt.fieldPath?.length > 1)
                         ? !validRefKeys.has(opt.fieldPath[0])
                         : !validKeys.has(opt.key);
@@ -1770,6 +1779,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 const isStale = !isArrayRef && opt && (
                     opt.fieldControl
                         ? opt.fieldControl.controlKey?.value !== opt.key
+                            || !this._isIfControlLive(opt.fieldControl, condition)
                         : (opt.fieldPath?.length > 1)
                             ? !validRefKeys.has(opt.fieldPath[0])
                             : !validKeys.has(opt.key)

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -94,6 +94,7 @@ export class SchemaConfigurationComponent implements OnInit {
     private _fieldOptionGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
     private _crossThenGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
     private _crossElseGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
+    private _staleTargetKeys = new Map<ConditionControl, Set<string>>();
 
     public get isSystem(): boolean {
         return this.schemaType === SchemaType.System;
@@ -496,14 +497,28 @@ export class SchemaConfigurationComponent implements OnInit {
                 }
                 const fieldName = pickName(p.field);
                 const fc = fieldName ? availableByKey.get(fieldName) : undefined;
-                if (!fc) { return undefined; }
+                if (fc) {
+                    return {
+                        key: fc.controlKey.value,
+                        label: fc.controlTitle.value || fc.controlKey.value,
+                        fieldPath: [fc.controlKey.value],
+                        typeKey: fc.controlType.value,
+                        required: fc.controlRequired.value,
+                        fieldControl: fc,
+                    };
+                }
+                // Field is excluded from the IF picker but still exists — preserve the condition on round-trip.
+                const fallbackFc = fieldName
+                    ? this.fields.find(f => f.controlKey?.value === fieldName)
+                    : undefined;
+                if (!fallbackFc) { return undefined; }
                 return {
-                    key: fc.controlKey.value,
-                    label: fc.controlTitle.value || fc.controlKey.value,
-                    fieldPath: [fc.controlKey.value],
-                    typeKey: fc.controlType.value,
-                    required: fc.controlRequired.value,
-                    fieldControl: fc,
+                    key: fallbackFc.controlKey.value,
+                    label: fallbackFc.controlTitle.value || fallbackFc.controlKey.value,
+                    fieldPath: [fallbackFc.controlKey.value],
+                    typeKey: fallbackFc.controlType.value,
+                    required: fallbackFc.controlRequired.value,
+                    fieldControl: fallbackFc,
                 };
             };
 
@@ -1046,13 +1061,42 @@ export class SchemaConfigurationComponent implements OnInit {
                     return true;
                 }
             }
+            if (path.length > 2) {
+                const getSubFields = (typeKey: string): SchemaField[] | undefined => {
+                    const info = this.schemaTypeMap[typeKey];
+                    if (!info?.isRef) { return undefined; }
+                    return this.subSchemas?.find(s => s.iri === info.type)?.fields;
+                };
+                const findFc = (): FieldControl | undefined => {
+                    const inFields = this.fields.find(fc => fc.controlKey?.value === key);
+                    if (inFields) { return inFields; }
+                    for (const cond of this.conditions) {
+                        const found = [...(cond.thenControls || []), ...(cond.elseControls || [])]
+                            .find(fc => fc.controlKey?.value === key);
+                        if (found) { return found; }
+                    }
+                    return undefined;
+                };
+                let currentFields = getSubFields(findFc()?.controlType?.value ?? '');
+                for (let i = 1; i < path.length - 1; i++) {
+                    if (!currentFields) { break; }
+                    const field = currentFields.find(f => f.name === path[i]);
+                    if (!field) { break; }
+                    if (field.isArray) { return true; }
+                    currentFields = getSubFields(this.getType(field));
+                }
+            }
             return false;
         };
 
         const resolveIfField = (opt: ConditionFieldOption | undefined): { field: SchemaField; fieldPath?: string[] } | null => {
             if (!opt?.fieldPath?.length) { return null; }
             if (startsWithArrayRefContainer(opt.fieldPath)) { return null; }
-            const leaf = traverseFieldPath(opt.fieldPath);
+            let leaf = traverseFieldPath(opt.fieldPath);
+            if (!leaf && opt.fieldPath.length === 1 && opt.fieldControl) {
+                const currentKey = opt.fieldControl.controlKey?.value;
+                if (currentKey) { leaf = fieldsBySchemaName.get(currentKey); }
+            }
             if (!leaf) { return null; }
             return opt.fieldPath.length === 1
                 ? { field: leaf }
@@ -1397,8 +1441,36 @@ export class SchemaConfigurationComponent implements OnInit {
     }
 
     public isValid(): boolean {
-        if (this.dataForm) {
-            return this.dataForm.valid;
+        if (!this.dataForm?.valid) { return false; }
+        return !this._hasStaleConditionSelections();
+    }
+
+    private _hasStaleConditionSelections(): boolean {
+        const validRefKeys = new Set(
+            this.getAllRefControls().map(fc => fc.controlKey?.value).filter(Boolean)
+        );
+        for (const condition of (this.conditions || [])) {
+            const groups = this._fieldOptionGroupsCache.get(condition) ?? [];
+            const validKeys = new Set(groups.flatMap(g => g.items.map(i => i.key)));
+            for (let i = 0; i < condition.conditions.length; i++) {
+                const row = condition.conditions.at(i) as UntypedFormGroup;
+                const opt: ConditionFieldOption = (row.get('field') as UntypedFormControl)?.value;
+                if (!opt) { continue; }
+                const isStale = opt.fieldControl
+                    ? opt.fieldControl.controlKey?.value !== opt.key
+                    : !validKeys.has(opt.key);
+                if (isStale) { return true; }
+            }
+            for (const t of [...condition.crossThenTargets, ...condition.crossElseTargets]) {
+                if (!t.fieldPath?.length) { return true; }
+                const refKey = t.fieldPath[0];
+                if (validRefKeys.has(refKey)) { continue; }
+                // type='' is a transient setSubSchemas reset; form required validator blocks save independently.
+                const isTransient = this.fields?.some(
+                    fc => fc.controlKey?.value === refKey && fc.controlType?.value === ''
+                );
+                if (!isTransient) { return true; }
+            }
         }
         return false;
     }
@@ -1647,7 +1719,12 @@ export class SchemaConfigurationComponent implements OnInit {
     }
 
     private watchFieldControl(fc: FieldControl): void {
-        merge(fc.controlType.valueChanges, fc.controlArray.valueChanges)
+        merge(
+            fc.controlType.valueChanges,
+            fc.controlArray.valueChanges,
+            fc.controlKey.valueChanges,
+            fc.controlTitle.valueChanges,
+        )
             .pipe(takeUntil(this.destroy$))
             .subscribe(() => this.rebuildOptionCaches());
     }
@@ -1662,6 +1739,63 @@ export class SchemaConfigurationComponent implements OnInit {
             this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
             this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
         }
+        this.validateConditionFieldOptions();
+    }
+
+    private validateConditionFieldOptions(): void {
+        const validRefKeys = new Set(
+            this.getAllRefControls().map(fc => fc.controlKey?.value).filter(Boolean)
+        );
+        for (const condition of this.conditions) {
+            const groups = this._fieldOptionGroupsCache.get(condition) ?? [];
+            const validKeys = new Set(groups.flatMap(g => g.items.map(i => i.key)));
+
+            for (let i = 0; i < condition.conditions.length; i++) {
+                const row = condition.conditions.at(i) as UntypedFormGroup;
+                const fieldCtrl = row.get('field') as UntypedFormControl;
+                const opt: ConditionFieldOption = fieldCtrl?.value;
+                const isStale = opt && (
+                    opt.fieldControl
+                        ? opt.fieldControl.controlKey?.value !== opt.key
+                        : !validKeys.has(opt.key)
+                );
+                if (isStale) {
+                    fieldCtrl.setErrors({ staleOption: true });
+                } else if (fieldCtrl?.hasError('staleOption')) {
+                    fieldCtrl.updateValueAndValidity({ emitEvent: false });
+                }
+            }
+
+            const staleKeys = new Set<string>();
+            for (const t of [...condition.crossThenTargets, ...condition.crossElseTargets]) {
+                if (!t.fieldPath?.length) { staleKeys.add(t.key); continue; }
+                const refKey = t.fieldPath[0];
+                if (validRefKeys.has(refKey)) { continue; }
+                const isTransient = this.fields?.some(
+                    fc => fc.controlKey?.value === refKey && fc.controlType?.value === ''
+                );
+                if (!isTransient) { staleKeys.add(t.key); }
+            }
+            this._staleTargetKeys.set(condition, staleKeys);
+
+            const hasStaleThen = condition.crossThenTargets.some(t => staleKeys.has(t.key));
+            if (hasStaleThen) {
+                condition.crossThenCount.setErrors({ staleTarget: true });
+            } else if (condition.crossThenCount.hasError('staleTarget')) {
+                condition.crossThenCount.updateValueAndValidity({ emitEvent: false });
+            }
+
+            const hasStaleElse = condition.crossElseTargets.some(t => staleKeys.has(t.key));
+            if (hasStaleElse) {
+                condition.crossElseCount.setErrors({ staleTarget: true });
+            } else if (condition.crossElseCount.hasError('staleTarget')) {
+                condition.crossElseCount.updateValueAndValidity({ emitEvent: false });
+            }
+        }
+    }
+
+    public isCrossTargetStale(condition: ConditionControl, target: ConditionFieldOption): boolean {
+        return this._staleTargetKeys.get(condition)?.has(target.key) ?? false;
     }
 
     public getFieldOptionGroupsForCondition(condition: ConditionControl): ConditionFieldGroup[] {

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -91,6 +91,9 @@ export class SchemaConfigurationComponent implements OnInit {
     private _schema: Schema;
     private _topicId: string;
     private _id: string | undefined;
+    private _fieldOptionGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
+    private _crossThenGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
+    private _crossElseGroupsCache = new Map<ConditionControl, ConditionFieldGroup[]>();
 
     public get isSystem(): boolean {
         return this.schemaType === SchemaType.System;
@@ -256,6 +259,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 field.type = '';
             }
         }
+        this.rebuildOptionCaches();
     }
 
     public build() {
@@ -355,6 +359,7 @@ export class SchemaConfigurationComponent implements OnInit {
         this.updateFieldControls(fields, conditionsFields);
         this.updateConditionControls(conditions);
         this.errors = errors;
+        this.rebuildOptionCaches();
     }
 
 
@@ -740,6 +745,7 @@ export class SchemaConfigurationComponent implements OnInit {
         type: 'then' | 'else'
     ) {
         condition.removeControl(type, conditionField);
+        this.rebuildOptionCaches();
     }
 
     public onConditionFieldAdd(condition: ConditionControl, type: 'then' | 'else') {
@@ -752,17 +758,20 @@ export class SchemaConfigurationComponent implements OnInit {
             this.getFieldName()
         );
         condition.addControl(type, field);
+        this.rebuildOptionCaches();
     }
 
     public onConditionAdd() {
         const condition = new ConditionControl(undefined, '', 'SINGLE');
         this.conditions.push(condition);
         this.conditionsForm.addControl(condition.name, condition.createGroup());
+        this.rebuildOptionCaches();
     }
 
     public onConditionRemove(condition: ConditionControl) {
         this.conditions = this.conditions.filter((e) => e != condition);
         this.conditionsForm.removeControl(condition.name);
+        this.rebuildOptionCaches();
     }
 
     public onAdd(event: MouseEvent) {
@@ -778,12 +787,14 @@ export class SchemaConfigurationComponent implements OnInit {
         control.append(this.fieldsForm);
         this.fields.push(control);
         this.fields = this.fields.slice();
+        this.rebuildOptionCaches();
     }
 
     public onRemove(item: FieldControl) {
         this.removeConditionsByField(item);
         this.fields = this.fields.filter((e) => e != item);
         item.remove(this.fieldsForm);
+        this.rebuildOptionCaches();
     }
 
     private removeConditionsByField(field: FieldControl) {
@@ -1508,6 +1519,7 @@ export class SchemaConfigurationComponent implements OnInit {
         for (const f of fields) {
             if (f.readOnly) { continue; }
             if (f.isRef) {
+                if (f.isArray) { continue; }
                 const nestedSchema = this.subSchemas?.find(s => s.iri === f.type);
                 if (!nestedSchema?.fields?.length) { continue; }
                 groups.push(...this.collectNestedFieldGroups(
@@ -1539,7 +1551,7 @@ export class SchemaConfigurationComponent implements OnInit {
         return groups;
     }
 
-    public getFieldOptionGroupsForCondition(condition: ConditionControl): ConditionFieldGroup[] {
+    private computeFieldOptionGroups(condition: ConditionControl): ConditionFieldGroup[] {
         const groups: ConditionFieldGroup[] = [];
 
         const topItems: ConditionFieldOption[] = [];
@@ -1586,7 +1598,7 @@ export class SchemaConfigurationComponent implements OnInit {
         return groups;
     }
 
-    public getCrossTargetGroupsForCondition(condition: ConditionControl, type: 'then' | 'else'): ConditionFieldGroup[] {
+    private computeCrossGroups(condition: ConditionControl, type: 'then' | 'else'): ConditionFieldGroup[] {
         const alreadySelected = new Set<string>(
             (type === 'then' ? condition.crossThenTargets : condition.crossElseTargets)
                 .map(t => t.fieldPath.join('.'))
@@ -1609,6 +1621,27 @@ export class SchemaConfigurationComponent implements OnInit {
         return groups;
     }
 
+    private rebuildOptionCaches(): void {
+        this._fieldOptionGroupsCache.clear();
+        this._crossThenGroupsCache.clear();
+        this._crossElseGroupsCache.clear();
+        if (!this.conditions) { return; }
+        for (const condition of this.conditions) {
+            this._fieldOptionGroupsCache.set(condition, this.computeFieldOptionGroups(condition));
+            this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
+            this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
+        }
+    }
+
+    public getFieldOptionGroupsForCondition(condition: ConditionControl): ConditionFieldGroup[] {
+        return this._fieldOptionGroupsCache.get(condition) ?? [];
+    }
+
+    public getCrossTargetGroupsForCondition(condition: ConditionControl, type: 'then' | 'else'): ConditionFieldGroup[] {
+        const cache = type === 'then' ? this._crossThenGroupsCache : this._crossElseGroupsCache;
+        return cache.get(condition) ?? [];
+    }
+
     public onCrossTargetAdd(condition: ConditionControl, type: 'then' | 'else', event: any): void {
         if (!event?.value) { return; }
         if (type === 'then') {
@@ -1616,6 +1649,8 @@ export class SchemaConfigurationComponent implements OnInit {
         } else {
             condition.addCrossElseTarget(event.value);
         }
+        this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
+        this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
     }
 
     public onCrossTargetRemove(condition: ConditionControl, type: 'then' | 'else', target: ConditionFieldOption): void {
@@ -1624,6 +1659,8 @@ export class SchemaConfigurationComponent implements OnInit {
         } else {
             condition.removeCrossElseTarget(target);
         }
+        this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
+        this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
     }
 
     public drop(event: CdkDragDrop<any[]>) {

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -948,6 +948,19 @@ export class SchemaConfigurationComponent implements OnInit {
             }
         }
 
+        const fieldsBySchemaName = new Map<string, SchemaField>(fields.map(f => [f.name, f]));
+
+        const getPickedName = (r: any): string | undefined => {
+            if (Array.isArray(r?.field?.fieldPath) && r.field.fieldPath.length > 0) {
+                return r.field.fieldPath[0];
+            }
+            if (Array.isArray(r?.fieldPath) && r.fieldPath.length > 0) {
+                return r.fieldPath[0];
+            }
+            return r?.field?.key || r?.field?.controlKey?.value ||
+                (typeof r?.field === 'string' ? r.field : undefined);
+        };
+
         const conditions: SchemaCondition[] = [];
         for (const element of this.conditions) {
             const conditionValue = value.conditions[element.name];
@@ -977,14 +990,10 @@ export class SchemaConfigurationComponent implements OnInit {
                 continue;
             }
 
-            const getPickedName = (r: any): string | undefined => {
-                return r?.field?.name || r?.field?.key || r?.field?.controlKey?.value || r?.field;
-            };
-
             if (op === 'SINGLE') {
                 const row = rows[0];
                 const name = getPickedName(row);
-                const sf = name ? allFieldsByName.get(name) : undefined;
+                const sf = name ? fieldsBySchemaName.get(name) : undefined;
                 if (!sf) {
                     continue;
                 }
@@ -1001,7 +1010,7 @@ export class SchemaConfigurationComponent implements OnInit {
                 const arr = rows
                     .map(r => {
                         const name = getPickedName(r);
-                        const sf = name ? allFieldsByName.get(name) : undefined;
+                        const sf = name ? fieldsBySchemaName.get(name) : undefined;
                         if (!sf) {
                             return null;
                         }

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1048,46 +1048,7 @@ export class SchemaConfigurationComponent implements OnInit {
             return current;
         };
 
-        const startsWithArrayRefContainer = (path: string[]): boolean => {
-            if (path.length <= 1) { return false; }
-            const key = path[0];
-            const isArrayRef = (fc: FieldControl) =>
-                fc.controlKey?.value === key &&
-                !!fc.controlArray?.value &&
-                !!this.schemaTypeMap[fc.controlType?.value]?.isRef;
-            if (this.fields.some(isArrayRef)) { return true; }
-            for (const cond of this.conditions) {
-                if ([...(cond.thenControls || []), ...(cond.elseControls || [])].some(isArrayRef)) {
-                    return true;
-                }
-            }
-            if (path.length > 2) {
-                const getSubFields = (typeKey: string): SchemaField[] | undefined => {
-                    const info = this.schemaTypeMap[typeKey];
-                    if (!info?.isRef) { return undefined; }
-                    return this.subSchemas?.find(s => s.iri === info.type)?.fields;
-                };
-                const findFc = (): FieldControl | undefined => {
-                    const inFields = this.fields.find(fc => fc.controlKey?.value === key);
-                    if (inFields) { return inFields; }
-                    for (const cond of this.conditions) {
-                        const found = [...(cond.thenControls || []), ...(cond.elseControls || [])]
-                            .find(fc => fc.controlKey?.value === key);
-                        if (found) { return found; }
-                    }
-                    return undefined;
-                };
-                let currentFields = getSubFields(findFc()?.controlType?.value ?? '');
-                for (let i = 1; i < path.length - 1; i++) {
-                    if (!currentFields) { break; }
-                    const field = currentFields.find(f => f.name === path[i]);
-                    if (!field) { break; }
-                    if (field.isArray) { return true; }
-                    currentFields = getSubFields(this.getType(field));
-                }
-            }
-            return false;
-        };
+        const startsWithArrayRefContainer = (path: string[]) => this.startsWithArrayRefContainer(path);
 
         const resolveIfField = (opt: ConditionFieldOption | undefined): { field: SchemaField; fieldPath?: string[] } | null => {
             if (!opt?.fieldPath?.length) { return null; }
@@ -1147,6 +1108,13 @@ export class SchemaConfigurationComponent implements OnInit {
                 const row = rows[0];
                 const resolved = resolveIfField(row?.field);
                 if (!resolved) {
+                    const opt = row?.field as ConditionFieldOption | undefined;
+                    if (opt?.fieldPath?.length && startsWithArrayRefContainer(opt.fieldPath)) {
+                        console.warn(
+                            `Schema condition skipped: IF trigger "${opt.fieldPath.join('.')}" ` +
+                            `passes through an array-ref field and cannot be evaluated at runtime.`
+                        );
+                    }
                     continue;
                 }
                 conditions.push({
@@ -1445,6 +1413,47 @@ export class SchemaConfigurationComponent implements OnInit {
         return !this._hasStaleConditionSelections();
     }
 
+    private startsWithArrayRefContainer(path: string[]): boolean {
+        if (path.length <= 1) { return false; }
+        const key = path[0];
+        const isArrayRef = (fc: FieldControl) =>
+            fc.controlKey?.value === key &&
+            !!fc.controlArray?.value &&
+            !!this.schemaTypeMap[fc.controlType?.value]?.isRef;
+        if (this.fields.some(isArrayRef)) { return true; }
+        for (const cond of this.conditions) {
+            if ([...(cond.thenControls || []), ...(cond.elseControls || [])].some(isArrayRef)) {
+                return true;
+            }
+        }
+        if (path.length >= 2) {
+            const getSubFields = (typeKey: string): SchemaField[] | undefined => {
+                const info = this.schemaTypeMap[typeKey];
+                if (!info?.isRef) { return undefined; }
+                return this.subSchemas?.find(s => s.iri === info.type)?.fields;
+            };
+            const findFc = (): FieldControl | undefined => {
+                const inFields = this.fields.find(fc => fc.controlKey?.value === key);
+                if (inFields) { return inFields; }
+                for (const cond of this.conditions) {
+                    const found = [...(cond.thenControls || []), ...(cond.elseControls || [])]
+                        .find(fc => fc.controlKey?.value === key);
+                    if (found) { return found; }
+                }
+                return undefined;
+            };
+            let currentFields = getSubFields(findFc()?.controlType?.value ?? '');
+            for (let i = 1; i < path.length; i++) {
+                if (!currentFields) { break; }
+                const field = currentFields.find(f => f.name === path[i]);
+                if (!field) { break; }
+                if (field.isArray) { return true; }
+                currentFields = getSubFields(this.getType(field));
+            }
+        }
+        return false;
+    }
+
     private _hasStaleConditionSelections(): boolean {
         const validRefKeys = new Set(
             this.getAllRefControls().map(fc => fc.controlKey?.value).filter(Boolean)
@@ -1456,9 +1465,12 @@ export class SchemaConfigurationComponent implements OnInit {
                 const row = condition.conditions.at(i) as UntypedFormGroup;
                 const opt: ConditionFieldOption = (row.get('field') as UntypedFormControl)?.value;
                 if (!opt) { continue; }
+                if (opt.fieldPath?.length > 0 && this.startsWithArrayRefContainer(opt.fieldPath)) { return true; }
                 const isStale = opt.fieldControl
                     ? opt.fieldControl.controlKey?.value !== opt.key
-                    : !validKeys.has(opt.key);
+                    : (opt.fieldPath?.length > 1)
+                        ? !validRefKeys.has(opt.fieldPath[0])
+                        : !validKeys.has(opt.key);
                 if (isStale) { return true; }
             }
             for (const t of [...condition.crossThenTargets, ...condition.crossElseTargets]) {
@@ -1754,14 +1766,19 @@ export class SchemaConfigurationComponent implements OnInit {
                 const row = condition.conditions.at(i) as UntypedFormGroup;
                 const fieldCtrl = row.get('field') as UntypedFormControl;
                 const opt: ConditionFieldOption = fieldCtrl?.value;
-                const isStale = opt && (
+                const isArrayRef = opt?.fieldPath?.length > 0 && this.startsWithArrayRefContainer(opt.fieldPath);
+                const isStale = !isArrayRef && opt && (
                     opt.fieldControl
                         ? opt.fieldControl.controlKey?.value !== opt.key
-                        : !validKeys.has(opt.key)
+                        : (opt.fieldPath?.length > 1)
+                            ? !validRefKeys.has(opt.fieldPath[0])
+                            : !validKeys.has(opt.key)
                 );
-                if (isStale) {
+                if (isArrayRef) {
+                    fieldCtrl.setErrors({ arrayRefTrigger: true });
+                } else if (isStale) {
                     fieldCtrl.setErrors({ staleOption: true });
-                } else if (fieldCtrl?.hasError('staleOption')) {
+                } else if (fieldCtrl?.hasError('staleOption') || fieldCtrl?.hasError('arrayRefTrigger')) {
                     fieldCtrl.updateValueAndValidity({ emitEvent: false });
                 }
             }

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -563,30 +563,6 @@ export class SchemaConfigurationComponent implements OnInit {
         this.ifFormatValueForOption(valueCtrl, opt);
     }
 
-    private ifFormatValueFor(valueCtrl: UntypedFormControl, field: FieldControl) {
-        const type = this.schemaTypeMap[field.controlType.value];
-        const isNumber = ['number', 'integer'].includes(type.type) || type.format === 'duration';
-
-        const validators = [];
-        if (field.controlRequired.value) {
-            validators.push(Validators.required);
-        }
-        if (isNumber) {
-            validators.push(this.isNumberOrEmptyValidator());
-        }
-
-        valueCtrl.clearValidators();
-        valueCtrl.setValidators(validators);
-
-        if (['date', 'date-time', 'time'].includes(type.format)) {
-            this.subscribeFormatDateValue(valueCtrl, type.format);
-        } else if (isNumber) {
-            this.subscribeFormatNumberValue(valueCtrl, type.format || type.type);
-        }
-
-        valueCtrl.updateValueAndValidity();
-    }
-
     public getOperatorControl(condition: ConditionControl): UntypedFormControl {
         return (this.conditionsForm.get(condition.name) as UntypedFormGroup)
             .get('ifCondition')!
@@ -1027,17 +1003,6 @@ export class SchemaConfigurationComponent implements OnInit {
         }
 
         const fieldsBySchemaName = new Map<string, SchemaField>(fields.map(f => [f.name, f]));
-
-        const getPickedName = (r: any): string | undefined => {
-            if (Array.isArray(r?.field?.fieldPath) && r.field.fieldPath.length > 0) {
-                return r.field.fieldPath[0];
-            }
-            if (Array.isArray(r?.fieldPath) && r.fieldPath.length > 0) {
-                return r.fieldPath[0];
-            }
-            return r?.field?.key || r?.field?.controlKey?.value ||
-                (typeof r?.field === 'string' ? r.field : undefined);
-        };
 
         const traverseFieldPath = (path: string[]): SchemaField | undefined => {
             let current: SchemaField | undefined = fieldsBySchemaName.get(path[0]);

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1491,6 +1491,7 @@ export class SchemaConfigurationComponent implements OnInit {
         const add = (fc: FieldControl) => {
             const typeKey = fc.controlType?.value;
             if (!this.schemaTypeMap[typeKey]?.isRef) { return; }
+            if (fc.controlArray?.value) { return; }
             const key = fc.controlKey?.value;
             if (!key || seen.has(key)) { return; }
             seen.add(key);

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1490,21 +1490,23 @@ export class SchemaConfigurationComponent implements OnInit {
         return result;
     }
 
-    private collectNestedFieldOptions(
+    private collectNestedFieldGroups(
         fields: SchemaField[],
         prefix: string[],
         labelPrefix: string,
         alreadySelected?: Set<string>,
         maxDepth: number = 12,
-    ): ConditionFieldOption[] {
+    ): ConditionFieldGroup[] {
         if (prefix.length > maxDepth) { return []; }
-        const result: ConditionFieldOption[] = [];
+        const groups: ConditionFieldGroup[] = [];
+        const directItems: ConditionFieldOption[] = [];
+
         for (const f of fields) {
             if (f.readOnly) { continue; }
             if (f.isRef) {
                 const nestedSchema = this.subSchemas?.find(s => s.iri === f.type);
                 if (!nestedSchema?.fields?.length) { continue; }
-                result.push(...this.collectNestedFieldOptions(
+                groups.push(...this.collectNestedFieldGroups(
                     nestedSchema.fields,
                     [...prefix, f.name],
                     `${labelPrefix} > ${f.title || f.name}`,
@@ -1516,9 +1518,9 @@ export class SchemaConfigurationComponent implements OnInit {
                 if (!leafTypeKey || !this.schemaTypeMap[leafTypeKey]) { continue; }
                 const path = [...prefix, f.name];
                 if (alreadySelected?.has(path.join('.'))) { continue; }
-                result.push({
+                directItems.push({
                     key: path.join('.'),
-                    label: `${labelPrefix} > ${f.title || f.name}`,
+                    label: f.title || f.name,
                     shortLabel: f.title || f.name,
                     fieldPath: path,
                     typeKey: leafTypeKey,
@@ -1526,7 +1528,11 @@ export class SchemaConfigurationComponent implements OnInit {
                 });
             }
         }
-        return result;
+
+        if (directItems.length) {
+            groups.unshift({ label: labelPrefix, items: directItems });
+        }
+        return groups;
     }
 
     public getFieldOptionGroupsForCondition(condition: ConditionControl): ConditionFieldGroup[] {
@@ -1566,14 +1572,11 @@ export class SchemaConfigurationComponent implements OnInit {
             const subSchema = this.subSchemas?.find(s => s.iri === type.type);
             if (!subSchema?.fields?.length) { continue; }
             const groupLabel = fc.controlTitle.value || fc.controlKey.value;
-            const nestedItems = this.collectNestedFieldOptions(
+            groups.push(...this.collectNestedFieldGroups(
                 subSchema.fields,
                 [fc.controlKey.value],
                 groupLabel,
-            );
-            if (nestedItems.length) {
-                groups.push({ label: groupLabel, items: nestedItems });
-            }
+            ));
         }
 
         return groups;
@@ -1592,15 +1595,12 @@ export class SchemaConfigurationComponent implements OnInit {
             const subSchema = this.subSchemas?.find(s => s.iri === schemaType.type);
             if (!subSchema?.fields?.length) { continue; }
             const groupLabel = fc.controlTitle.value || fc.controlKey.value;
-            const items = this.collectNestedFieldOptions(
+            groups.push(...this.collectNestedFieldGroups(
                 subSchema.fields,
                 [fc.controlKey.value],
                 groupLabel,
                 alreadySelected,
-            );
-            if (items.length) {
-                groups.push({ label: groupLabel, items });
-            }
+            ));
         }
         return groups;
     }

--- a/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-configuration/schema-configuration.component.ts
@@ -1677,21 +1677,21 @@ export class SchemaConfigurationComponent implements OnInit {
         if (!event?.value) { return; }
         if (type === 'then') {
             condition.addCrossThenTarget(event.value);
+            this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
         } else {
             condition.addCrossElseTarget(event.value);
+            this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
         }
-        this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
-        this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
     }
 
     public onCrossTargetRemove(condition: ConditionControl, type: 'then' | 'else', target: ConditionFieldOption): void {
         if (type === 'then') {
             condition.removeCrossThenTarget(target);
+            this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
         } else {
             condition.removeCrossElseTarget(target);
+            this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
         }
-        this._crossThenGroupsCache.set(condition, this.computeCrossGroups(condition, 'then'));
-        this._crossElseGroupsCache.set(condition, this.computeCrossGroups(condition, 'else'));
     }
 
     public drop(event: CdkDragDrop<any[]>) {

--- a/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
@@ -1,5 +1,5 @@
 import { UntypedFormGroup, UntypedFormControl, UntypedFormArray, ValidatorFn, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
-import { Schema, SchemaField, SchemaRuleValidateResult, GenerateUUIDv4, SchemaCondition } from '@guardian/interfaces';
+import { Schema, SchemaCondition, SchemaConditionTarget, SchemaField, SchemaRuleValidateResult, GenerateUUIDv4 } from '@guardian/interfaces';
 import { fullFormats } from 'ajv-formats/dist/formats';
 import moment from 'moment';
 import { Subject, takeUntil } from 'rxjs';
@@ -49,10 +49,19 @@ type IfOp = 'SINGLE' | 'AND' | 'OR';
 interface IConditionPair {
     name: string;
     value: any;
+    path?: string;
 }
 interface IConditionExpr {
     op: IfOp;
     pairs: IConditionPair[];
+}
+
+interface ICrossSchemaConditionItem {
+    expr: IConditionExpr;
+    conditionInvert: boolean;
+    field: SchemaField;
+    fieldPath: string[];
+    visibility: boolean;
 }
 
 export class FieldForm {
@@ -70,8 +79,14 @@ export class FieldForm {
     public controls: IFieldControl<any>[] | null;
     private fieldControls: IFieldControl<any>[] | null;
     private conditionControls: IConditionControl<any>[] | null;
+    private crossSchemaItems: ICrossSchemaConditionItem[];
 
     private readonly conditionFields: Set<string>;
+    private ownParentControlledFields: Set<string>;
+    private readonly childControlledFields: Map<string, Set<string>>;
+    private readonly ancestorChildPaths: Map<string, Set<string>>;
+    public rootForm: FieldForm;
+
     private readonly destroy$: Subject<boolean>;
 
     private readonly validateLikeDryRun?: boolean;
@@ -82,10 +97,15 @@ export class FieldForm {
         this.validateLikeDryRun = validateLikeDryRun;
         this.privateFields = {};
         this.conditionFields = new Set<string>();
+        this.ownParentControlledFields = new Set<string>();
+        this.childControlledFields = new Map<string, Set<string>>();
+        this.ancestorChildPaths = new Map<string, Set<string>>();
         this.destroy$ = new Subject<boolean>();
         this.fieldControls = null;
         this.conditionControls = null;
+        this.crossSchemaItems = [];
         this.controls = null;
+        this.rootForm = this;
     }
 
     public destroy() {
@@ -94,31 +114,18 @@ export class FieldForm {
     }
 
     private normalizeIfCondition(raw: any): IConditionExpr {
+        const toPair = (r: any): IConditionPair => ({
+            name: r?.field?.name || r?.field?.key || r?.field,
+            value: r?.fieldValue,
+            path: r?.fieldPath?.length > 1 ? (r.fieldPath as string[]).join('.') : undefined,
+        });
         if (raw?.OR) {
-            return {
-                op: 'OR',
-                pairs: (raw.OR || []).map((r: any) => ({
-                    name: r?.field?.name || r?.field?.key || r?.field,
-                    value: r?.fieldValue
-                }))
-            };
+            return { op: 'OR', pairs: (raw.OR || []).map(toPair) };
         }
         if (raw?.AND) {
-            return {
-                op: 'AND',
-                pairs: (raw.AND || []).map((r: any) => ({
-                    name: r?.field?.name || r?.field?.key || r?.field,
-                    value: r?.fieldValue
-                }))
-            };
+            return { op: 'AND', pairs: (raw.AND || []).map(toPair) };
         }
-        return {
-            op: 'SINGLE',
-            pairs: [{
-                name: raw?.field?.name || raw?.field?.key || raw?.field,
-                value: raw?.fieldValue
-            }]
-        };
+        return { op: 'SINGLE', pairs: [toPair(raw)] };
     }
 
     public setData(data: {
@@ -128,6 +135,7 @@ export class FieldForm {
         preset?: any;
         privateFields?: { [x: string]: boolean; };
         readonlyFields?: any;
+        ownParentControlledFields?: Set<string>;
     }) {
         if (data.privateFields) {
             this.privateFields = data.privateFields;
@@ -147,10 +155,28 @@ export class FieldForm {
         if (data.preset) {
             this.preset = data.preset;
         }
+        if (data.ownParentControlledFields) {
+            this.ownParentControlledFields = new Set<string>();
+            this.ancestorChildPaths.clear();
+            for (const path of data.ownParentControlledFields) {
+                const dotIdx = path.indexOf('.');
+                if (dotIdx < 0) {
+                    this.ownParentControlledFields.add(path);
+                } else {
+                    const containerName = path.substring(0, dotIdx);
+                    const remaining = path.substring(dotIdx + 1);
+                    if (!this.ancestorChildPaths.has(containerName)) {
+                        this.ancestorChildPaths.set(containerName, new Set<string>());
+                    }
+                    this.ancestorChildPaths.get(containerName)!.add(remaining);
+                }
+            }
+        }
     }
 
     public build() {
         const { fields, conditions } = this.updateData();
+        this.crossSchemaItems = [];
         this.fieldControls = this.buildFields(fields);
         this.conditionControls = this.buildConditions(conditions);
         this.controls = this.rebuildControls();
@@ -176,6 +202,7 @@ export class FieldForm {
         }
 
         this.conditionFields.clear();
+        this.childControlledFields.clear();
         if (conditions) {
             for (const condition of conditions) {
                 for (const field of (condition.thenFields || [])) {
@@ -184,6 +211,27 @@ export class FieldForm {
                 for (const field of (condition.elseFields || [])) {
                     this.conditionFields.add(field.name);
                 }
+                const allTargets: SchemaConditionTarget[] = [
+                    ...(condition.thenTargets || []),
+                    ...(condition.elseTargets || []),
+                ];
+                for (const target of allTargets) {
+                    if (!target.fieldPath || target.fieldPath.length < 2) { continue; }
+                    const containerName = target.fieldPath[0];
+                    const remainingPath = target.fieldPath.slice(1).join('.');
+                    if (!this.childControlledFields.has(containerName)) {
+                        this.childControlledFields.set(containerName, new Set<string>());
+                    }
+                    this.childControlledFields.get(containerName)!.add(remainingPath);
+                }
+            }
+        }
+        for (const [containerName, paths] of this.ancestorChildPaths) {
+            if (!this.childControlledFields.has(containerName)) {
+                this.childControlledFields.set(containerName, new Set<string>());
+            }
+            for (const path of paths) {
+                this.childControlledFields.get(containerName)!.add(path);
             }
         }
 
@@ -207,7 +255,7 @@ export class FieldForm {
         if (!expr || !expr.pairs?.length) return false;
 
         const test = (p: IConditionPair) => {
-            const c = this.form.controls[p.name];
+            const c = p.path ? this.form.get(p.path) : this.form.controls[p.name];
             if (!c) return false;
             return this.equalsLoosely(c.value, p.value);
         };
@@ -224,7 +272,7 @@ export class FieldForm {
 
         const controls: IFieldControl<any>[] = [];
         for (const field of fields) {
-            if (this.privateFields[field.name] || this.conditionFields.has(field.name)) {
+            if (this.privateFields[field.name] || this.conditionFields.has(field.name) || this.ownParentControlledFields.has(field.name)) {
                 continue;
             }
             const item = this.createFieldControl(field, this.preset);
@@ -249,7 +297,7 @@ export class FieldForm {
 
         for (const condition of conditions) {
             const expr = this.normalizeIfCondition((condition as any).ifCondition);
-            const deps = Array.from(new Set(expr.pairs.map(p => p.name).filter(Boolean)));
+            const deps = Array.from(new Set(expr.pairs.map(p => p.path ? p.path.split('.')[0] : p.name).filter(Boolean)));
             for (const thenField of condition.thenFields) {
                 const fieldControl = this.createFieldControl(thenField, this.preset);
                 const item: IConditionControl<any> = {
@@ -273,6 +321,21 @@ export class FieldForm {
                 };
                 controls.push(item);
             }
+
+            const buildCrossItems = (targets: SchemaConditionTarget[] | undefined, invert: boolean) => {
+                for (const target of (targets || [])) {
+                    if (!target.fieldPath || target.fieldPath.length < 2) { continue; }
+                    this.crossSchemaItems.push({
+                        expr,
+                        conditionInvert: invert,
+                        field: target.field,
+                        fieldPath: target.fieldPath,
+                        visibility: false,
+                    });
+                }
+            };
+            buildCrossItems(condition.thenTargets, false);
+            buildCrossItems(condition.elseTargets, true);
         }
 
         for (const item of controls) {
@@ -282,7 +345,89 @@ export class FieldForm {
             }
         }
 
+        for (const item of this.crossSchemaItems) {
+            const childModel = this.resolveChildModel(item.fieldPath);
+            if (!childModel) { continue; }
+            const visible = this.checkCrossConditionValue(item);
+            item.visibility = visible;
+            if (visible) {
+                childModel.addParentControlledField(item.field, this.getPresetForPath(item.fieldPath));
+            }
+        }
+
         return controls;
+    }
+
+    private checkCrossConditionValue(item: ICrossSchemaConditionItem): boolean {
+        const ok = this.evaluateIf(item.expr);
+        return item.conditionInvert ? !ok : ok;
+    }
+
+    public addParentControlledField(field: SchemaField, containerPreset?: any): void {
+        if (!this.fieldControls) { this.fieldControls = []; }
+        if (this.fieldControls.find(c => c.name === field.name)) { return; }
+        const item = this.createFieldControl(field, containerPreset?.[field.name]);
+        this.fieldControls.push(item);
+        if (item.control) {
+            this.form.addControl(item.name, item.control, { emitEvent: false });
+        }
+        this.controls = this.rebuildControls();
+    }
+
+    public removeParentControlledField(fieldName: string): void {
+        if (!this.fieldControls) { return; }
+        const idx = this.fieldControls.findIndex(c => c.name === fieldName);
+        if (idx < 0) { return; }
+        const item = this.fieldControls[idx];
+        this.fieldControls.splice(idx, 1);
+        this.form.removeControl(item.name, { emitEvent: false });
+        this.controls = this.rebuildControls();
+    }
+
+    private rebuildCrossSchemaConditions(force: boolean = true): void {
+        if (!this.crossSchemaItems.length) { return; }
+        for (const item of this.crossSchemaItems) {
+            const childModel = this.resolveChildModel(item.fieldPath);
+            if (!childModel) { continue; }
+            const visible = this.checkCrossConditionValue(item);
+            const wasVisible = item.visibility;
+            if (force || visible !== wasVisible) {
+                item.visibility = visible;
+                if (visible) {
+                    childModel.addParentControlledField(item.field, this.getPresetForPath(item.fieldPath));
+                } else {
+                    childModel.removeParentControlledField(item.field.name);
+                }
+            }
+        }
+    }
+
+    private resolveChildModel(fieldPath: string[]): FieldForm | null {
+        if (!fieldPath || fieldPath.length < 2) { return null; }
+        let model: FieldForm = this;
+        for (let i = 0; i < fieldPath.length - 1; i++) {
+            const name = fieldPath[i];
+            const ctrl = model.fieldControls?.find(c => c.name === name);
+            const next = ctrl?.model as FieldForm | null;
+            if (!next) { return null; }
+            model = next;
+        }
+        return model;
+    }
+
+    private getPresetForPath(fieldPath: string[]): any {
+        let val = this.preset;
+        for (let i = 0; i < fieldPath.length - 1; i++) {
+            if (val == null) { return undefined; }
+            val = val[fieldPath[i]];
+        }
+        return val;
+    }
+
+    private getMergedChildPaths(fieldName: string): Set<string> | undefined {
+        const own = this.childControlledFields.get(fieldName);
+        if (!own?.size) { return undefined; }
+        return own;
     }
 
     private subscribeConditions() {
@@ -383,6 +528,8 @@ export class FieldForm {
             if (!passChanged) break;
         }
 
+        this.rebuildCrossSchemaConditions(force);
+
         if (anyChanged) {
             this.controls = this.rebuildControls();
             this.form.updateValueAndValidity({ emitEvent: false });
@@ -398,7 +545,8 @@ export class FieldForm {
                         control.control,
                         control.preset,
                         control.fields,
-                        control.conditions
+                        control.conditions,
+                        control.name,
                     )
                 }
                 if (this.ifSubSchemaArray(control) && control.list) {
@@ -408,7 +556,8 @@ export class FieldForm {
                             listItem.control,
                             listItem.preset,
                             control.fields,
-                            control.conditions
+                            control.conditions,
+                            control.name,
                         )
                     }
                 }
@@ -422,6 +571,7 @@ export class FieldForm {
         preset: any,
         fields: any,
         conditions: any,
+        fieldName?: string,
     ) {
         if (type === 'geo') {
             const form = new GeoForm(control);
@@ -438,12 +588,17 @@ export class FieldForm {
             form.build();
             return form;
         } else {
+            const ownParentControlledFields = fieldName
+                ? this.getMergedChildPaths(fieldName)
+                : undefined;
             const form = new FieldForm(control, this.lvl + 1, this.validateLikeDryRun);
+            form.rootForm = this.rootForm;
             form.setData({
                 fields,
                 conditions,
                 preset,
                 privateFields: this.privateFields,
+                ownParentControlledFields,
             });
             form.build();
             return form;
@@ -677,7 +832,8 @@ export class FieldForm {
                     item.control,
                     item.preset,
                     item.fields,
-                    item.conditions
+                    item.conditions,
+                    field.name,
                 )
             }
         }
@@ -763,7 +919,8 @@ export class FieldForm {
                 listItem.control,
                 listItem.preset,
                 item.fields,
-                item.conditions
+                item.conditions,
+                item.name,
             )
         } else {
             // ifSimpleArray
@@ -867,9 +1024,14 @@ export class FieldForm {
             item.control,
             item.preset,
             item.fields,
-            item.conditions
+            item.conditions,
+            item.name,
         )
         this.form.addControl(item.name, item.control);
+        this.rebuildCrossSchemaConditions(true);
+        if (this.rootForm !== this) {
+            this.rootForm.rebuildCrossSchemaConditions(true);
+        }
     }
 
     public addItem(item: IFieldControl<UntypedFormArray>) {

--- a/frontend/src/app/modules/schema-engine/schema-form-view/schema-form-view.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-view/schema-form-view.component.ts
@@ -156,15 +156,15 @@ export class SchemaFormViewComponent implements OnInit {
         return ic && 'OR' in ic && Array.isArray(ic.OR);
     }
 
-    private getPredicates(ic: any): { field: any; fieldValue: any }[] {
+    private getPredicates(ic: any): { field: any; fieldValue: any; fieldPath?: string[] }[] {
         if (this.isSingleIF(ic)) {
-            return [{ field: ic.field, fieldValue: ic.fieldValue }];
+            return [{ field: ic.field, fieldValue: ic.fieldValue, fieldPath: (ic as any).fieldPath }];
         }
         if (this.isAND(ic)) {
-            return ic.AND.map(p => ({ field: (p as any).field, fieldValue: (p as any).fieldValue ?? (p as any).const }));
+            return ic.AND.map(p => ({ field: (p as any).field, fieldValue: (p as any).fieldValue ?? (p as any).const, fieldPath: (p as any).fieldPath }));
         }
         if (this.isOR(ic)) {
-            return ic.OR.map(p => ({ field: (p as any).field, fieldValue: (p as any).fieldValue ?? (p as any).const }));
+            return ic.OR.map(p => ({ field: (p as any).field, fieldValue: (p as any).fieldValue ?? (p as any).const, fieldPath: (p as any).fieldPath }));
         }
         return [];
     }
@@ -178,12 +178,21 @@ export class SchemaFormViewComponent implements OnInit {
             return false;
         }
 
-        const check = (pred: { field: any; fieldValue: any }) => {
-            const fieldName = pred.field?.name;
-            if (!fieldName) {
+        const check = (pred: { field: any; fieldValue: any; fieldPath?: string[] }) => {
+            // For nested sub-schema fields the predicate carries a full path; walk it from subValues.
+            const path = (pred.fieldPath && pred.fieldPath.length > 1)
+                ? pred.fieldPath
+                : [pred.field?.name];
+            if (!path[0]) {
                 return false;
             }
-            const current = subValues ? subValues[fieldName] : undefined;
+            let current = subValues;
+            for (const segment of path) {
+                if (current === null || current === undefined) {
+                    return false;
+                }
+                current = current[segment];
+            }
             return current === pred.fieldValue;
         };
 
@@ -503,7 +512,7 @@ export class SchemaFormViewComponent implements OnInit {
             }
         }
     }
-    
+
     public openAccordion(link?: string): void {
         let _rootLink: string | undefined = undefined;
         let _subLink: string | undefined = undefined;
@@ -575,9 +584,9 @@ export class SchemaFormViewComponent implements OnInit {
     }
 
     private findFieldRecursive(list: any[], targetFullPath: string): any | null {
-        if (!list || !list.length) 
+        if (!list || !list.length)
             return null;
-        
+
         for (const f of list) {
             if (f.fullPath === targetFullPath)
                 return f;
@@ -632,18 +641,18 @@ export class SchemaFormViewComponent implements OnInit {
         if (customTypes.includes(item.customType || '')) {
             return false;
         }
-        
+
         const visibleFields = item.fields?.filter(f => !f.hidden) || [];
         if (visibleFields.length === 0) {
             return false;
         }
-        
-        return !visibleFields.some(f => 
-            f.isArray || f.isRef || 
+
+        return !visibleFields.some(f =>
+            f.isArray || f.isRef ||
             customTypes.includes(f.customType || '')
         );
     }
-    
+
     public getTableHeaderFields(item: IFieldControl): any[] | undefined {
         if (this.hide) {
             return item.fields?.filter(f => f.type !== 'null' && !this.hide[f.name] && !f.hidden);
@@ -664,7 +673,7 @@ export class SchemaFormViewComponent implements OnInit {
 
             for (let j = 0; j < item.fields.length; j++) {
                 const field = item.fields[j];
-                if (this.hide && this.hide[field.name] || field.hidden || field.type === 'null') 
+                if (this.hide && this.hide[field.name] || field.hidden || field.type === 'null')
                     continue;
 
                 const tableField: IFieldControl = {
@@ -701,7 +710,7 @@ export class SchemaFormViewComponent implements OnInit {
 
      public onAccordionSelectEvent(isOpen: any, item: any, childrenAccordionId?: string) {
         let accordionId = item.fullPath;
-    
+
         if (childrenAccordionId) {
             accordionId = `${accordionId};${childrenAccordionId}`;
         }

--- a/guardian-service/src/analytics/compare/interfaces/raw-data.interface.ts
+++ b/guardian-service/src/analytics/compare/interfaces/raw-data.interface.ts
@@ -77,7 +77,7 @@ export interface ISchemaDocument {
      * Properties
      */
     properties?: {
-        [x: string]: ISchemaDocument;
+        [x: string]: ISchemaDocument | false;
     }
     /**
      * Required fields

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -688,8 +688,9 @@ export class SchemaHelper {
         };
 
         const deepMergeSchemaObj = (a: any, b: any): any => {
-            if (!a) { return b; }
-            if (!b) { return a; }
+            if (a === null || a === undefined) { return b; }
+            if (b === null || b === undefined) { return a; }
+            if (b === false || a === false) { return false; }
             const result: any = { ...a };
             for (const key of Object.keys(b)) {
                 if (key === 'properties') {
@@ -714,7 +715,6 @@ export class SchemaHelper {
             for (const t of targets) {
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }
-                if (!t.field?.required) { continue; }
                 let node = root;
                 for (let i = 0; i < path.length - 1; i++) {
                     if (!node.properties) { node.properties = {}; }
@@ -1118,7 +1118,8 @@ export class SchemaHelper {
                 if (!path || path.length < 2) { continue; }
                 let iri: string | undefined = fieldNameToIRI.get(path[0]);
                 for (let i = 1; i < path.length - 1 && iri; i++) {
-                    iri = schemaMap[iri]?.properties?.[path[i]]?.['$ref'];
+                    const prop = schemaMap[iri]?.properties?.[path[i]];
+                    iri = prop?.['$ref'] ?? prop?.items?.['$ref'];
                 }
                 if (!iri) { continue; }
                 const leaf = path[path.length - 1];

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -276,14 +276,33 @@ export class SchemaHelper {
         const buildFields = (node: any) =>
             SchemaHelper.parseFields(node, context, schemaCache, document.$defs || defs) as SchemaField[];
 
-        const predicatesFromProperties = (props: any): SchemaFieldPredicate[] => {
+        const predicatesFromProperties = (
+            props: any,
+            currentFields: SchemaField[] = fields,
+            pathSoFar: string[] = []
+        ): SchemaFieldPredicate[] => {
             const preds: SchemaFieldPredicate[] = [];
             for (const key of Object.keys(props || {})) {
                 const rule = props[key];
-                if (rule && Object.prototype.hasOwnProperty.call(rule, 'const')) {
-                    const f = fields.find(x => x.name === key);
+                if (!rule) { continue; }
+                if (Object.prototype.hasOwnProperty.call(rule, 'const')) {
+                    const f = currentFields.find(x => x.name === key);
                     if (f) {
-                        preds.push({ field: f, fieldValue: rule.const });
+                        const fullPath = [...pathSoFar, key];
+                        preds.push({
+                            field: f,
+                            fieldValue: rule.const,
+                            fieldPath: fullPath.length > 1 ? fullPath : undefined,
+                        });
+                    }
+                } else if (rule.properties) {
+                    const refField = currentFields.find(x => x.name === key && x.isRef);
+                    if (refField && (refField as any).fields?.length) {
+                        preds.push(...predicatesFromProperties(
+                            rule.properties,
+                            (refField as any).fields,
+                            [...pathSoFar, key]
+                        ));
                     }
                 }
             }
@@ -335,6 +354,102 @@ export class SchemaHelper {
             return null;
         };
 
+        const extractCrossFromLevel = (
+            node: any,
+            refFieldsAtLevel: SchemaField[],
+            pathPrefix: string[],
+        ): {
+            thenTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            elseTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            cleanProps: any;
+            hasCrossKeys: boolean;
+        } => {
+            const thenTargets: Array<{ field: SchemaField; fieldPath: string[] }> = [];
+            const elseTargets: Array<{ field: SchemaField; fieldPath: string[] }> = [];
+            const cleanProps: any = {};
+            let hasCrossKeys = false;
+
+            if (!node?.properties) {
+                return { thenTargets, elseTargets, cleanProps: node?.properties, hasCrossKeys };
+            }
+
+            for (const key of Object.keys(node.properties)) {
+                const val = node.properties[key];
+                const refField = refFieldsAtLevel.find(f => f.name === key && f.isRef);
+                const isCrossConstraint = refField && val && !val.$comment && !val.type && !val.$ref;
+                if (isCrossConstraint) {
+                    hasCrossKeys = true;
+                    const childPath = [...pathPrefix, key];
+                    const childFields: SchemaField[] = (refField as any).fields || [];
+                    // Direct required targets (leaf one level inside this ref)
+                    if (Array.isArray(val.required)) {
+                        for (const fieldName of val.required) {
+                            const childField = childFields.find(f => f.name === fieldName);
+                            if (childField) {
+                                thenTargets.push({ field: childField, fieldPath: [...childPath, fieldName] });
+                            }
+                        }
+                    }
+                    // Properties: either forbidden (=== false) or deeper nesting (recurse)
+                    if (val.properties) {
+                        for (const fieldName of Object.keys(val.properties)) {
+                            const subVal = val.properties[fieldName];
+                            if (subVal === false) {
+                                const childField = childFields.find(f => f.name === fieldName);
+                                if (childField) {
+                                    elseTargets.push({ field: childField, fieldPath: [...childPath, fieldName] });
+                                }
+                            } else {
+                                // Recurse if this is another ref field at the child level
+                                const subRefField = childFields.find(f => f.name === fieldName && f.isRef);
+                                if (subRefField) {
+                                    const subResult = extractCrossFromLevel(
+                                        { properties: { [fieldName]: subVal } },
+                                        childFields,
+                                        childPath,
+                                    );
+                                    thenTargets.push(...subResult.thenTargets);
+                                    elseTargets.push(...subResult.elseTargets);
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    cleanProps[key] = val;
+                }
+            }
+            return { thenTargets, elseTargets, cleanProps, hasCrossKeys };
+        };
+
+        const extractCrossTargets = (node: any): {
+            thenTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            elseTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            cleanNode: any;
+        } => {
+            if (!node?.properties) {
+                return { thenTargets: [], elseTargets: [], cleanNode: node };
+            }
+            const result = extractCrossFromLevel(node, fields, []);
+            if (!result.hasCrossKeys) {
+                return { thenTargets: [], elseTargets: [], cleanNode: node };
+            }
+            const cleanNode: any = { ...node };
+            if (result.cleanProps && Object.keys(result.cleanProps).length) {
+                cleanNode.properties = result.cleanProps;
+                if (Array.isArray(node.required)) {
+                    cleanNode.required = node.required.filter((n: string) => n in result.cleanProps);
+                }
+            } else {
+                delete cleanNode.properties;
+                delete cleanNode.required;
+            }
+            return {
+                thenTargets: result.thenTargets,
+                elseTargets: result.elseTargets,
+                cleanNode: Object.keys(cleanNode).length ? cleanNode : null,
+            };
+        };
+
         const parseArray = (arr: any[]): SchemaCondition[] => {
             const out: SchemaCondition[] = [];
             for (const n of arr || []) {
@@ -342,9 +457,14 @@ export class SchemaHelper {
                     continue;
                 }
                 const ifCondition = toIfCondition(n.if);
-                const thenFields = buildFields(n.then);
-                const elseFields = buildFields(n.else);
-                out.push({ ifCondition, thenFields, elseFields });
+                const { thenTargets, elseTargets, cleanNode: cleanThen } = extractCrossTargets(n.then);
+                const { cleanNode: cleanElse } = extractCrossTargets(n.else);
+                const thenFields = buildFields(cleanThen);
+                const elseFields = buildFields(cleanElse);
+                const condition: any = { ifCondition, thenFields, elseFields };
+                if (thenTargets.length) { condition.thenTargets = thenTargets; }
+                if (elseTargets.length) { condition.elseTargets = elseTargets; }
+                out.push(condition as SchemaCondition);
             }
             return out;
         };
@@ -520,9 +640,18 @@ export class SchemaHelper {
             }
 
             const single = (p: SchemaFieldPredicate | { field: SchemaField; fieldValue: any }) => {
-                return {
-                    properties: { [p.field.name]: { const: p.fieldValue } }
+                const path = ('fieldPath' in p && p.fieldPath && p.fieldPath.length > 1)
+                    ? p.fieldPath
+                    : [p.field.name];
+                let node: any = { const: p.fieldValue };
+                for (let i = path.length - 1; i >= 0; i--) {
+                    const wrapper: any = { properties: { [path[i]]: node } };
+                    if (path.length > 1) {
+                        wrapper.required = [path[i]];
+                    }
+                    node = wrapper;
                 }
+                return node;
             };
 
             if ('field' in ic && 'fieldValue' in ic) {
@@ -556,6 +685,67 @@ export class SchemaHelper {
             return null;
         };
 
+        const deepMergeSchemaObj = (a: any, b: any): any => {
+            if (!a) { return b; }
+            if (!b) { return a; }
+            const result: any = { ...a };
+            for (const key of Object.keys(b)) {
+                if (key === 'properties') {
+                    result.properties = { ...(a.properties || {}) };
+                    for (const pk of Object.keys(b.properties)) {
+                        result.properties[pk] = (a.properties?.[pk] !== undefined)
+                            ? deepMergeSchemaObj(a.properties[pk], b.properties[pk])
+                            : b.properties[pk];
+                    }
+                } else if (key === 'required') {
+                    result.required = [...new Set([...(a.required || []), ...(b.required || [])])];
+                } else {
+                    result[key] = b[key];
+                }
+            }
+            return result;
+        };
+
+        // Build a nested JSON Schema object that requires the leaf field at each target's path.
+        const buildCrossRequired = (targets?: { fieldPath: string[] }[]): any | undefined => {
+            if (!targets?.length) { return undefined; }
+            const root: any = {};
+            for (const t of targets) {
+                const path = t.fieldPath;
+                if (!path || path.length < 2) { continue; }
+                let node = root;
+                for (let i = 0; i < path.length - 1; i++) {
+                    if (!node.properties) { node.properties = {}; }
+                    if (!node.properties[path[i]]) { node.properties[path[i]] = {}; }
+                    node = node.properties[path[i]];
+                }
+                const fieldName = path[path.length - 1];
+                if (!node.required) { node.required = []; }
+                if (!node.required.includes(fieldName)) { node.required.push(fieldName); }
+            }
+            return Object.keys(root).length ? root : undefined;
+        };
+
+        // Build a nested JSON Schema object that forbids the leaf field (property: false).
+        const buildCrossForbidden = (targets?: { fieldPath: string[] }[]): any | undefined => {
+            if (!targets?.length) { return undefined; }
+            const root: any = {};
+            for (const t of targets) {
+                const path = t.fieldPath;
+                if (!path || path.length < 2) { continue; }
+                let node = root;
+                for (let i = 0; i < path.length - 1; i++) {
+                    if (!node.properties) { node.properties = {}; }
+                    if (!node.properties[path[i]]) { node.properties[path[i]] = {}; }
+                    node = node.properties[path[i]];
+                }
+                const fieldName = path[path.length - 1];
+                if (!node.properties) { node.properties = {}; }
+                node.properties[fieldName] = false;
+            }
+            return Object.keys(root).length ? root : undefined;
+        };
+
         const serializeCondition = (cond: SchemaCondition) => {
             const ifNode = serializeIf(cond);
             if (!ifNode) {
@@ -569,8 +759,14 @@ export class SchemaHelper {
                 return Object.keys(props).length ? { properties: props, required: req } : undefined;
             };
 
-            const thenObj = buildSub(cond.thenFields);
-            const elseObj = buildSub(cond.elseFields);
+            const thenObj = deepMergeSchemaObj(
+                deepMergeSchemaObj(buildSub(cond.thenFields), buildCrossRequired(cond.thenTargets)),
+                buildCrossForbidden(cond.elseTargets)
+            );
+            const elseObj = deepMergeSchemaObj(
+                deepMergeSchemaObj(buildSub(cond.elseFields), buildCrossRequired(cond.elseTargets)),
+                buildCrossForbidden(cond.thenTargets)
+            );
 
             const obj: any = { if: ifNode };
             if (thenObj) {
@@ -593,6 +789,15 @@ export class SchemaHelper {
         }
 
         SchemaHelper.getFieldsFromObject(fields, document.required, document.properties, schema.contextURL);
+
+        const conditionFieldNames = new Set<string>();
+        for (const cond of (conditions || [])) {
+            for (const f of (cond.thenFields || [])) { conditionFieldNames.add(f.name); }
+            for (const f of (cond.elseFields || [])) { conditionFieldNames.add(f.name); }
+        }
+        if (conditionFieldNames.size && Array.isArray(document.required)) {
+            document.required = document.required.filter((name: string) => !conditionFieldNames.has(name));
+        }
 
         return document;
     }
@@ -857,7 +1062,7 @@ export class SchemaHelper {
      */
     public static findRefs(target: Schema, schemas: Schema[]) {
         const map = {};
-        const schemaMap = {
+        const schemaMap: Record<string, any> = {
             '#GeoJSON': geoJson,
             '#SentinelHUB': SentinelHubSchema
         };
@@ -869,25 +1074,69 @@ export class SchemaHelper {
                 map[field.type] = schemaMap[field.type];
             }
         }
-        return SchemaHelper.uniqueRefs(map, {});
+
+        const patchMap = SchemaHelper.buildCrossTargetPatchMap(target, schemaMap);
+        return SchemaHelper.uniqueRefs(map, {}, patchMap);
+    }
+
+    /**
+     * Build a map from sub-schema IRI → set of field names to strip from required,
+     * derived from cross-schema condition targets on the given schema.
+     */
+    private static buildCrossTargetPatchMap(
+        target: Schema,
+        schemaMap: Record<string, any>
+    ): Map<string, Set<string>> {
+        const patchMap = new Map<string, Set<string>>();
+        const fieldNameToIRI = new Map<string, string>();
+        for (const field of target.fields) {
+            if (field.isRef && field.type) {
+                fieldNameToIRI.set(field.name, field.type);
+            }
+        }
+        for (const condition of (target.conditions || [])) {
+            const allTargets = [
+                ...(condition.thenTargets || []),
+                ...(condition.elseTargets || []),
+            ];
+            for (const t of allTargets) {
+                const path = t.fieldPath;
+                if (!path || path.length < 2) { continue; }
+                // Walk the path to find the IRI of the schema that owns the leaf field.
+                let iri: string | undefined = fieldNameToIRI.get(path[0]);
+                for (let i = 1; i < path.length - 1 && iri; i++) {
+                    iri = schemaMap[iri]?.properties?.[path[i]]?.['$ref'];
+                }
+                if (!iri) { continue; }
+                const leaf = path[path.length - 1];
+                if (!patchMap.has(iri)) { patchMap.set(iri, new Set()); }
+                patchMap.get(iri)!.add(leaf);
+            }
+        }
+        return patchMap;
     }
 
     /**
      * Get unique refs
      * @param map
      * @param newMap
+     * @param patchMap fields to strip from required per schema IRI
      * @private
      */
-    private static uniqueRefs(map: any, newMap: any) {
+    private static uniqueRefs(map: any, newMap: any, patchMap?: Map<string, Set<string>>) {
         const keys = Object.keys(map);
         for (const iri of keys) {
             if (!newMap[iri]) {
                 const oldSchema = map[iri];
                 const newSchema = { ...oldSchema };
                 delete newSchema.$defs;
+                const toRemove = patchMap?.get(iri);
+                if (toRemove?.size && Array.isArray(newSchema.required)) {
+                    newSchema.required = newSchema.required.filter((r: string) => !toRemove.has(r));
+                }
                 newMap[iri] = newSchema;
                 if (oldSchema.$defs) {
-                    SchemaHelper.uniqueRefs(oldSchema.$defs, newMap);
+                    SchemaHelper.uniqueRefs(oldSchema.$defs, newMap, patchMap);
                 }
             }
         }

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -447,6 +447,9 @@ export class SchemaHelper {
             };
         };
 
+        const dedupeTargets = (targets: { field: SchemaField; fieldPath: string[] }[]) =>
+            [...new Map(targets.map(t => [t.fieldPath.join('.'), t])).values()];
+
         const parseArray = (arr: any[]): SchemaCondition[] => {
             const out: SchemaCondition[] = [];
             for (const n of arr || []) {
@@ -455,12 +458,18 @@ export class SchemaHelper {
                 }
                 const ifCondition = toIfCondition(n.if);
                 const { thenTargets, elseTargets, cleanNode: cleanThen } = extractCrossTargets(n.then);
-                const { cleanNode: cleanElse } = extractCrossTargets(n.else);
+                const {
+                    thenTargets: elseRequiredTargets,
+                    elseTargets: elseForbiddenTargets,
+                    cleanNode: cleanElse,
+                } = extractCrossTargets(n.else);
                 const thenFields = buildFields(cleanThen);
                 const elseFields = buildFields(cleanElse);
+                const allThenTargets = dedupeTargets([...thenTargets, ...elseForbiddenTargets]);
+                const allElseTargets = dedupeTargets([...elseTargets, ...elseRequiredTargets]);
                 const condition: any = { ifCondition, thenFields, elseFields };
-                if (thenTargets.length) { condition.thenTargets = thenTargets; }
-                if (elseTargets.length) { condition.elseTargets = elseTargets; }
+                if (allThenTargets.length) { condition.thenTargets = allThenTargets; }
+                if (allElseTargets.length) { condition.elseTargets = allElseTargets; }
                 out.push(condition as SchemaCondition);
             }
             return out;
@@ -520,6 +529,7 @@ export class SchemaHelper {
         const properties = Object.keys(document.properties);
         for (const name of properties) {
             const property = document.properties[name];
+            if (property === false) { continue; }
             if (!includeSystemProperties && property.readOnly) {
                 continue;
             }
@@ -641,11 +651,7 @@ export class SchemaHelper {
                     : [p.field.name];
                 let node: any = { const: p.fieldValue };
                 for (let i = path.length - 1; i >= 0; i--) {
-                    const wrapper: any = { properties: { [path[i]]: node } };
-                    if (path.length > 1) {
-                        wrapper.required = [path[i]];
-                    }
-                    node = wrapper;
+                    node = { properties: { [path[i]]: node }, required: [path[i]] };
                 }
                 return node;
             };
@@ -702,12 +708,13 @@ export class SchemaHelper {
             return result;
         };
 
-        const buildCrossRequired = (targets?: { fieldPath: string[] }[]): any | undefined => {
+        const buildCrossRequired = (targets?: { field: SchemaField; fieldPath: string[] }[]): any | undefined => {
             if (!targets?.length) { return undefined; }
             const root: any = {};
             for (const t of targets) {
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }
+                if (!t.field?.required) { continue; }
                 let node = root;
                 for (let i = 0; i < path.length - 1; i++) {
                     if (!node.properties) { node.properties = {}; }
@@ -740,6 +747,13 @@ export class SchemaHelper {
             return Object.keys(root).length ? root : undefined;
         };
 
+        const buildForbid = (sub?: SchemaField[]) => {
+            if (!sub?.length) { return undefined; }
+            const props: any = {};
+            for (const f of sub) { props[f.name] = false; }
+            return { properties: props };
+        };
+
         const serializeCondition = (cond: SchemaCondition) => {
             const ifNode = serializeIf(cond);
             if (!ifNode) {
@@ -758,10 +772,16 @@ export class SchemaHelper {
                 buildCrossForbidden(cond.elseTargets)
             );
             const elseObj = deepMergeSchemaObj(
-                deepMergeSchemaObj(buildSub(cond.elseFields), buildCrossRequired(cond.elseTargets)),
-                buildCrossForbidden(cond.thenTargets)
+                deepMergeSchemaObj(
+                    deepMergeSchemaObj(buildSub(cond.elseFields), buildCrossRequired(cond.elseTargets)),
+                    buildCrossForbidden(cond.thenTargets)
+                ),
+                buildForbid(cond.thenFields)
             );
 
+            if (!thenObj && !elseObj) {
+                return null;
+            }
             const obj: any = { if: ifNode };
             if (thenObj) {
                 obj.then = thenObj;

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -1105,68 +1105,25 @@ export class SchemaHelper {
             }
         }
 
-        const patchMap = SchemaHelper.buildCrossTargetPatchMap(target, schemaMap);
-        return SchemaHelper.uniqueRefs(map, {}, patchMap);
-    }
-
-    /**
-     * Build a map from sub-schema IRI → set of field names to strip from required,
-     * derived from cross-schema condition targets on the given schema.
-     */
-    private static buildCrossTargetPatchMap(
-        target: Schema,
-        schemaMap: Record<string, any>
-    ): Map<string, Set<string>> {
-        const patchMap = new Map<string, Set<string>>();
-        const fieldByName = new Map<string, SchemaField>();
-        for (const field of target.fields) {
-            if (field.isRef && field.type) {
-                fieldByName.set(field.name, field);
-            }
-        }
-        for (const condition of (target.conditions || [])) {
-            const allTargets = [
-                ...(condition.thenTargets || []),
-                ...(condition.elseTargets || []),
-            ];
-            for (const t of allTargets) {
-                const path = t.fieldPath;
-                if (!path || path.length < 2) { continue; }
-                let currentField: SchemaField | undefined = fieldByName.get(path[0]);
-                for (let i = 1; i < path.length - 1 && currentField; i++) {
-                    currentField = currentField.fields?.find(f => f.name === path[i] && f.isRef);
-                }
-                const iri = currentField?.type;
-                if (!iri) { continue; }
-                const leaf = path[path.length - 1];
-                if (!patchMap.has(iri)) { patchMap.set(iri, new Set()); }
-                patchMap.get(iri)!.add(leaf);
-            }
-        }
-        return patchMap;
+        return SchemaHelper.uniqueRefs(map, {});
     }
 
     /**
      * Get unique refs
      * @param map
      * @param newMap
-     * @param patchMap fields to strip from required per schema IRI
      * @private
      */
-    private static uniqueRefs(map: any, newMap: any, patchMap?: Map<string, Set<string>>) {
+    private static uniqueRefs(map: any, newMap: any) {
         const keys = Object.keys(map);
         for (const iri of keys) {
             if (!newMap[iri]) {
                 const oldSchema = map[iri];
                 const newSchema = { ...oldSchema };
                 delete newSchema.$defs;
-                const toRemove = patchMap?.get(iri);
-                if (toRemove?.size && Array.isArray(newSchema.required)) {
-                    newSchema.required = newSchema.required.filter((r: string) => !toRemove.has(r));
-                }
                 newMap[iri] = newSchema;
                 if (oldSchema.$defs) {
-                    SchemaHelper.uniqueRefs(oldSchema.$defs, newMap, patchMap);
+                    SchemaHelper.uniqueRefs(oldSchema.$defs, newMap);
                 }
             }
         }

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -359,13 +359,13 @@ export class SchemaHelper {
             refFieldsAtLevel: SchemaField[],
             pathPrefix: string[],
         ): {
-            thenTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
-            elseTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            thenTargets: { field: SchemaField; fieldPath: string[] }[];
+            elseTargets: { field: SchemaField; fieldPath: string[] }[];
             cleanProps: any;
             hasCrossKeys: boolean;
         } => {
-            const thenTargets: Array<{ field: SchemaField; fieldPath: string[] }> = [];
-            const elseTargets: Array<{ field: SchemaField; fieldPath: string[] }> = [];
+            const thenTargets: { field: SchemaField; fieldPath: string[] }[] = [];
+            const elseTargets: { field: SchemaField; fieldPath: string[] }[] = [];
             const cleanProps: any = {};
             let hasCrossKeys = false;
 
@@ -419,8 +419,8 @@ export class SchemaHelper {
         };
 
         const extractCrossTargets = (node: any): {
-            thenTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
-            elseTargets: Array<{ field: SchemaField; fieldPath: string[] }>;
+            thenTargets: { field: SchemaField; fieldPath: string[] }[];
+            elseTargets: { field: SchemaField; fieldPath: string[] }[];
             cleanNode: any;
         } => {
             if (!node?.properties) {
@@ -1119,7 +1119,7 @@ export class SchemaHelper {
                 let iri: string | undefined = fieldNameToIRI.get(path[0]);
                 for (let i = 1; i < path.length - 1 && iri; i++) {
                     const prop = schemaMap[iri]?.properties?.[path[i]];
-                    iri = prop?.['$ref'] ?? prop?.items?.['$ref'];
+                    iri = prop?.$ref ?? prop?.items?.$ref;
                 }
                 if (!iri) { continue; }
                 const leaf = path[path.length - 1];

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -819,7 +819,14 @@ export class SchemaHelper {
             for (const f of (cond.elseFields || [])) { conditionFieldNames.add(f.name); }
         }
         if (conditionFieldNames.size && Array.isArray(document.required)) {
-            document.required = document.required.filter((name: string) => !conditionFieldNames.has(name));
+            const fieldNameCount = new Map<string, number>();
+            for (const f of (fields || [])) {
+                fieldNameCount.set(f.name, (fieldNameCount.get(f.name) ?? 0) + 1);
+            }
+            document.required = document.required.filter(
+                (name: string) =>
+                    !conditionFieldNames.has(name) || (fieldNameCount.get(name) ?? 0) > 1
+            );
         }
 
         return document;

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -778,14 +778,14 @@ export class SchemaHelper {
                     deepMergeSchemaObj(buildSub(cond.thenFields), buildCrossRequired(cond.thenTargets)),
                     buildCrossForbidden(cond.elseTargets)
                 ),
-                buildForbid(cond.elseFields)
+                buildForbid(cond.elseFields?.filter(f => !cond.thenFields?.some(t => t.name === f.name)))
             );
             const elseObj = deepMergeSchemaObj(
                 deepMergeSchemaObj(
                     deepMergeSchemaObj(buildSub(cond.elseFields), buildCrossRequired(cond.elseTargets)),
                     buildCrossForbidden(cond.thenTargets)
                 ),
-                buildForbid(cond.thenFields)
+                buildForbid(cond.thenFields?.filter(f => !cond.elseFields?.some(t => t.name === f.name)))
             );
 
             if (!thenObj && !elseObj) {
@@ -1118,10 +1118,10 @@ export class SchemaHelper {
         schemaMap: Record<string, any>
     ): Map<string, Set<string>> {
         const patchMap = new Map<string, Set<string>>();
-        const fieldNameToIRI = new Map<string, string>();
+        const fieldByName = new Map<string, SchemaField>();
         for (const field of target.fields) {
             if (field.isRef && field.type) {
-                fieldNameToIRI.set(field.name, field.type);
+                fieldByName.set(field.name, field);
             }
         }
         for (const condition of (target.conditions || [])) {
@@ -1132,11 +1132,11 @@ export class SchemaHelper {
             for (const t of allTargets) {
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }
-                let iri: string | undefined = fieldNameToIRI.get(path[0]);
-                for (let i = 1; i < path.length - 1 && iri; i++) {
-                    const prop = schemaMap[iri]?.properties?.[path[i]];
-                    iri = prop?.$ref ?? prop?.items?.$ref;
+                let currentField: SchemaField | undefined = fieldByName.get(path[0]);
+                for (let i = 1; i < path.length - 1 && currentField; i++) {
+                    currentField = currentField.fields?.find(f => f.name === path[i] && f.isRef);
                 }
+                const iri = currentField?.type;
                 if (!iri) { continue; }
                 const leaf = path[path.length - 1];
                 if (!patchMap.has(iri)) { patchMap.set(iri, new Set()); }

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -706,6 +706,12 @@ export class SchemaHelper {
                     result[key] = b[key];
                 }
             }
+            if (Array.isArray(result.required) && result.properties) {
+                result.required = result.required.filter(
+                    (name: string) => result.properties[name] !== false
+                );
+                if (result.required.length === 0) { delete result.required; }
+            }
             return result;
         };
 

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -768,8 +768,11 @@ export class SchemaHelper {
             };
 
             const thenObj = deepMergeSchemaObj(
-                deepMergeSchemaObj(buildSub(cond.thenFields), buildCrossRequired(cond.thenTargets)),
-                buildCrossForbidden(cond.elseTargets)
+                deepMergeSchemaObj(
+                    deepMergeSchemaObj(buildSub(cond.thenFields), buildCrossRequired(cond.thenTargets)),
+                    buildCrossForbidden(cond.elseTargets)
+                ),
+                buildForbid(cond.elseFields)
             );
             const elseObj = deepMergeSchemaObj(
                 deepMergeSchemaObj(

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -381,7 +381,6 @@ export class SchemaHelper {
                     hasCrossKeys = true;
                     const childPath = [...pathPrefix, key];
                     const childFields: SchemaField[] = (refField as any).fields || [];
-                    // Direct required targets (leaf one level inside this ref)
                     if (Array.isArray(val.required)) {
                         for (const fieldName of val.required) {
                             const childField = childFields.find(f => f.name === fieldName);
@@ -390,7 +389,6 @@ export class SchemaHelper {
                             }
                         }
                     }
-                    // Properties: either forbidden (=== false) or deeper nesting (recurse)
                     if (val.properties) {
                         for (const fieldName of Object.keys(val.properties)) {
                             const subVal = val.properties[fieldName];
@@ -400,7 +398,6 @@ export class SchemaHelper {
                                     elseTargets.push({ field: childField, fieldPath: [...childPath, fieldName] });
                                 }
                             } else {
-                                // Recurse if this is another ref field at the child level
                                 const subRefField = childFields.find(f => f.name === fieldName && f.isRef);
                                 if (subRefField) {
                                     const subResult = extractCrossFromLevel(
@@ -550,7 +547,6 @@ export class SchemaHelper {
                     });
                 }
                 const subSchema = schemaCache.get(field.type);
-                // Clone schema field array to avoid path mutations
                 field.fields = SchemaHelper.cloneFields(subSchema.fields);
                 field.conditions = subSchema.conditions;
             }
@@ -706,7 +702,6 @@ export class SchemaHelper {
             return result;
         };
 
-        // Build a nested JSON Schema object that requires the leaf field at each target's path.
         const buildCrossRequired = (targets?: { fieldPath: string[] }[]): any | undefined => {
             if (!targets?.length) { return undefined; }
             const root: any = {};
@@ -726,7 +721,6 @@ export class SchemaHelper {
             return Object.keys(root).length ? root : undefined;
         };
 
-        // Build a nested JSON Schema object that forbids the leaf field (property: false).
         const buildCrossForbidden = (targets?: { fieldPath: string[] }[]): any | undefined => {
             if (!targets?.length) { return undefined; }
             const root: any = {};
@@ -1102,7 +1096,6 @@ export class SchemaHelper {
             for (const t of allTargets) {
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }
-                // Walk the path to find the IRI of the schema that owns the leaf field.
                 let iri: string | undefined = fieldNameToIRI.get(path[0]);
                 for (let i = 1; i < path.length - 1 && iri; i++) {
                     iri = schemaMap[iri]?.properties?.[path[i]]?.['$ref'];

--- a/interfaces/src/helpers/schema-json.ts
+++ b/interfaces/src/helpers/schema-json.ts
@@ -378,7 +378,7 @@ export class SchemaToJson {
             }
             json.if.AND = ic.AND
                 .filter((p: any) => p?.field?.name !== undefined)
-                .map((p: any) => ({ field: p.field.name, value: p.fieldValue }));
+                .map((p: any) => ({ field: p.field.name, fieldValue: p.fieldValue }));
             return json;
         }
 

--- a/interfaces/src/helpers/schema-json.ts
+++ b/interfaces/src/helpers/schema-json.ts
@@ -60,17 +60,25 @@ export interface IFieldJson {
 export interface IIfRuleJson {
     field: string;
     fieldValue: any;
+    fieldPath?: string[];
+}
+
+export interface IConditionTargetJson {
+    fieldPath: string[];
 }
 
 export interface IConditionJson {
     if: {
         field?: string;
         fieldValue?: any;
+        fieldPath?: string[];
         AND?: IIfRuleJson[];
         OR?: IIfRuleJson[];
     },
     then: IFieldJson[],
-    else: IFieldJson[]
+    else: IFieldJson[],
+    thenTargets?: IConditionTargetJson[],
+    elseTargets?: IConditionTargetJson[],
 }
 
 export interface ISchemaJson {
@@ -368,17 +376,31 @@ export class SchemaToJson {
             }
         }
 
+        if (condition.thenTargets?.length) {
+            json.thenTargets = condition.thenTargets.map(t => ({ fieldPath: t.fieldPath }));
+        }
+        if (condition.elseTargets?.length) {
+            json.elseTargets = condition.elseTargets.map(t => ({ fieldPath: t.fieldPath }));
+        }
+
         const ic: any = condition.ifCondition;
+
+        const serializePredicate = (p: any): IIfRuleJson => {
+            const r: IIfRuleJson = { field: p.field.name, fieldValue: p.fieldValue };
+            if (p.fieldPath?.length > 1) { r.fieldPath = p.fieldPath; }
+            return r;
+        };
 
         if (ic?.AND && Array.isArray(ic.AND)) {
             if (ic.AND.length === 1) {
                 json.if.field = ic.AND[0]?.field?.name;
                 json.if.fieldValue = ic.AND[0]?.fieldValue;
+                if (ic.AND[0]?.fieldPath?.length > 1) { json.if.fieldPath = ic.AND[0].fieldPath; }
                 return json;
             }
             json.if.AND = ic.AND
                 .filter((p: any) => p?.field?.name !== undefined)
-                .map((p: any) => ({ field: p.field.name, fieldValue: p.fieldValue }));
+                .map(serializePredicate);
             return json;
         }
 
@@ -386,31 +408,34 @@ export class SchemaToJson {
             if (ic.OR.length === 1) {
                 json.if.field = ic.OR[0]?.field?.name;
                 json.if.fieldValue = ic.OR[0]?.fieldValue;
+                if (ic.OR[0]?.fieldPath?.length > 1) { json.if.fieldPath = ic.OR[0].fieldPath; }
                 return json;
             }
             json.if.OR = ic.OR
                 .filter((p: any) => p?.field?.name !== undefined)
-                .map((p: any) => ({ field: p.field.name, fieldValue: p.fieldValue }));
+                .map(serializePredicate);
             return json;
         }
 
         if (ic?.field?.name !== undefined) {
             json.if.field = ic.field.name;
             json.if.fieldValue = ic.fieldValue;
+            if (ic.fieldPath?.length > 1) { json.if.fieldPath = ic.fieldPath; }
             return json;
         }
         if (Array.isArray(ic?.predicates) && ic.predicates.length) {
             if (ic.predicates.length === 1) {
                 json.if.field = ic.predicates[0].field?.name;
                 json.if.fieldValue = ic.predicates[0].fieldValue;
+                if (ic.predicates[0]?.fieldPath?.length > 1) { json.if.fieldPath = ic.predicates[0].fieldPath; }
             } else if (ic.op === 'ANY_OF') {
                 json.if.OR = ic.predicates
                     .filter((p: any) => p?.field?.name !== undefined)
-                    .map((p: any) => ({ field: p.field.name, fieldValue: p.fieldValue }));
+                    .map(serializePredicate);
             } else {
                 json.if.AND = ic.predicates
                     .filter((p: any) => p?.field?.name !== undefined)
-                    .map((p: any) => ({ field: p.field.name, fieldValue: p.fieldValue }));
+                    .map(serializePredicate);
             }
             return json;
         }
@@ -1137,12 +1162,51 @@ export class JsonToSchema {
         return target;
     }
 
+    private static resolveFieldByPath(
+        path: string[],
+        fields: SchemaField[],
+        context: ErrorContext
+    ): SchemaField {
+        let current = fields;
+        let field: SchemaField | undefined;
+        for (let i = 0; i < path.length; i++) {
+            field = current.find(f => f.name === path[i]);
+            if (!field) {
+                throw JsonToSchema.createErrorWithValue(
+                    context.setMessage(JsonError.INVALID_FORMAT, JsonErrorMessage.REF),
+                    path[i]
+                );
+            }
+            if (i < path.length - 1) {
+                current = field.fields || [];
+            }
+        }
+        return field!;
+    }
+
     private static fromCondIf(
         value: IConditionJson,
         fields: SchemaField[],
         context: ErrorContext
     ): SchemaCondition['ifCondition'] {
         const ifCtx = context.add('if');
+
+        const resolvePredicateField = (
+            fieldName: string | undefined,
+            fp: string[] | undefined,
+            ctx: ErrorContext
+        ): SchemaField => fp?.length > 1
+            ? JsonToSchema.resolveFieldByPath(fp, fields, ctx)
+            : JsonToSchema.resolveFieldByName(fieldName, fields, ctx);
+
+        const buildPredicate = (p: IIfRuleJson, ctx: ErrorContext): any => {
+            const pred: any = {
+                field: resolvePredicateField(p.field, p.fieldPath, ctx),
+                fieldValue: p.fieldValue,
+            };
+            if (p.fieldPath?.length > 1) { pred.fieldPath = p.fieldPath; }
+            return pred;
+        };
 
         if (Array.isArray(value?.if?.AND)) {
             const andArr = value.if.AND;
@@ -1152,18 +1216,10 @@ export class JsonToSchema {
                 );
             }
             if (andArr.length === 1) {
-                const p = andArr[0];
-                const field = JsonToSchema.resolveFieldByName(p?.field, fields, ifCtx.add('AND').add('[0]').add('field'));
-                return {
-                    field,
-                    fieldValue: p.fieldValue
-                } as any;
+                return buildPredicate(andArr[0], ifCtx.add('AND').add('[0]')) as any;
             }
             return {
-                AND: andArr.map((p, idx) => ({
-                    field: JsonToSchema.resolveFieldByName(p?.field, fields, ifCtx.add('AND').add(`[${idx}]`).add('field')),
-                    fieldValue: p?.fieldValue
-                }))
+                AND: andArr.map((p, idx) => buildPredicate(p, ifCtx.add('AND').add(`[${idx}]`)))
             } as any;
         }
 
@@ -1175,28 +1231,20 @@ export class JsonToSchema {
                 );
             }
             if (orArr.length === 1) {
-                const p = orArr[0];
-                const field = JsonToSchema.resolveFieldByName(p?.field, fields, ifCtx.add('OR').add('[0]').add('field'));
-                return {
-                    field,
-                    fieldValue: p.fieldValue
-                } as any;
+                return buildPredicate(orArr[0], ifCtx.add('OR').add('[0]')) as any;
             }
             return {
-                OR: orArr.map((p, idx) => ({
-                    field: JsonToSchema.resolveFieldByName(p?.field, fields, ifCtx.add('OR').add(`[${idx}]`).add('field')),
-                    fieldValue: p?.fieldValue
-                }))
+                OR: orArr.map((p, idx) => buildPredicate(p, ifCtx.add('OR').add(`[${idx}]`)))
             } as any;
         }
 
+        const fp = value?.if?.fieldPath;
         const fieldName = value?.if?.field;
         const val = value?.if?.fieldValue;
-        const target = JsonToSchema.resolveFieldByName(fieldName, fields, ifCtx.add('field'));
-        return {
-            field: target,
-            fieldValue: val
-        } as any;
+        const target = resolvePredicateField(fieldName, fp, ifCtx.add('field'));
+        const single: any = { field: target, fieldValue: val };
+        if (fp?.length > 1) { single.fieldPath = fp; }
+        return single as any;
     }
 
     private static fromCondFields(
@@ -1239,11 +1287,6 @@ export class JsonToSchema {
         } else {
             elseFields = [];
         }
-        if (thenFields.length === 0 && elseFields.length === 0) {
-            throw JsonToSchema.createError(
-                context.setMessage(JsonError.THEN_ELSE)
-            );
-        }
         return {
             then: thenFields,
             else: elseFields
@@ -1261,10 +1304,32 @@ export class JsonToSchema {
         context = context.add(`[${index}]`);
         const ifCondition = JsonToSchema.fromCondIf(value, fields, context);
         const { then, else: _else } = JsonToSchema.fromCondFields(value, all, entity, new Set<string>(), context);
+
+        const thenTargets = (value.thenTargets || [])
+            .filter(t => Array.isArray(t.fieldPath) && t.fieldPath.length >= 2)
+            .map(t => ({
+                fieldPath: t.fieldPath,
+                field: JsonToSchema.resolveFieldByPath(t.fieldPath, fields, context.add('thenTargets')),
+            }));
+        const elseTargets = (value.elseTargets || [])
+            .filter(t => Array.isArray(t.fieldPath) && t.fieldPath.length >= 2)
+            .map(t => ({
+                fieldPath: t.fieldPath,
+                field: JsonToSchema.resolveFieldByPath(t.fieldPath, fields, context.add('elseTargets')),
+            }));
+
+        if (then.length === 0 && _else.length === 0 && thenTargets.length === 0 && elseTargets.length === 0) {
+            throw JsonToSchema.createError(
+                context.setMessage(JsonError.THEN_ELSE)
+            );
+        }
+
         const condition: SchemaCondition = {
             ifCondition,
             thenFields: then,
-            elseFields: _else
+            elseFields: _else,
+            thenTargets: thenTargets.length ? thenTargets : undefined,
+            elseTargets: elseTargets.length ? elseTargets : undefined,
         } as any;
         return condition;
     }

--- a/interfaces/src/helpers/schema-json.ts
+++ b/interfaces/src/helpers/schema-json.ts
@@ -1238,12 +1238,12 @@ export class JsonToSchema {
             } as any;
         }
 
-        const fp = value?.if?.fieldPath;
-        const fieldName = value?.if?.field;
+        const ifFieldPath = value?.if?.fieldPath;
+        const ifField = value?.if?.field;
         const val = value?.if?.fieldValue;
-        const target = resolvePredicateField(fieldName, fp, ifCtx.add('field'));
+        const target = resolvePredicateField(ifField, ifFieldPath, ifCtx.add('field'));
         const single: any = { field: target, fieldValue: val };
-        if (fp?.length > 1) { single.fieldPath = fp; }
+        if (ifFieldPath?.length > 1) { single.fieldPath = ifFieldPath; }
         return single as any;
     }
 

--- a/interfaces/src/interface/schema-condition.interface.ts
+++ b/interfaces/src/interface/schema-condition.interface.ts
@@ -1,11 +1,5 @@
 import { SchemaField } from './schema-field.interface.js';
 
-/**
- * A cross-schema condition target: a field that lives inside a nested sub-schema
- * and is controlled by a parent schema's condition (not defined at the parent level).
- * fieldPath is the full path from the parent schema root to the leaf field,
- * e.g. ['fieldC_ref', 'NumberC'].
- */
 export interface SchemaConditionTarget {
   field: SchemaField;
   fieldPath: string[];

--- a/interfaces/src/interface/schema-condition.interface.ts
+++ b/interfaces/src/interface/schema-condition.interface.ts
@@ -1,20 +1,34 @@
 import { SchemaField } from './schema-field.interface.js';
 
 /**
+ * A cross-schema condition target: a field that lives inside a nested sub-schema
+ * and is controlled by a parent schema's condition (not defined at the parent level).
+ * fieldPath is the full path from the parent schema root to the leaf field,
+ * e.g. ['fieldC_ref', 'NumberC'].
+ */
+export interface SchemaConditionTarget {
+  field: SchemaField;
+  fieldPath: string[];
+}
+
+/**
  * Schema condition
  */
 export interface SchemaCondition {
   ifCondition: (
-    { field: SchemaField; fieldValue: any } |
+    SchemaFieldPredicate |
     { AND: SchemaFieldPredicate[] } |
     { OR: SchemaFieldPredicate[] }
   );
   thenFields: SchemaField[];
   elseFields: SchemaField[];
+  thenTargets?: SchemaConditionTarget[];
+  elseTargets?: SchemaConditionTarget[];
   errors?: any[];
 }
 
 export interface SchemaFieldPredicate {
   field: SchemaField;
   fieldValue: any;
+  fieldPath?: string[];
 }

--- a/interfaces/src/interface/schema-document.interface.ts
+++ b/interfaces/src/interface/schema-document.interface.ts
@@ -75,7 +75,7 @@ export interface ISchemaDocument {
      * Properties
      */
     properties?: {
-        [x: string]: ISchemaDocument;
+        [x: string]: ISchemaDocument | false;
     }
     /**
      * Required fields


### PR DESCRIPTION
### Description
- Added fieldPath and cross-schema targets to ISchemaCondition interface
- Added support for nested fieldPath and cross-schema condition targets
- Added cross-schema condition editor to the schema configuration UI
- Added cross-schema condition import and export for XLSX
- Improved schema validation error messages for condition failures
- Improved condition UX in the schema editor
- Fixed required fields API validation

### Related issue(s)
Resolves: [#4907](https://github.com/hashgraph/guardian/issues/4907)
