### PR TITLE
fix(queue-service): offload large task payloads to GridFS and surface enqueue errors

### DIFF
--- a/common/src/helpers/workers.ts
+++ b/common/src/helpers/workers.ts
@@ -360,6 +360,9 @@ export class Workers extends NatsService {
 
         const addTaskToQueue = async (): Promise<void> => {
             const result = await this.sendMessage<any>(QueueEvents.ADD_TASK_TO_QUEUE, task);
+            if (result?.ok === false) {
+                throw new Error(result.reason || 'ADD_TASK_TO_QUEUE: task rejected by queue service');
+            }
             if (!result?.ok) {
                 await addTaskToQueue();
             }

--- a/common/tests/unit-tests/workers-add-task.test.mjs
+++ b/common/tests/unit-tests/workers-add-task.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import { Workers } from '@guardian/common';
+// Load the package entry first so the module graph initializes in the right order
+// (importing workers.js directly otherwise hits a circular init: vc-helper -> VCJS).
+import '../../dist/index.js';
+import { Workers } from '../../dist/helpers/workers.js';
 
 // Build a Workers instance without running the NatsService constructor (and without
 // the @Singleton shared instance): we only need addTask + its dependencies.

--- a/common/tests/unit-tests/workers-add-task.test.mjs
+++ b/common/tests/unit-tests/workers-add-task.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { Workers } from '@guardian/common';
+
+// Build a Workers instance without running the NatsService constructor (and without
+// the @Singleton shared instance): we only need addTask + its dependencies.
+function makeWorkers(sendMessageStub) {
+    const w = Object.create(Workers.prototype);
+    w.tasksCallbacks = new Map();
+    w.sendMessage = sendMessageStub;
+    return w;
+}
+
+function options(overrides = {}) {
+    return {
+        task: { type: 'CREATE_ACCOUNT', data: {} },
+        priority: 10,
+        attempts: 0,
+        isRetryableTask: true,
+        registerCallback: false,
+        interception: null,
+        dryRun: null,
+        mockId: null,
+        userId: null,
+        ...overrides,
+    };
+}
+
+describe('Workers.addTask enqueue handling', () => {
+    it('rejects on an explicit ok:false and does not retry', async () => {
+        let calls = 0;
+        const reason = 'Document is larger than the maximum size 16777216';
+        const w = makeWorkers(async () => {
+            calls++;
+            return { ok: false, reason };
+        });
+
+        await assert.rejects(w.addTask(options()), (err) => {
+            assert.equal(err.message, reason);
+            return true;
+        });
+        assert.equal(calls, 1);
+    });
+
+    it('uses the fallback message when ok:false has no reason', async () => {
+        const w = makeWorkers(async () => ({ ok: false }));
+
+        await assert.rejects(w.addTask(options()), {
+            message: 'ADD_TASK_TO_QUEUE: task rejected by queue service',
+        });
+    });
+
+    it('retries when there is no response, then succeeds', async () => {
+        let calls = 0;
+        const w = makeWorkers(async () => {
+            calls++;
+            return calls === 1 ? undefined : { ok: true };
+        });
+
+        const result = await w.addTask(options({ registerCallback: false }));
+        assert.equal(result, null);
+        assert.equal(calls, 2);
+    });
+
+    it('resolves on a successful enqueue', async () => {
+        let calls = 0;
+        const w = makeWorkers(async () => {
+            calls++;
+            return { ok: true };
+        });
+
+        const result = await w.addTask(options({ registerCallback: false }));
+        assert.equal(result, null);
+        assert.equal(calls, 1);
+    });
+});

--- a/queue-service/src/entity/task.ts
+++ b/queue-service/src/entity/task.ts
@@ -1,6 +1,19 @@
-import { Entity, Index, Property } from '@mikro-orm/core';
+import {
+    AfterCreate,
+    AfterDelete,
+    AfterUpdate,
+    BeforeCreate,
+    BeforeUpdate,
+    Entity,
+    Index,
+    OnLoad,
+    Property,
+} from '@mikro-orm/core';
+import { ObjectId } from '@mikro-orm/mongodb';
 import { ITask, WorkerTaskType } from '@guardian/interfaces';
-import { BaseEntity } from '@guardian/common';
+import { BaseEntity, DataBaseHelper } from '@guardian/common';
+
+const TASK_DATA_GRIDFS_LIMIT = (+process.env.TASK_DATA_GRIDFS_LIMIT || 5 * 1024 * 1024);
 
 @Entity()
 @Index({ name: 'idx_status_createDate', properties: ['done', 'sent', 'createDate'], options: { createDate: -1 } })
@@ -27,8 +40,11 @@ export class TaskEntity extends BaseEntity implements ITask {
     @Property()
     type: WorkerTaskType;
 
-    @Property()
+    @Property({ nullable: true })
     data: any;
+
+    @Property({ nullable: true })
+    dataFileId?: ObjectId;
 
     @Property({ nullable: true })
     sent: boolean;
@@ -56,4 +72,51 @@ export class TaskEntity extends BaseEntity implements ITask {
 
     @Property({ nullable: true })
     interception: string | null;
+
+    @BeforeCreate()
+    async offloadDataOnCreate() {
+        await this.offloadData();
+    }
+
+    @BeforeUpdate()
+    async offloadDataOnUpdate() {
+        if (this.dataFileId) {
+            this.data = null;
+            return;
+        }
+        await this.offloadData();
+    }
+
+    @OnLoad()
+    @AfterCreate()
+    @AfterUpdate()
+    async restoreData() {
+        if (this.dataFileId && (this.data === null || this.data === undefined)) {
+            const buffer = await this._loadFile(this.dataFileId);
+            this.data = JSON.parse(buffer.toString());
+        }
+    }
+
+    @AfterDelete()
+    deleteDataFile() {
+        if (this.dataFileId) {
+            DataBaseHelper.gridFS
+                .delete(this.dataFileId)
+                .catch((reason) => {
+                    console.error(`AfterDelete: Task, ${this._id}, dataFileId`);
+                    console.error(reason);
+                });
+        }
+    }
+
+    private async offloadData(): Promise<void> {
+        if (this.data === null || this.data === undefined) {
+            return;
+        }
+        const json = JSON.stringify(this.data);
+        if (Buffer.byteLength(json) > TASK_DATA_GRIDFS_LIMIT) {
+            this.dataFileId = await this._createFile(json, 'Task');
+            this.data = null;
+        }
+    }
 }

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -25,9 +25,9 @@ export class QueueService extends NatsService {
             await this.clearLongPendingTasks();
         }, this.clearInterval);
 
-        this.getMessages(QueueEvents.ADD_TASK_TO_QUEUE, (task: ITask) => {
+        this.getMessages(QueueEvents.ADD_TASK_TO_QUEUE, async (task: ITask) => {
             try {
-                this.addTaskToQueue(task);
+                await this.addTaskToQueue(task);
                 return new MessageResponse({
                     ok: true
                 });

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -86,11 +86,13 @@ export class QueueService extends NatsService {
                         },
                         limit: pageSize,
                         offset: pageIndex * pageSize,
+                        exclude: ['data', 'dataFileId'],
                     }
                     : {
                         orderBy: {
                             processedTime: OrderDirection.DESC,
                         },
+                        exclude: ['data', 'dataFileId'],
                     };
             const filters: any = { userId, interception: { $ne: null } };
             if (status) {
@@ -112,14 +114,13 @@ export class QueueService extends NatsService {
             }
             const result = await new DatabaseServer().findAndCount(TaskEntity, filters, options);
             for (const task of result[0]) {
-                if (task.data) {
-                    delete task.data;
-                    delete task.userId;
-                    delete task.priority;
-                    delete task.attempt;
-                    delete task.attempts;
-                    delete task._id;
-                }
+                delete task.data;
+                delete task.dataFileId;
+                delete task.userId;
+                delete task.priority;
+                delete task.attempt;
+                delete task.attempts;
+                delete task._id;
             }
             return new MessageResponse(result);
         })

--- a/queue-service/tests/task-entity.test.mjs
+++ b/queue-service/tests/task-entity.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import { TaskEntity } from '../dist/entity/task.js';
+import { DataBaseHelper } from '@guardian/common';
+
+const largeData = () => ({ blob: 'x'.repeat(5 * 1024 * 1024 + 1024) });
+const smallData = () => ({ foo: 'bar', n: 42 });
 
 describe('TaskEntity', () => {
     it('instantiates with no constructor arguments', () => {
@@ -48,5 +52,142 @@ describe('TaskEntity', () => {
         t.interception = null;
         assert.equal(t.userId, null);
         assert.equal(t.interception, null);
+    });
+});
+
+describe('TaskEntity large-payload GridFS offloading', () => {
+    function stubFiles(t) {
+        const calls = { create: [], load: [] };
+        const nextId = 'grid-file-id';
+        const store = new Map();
+        t._createFile = async (json, name) => {
+            calls.create.push({ json, name });
+            store.set(nextId, json);
+            return nextId;
+        };
+        t._loadFile = async (id) => {
+            calls.load.push(id);
+            return Buffer.from(store.get(id) ?? '');
+        };
+        return calls;
+    }
+
+    it('keeps small data inline and does not offload', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        t.data = smallData();
+
+        await t.offloadDataOnCreate();
+
+        assert.equal(t.dataFileId, undefined);
+        assert.equal(calls.create.length, 0);
+        assert.deepEqual(t.data, smallData());
+    });
+
+    it('offloads data larger than the limit to GridFS on create', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        const original = largeData();
+        t.data = original;
+
+        await t.offloadDataOnCreate();
+
+        assert.equal(calls.create.length, 1);
+        assert.equal(calls.create[0].name, 'Task');
+        assert.ok(t.dataFileId);
+        assert.equal(t.data, null);
+        assert.deepEqual(JSON.parse(calls.create[0].json), original);
+    });
+
+    it('restores offloaded data from GridFS on load', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        const original = largeData();
+
+        t.data = original;
+        await t.offloadDataOnCreate();
+        assert.equal(t.data, null);
+        const fileId = t.dataFileId;
+
+        await t.restoreData();
+
+        assert.deepEqual(t.data, original);
+        assert.deepEqual(calls.load, [fileId]);
+    });
+
+    it('round-trips large data through offload then restore', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        const original = largeData();
+        t.data = original;
+
+        await t.offloadDataOnCreate();
+        t.data = null;
+        await t.restoreData();
+
+        assert.deepEqual(t.data, original);
+    });
+
+    it('does not re-upload on update when already offloaded', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        t.dataFileId = 'existing-file-id';
+        t.data = largeData();
+
+        await t.offloadDataOnUpdate();
+
+        assert.equal(calls.create.length, 0);
+        assert.equal(t.dataFileId, 'existing-file-id');
+        assert.equal(t.data, null);
+    });
+
+    it('offloads on update when not yet offloaded', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        t.data = largeData();
+
+        await t.offloadDataOnUpdate();
+
+        assert.equal(calls.create.length, 1);
+        assert.ok(t.dataFileId);
+        assert.equal(t.data, null);
+    });
+
+    it('restore is a no-op when data was never offloaded', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        t.data = smallData();
+
+        await t.restoreData();
+
+        assert.equal(calls.load.length, 0);
+        assert.deepEqual(t.data, smallData());
+    });
+
+    it('deletes the GridFS file on delete', () => {
+        const original = DataBaseHelper.gridFS;
+        const deleted = [];
+        DataBaseHelper.gridFS = { delete: async (id) => { deleted.push(id); } };
+        try {
+            const t = new TaskEntity();
+            t.dataFileId = 'grid-file-id';
+            t.deleteDataFile();
+            assert.deepEqual(deleted, ['grid-file-id']);
+        } finally {
+            DataBaseHelper.gridFS = original;
+        }
+    });
+
+    it('does not touch GridFS on delete when there is no offloaded file', () => {
+        const original = DataBaseHelper.gridFS;
+        let called = false;
+        DataBaseHelper.gridFS = { delete: async () => { called = true; } };
+        try {
+            const t = new TaskEntity();
+            t.deleteDataFile();
+            assert.equal(called, false);
+        } finally {
+            DataBaseHelper.gridFS = original;
+        }
     });
 });


### PR DESCRIPTION
## Problem

Publishing a large policy can produce a queue task whose `data` exceeds MongoDB's hard **16MB BSON document limit**. When `QueueService.addTaskToQueue` tries to persist it:

1. `dataBaseServer.save(TaskEntity, ...)` throws (`Document is larger than the maximum size 16777216`).
2. The `ADD_TASK_TO_QUEUE` handler invoked `addTaskToQueue()` **without `await`**, so the rejection became an **unhandled promise rejection** that crashed the queue-service process, while the handler had already returned a false `ok: true`.
3. The upstream caller (`Workers.addTask`) therefore stopped retrying and waited on a completion callback that never fired — so the publish hung indefinitely with no error reaching the client.

## Changes

**1. Offload oversized task `data` to GridFS** (`queue-service/src/entity/task.ts`)
- New `dataFileId` field. When `data`'s serialized size exceeds `TASK_DATA_GRIDFS_LIMIT` (default 5MB), it's written to GridFS via the existing `BaseEntity._createFile` and stripped from the inline document; it's restored via `_loadFile` on `@OnLoad` / `@AfterCreate` / `@AfterUpdate`, and the file is removed on `@AfterDelete`.
- Task `data` is immutable after creation, so an already-offloaded task is **not re-uploaded** on subsequent status updates.
- Tasks under the limit are unchanged (stored inline) — backward compatible, no migration.

**2. Don't crash on enqueue failure** (`queue-service/src/queue-service/queue-service.ts`)
- The handler is now `async` and `await`s `addTaskToQueue`, returning `ok: false` on failure instead of leaking an unhandled rejection.

**3. Make a definitive rejection terminal** (`common/src/helpers/workers.ts`)
- `addTask` now treats an explicit `ok: false` as a terminal error (propagated to the caller) instead of retrying forever, while still retrying on a transient no-response.

## Tests
Adds unit tests in `queue-service/tests/task-entity.test.mjs` covering offload-on-create, restore-on-load, round-trip, no-re-upload-on-update, inline small-data, and GridFS delete.