### PR TITLE
fix(policy-service): surface customLogicBlock errors to the UI instead of swallowing them

### DIFF
--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -138,10 +138,8 @@ export class CustomLogicBlock {
         } catch (error) {
             const message = PolicyUtils.getErrorMessage(error);
             ref.error(message);
-            // Surface the failure to the UI as well. This local try/catch otherwise
-            // pre-empts the @CatchErrors decorator, which is what normally broadcasts block
-            // errors to the frontend via BlockErrorFn / errorBlockEvent — so without this the
-            // error is logged server-side only and the user sees nothing.
+            // Also surface to the UI: this local catch pre-empts @CatchErrors, which would
+            // otherwise broadcast the failure via BlockErrorFn. Without it the error is logged only.
             PolicyComponentsUtils.BlockErrorFn(ref.blockType, message, event.user)
                 .catch((broadcastError) => ref.error(PolicyUtils.getErrorMessage(broadcastError)));
             ref.triggerEvents(PolicyOutputEventType.ErrorEvent, event.user, event.data, event.actionStatus);

--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -136,7 +136,15 @@ export class CustomLogicBlock {
             await this.execute(event.data, event.user, triggerEvents, event?.user?.userId, event.actionStatus);
             ref.backup();
         } catch (error) {
-            ref.error(PolicyUtils.getErrorMessage(error));
+            const message = PolicyUtils.getErrorMessage(error);
+            ref.error(message);
+            // Surface the failure to the UI as well. This local try/catch otherwise
+            // pre-empts the @CatchErrors decorator, which is what normally broadcasts block
+            // errors to the frontend via BlockErrorFn / errorBlockEvent — so without this the
+            // error is logged server-side only and the user sees nothing.
+            PolicyComponentsUtils.BlockErrorFn(ref.blockType, message, event.user)
+                .catch((broadcastError) => ref.error(PolicyUtils.getErrorMessage(broadcastError)));
+            ref.triggerEvents(PolicyOutputEventType.ErrorEvent, event.user, event.data, event.actionStatus);
         }
 
         return event.data;

--- a/policy-service/tests/unit-tests/blocks/custom-logic-error-surfacing.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/custom-logic-error-surfacing.test.mjs
@@ -4,15 +4,8 @@ import { CustomLogicBlock } from '../../../dist/policy-engine/blocks/custom-logi
 import { PolicyComponentsUtils } from '../../../dist/policy-engine/policy-components-utils.js';
 import { PolicyOutputEventType } from '../../../dist/policy-engine/interfaces/index.js';
 
-/**
- * customLogicBlock must surface execution errors to the UI, not swallow them.
- *
- * runAction wraps execute() in a local try/catch. Previously that catch only called
- * ref.error() (server logger) and returned, pre-empting the @CatchErrors decorator
- * that broadcasts block errors to the frontend via BlockErrorFn — so failures (e.g.
- * an output VC failing schema validation) were logged server-side only and the user
- * saw nothing. The fix additionally calls BlockErrorFn(...) and triggers an ErrorEvent.
- */
+// customLogicBlock must surface execution errors to the UI (via BlockErrorFn / ErrorEvent),
+// not just log them server-side. See #6271.
 describe('@unit customLogicBlock error surfacing', () => {
     let origBlockErrorFn;
     let uiErrors;
@@ -35,7 +28,6 @@ describe('@unit customLogicBlock error surfacing', () => {
         });
         const events = [];
         block.triggerEvents = async (...a) => { events.push(a); };
-        // simulate execute() throwing the way verifySubject() does on schema failure
         block.execute = async () => {
             throw new Error('{"type":"JSON_SCHEMA_VALIDATION_ERROR","details":[{"message":"must be number"}]}');
         };

--- a/policy-service/tests/unit-tests/blocks/custom-logic-error-surfacing.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/custom-logic-error-surfacing.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { makeBlock, makeUser } from './_block-exec-harness.mjs';
+import { CustomLogicBlock } from '../../../dist/policy-engine/blocks/custom-logic-block.js';
+import { PolicyComponentsUtils } from '../../../dist/policy-engine/policy-components-utils.js';
+import { PolicyOutputEventType } from '../../../dist/policy-engine/interfaces/index.js';
+
+/**
+ * customLogicBlock must surface execution errors to the UI, not swallow them.
+ *
+ * runAction wraps execute() in a local try/catch. Previously that catch only called
+ * ref.error() (server logger) and returned, pre-empting the @CatchErrors decorator
+ * that broadcasts block errors to the frontend via BlockErrorFn — so failures (e.g.
+ * an output VC failing schema validation) were logged server-side only and the user
+ * saw nothing. The fix additionally calls BlockErrorFn(...) and triggers an ErrorEvent.
+ */
+describe('@unit customLogicBlock error surfacing', () => {
+    let origBlockErrorFn;
+    let uiErrors;
+
+    beforeEach(() => {
+        uiErrors = [];
+        origBlockErrorFn = PolicyComponentsUtils.BlockErrorFn;
+        PolicyComponentsUtils.BlockErrorFn = async (blockType, message, user) => {
+            uiErrors.push({ blockType, message, user });
+        };
+    });
+
+    afterEach(() => {
+        PolicyComponentsUtils.BlockErrorFn = origBlockErrorFn;
+    });
+
+    function setup() {
+        const { block, components } = makeBlock(CustomLogicBlock, {
+            options: { onErrorAction: 'no-action' },
+        });
+        const events = [];
+        block.triggerEvents = async (...a) => { events.push(a); };
+        // simulate execute() throwing the way verifySubject() does on schema failure
+        block.execute = async () => {
+            throw new Error('{"type":"JSON_SCHEMA_VALIDATION_ERROR","details":[{"message":"must be number"}]}');
+        };
+        return { block, components, events };
+    }
+
+    const makeEvent = () => ({
+        data: { data: { foo: 1 } },
+        user: makeUser({ userId: 'u1' }),
+        actionStatus: {},
+    });
+
+    it('writes the execution error to the server logger', async () => {
+        const { block, components } = setup();
+        await block.runAction(makeEvent());
+        const errs = components.__logs.filter(([level]) => level === 'error');
+        assert.equal(errs.length, 1);
+        assert.match(errs[0][1], /JSON_SCHEMA_VALIDATION_ERROR/);
+    });
+
+    it('does not rethrow — the caller sees a normal return', async () => {
+        const { block } = setup();
+        await assert.doesNotReject(() => block.runAction(makeEvent()));
+    });
+
+    it('surfaces the error to the UI via BlockErrorFn', async () => {
+        const { block } = setup();
+        await block.runAction(makeEvent());
+        assert.equal(uiErrors.length, 1, 'block error broadcast to the UI exactly once');
+        assert.equal(uiErrors[0].blockType, 'customLogicBlock');
+        assert.match(uiErrors[0].message, /JSON_SCHEMA_VALIDATION_ERROR/);
+    });
+
+    it('triggers an ErrorEvent and no RunEvent (flow stops, error routed)', async () => {
+        const { block, events } = setup();
+        await block.runAction(makeEvent());
+        const types = events.map((e) => e[0]);
+        assert.ok(types.includes(PolicyOutputEventType.ErrorEvent), 'ErrorEvent is triggered');
+        assert.ok(!types.includes(PolicyOutputEventType.RunEvent), 'no RunEvent — output document does not propagate on failure');
+    });
+});


### PR DESCRIPTION
### Issue

Closes #6271.

### Problem

When a `customLogicBlock` throws during execution (for example, the generated output VC fails schema validation), the error is **caught internally, logged, and swallowed** — it never reaches the frontend. The user sees no error, the document simply stops progressing, and the only trace is a server-side log entry.

The engine already has a UI error channel: the `@CatchErrors` decorator's default/`no-action` path calls `PolicyComponentsUtils.BlockErrorFn(...)` → `errorBlockEvent` → `BLOCK_UPDATE_BROADCAST(type:'error')` → frontend. But `customLogicBlock.runAction` wraps `execute()` in its **own** `try/catch` that only calls `ref.error()` (logger) and returns — so the error never propagates to `@CatchErrors`, and `BlockErrorFn` is never invoked. Most other blocks let errors propagate to `@CatchErrors` and therefore do surface to the UI; `customLogicBlock` is the outlier.

`policy-service/src/policy-engine/blocks/custom-logic-block.ts` (before):
```ts
} catch (error) {
    ref.error(PolicyUtils.getErrorMessage(error));   // logger only, then swallowed
}
return event.data;
```

### Fix

In the catch, in addition to logging, broadcast the error to the UI and route it as an `ErrorEvent` — mirroring what `@CatchErrors` would have done — without rethrowing, so the existing graceful-stop flow semantics are preserved:

```ts
} catch (error) {
    const message = PolicyUtils.getErrorMessage(error);
    ref.error(message);
    PolicyComponentsUtils.BlockErrorFn(ref.blockType, message, event.user)
        .catch((broadcastError) => ref.error(PolicyUtils.getErrorMessage(broadcastError)));
    ref.triggerEvents(PolicyOutputEventType.ErrorEvent, event.user, event.data, event.actionStatus);
}
return event.data;
```

### Test

Adds `policy-service/tests/unit-tests/blocks/custom-logic-error-surfacing.test.mjs`, using the existing `_block-exec-harness.mjs`. It asserts the execution error is:
- written to the server logger,
- not rethrown,
- broadcast to the UI via `BlockErrorFn`,
- routed as an `ErrorEvent` (and **not** a `RunEvent`).

Verified locally against `develop`:
```
✔ writes the execution error to the server logger
✔ does not rethrow — the caller sees a normal return
✔ surfaces the error to the UI via BlockErrorFn
✔ triggers an ErrorEvent and no RunEvent (flow stops, error routed)
4 passing
```
With the fix reverted, the `BlockErrorFn` and `ErrorEvent` assertions fail — confirming the test guards the regression.

### How to reproduce (manually)

1. A policy with a `customLogicBlock` whose script produces an output VC that fails its `outputSchema` (e.g. a numeric field computed as `NaN`/`undefined` → serializes to `null`).
2. Run the policy to that block.
3. Before: server log shows `JSON_SCHEMA_VALIDATION_ERROR` ("must be number"), UI shows nothing, flow stalls. After: the error is broadcast to the UI.