### PR TITLE
fix: enable revert to draft on publish error

### DIFF
--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -276,6 +276,12 @@ export class PoliciesComponent implements OnInit {
     ];
     private publishErrorMenuOption = [
         {
+            id: 'Draft',
+            title: 'To Draft',
+            description: 'Return to editing.',
+            color: '#9c27b0',
+        },
+        {
             id: 'Publish',
             title: 'Publish',
             description: 'Release version into public domain.',
@@ -1569,10 +1575,9 @@ export class PoliciesComponent implements OnInit {
     private onPublishErrorAction(event: any, element: any) {
         if (event.value.id === 'Publish') {
             this.setVersion(element);
+        } else if (event.value.id === 'Draft') {
+            this.draft(element);
         }
-        // else if (event.id === 'Draft') {
-        //     this.draft(element);
-        // }
         setTimeout(() => this.publishMenuSelector = null, 0);
     }
 

--- a/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.scss
+++ b/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.scss
@@ -903,7 +903,7 @@
     color: var(--color-accent-red-1);
     border: 1px solid var(--color-accent-red-1);
     // width: auto;
-    width: 130px;
+    width: 160px;
 
     .p-select-dropdown-icon {
         color: var(--color-accent-red-1);

--- a/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.ts
+++ b/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.ts
@@ -95,6 +95,12 @@ export class ToolsListComponent implements OnInit, OnDestroy {
     ];
     private publishErrorMenuOption = [
         {
+            id: 'Draft',
+            title: 'To Draft',
+            description: 'Return to editing.',
+            color: '#9c27b0',
+        },
+        {
             id: 'Publish',
             title: 'Publish',
             description: 'Release version into public domain.',
@@ -602,6 +608,8 @@ export class ToolsListComponent implements OnInit, OnDestroy {
     private onPublishErrorAction(event: any, element: any) {
         if (event.value.id === 'Publish') {
             this.setToolVersion(element);
+        } else if (event.value.id === 'Draft') {
+            this.draftTool(element);
         }
         setTimeout(() => this.publishMenuSelector = null, 0);
     }


### PR DESCRIPTION
### Description

- Tools and policies stuck in a failed-publish state (`PUBLISH_ERROR`, shown as "Not published") could previously only be re-published, leaving them stranded if publishing kept failing.
- Added a "To Draft" option to the publish-error status menu for both tools and policies, wired to the existing draft endpoint that the backend already supports for this transition.
- Enabled the policy publish-error draft handler (previously commented out) and fixed it to read `event.value.id` — the old commented code referenced `event.id` and would never have fired.
- Widened the tools publish-error status dropdown to 160px so the "Not published" label is no longer truncated.