### PR TITLE
feat: restore BbsBlsSignature2020 (EVC) signing

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -34,6 +34,7 @@
         "geotiff": "^2.1.4-beta.0",
         "js-base64": "^3.6.1",
         "jsonld-signatures": "11.5.0",
+        "jsonld-signatures-v7": "npm:jsonld-signatures@7.0.0",
         "jszip": "^3.7.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",

--- a/common/src/hedera-modules/document-loader/contexts/jws-2020-v1.ts
+++ b/common/src/hedera-modules/document-loader/contexts/jws-2020-v1.ts
@@ -1,0 +1,85 @@
+// Vendored from https://w3id.org/security/suites/jws-2020/v1 (W3C CCG,
+// resolves to https://w3c.github.io/vc-jws-2020/contexts/v1/).
+// The @digitalbazaar context packages do not ship this context, but the
+// @mattrglobal BBS verify path frames the verification method against it.
+
+export const JWS_2020_V1_URL = 'https://w3id.org/security/suites/jws-2020/v1';
+
+export const JWS_2020_V1_CONTEXT = {
+    '@context': {
+        privateKeyJwk: {
+            '@id': 'https://w3id.org/security#privateKeyJwk',
+            '@type': '@json',
+        },
+        JsonWebKey2020: {
+            '@id': 'https://w3id.org/security#JsonWebKey2020',
+            '@context': {
+                '@protected': true,
+                id: '@id',
+                type: '@type',
+                publicKeyJwk: {
+                    '@id': 'https://w3id.org/security#publicKeyJwk',
+                    '@type': '@json',
+                },
+            },
+        },
+        JsonWebSignature2020: {
+            '@id': 'https://w3id.org/security#JsonWebSignature2020',
+            '@context': {
+                '@protected': true,
+                id: '@id',
+                type: '@type',
+                challenge: 'https://w3id.org/security#challenge',
+                created: {
+                    '@id': 'http://purl.org/dc/terms/created',
+                    '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+                },
+                domain: 'https://w3id.org/security#domain',
+                expires: {
+                    '@id': 'https://w3id.org/security#expiration',
+                    '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+                },
+                jws: 'https://w3id.org/security#jws',
+                nonce: 'https://w3id.org/security#nonce',
+                proofPurpose: {
+                    '@id': 'https://w3id.org/security#proofPurpose',
+                    '@type': '@vocab',
+                    '@context': {
+                        '@protected': true,
+                        id: '@id',
+                        type: '@type',
+                        assertionMethod: {
+                            '@id': 'https://w3id.org/security#assertionMethod',
+                            '@type': '@id',
+                            '@container': '@set',
+                        },
+                        authentication: {
+                            '@id': 'https://w3id.org/security#authenticationMethod',
+                            '@type': '@id',
+                            '@container': '@set',
+                        },
+                        capabilityInvocation: {
+                            '@id': 'https://w3id.org/security#capabilityInvocationMethod',
+                            '@type': '@id',
+                            '@container': '@set',
+                        },
+                        capabilityDelegation: {
+                            '@id': 'https://w3id.org/security#capabilityDelegationMethod',
+                            '@type': '@id',
+                            '@container': '@set',
+                        },
+                        keyAgreement: {
+                            '@id': 'https://w3id.org/security#keyAgreementMethod',
+                            '@type': '@id',
+                            '@container': '@set',
+                        },
+                    },
+                },
+                verificationMethod: {
+                    '@id': 'https://w3id.org/security#verificationMethod',
+                    '@type': '@id',
+                },
+            },
+        },
+    },
+};

--- a/common/src/hedera-modules/document-loader/document-loader-default.ts
+++ b/common/src/hedera-modules/document-loader/document-loader-default.ts
@@ -1,8 +1,6 @@
 import didContexts from 'did-context';
 import { contexts as credentialsContexts } from '@digitalbazaar/credentials-context';
 import securityContexts from '@digitalbazaar/security-context';
-// Two URLs alias the same BBS context and @digitalbazaar/security-context ships neither,
-// so the vendored copy is served for both (see the has/get branches below).
 import { BBS_V1_URL, BLS12381_2020_V1_CONTEXT, BLS12381_2020_V1_URL } from './contexts/bls12381-2020-v1.js';
 import { JWS_2020_V1_CONTEXT, JWS_2020_V1_URL } from './contexts/jws-2020-v1.js';
 import { IDocumentFormat } from './document-format.js';
@@ -13,6 +11,16 @@ import { DocumentLoader } from './document-loader.js';
  * Used for VC validation.
  */
 export class DefaultDocumentLoader extends DocumentLoader {
+    /**
+     * Vendored JSON-LD contexts the @digitalbazaar packages do not ship.
+     * The two BBS URLs alias the same context, so both map to it.
+     */
+    private static readonly vendoredContexts = new Map<string, object>([
+        [BBS_V1_URL, BLS12381_2020_V1_CONTEXT],
+        [BLS12381_2020_V1_URL, BLS12381_2020_V1_CONTEXT],
+        [JWS_2020_V1_URL, JWS_2020_V1_CONTEXT],
+    ]);
+
     /**
      * Has context
      * @param iri
@@ -27,13 +35,7 @@ export class DefaultDocumentLoader extends DocumentLoader {
         if ((securityContexts.contexts as Map<string, object>).has(iri)) {
             return true;
         }
-        if (iri === BBS_V1_URL || iri === BLS12381_2020_V1_URL) {
-            return true;
-        }
-        if (iri === JWS_2020_V1_URL) {
-            return true;
-        }
-        return false;
+        return DefaultDocumentLoader.vendoredContexts.has(iri);
     }
 
     /**
@@ -59,16 +61,10 @@ export class DefaultDocumentLoader extends DocumentLoader {
                 document: securityContexts.contexts.get(iri),
             };
         }
-        if (iri === BBS_V1_URL || iri === BLS12381_2020_V1_URL) {
+        if (DefaultDocumentLoader.vendoredContexts.has(iri)) {
             return {
                 documentUrl: iri,
-                document: BLS12381_2020_V1_CONTEXT,
-            };
-        }
-        if (iri === JWS_2020_V1_URL) {
-            return {
-                documentUrl: iri,
-                document: JWS_2020_V1_CONTEXT,
+                document: DefaultDocumentLoader.vendoredContexts.get(iri),
             };
         }
         throw new Error('IRI not found: ' + iri);

--- a/common/src/hedera-modules/document-loader/document-loader-default.ts
+++ b/common/src/hedera-modules/document-loader/document-loader-default.ts
@@ -4,6 +4,7 @@ import securityContexts from '@digitalbazaar/security-context';
 // Two URLs alias the same BBS context and @digitalbazaar/security-context ships neither,
 // so the vendored copy is served for both (see the has/get branches below).
 import { BBS_V1_URL, BLS12381_2020_V1_CONTEXT, BLS12381_2020_V1_URL } from './contexts/bls12381-2020-v1.js';
+import { JWS_2020_V1_CONTEXT, JWS_2020_V1_URL } from './contexts/jws-2020-v1.js';
 import { IDocumentFormat } from './document-format.js';
 import { DocumentLoader } from './document-loader.js';
 
@@ -27,6 +28,9 @@ export class DefaultDocumentLoader extends DocumentLoader {
             return true;
         }
         if (iri === BBS_V1_URL || iri === BLS12381_2020_V1_URL) {
+            return true;
+        }
+        if (iri === JWS_2020_V1_URL) {
             return true;
         }
         return false;
@@ -59,6 +63,12 @@ export class DefaultDocumentLoader extends DocumentLoader {
             return {
                 documentUrl: iri,
                 document: BLS12381_2020_V1_CONTEXT,
+            };
+        }
+        if (iri === JWS_2020_V1_URL) {
+            return {
+                documentUrl: iri,
+                document: JWS_2020_V1_CONTEXT,
             };
         }
         throw new Error('IRI not found: ' + iri);

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -20,9 +20,13 @@ import { BbsBlsSignature2020, BbsBlsSignatureProof2020, Bls12381G2KeyPair, KeyPa
 import { IPFS } from '../../helpers/index.js';
 import { CommonDidDocument, HederaBBSMethod, HederaDidDocument, HederaEd25519Method } from './did/index.js';
 
-import * as pkg from 'jsonld-signatures';
+import * as jsigV7Module from 'jsonld-signatures-v7';
 import { ContextHelper } from './context-helper.js';
-const { verify, purposes } = pkg;
+// BbsBlsSignature2020 targets jsonld-signatures@7. Drive its sign/verify with the v7 alias
+// (jsonld-signatures@11, used by @digitalbazaar/vc for Ed25519, is incompatible with it).
+// Under ESM the CJS named exports live on `.default`, so resolve that before destructuring.
+const jsigV7: any = (jsigV7Module as any).default ?? jsigV7Module;
+const { sign: signV7, verify: verifyV7, purposes: purposesV7 } = jsigV7;
 
 /**
  * Suite interface
@@ -203,8 +207,8 @@ export class VCJS {
                 documentLoader: this.ed25519VerificationDocumentLoader(documentLoader),
             });
         } else {
-            result = await verify(json, {
-                purpose: new purposes.AssertionProofPurpose(),
+            result = await verifyV7(json, {
+                purpose: new purposesV7.AssertionProofPurpose(),
                 suite: [new BbsBlsSignature2020(), new BbsBlsSignatureProof2020()],
                 documentLoader,
             });
@@ -513,16 +517,24 @@ export class VCJS {
     ): Promise<VcDocument> {
         const vc: any = vcDocument.getDocument();
         ContextHelper.clearContext(vc);
-        const verifiableCredential = await vcLib.issue({
-            credential: vc,
-            suite,
-            documentLoader,
-        });
-        if (
-            suite instanceof BbsBlsSignature2020 &&
-            verifiableCredential.proof?.type
-        ) {
-            verifiableCredential.proof.type = SignatureType.BbsBlsSignature2020;
+        let verifiableCredential: any;
+        if (suite instanceof BbsBlsSignature2020) {
+            // BbsBlsSignature2020 must be signed with the v7 driver; @digitalbazaar/vc's
+            // issue() (jsonld-signatures@11) calls APIs the v7-era suite does not implement.
+            verifiableCredential = await signV7(vc, {
+                suite,
+                purpose: new purposesV7.AssertionProofPurpose(),
+                documentLoader,
+            });
+            if (verifiableCredential.proof?.type) {
+                verifiableCredential.proof.type = SignatureType.BbsBlsSignature2020;
+            }
+        } else {
+            verifiableCredential = await vcLib.issue({
+                credential: vc,
+                suite,
+                documentLoader,
+            });
         }
         vcDocument.proofFromJson(verifiableCredential);
         return vcDocument;

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -200,7 +200,11 @@ export class VCJS {
      */
     public async verify(json: any, documentLoader: DocumentLoaderFunction): Promise<boolean> {
         let result: vcLib.VerificationResult;
-        if (json.proof.type === SignatureType.Ed25519Signature2018) {
+        const proof = Array.isArray(json?.proof) ? json.proof[0] : json?.proof;
+        if (!proof || !proof.type) {
+            throw new Error('Verification error: document is missing a proof');
+        }
+        if (proof.type === SignatureType.Ed25519Signature2018) {
             result = await vcLib.verifyCredential({
                 credential: json,
                 suite: [new Ed25519Signature2018()],

--- a/common/src/helpers/vc-helper.ts
+++ b/common/src/helpers/vc-helper.ts
@@ -335,15 +335,10 @@ export class VcHelper extends VCJS {
         const vcSchema = await VcHelper.getSchemaByContext(subject['@context'], subject.type);
         const entity: SchemaEntity = vcSchema?.entity;
         if (entity === SchemaEntity.EVC) {
-            // EVC schemas are signed with BbsBlsSignature2020, whose archived @mattrglobal
-            // stack is incompatible with the current jsonld-signatures version and JSON-LD
-            // contexts. Fail with a clear, intentional error until the BBS cryptosuite
-            // migration restores the path, instead of a cryptic library exception.
-            throw new Error(
-                'Encrypted Verifiable Credentials (BbsBlsSignature2020) are temporarily unsupported pending the BBS cryptosuite migration; use a standard (Ed25519) schema in the meantime.'
-            );
+            return SignatureType.BbsBlsSignature2020;
+        } else {
+            return SignatureType.Ed25519Signature2018;
         }
-        return SignatureType.Ed25519Signature2018;
     }
 
     /**

--- a/common/src/types/digitalbazaar.d.ts
+++ b/common/src/types/digitalbazaar.d.ts
@@ -30,11 +30,7 @@ declare module '@digitalbazaar/ed25519-verification-key-2018' {
 }
 
 declare module 'jsonld-signatures-v7' {
-    export interface VerificationResult {
-        verified: boolean;
-        results?: Array<{ verified: boolean; error?: { message?: string } }>;
-        error?: any;
-    }
+    import type { VerificationResult } from '@digitalbazaar/vc';
     export function sign(document: any, options: any): Promise<any>;
     export function verify(document: any, options: any): Promise<VerificationResult>;
     export const purposes: { AssertionProofPurpose: new (options?: any) => any; [key: string]: any };

--- a/common/src/types/digitalbazaar.d.ts
+++ b/common/src/types/digitalbazaar.d.ts
@@ -29,6 +29,20 @@ declare module '@digitalbazaar/ed25519-verification-key-2018' {
     }
 }
 
+declare module 'jsonld-signatures-v7' {
+    export interface VerificationResult {
+        verified: boolean;
+        results?: Array<{ verified: boolean; error?: { message?: string } }>;
+        error?: any;
+    }
+    export function sign(document: any, options: any): Promise<any>;
+    export function verify(document: any, options: any): Promise<VerificationResult>;
+    export const purposes: { AssertionProofPurpose: new (options?: any) => any; [key: string]: any };
+    export const suites: Record<string, any>;
+    export const SECURITY_CONTEXT_URL: string;
+    export const SECURITY_PROOF_URL: string;
+}
+
 declare module '@digitalbazaar/vc' {
     export interface VerificationResult {
         verified: boolean;

--- a/common/tests/fixtures/credentials/bbs-legacy-did.json
+++ b/common/tests/fixtures/credentials/bbs-legacy-did.json
@@ -1,0 +1,18 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/bls12381-2020/v1"
+  ],
+  "id": "did:example:bbs-oracle",
+  "verificationMethod": [
+    {
+      "id": "did:example:bbs-oracle#bbs",
+      "type": "Bls12381G2Key2020",
+      "controller": "did:example:bbs-oracle",
+      "publicKeyBase58": "nrRqDapGinDU4kA9MrD8JKtNzfteuDm7QSs5oNAu3iqjpnYC7mRCXp86z72WLQoWMphU7h2E3hqRhaMsqQjnmLvULuCPs5dGxiBcz1W98rFYDj3M8U5xmkbHNcN6okJzxc4"
+    }
+  ],
+  "assertionMethod": [
+    "did:example:bbs-oracle#bbs"
+  ]
+}

--- a/common/tests/fixtures/credentials/bbs-legacy-vc.json
+++ b/common/tests/fixtures/credentials/bbs-legacy-vc.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/bbs/v1",
+    "https://example.org/evc-test/v1"
+  ],
+  "id": "urn:uuid:bbs-oracle-1",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:example:bbs-oracle",
+  "issuanceDate": "2024-01-01T00:00:00Z",
+  "credentialSubject": {
+    "type": "EvcTest",
+    "name": "Alice",
+    "value": "42"
+  },
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2026-06-23T21:57:02Z",
+    "verificationMethod": "did:example:bbs-oracle#bbs",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "jvcxCAJ/lvRH+3BZa/wgGV4Muq5YmIMA0eiucxR8RO2NlDiQrwYXLHL6veCfmVZsYUHlKfzccE4m7waZyoLEkBLFiK2g54Q2i+CdtYBgDdkUDsoULSBMcH1MwGHwdjfXpldFNFrHFx/IAvLVniyeMQ=="
+  }
+}

--- a/common/tests/unit-tests/hedera-modules/vcjs/bbs-signature.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/bbs-signature.test.mjs
@@ -158,11 +158,14 @@ describe('VCJS BbsBlsSignature2020 signing and verification', function () {
         assert.isTrue(await vcjs.verifyVC(legacyVc));
     });
 
-    it('derives a selectively disclosed credential that hides undisclosed fields', async function () {
+    it('derives a selectively disclosed credential that hides undisclosed fields and still verifies', async function () {
         // deriveProof is what VcHelper.vcDeriveProof calls; this exercises the same path
-        // through the default document loader. End-to-end verification of a derived proof
-        // is a separate concern: it fails identically on the pre-migration @transmute stack
-        // and is not addressed by this change.
+        // through the default document loader. The credentialSubject carries an `id`, as it
+        // always does in production: VcHelper.prepareSubject -> setNestedNodeIds assigns one
+        // to every BBS subject node before signing. That id keeps the subject from becoming a
+        // blank node, which is what makes the derived proof verify: @mattrglobal skolemizes a
+        // blank-node subject to `urn:bnid:_:c14n*`, and that form sorts differently from its
+        // `_:c14n*` form, scrambling the ascending reveal-index order blsVerifyProof requires.
         const did = 'did:example:bbs-derive';
         const vm = `${did}#bbs`;
         const key = await Bls12381G2KeyPair.generate({ id: vm, controller: did });
@@ -172,6 +175,11 @@ describe('VCJS BbsBlsSignature2020 signing and verification', function () {
             verificationMethod: [{ id: vm, type: 'Bls12381G2Key2020', controller: did, publicKeyBase58: key.publicKey }],
             assertionMethod: [vm],
         };
+        const vcjs = new VCJS();
+        vcjs.addDocumentLoader(new DefaultDocumentLoader());
+        vcjs.addDocumentLoader(new TestContextLoader());
+        vcjs.addDocumentLoader(new Bls12381DidLoader(didDocument));
+        vcjs.buildDocumentLoader();
         const documentLoader = DocumentLoader.build([
             new DefaultDocumentLoader(),
             new TestContextLoader(),
@@ -184,7 +192,7 @@ describe('VCJS BbsBlsSignature2020 signing and verification', function () {
             type: ['VerifiableCredential'],
             issuer: did,
             issuanceDate: '2024-01-01T00:00:00Z',
-            credentialSubject: { type: 'EvcTest', name: 'Alice', value: '42' },
+            credentialSubject: { id: 'urn:uuid:bbs-derive-subject', type: 'EvcTest', name: 'Alice', value: '42' },
         };
         const signed = await jsigV7.sign(credential, {
             suite: new BbsBlsSignature2020({ key }),
@@ -196,7 +204,7 @@ describe('VCJS BbsBlsSignature2020 signing and verification', function () {
         const reveal = {
             '@context': signed['@context'],
             type: ['VerifiableCredential'],
-            credentialSubject: { '@explicit': true, type: 'EvcTest', name: {} },
+            credentialSubject: { '@explicit': true, id: 'urn:uuid:bbs-derive-subject', type: 'EvcTest', name: {} },
         };
         const derived = await deriveProof(signed, reveal, {
             suite: new BbsBlsSignatureProof2020(),
@@ -206,6 +214,8 @@ describe('VCJS BbsBlsSignature2020 signing and verification', function () {
         assert.equal(derived.proof.type, 'BbsBlsSignatureProof2020');
         assert.equal(derived.credentialSubject.name, 'Alice', 'revealed field must be present');
         assert.isUndefined(derived.credentialSubject.value, 'undisclosed field must be absent');
+        // The derived proof must verify through the production verify() path.
+        assert.isTrue(await vcjs.verifyVC(derived), 'derived proof must verify');
     });
 
     it('serves the vendored jws-2020/v1 context from the default document loader', async function () {

--- a/common/tests/unit-tests/hedera-modules/vcjs/bbs-signature.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/bbs-signature.test.mjs
@@ -1,0 +1,219 @@
+/**
+ * BbsBlsSignature2020 signing, verification and selective-disclosure tests.
+ *
+ * EVC schemas are signed with BbsBlsSignature2020 (the @mattrglobal BBS+ suite).
+ * After the @transmute -> @digitalbazaar migration this suite is driven by the
+ * jsonld-signatures@7 alias (the version it targets) while Ed25519 stays on
+ * @digitalbazaar/vc. These tests assert that the new stack signs and verifies a
+ * BBS credential, rejects a tampered proof, and that a derived (selectively
+ * disclosed) credential still verifies while hiding the undisclosed fields.
+ */
+import { assert } from 'chai';
+import '../../../../dist/index.js'; // warm the module graph (avoids the barrel init cycle when run in isolation)
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import bbs from '@mattrglobal/jsonld-signatures-bbs';
+import jsigV7Module from 'jsonld-signatures-v7';
+import { PrivateKey } from '@hiero-ledger/sdk';
+import { SignatureType } from '@guardian/interfaces';
+import { VCJS } from '../../../../dist/hedera-modules/vcjs/vcjs.js';
+import { DocumentLoader } from '../../../../dist/hedera-modules/document-loader/document-loader.js';
+import { DefaultDocumentLoader } from '../../../../dist/hedera-modules/document-loader/document-loader-default.js';
+import {
+    JWS_2020_V1_CONTEXT,
+    JWS_2020_V1_URL,
+} from '../../../../dist/hedera-modules/document-loader/contexts/jws-2020-v1.js';
+import { HederaDidDocument } from '../../../../dist/hedera-modules/vcjs/did/hedera-did-document.js';
+import { LocalSchemaContextLoader } from '../../../../dist/document-loader/local-schema-context-loader.js';
+import { LocalDidLoader } from '../../../../dist/document-loader/local-did-loader.js';
+
+const { BbsBlsSignature2020, BbsBlsSignatureProof2020, Bls12381G2KeyPair, deriveProof } = bbs;
+const jsigV7 = jsigV7Module.default ?? jsigV7Module;
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '../../../fixtures/credentials');
+const read = (file) => JSON.parse(readFileSync(join(fixtures, file), 'utf8'));
+
+// A small EVC-style context with distinct predicates per field, so selective
+// disclosure can be observed field-by-field (the shared fixtures map every field
+// to one predicate). The bbs-legacy-* fixtures reference this context too.
+const TEST_CONTEXT_URL = 'https://example.org/evc-test/v1';
+const TEST_CONTEXT = {
+    '@context': {
+        '@version': 1.1,
+        '@protected': true,
+        EvcTest: 'https://example.org/evc-test#EvcTest',
+        name: 'https://example.org/evc-test#name',
+        value: 'https://example.org/evc-test#value',
+    },
+};
+
+describe('VCJS BbsBlsSignature2020 signing and verification', function () {
+    const schema = read('schema.json');
+    const subject = read('subject.json');
+
+    // Database-free stub loaders (the production loaders read from MongoDB).
+    class SchemaContextLoader extends LocalSchemaContextLoader {
+        async has(iri) { return typeof iri === 'string' && iri.startsWith('https://ipfs.io/ipfs/'); }
+        loadSchemaContext() { return schema; }
+    }
+    class StaticDidLoader extends LocalDidLoader {
+        constructor(document) { super('did:'); this.document = document; }
+        async has(iri) { return typeof iri === 'string' && iri.startsWith('did:'); }
+        async getDocument() { return this.document; }
+    }
+    class TestContextLoader extends LocalDidLoader {
+        constructor() { super('https://example.org/'); }
+        async has(iri) { return iri === TEST_CONTEXT_URL; }
+        async get(iri) { return { documentUrl: iri, document: TEST_CONTEXT, contextUrl: null }; }
+    }
+    // Resolves the DID and its Bls12381G2 verification method (with the suite context),
+    // mirroring how the production DID loader frames a BBS verification method.
+    class Bls12381DidLoader extends LocalDidLoader {
+        constructor(document) { super('did:'); this.document = document; }
+        async has(iri) { return typeof iri === 'string' && iri.startsWith('did:'); }
+        async get(iri) {
+            if (iri === this.document.id) {
+                return { documentUrl: iri, document: this.document, contextUrl: null };
+            }
+            const method = this.document.verificationMethod[0];
+            if (iri === method.id) {
+                return {
+                    documentUrl: iri,
+                    document: { '@context': 'https://w3id.org/security/suites/bls12381-2020/v1', ...method },
+                    contextUrl: null,
+                };
+            }
+            throw new Error('Unresolved IRI: ' + iri);
+        }
+    }
+
+    function loaders(didDocument) {
+        return [
+            new DefaultDocumentLoader(),
+            new SchemaContextLoader(),
+            new StaticDidLoader(didDocument),
+        ];
+    }
+    function buildVcjs(didDocument) {
+        const vcjs = new VCJS();
+        for (const loader of loaders(didDocument)) {
+            vcjs.addDocumentLoader(loader);
+        }
+        vcjs.buildDocumentLoader();
+        return vcjs;
+    }
+
+    async function generateDidAndVcjs() {
+        const key = PrivateKey.fromString(
+            '302e020100300506032b657004220420bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        );
+        const didDocument = await HederaDidDocument.generate('testnet', key, '0.0.0');
+        return { didDocument, vcjs: buildVcjs(didDocument.toJsonTree()) };
+    }
+
+    it('signs and verifies a BbsBlsSignature2020 credential round-trip', async function () {
+        const { didDocument, vcjs } = await generateDidAndVcjs();
+        const credential = await vcjs.createVerifiableCredential(
+            subject,
+            didDocument,
+            SignatureType.BbsBlsSignature2020
+        );
+        const json = credential.toJsonTree();
+        assert.equal(json.proof.type, SignatureType.BbsBlsSignature2020);
+        assert.isTrue(await vcjs.verifyVC(json));
+    });
+
+    it('rejects a credential whose BBS proof was tampered with', async function () {
+        const { didDocument, vcjs } = await generateDidAndVcjs();
+        const credential = await vcjs.createVerifiableCredential(
+            subject,
+            didDocument,
+            SignatureType.BbsBlsSignature2020
+        );
+        const tampered = credential.toJsonTree();
+        tampered.proof.proofValue = tampered.proof.proofValue.slice(0, -6) + 'AAAAAA';
+        let failed = false;
+        try {
+            failed = (await vcjs.verifyVC(tampered)) === false;
+        } catch (error) {
+            failed = true;
+        }
+        assert.isTrue(failed, 'tampered BBS credential must not verify');
+    });
+
+    it('verifies a BbsBlsSignature2020 credential signed by the previous (@transmute) stack', async function () {
+        // Backward-compat oracle: bbs-legacy-vc.json was signed with the pre-migration
+        // @transmute stack (fixed key) and must still verify on the @digitalbazaar +
+        // jsonld-signatures-v7 stack, so existing on-ledger EVCs remain verifiable.
+        const legacyVc = read('bbs-legacy-vc.json');
+        const legacyDid = read('bbs-legacy-did.json');
+        const vcjs = new VCJS();
+        vcjs.addDocumentLoader(new DefaultDocumentLoader());
+        vcjs.addDocumentLoader(new TestContextLoader());
+        vcjs.addDocumentLoader(new Bls12381DidLoader(legacyDid));
+        vcjs.buildDocumentLoader();
+
+        assert.equal(legacyVc.proof.type, SignatureType.BbsBlsSignature2020);
+        assert.isTrue(await vcjs.verifyVC(legacyVc));
+    });
+
+    it('derives a selectively disclosed credential that hides undisclosed fields', async function () {
+        // deriveProof is what VcHelper.vcDeriveProof calls; this exercises the same path
+        // through the default document loader. End-to-end verification of a derived proof
+        // is a separate concern: it fails identically on the pre-migration @transmute stack
+        // and is not addressed by this change.
+        const did = 'did:example:bbs-derive';
+        const vm = `${did}#bbs`;
+        const key = await Bls12381G2KeyPair.generate({ id: vm, controller: did });
+        const didDocument = {
+            '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/bls12381-2020/v1'],
+            id: did,
+            verificationMethod: [{ id: vm, type: 'Bls12381G2Key2020', controller: did, publicKeyBase58: key.publicKey }],
+            assertionMethod: [vm],
+        };
+        const documentLoader = DocumentLoader.build([
+            new DefaultDocumentLoader(),
+            new TestContextLoader(),
+            new Bls12381DidLoader(didDocument),
+        ]);
+
+        const credential = {
+            '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/security/bbs/v1', TEST_CONTEXT_URL],
+            id: 'urn:uuid:bbs-derive-1',
+            type: ['VerifiableCredential'],
+            issuer: did,
+            issuanceDate: '2024-01-01T00:00:00Z',
+            credentialSubject: { type: 'EvcTest', name: 'Alice', value: '42' },
+        };
+        const signed = await jsigV7.sign(credential, {
+            suite: new BbsBlsSignature2020({ key }),
+            purpose: new jsigV7.purposes.AssertionProofPurpose(),
+            documentLoader,
+        });
+
+        // Reveal only `name`; `@explicit` drops the unlisted `value`.
+        const reveal = {
+            '@context': signed['@context'],
+            type: ['VerifiableCredential'],
+            credentialSubject: { '@explicit': true, type: 'EvcTest', name: {} },
+        };
+        const derived = await deriveProof(signed, reveal, {
+            suite: new BbsBlsSignatureProof2020(),
+            documentLoader,
+        });
+
+        assert.equal(derived.proof.type, 'BbsBlsSignatureProof2020');
+        assert.equal(derived.credentialSubject.name, 'Alice', 'revealed field must be present');
+        assert.isUndefined(derived.credentialSubject.value, 'undisclosed field must be absent');
+    });
+
+    it('serves the vendored jws-2020/v1 context from the default document loader', async function () {
+        const loader = new DefaultDocumentLoader();
+        assert.isTrue(await loader.has(JWS_2020_V1_URL));
+        const { document } = await loader.get(JWS_2020_V1_URL);
+        assert.deepEqual(document, JWS_2020_V1_CONTEXT);
+        assert.property(document['@context'], 'JsonWebSignature2020');
+        assert.property(document['@context'], 'JsonWebKey2020');
+    });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "private": true,
     "resolutions": {
         "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
+        "image-size": "1.0.2",
+        "@mattrglobal/bls12381-key-pair": "2.0.0",
+        "@mattrglobal/bbs-signatures": "2.0.0"
     },
     "scripts": {
         "detect-secrets": "detect-secrets-launcher --word-list exclude-secrets.txt k8s-manifests/**/* */src/**.ts **/.env*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,6 +1495,7 @@ __metadata:
     geotiff: "npm:^2.1.4-beta.0"
     js-base64: "npm:^3.6.1"
     jsonld-signatures: "npm:11.5.0"
+    jsonld-signatures-v7: "npm:jsonld-signatures@7.0.0"
     jszip: "npm:^3.7.1"
     lodash.get: "npm:^4.4.2"
     lodash.set: "npm:^4.3.2"
@@ -2488,27 +2489,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mattrglobal/bbs-signatures@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@mattrglobal/bbs-signatures@npm:1.2.0"
+"@mattrglobal/bbs-signatures@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@mattrglobal/bbs-signatures@npm:2.0.0"
   dependencies:
-    "@mattrglobal/node-bbs-signatures": "npm:0.17.0"
+    "@mattrglobal/node-bbs-signatures": "npm:0.20.0"
     "@stablelib/random": "npm:1.0.0"
   dependenciesMeta:
     "@mattrglobal/node-bbs-signatures":
       optional: true
-  checksum: 10c0/2121b914d277b128686d728e012a3fb54365a1efe8de944b77837aa315cf8da88ad3da3755eafa10aae5d6e3c8ffac20fa65f0efa39fa7ca7f8592e1f68e3b1e
+  checksum: 10c0/a46dd13de9e2b29638c1e6689e830605173624cbe0f3a2b2da0d0dc223262c3975f4c37c1bf27ec8f8383c1bb8f10f357950d31adf434add80869f8c180de243
   languageName: node
   linkType: hard
 
-"@mattrglobal/bls12381-key-pair@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@mattrglobal/bls12381-key-pair@npm:1.1.0"
+"@mattrglobal/bls12381-key-pair@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@mattrglobal/bls12381-key-pair@npm:2.0.0"
   dependencies:
-    "@mattrglobal/bbs-signatures": "npm:1.2.0"
-    bs58: "npm:4.0.1"
-    rfc4648: "npm:1.5.2"
-  checksum: 10c0/6d8c630f4387d133301f7d61de5d23d25e135399919ef4cbd8d71d104240d7d6b38040edc710c557bdc324a4768edfb03eacc2045fec683c176184ac83d48005
+    "@mattrglobal/bbs-signatures": "npm:2.0.0"
+    bs58: "npm:6.0.0"
+    rfc4648: "npm:1.5.3"
+  checksum: 10c0/e45f74b90b3dd373238debb4eec554c60fc915517bc57f82ff90bee2a392f830e155ab06479fe3637b914b856684d0bf6ae31dce624c6251c36e846c57375008
   languageName: node
   linkType: hard
 
@@ -2526,13 +2527,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mattrglobal/node-bbs-signatures@npm:0.17.0":
-  version: 0.17.0
-  resolution: "@mattrglobal/node-bbs-signatures@npm:0.17.0"
+"@mattrglobal/node-bbs-signatures@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@mattrglobal/node-bbs-signatures@npm:0.20.0"
   dependencies:
     "@mapbox/node-pre-gyp": "npm:1.0.11"
-    neon-cli: "npm:0.10.1"
-  checksum: 10c0/2f3b268bdf5ebc8069be093a9e83ee6fa49f165762ca8349ef97e759bb82ce25e53fc603ac78e91348f3b55b07b4b498082433bf05e84a1c0aee2de3d1b9d95b
+  checksum: 10c0/e7f4ec64a3db16872fc04f83123c7fbbdcb59917e8e1c23b99fc58297e06d0e55535112521e67f7b5e030dc7e72150d921f1a78a6190d9d8851bec82128e8758
   languageName: node
   linkType: hard
 
@@ -5096,15 +5096,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1":
-  version: 4.3.2
-  resolution: "ansi-escapes@npm:4.3.2"
-  dependencies:
-    type-fest: "npm:^0.21.3"
-  checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:6.2.2, ansi-regex@npm:^6.0.1":
   version: 6.2.2
   resolution: "ansi-regex@npm:6.2.2"
@@ -5394,20 +5385,6 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
-  languageName: node
-  linkType: hard
-
-"array-back@npm:^3.0.1, array-back@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "array-back@npm:3.1.0"
-  checksum: 10c0/bb1fe86aa8b39c21e73c68c7abf8b05ed939b8951a3b17527217f6a2a84e00e4cfa4fdec823081689c5e216709bf1f214a4f5feeee6726eaff83897fa1a7b8ee
-  languageName: node
-  linkType: hard
-
-"array-back@npm:^4.0.1, array-back@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "array-back@npm:4.0.2"
-  checksum: 10c0/8beb5b4c9535eab2905d4ff7d16c4d90ee5ca080d2b26b1e637434c0fcfadb3585283524aada753bd5d06bb88a5dac9e175c3a236183741d3d795a69b6678c96
   languageName: node
   linkType: hard
 
@@ -6089,7 +6066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^6.0.0":
+"bs58@npm:6.0.0, bs58@npm:^6.0.0":
   version: 6.0.0
   resolution: "bs58@npm:6.0.0"
   dependencies:
@@ -6190,13 +6167,6 @@ __metadata:
   version: 1.1.1
   resolution: "builtin-modules@npm:1.1.1"
   checksum: 10c0/58d72ea7f59db3c2ae854e1058d85b226f75ff7386d0f71d628e25a600383fc6652af218e20ba2361925c605a4144590ceb890dfdca298fdf8f3d040c0591a23
-  languageName: node
-  linkType: hard
-
-"builtins@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "builtins@npm:1.0.3"
-  checksum: 10c0/493afcc1db0a56d174cc85bebe5ca69144f6fdd0007d6cbe6b2434185314c79d83cb867e492b56aa5cf421b4b8a8135bf96ba4c3ce71994cf3da154d1ea59747
   languageName: node
   linkType: hard
 
@@ -6443,13 +6413,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chardet@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "chardet@npm:0.7.0"
-  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
-  languageName: node
-  linkType: hard
-
 "charenc@npm:0.0.2":
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
@@ -6569,22 +6532,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0"
-  dependencies:
-    restore-cursor: "npm:^3.1.0"
-  checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
-  languageName: node
-  linkType: hard
-
-"cli-width@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "cli-width@npm:3.0.0"
-  checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -6697,39 +6644,6 @@ __metadata:
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
-"command-line-args@npm:^5.1.1":
-  version: 5.2.1
-  resolution: "command-line-args@npm:5.2.1"
-  dependencies:
-    array-back: "npm:^3.1.0"
-    find-replace: "npm:^3.0.0"
-    lodash.camelcase: "npm:^4.3.0"
-    typical: "npm:^4.0.0"
-  checksum: 10c0/a4f6a23a1e420441bd1e44dee24efd12d2e49af7efe6e21eb32fca4e843ca3d5501ddebad86a4e9d99aa626dd6dcb64c04a43695388be54e3a803dbc326cc89f
-  languageName: node
-  linkType: hard
-
-"command-line-commands@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "command-line-commands@npm:3.0.2"
-  dependencies:
-    array-back: "npm:^4.0.1"
-  checksum: 10c0/ba04828c831dcd2cecb569f9bef42c3feabe0435ab14259562266f1146ecc1eb3d5d4b91331266c23dbcfe03c9c977b4e144b8bd92fa4633426bbf4119918a27
-  languageName: node
-  linkType: hard
-
-"command-line-usage@npm:^6.1.0":
-  version: 6.1.3
-  resolution: "command-line-usage@npm:6.1.3"
-  dependencies:
-    array-back: "npm:^4.0.2"
-    chalk: "npm:^2.4.2"
-    table-layout: "npm:^1.0.2"
-    typical: "npm:^5.2.0"
-  checksum: 10c0/23d7577ccb6b6c004e67bb6a9a8cb77282ae7b7507ae92249a9548a39050b7602fef70f124c765000ab23b8f7e0fb7a3352419ab73ea42a2d9ea32f520cdfe9e
   languageName: node
   linkType: hard
 
@@ -7286,7 +7200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-extend@npm:^0.6.0, deep-extend@npm:~0.6.0":
+"deep-extend@npm:^0.6.0":
   version: 0.6.0
   resolution: "deep-extend@npm:0.6.0"
   checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
@@ -8375,17 +8289,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"external-editor@npm:^3.0.3":
-  version: 3.1.0
-  resolution: "external-editor@npm:3.1.0"
-  dependencies:
-    chardet: "npm:^0.7.0"
-    iconv-lite: "npm:^0.4.24"
-    tmp: "npm:^0.0.33"
-  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
-  languageName: node
-  linkType: hard
-
 "extsprintf@npm:1.3.0":
   version: 1.3.0
   resolution: "extsprintf@npm:1.3.0"
@@ -8628,15 +8531,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^3.0.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
-  languageName: node
-  linkType: hard
-
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
@@ -8703,15 +8597,6 @@ __metadata:
     fast-querystring: "npm:^1.0.0"
     safe-regex2: "npm:^5.0.0"
   checksum: 10c0/d103e51a1e73e202e7533b2efc42e40c3618f8bd24a37cfa140da5e079c2baf5d5baeb01b2b8a7c104d680aa09c4b716851184f8ae103be374e8f46b17f6608d
-  languageName: node
-  linkType: hard
-
-"find-replace@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "find-replace@npm:3.0.0"
-  dependencies:
-    array-back: "npm:^3.0.1"
-  checksum: 10c0/fcd1bf7960388c8193c2861bcdc760c18ac14edb4bde062a961915d9a25727b2e8aabf0229e90cc09c753fd557e5a3e5ae61e49cadbe727be89a9e8e49ce7668
   languageName: node
   linkType: hard
 
@@ -9240,15 +9125,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-config@npm:0.0.7":
-  version: 0.0.7
-  resolution: "git-config@npm:0.0.7"
-  dependencies:
-    iniparser: "npm:~1.0.5"
-  checksum: 10c0/b90310802585de6fb8d61f0eb090d42b5d710c56a8109f7f1720a25c03eb2d9f089a4082fde460eebf06cf3f61248565a351eb8634b60dcc495639388b7f015c
-  languageName: node
-  linkType: hard
-
 "github-from-package@npm:0.0.0":
   version: 0.0.0
   resolution: "github-from-package@npm:0.0.0"
@@ -9528,7 +9404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.6, handlebars@npm:^4.7.9":
+"handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -9784,15 +9660,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -10044,34 +9911,6 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
-  languageName: node
-  linkType: hard
-
-"iniparser@npm:~1.0.5":
-  version: 1.0.5
-  resolution: "iniparser@npm:1.0.5"
-  checksum: 10c0/196460705d9cfd17c4633a52e47c4b8cc27fd6e5890dbfd941742d003d18a7cb72ae3ac8f7e9272fcd9989ed597b8137105ddb90476d044b2101495ff39e4575
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:^7.3.3":
-  version: 7.3.3
-  resolution: "inquirer@npm:7.3.3"
-  dependencies:
-    ansi-escapes: "npm:^4.2.1"
-    chalk: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
-    cli-width: "npm:^3.0.0"
-    external-editor: "npm:^3.0.3"
-    figures: "npm:^3.0.0"
-    lodash: "npm:^4.17.19"
-    mute-stream: "npm:0.0.8"
-    run-async: "npm:^2.4.0"
-    rxjs: "npm:^6.6.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-    through: "npm:^2.3.6"
-  checksum: 10c0/96e75974cfd863fe6653c075e41fa5f1a290896df141189816db945debabcd92d3277145f11aef8d2cfca5409ab003ccdd18a099744814057b52a2f27aeb8c94
   languageName: node
   linkType: hard
 
@@ -11236,19 +11075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonld-signatures@npm:11.5.0":
-  version: 11.5.0
-  resolution: "jsonld-signatures@npm:11.5.0"
-  dependencies:
-    "@digitalbazaar/security-context": "npm:^1.0.0"
-    jsonld: "npm:^8.0.0"
-    rdf-canonize: "npm:^4.0.1"
-    serialize-error: "npm:^8.1.0"
-  checksum: 10c0/a624ef4706c91064ba19dd3f1bb2a43f40cabd68f38e1c3e57fb0cea830b5ff4763364a00197313ccf704f571295803220d5c20d40df371562d84de98c5df9a0
-  languageName: node
-  linkType: hard
-
-"jsonld-signatures@npm:7.0.0":
+"jsonld-signatures-v7@npm:jsonld-signatures@7.0.0, jsonld-signatures@npm:7.0.0":
   version: 7.0.0
   resolution: "jsonld-signatures@npm:7.0.0"
   dependencies:
@@ -11259,6 +11086,18 @@ __metadata:
     security-context: "npm:^4.0.0"
     serialize-error: "npm:^5.0.0"
   checksum: 10c0/2b888e62498b92c7a43e2fcd500ed23f8e949fe1efe669b16502efabf9d082f10f40e933b966319b9a11e93cfdf790a27a32167d036f326f26556b70689de6db
+  languageName: node
+  linkType: hard
+
+"jsonld-signatures@npm:11.5.0":
+  version: 11.5.0
+  resolution: "jsonld-signatures@npm:11.5.0"
+  dependencies:
+    "@digitalbazaar/security-context": "npm:^1.0.0"
+    jsonld: "npm:^8.0.0"
+    rdf-canonize: "npm:^4.0.1"
+    serialize-error: "npm:^8.1.0"
+  checksum: 10c0/a624ef4706c91064ba19dd3f1bb2a43f40cabd68f38e1c3e57fb0cea830b5ff4763364a00197313ccf704f571295803220d5c20d40df371562d84de98c5df9a0
   languageName: node
   linkType: hard
 
@@ -11918,7 +11757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.18.1, lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
+"lodash@npm:4.18.1, lodash@npm:^4.17.12, lodash@npm:^4.17.15, lodash@npm:^4.17.21":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
@@ -12072,13 +11911,6 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^10.0.0"
   checksum: 10c0/df5f4dbb6d98153b751bccf4dc4cc500de85a96a9331db9805596c46aa9f99d9555983954e6c1266d9f981ae37a9e4647f42b9a4bb5466f867f4012e582c9e7e
-  languageName: node
-  linkType: hard
-
-"make-promises-safe@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "make-promises-safe@npm:5.1.0"
-  checksum: 10c0/e7344a7588c9f541011973a754d47345279af41e9068d43b3a8bd9eecba507e9cfe26b420361b6eb1dc14c636fdbb1855fe5af8c7b7dc8a8b054efb182cee084
   languageName: node
   linkType: hard
 
@@ -12326,13 +12158,6 @@ __metadata:
   bin:
     mime: cli.js
   checksum: 10c0/402e792a8df1b2cc41cb77f0dcc46472b7944b7ec29cb5bbcd398624b6b97096728f1239766d3fdeb20551dd8d94738344c195a6ea10c4f906eb0356323b0531
-  languageName: node
-  linkType: hard
-
-"mimic-fn@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "mimic-fn@npm:2.1.0"
-  checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
   languageName: node
   linkType: hard
 
@@ -12876,13 +12701,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:0.0.8":
-  version: 0.0.8
-  resolution: "mute-stream@npm:0.0.8"
-  checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
-  languageName: node
-  linkType: hard
-
 "mylas@npm:^2.1.9":
   version: 2.1.14
   resolution: "mylas@npm:2.1.14"
@@ -12992,30 +12810,6 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
-  languageName: node
-  linkType: hard
-
-"neon-cli@npm:0.10.1":
-  version: 0.10.1
-  resolution: "neon-cli@npm:0.10.1"
-  dependencies:
-    chalk: "npm:^4.1.0"
-    command-line-args: "npm:^5.1.1"
-    command-line-commands: "npm:^3.0.1"
-    command-line-usage: "npm:^6.1.0"
-    git-config: "npm:0.0.7"
-    handlebars: "npm:^4.7.6"
-    inquirer: "npm:^7.3.3"
-    make-promises-safe: "npm:^5.1.0"
-    rimraf: "npm:^3.0.2"
-    semver: "npm:^7.3.2"
-    toml: "npm:^3.0.0"
-    ts-typed-json: "npm:^0.3.2"
-    validate-npm-package-license: "npm:^3.0.4"
-    validate-npm-package-name: "npm:^3.0.0"
-  bin:
-    neon: bin/cli.js
-  checksum: 10c0/bd4481310fc485ad684b5ce0e9c8b2ba9ec3ff3b83ab569696337411c04ce41ddede2d6d6e0388bab5de5cd74c558b46af0f59d79d746fd44fd943afa4ac95a0
   languageName: node
   linkType: hard
 
@@ -13597,15 +13391,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0":
-  version: 5.1.2
-  resolution: "onetime@npm:5.1.2"
-  dependencies:
-    mimic-fn: "npm:^2.1.0"
-  checksum: 10c0/ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
-  languageName: node
-  linkType: hard
-
 "open@npm:^10.1.0":
   version: 10.2.0
   resolution: "open@npm:10.2.0"
@@ -13692,7 +13477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:^1.0.0, os-tmpdir@npm:~1.0.2":
+"os-tmpdir@npm:^1.0.0":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
@@ -14968,13 +14753,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reduce-flatten@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "reduce-flatten@npm:2.0.0"
-  checksum: 10c0/9275064535bc070a787824c835a4f18394942f8a78f08e69fb500920124ce1c46a287c8d9e565a7ffad8104875a6feda14efa8e951e8e4585370b8ff007b0abd
-  languageName: node
-  linkType: hard
-
 "reflect-metadata@npm:0.2.2, reflect-metadata@npm:^0.2.2":
   version: 0.2.2
   resolution: "reflect-metadata@npm:0.2.2"
@@ -15117,16 +14895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0"
-  dependencies:
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
-  languageName: node
-  linkType: hard
-
 "ret@npm:~0.5.0":
   version: 0.5.0
   resolution: "ret@npm:0.5.0"
@@ -15178,13 +14946,6 @@ __metadata:
   dependencies:
     eslint: "npm:^7.32.0"
   checksum: 10c0/524e2da87122fd8f71449b23f949bcd4fd83ebc27c743440944fb0dcef92f7df63a4e70a16dfcde6f2325cafc84d2ca57e0ec79b323984a4c54e41c99f0838c4
-  languageName: node
-  linkType: hard
-
-"rfc4648@npm:1.5.2":
-  version: 1.5.2
-  resolution: "rfc4648@npm:1.5.2"
-  checksum: 10c0/53ef37172324df83db204802ea08bdcb99d24d311543bfe50edef5bca16d8a4f64fd82cc1dfc975847737d774178f488c8d5dd2aa280385cc785374eb5cf04cc
   languageName: node
   linkType: hard
 
@@ -15244,13 +15005,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-async@npm:^2.4.0":
-  version: 2.4.1
-  resolution: "run-async@npm:2.4.1"
-  checksum: 10c0/35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -15264,15 +15018,6 @@ __metadata:
   version: 1.1.7
   resolution: "run-waterfall@npm:1.1.7"
   checksum: 10c0/3fb7e97859e88d273c1da1f5c5c2143ab024598fc5d7b95045520fd229a6fdc227452052fe8bbd2f188013978dfd1c66e48ece7c4860db28506b52d0da12fa3e
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^6.6.0":
-  version: 6.6.7
-  resolution: "rxjs@npm:6.6.7"
-  dependencies:
-    tslib: "npm:^1.9.0"
-  checksum: 10c0/e556a13a9aa89395e5c9d825eabcfa325568d9c9990af720f3f29f04a888a3b854f25845c2b55875d875381abcae2d8100af9cacdc57576e7ed6be030a01d2fe
   languageName: node
   linkType: hard
 
@@ -15358,7 +15103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -15420,7 +15165,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.2, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+"semver@npm:^7.1.2, semver@npm:^7.2.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -15671,7 +15416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -16308,18 +16053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table-layout@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "table-layout@npm:1.0.2"
-  dependencies:
-    array-back: "npm:^4.0.1"
-    deep-extend: "npm:~0.6.0"
-    typical: "npm:^5.2.0"
-    wordwrapjs: "npm:^4.0.0"
-  checksum: 10c0/c1d16d5ba2199571606ff574a5c91cff77f14e8477746e191e7dfd294da03e61af4e8004f1f6f783da9582e1365f38d3c469980428998750d558bf29462cc6c3
-  languageName: node
-  linkType: hard
-
 "table@npm:^6.0.9":
   version: 6.9.0
   resolution: "table@npm:6.9.0"
@@ -16467,13 +16200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.6":
-  version: 2.3.8
-  resolution: "through@npm:2.3.8"
-  checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
-  languageName: node
-  linkType: hard
-
 "time2fa@npm:^1.4.2":
   version: 1.4.2
   resolution: "time2fa@npm:1.4.2"
@@ -16515,15 +16241,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
 "tmp@npm:^0.2.0, tmp@npm:^0.2.1":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
@@ -16562,13 +16279,6 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     ieee754: "npm:^1.2.1"
   checksum: 10c0/8786e28e3cb65b9e890bc3c38def98e6dfe4565538237f8c0e47dbe549ed8f5f00de8dc464717868308abb4729f1958f78f69e1c4c3deebbb685729113a6fee8
-  languageName: node
-  linkType: hard
-
-"toml@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "toml@npm:3.0.0"
-  checksum: 10c0/8d7ed3e700ca602e5419fca343e1c595eb7aa177745141f0761a5b20874b58ee5c878cd045c408da9d130cb2b611c639912210ba96ce2f78e443569aa8060c18
   languageName: node
   linkType: hard
 
@@ -16739,13 +16449,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-typed-json@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "ts-typed-json@npm:0.3.2"
-  checksum: 10c0/6c47e9f45b0a9e20fced5e4c8ad1548b9727b8114f5dfbaadc25822a1f96dd219a4e58ca8270a6f20abb519d9b1b9ea344601a4c5fe9459650b96d0201ddabe7
-  languageName: node
-  linkType: hard
-
 "tsc-alias@npm:1.8.17":
   version: 1.8.17
   resolution: "tsc-alias@npm:1.8.17"
@@ -16784,7 +16487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0, tslib@npm:^1.8.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0":
+"tslib@npm:^1.13.0, tslib@npm:^1.8.0, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
@@ -16962,13 +16665,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.21.3":
-  version: 0.21.3
-  resolution: "type-fest@npm:0.21.3"
-  checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
-  languageName: node
-  linkType: hard
-
 "type-fest@npm:^0.6.0":
   version: 0.6.0
   resolution: "type-fest@npm:0.6.0"
@@ -17109,20 +16805,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
-  languageName: node
-  linkType: hard
-
-"typical@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "typical@npm:4.0.0"
-  checksum: 10c0/f300b198fb9fe743859b75ec761d53c382723dc178bbce4957d9cb754f2878a44ce17dc0b6a5156c52be1065449271f63754ba594dac225b80ce3aa39f9241ed
-  languageName: node
-  linkType: hard
-
-"typical@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "typical@npm:5.2.0"
-  checksum: 10c0/1cceaa20d4b77a02ab8eccfe4a20500729431aecc1e1b7dc70c0e726e7966efdca3bf0b4bee285555b751647e37818fd99154ea73f74b5c29adc95d3c13f5973
   languageName: node
   linkType: hard
 
@@ -17468,22 +17150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+"validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 10c0/7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
-  languageName: node
-  linkType: hard
-
-"validate-npm-package-name@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "validate-npm-package-name@npm:3.0.0"
-  dependencies:
-    builtins: "npm:^1.0.3"
-  checksum: 10c0/064f21f59aefae6cc286dd4a50b15d14adb0227e0facab4316197dfb8d06801669e997af5081966c15f7828a5e6ff1957bd20886aeb6b9d0fa430e4cb5db9c4a
   languageName: node
   linkType: hard
 
@@ -17738,16 +17411,6 @@ __metadata:
   version: 1.0.0
   resolution: "wordwrap@npm:1.0.0"
   checksum: 10c0/7ed2e44f3c33c5c3e3771134d2b0aee4314c9e49c749e37f464bf69f2bcdf0cbf9419ca638098e2717cff4875c47f56a007532f6111c3319f557a2ca91278e92
-  languageName: node
-  linkType: hard
-
-"wordwrapjs@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "wordwrapjs@npm:4.0.1"
-  dependencies:
-    reduce-flatten: "npm:^2.0.0"
-    typical: "npm:^5.2.0"
-  checksum: 10c0/4cc43eb0f6adb7214d427e68918357a9df483815efbb4c59beb30972714b1804ede2a551b1dfd2234c0bd413c6f07d6daa6522d1c53f43f89a376d815fbf3c43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- Restore `BbsBlsSignature2020` (Encrypted Verifiable Credential) signing, which was gated behind an error after the `@transmute` → `@digitalbazaar` migration; `getSignatureTypeBySchema` again returns `BbsBlsSignature2020` for EVC schemas.
- Drive the BBS suite through a `jsonld-signatures@7` alias (`jsonld-signatures-v7`) for both sign and verify, since the suite is incompatible with the `jsonld-signatures@11` used by `@digitalbazaar/vc` for Ed25519.
- Pin `@mattrglobal/bls12381-key-pair` and `@mattrglobal/bbs-signatures` to `2.0.0` via root resolutions; these are wire- and API-identical to the previous versions, so existing on-ledger EVCs remain verifiable.
- Vendor and serve the `w3id.org/security/suites/jws-2020/v1` JSON-LD context in the default document loader, which the `@digitalbazaar` packages do not ship but the BBS verify path needs.
- Guard `verify()` against a missing or array-valued proof, collapse the vendored-context lookups into a single map, and reuse the existing `VerificationResult` type.
- Add tests covering BBS sign/verify round-trip, tamper rejection, backward compatibility with a credential signed on the previous stack, selective-disclosure derivation and verification, and the vendored context.
