### PR TITLE
fix: relabel 'Prev' button to 'Try Again'

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/search-external-policy-dialog/search-external-policy-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/search-external-policy-dialog/search-external-policy-dialog.component.html
@@ -74,7 +74,7 @@
       <div class="dialog-button">
         <button
           (click)="onPrev()"
-        class="guardian-button guardian-button-primary">Prev</button>
+        class="guardian-button guardian-button-primary">Try Again</button>
       </div>
     }
   </div>


### PR DESCRIPTION
### Description

- In the Search Policy dialog's error state, renamed the recovery button from `Prev` to `Try Again`.
- The button returns the user to the search form to retry, so `Try Again` reflects what it does more clearly than the abbreviated `Prev`.