### PR TITLE
fix: prevent false service error alerts during operations

### DIFF
--- a/api-gateway/src/api/service/websockets.ts
+++ b/api-gateway/src/api/service/websockets.ts
@@ -57,6 +57,13 @@ export class WebSocketsService {
      */
     private wss: WebSocketServer;
 
+    // Silence allowed before a service is reported down. Kept above 2x the
+    // frontend heartbeat (30s) so a busy service answering late is not flagged.
+    private static readonly SERVICE_LIVENESS_TTL = 70 * 1000;
+    // Pause for the current poll's replies to land before broadcasting.
+    private static readonly STATUS_POLL_WAIT = 500;
+    // Last status reply per service instance (keyed by service channel, or name).
+    private readonly serviceLiveness = new Map<string, { name: string; state: string; lastSeen: number }>();
     /**
      * Get statuses mutex
      * @private
@@ -209,9 +216,7 @@ export class WebSocketsService {
     private async getStatusesHandler(
         type: MessageAPI.UPDATE_STATUS | MessageAPI.GET_STATUS
     ) {
-        const channel = new WebSocketsServiceChannel();
-
-        const statuses = {
+        const statuses: Record<string, string[]> = {
             // LOGGER_SERVICE: [],
             GUARDIAN_SERVICE: [],
             AUTH_SERVICE: [],
@@ -220,30 +225,22 @@ export class WebSocketsService {
             NOTIFICATION_SERVICE: [],
         };
 
-        const getStatuses = (): Promise<void> => {
-            channel.publish(MessageAPI.GET_STATUS);
-            return new Promise((resolve) => {
-                const sub = channel.subscribe(
-                    MessageAPI.SEND_STATUS,
-                    // tslint:disable-next-line:no-shadowed-variable
-                    (msg) => {
-                        const { name, state } = msg;
+        // Prompt replies; the persistent SEND_STATUS listener records them,
+        // including any that arrive after this wait (they count next time).
+        this.channel.publish(MessageAPI.GET_STATUS);
+        await new Promise((resolve) => setTimeout(resolve, WebSocketsService.STATUS_POLL_WAIT));
 
-                        if (!statuses[name]) {
-                            statuses[name] = [];
-                        }
-                        statuses[name].push(state);
-                    }
-                );
-
-                setTimeout(() => {
-                    sub.unsubscribe();
-                    resolve();
-                }, 300);
-            });
-        };
-
-        await getStatuses();
+        const now = Date.now();
+        this.serviceLiveness.forEach((info, key) => {
+            if (now - info.lastSeen > WebSocketsService.SERVICE_LIVENESS_TTL) {
+                this.serviceLiveness.delete(key);
+                return;
+            }
+            if (!statuses[info.name]) {
+                statuses[info.name] = [];
+            }
+            statuses[info.name].push(info.state);
+        });
 
         this.getStatusesClients.forEach((client: any) => {
             this.send(client, {
@@ -370,6 +367,18 @@ export class WebSocketsService {
             });
 
             return new MessageResponse({});
+        });
+
+        this.channel.subscribe(MessageAPI.SEND_STATUS, (msg) => {
+            const { name, state, serviceName } = msg || {};
+            if (!name) {
+                return;
+            }
+            this.serviceLiveness.set(serviceName || name, {
+                name,
+                state,
+                lastSeen: Date.now(),
+            });
         });
 
         this.channel.subscribe(MessageAPI.UPDATE_STATUS, async (msg) => {

--- a/frontend/src/app/services/web-socket.service.ts
+++ b/frontend/src/app/services/web-socket.service.ts
@@ -30,6 +30,8 @@ interface MeecoApproveSubmissionResponse {
 export class WebSocketService {
     private static HEARTBEAT_DELAY = 30 * 1000;
     private static RECONNECT_NOTIFY_AFTER_MS = 15 * 1000;
+    private static SERVICES_STATUS_GRACE_MS = 5 * 1000;
+    private static SERVICES_STATUS_POLL_MS = 1000;
     private socket: WebSocketSubject<string> | null;
     private wsSubjectConfig: WebSocketSubjectConfig<string>;
     private socketSubscription: Subscription | null = null;
@@ -60,6 +62,7 @@ export class WebSocketService {
     private sendingEvent: boolean;
 
     private requiredServicesWrongStatus: boolean = false;
+    private servicesStatusCheckTimeout: any = null;
 
     public readonly meecoPresentVP$: Observable<any> = this.meecoPresentVPSubject.asObservable();
     public readonly meecoVerifyVP$: Observable<any> = this.meecoVerifyVPSubject.asObservable();
@@ -122,6 +125,10 @@ export class WebSocketService {
         }
         if (this.heartbeatTimeout) {
             clearTimeout(this.heartbeatTimeout);
+        }
+        if (this.servicesStatusCheckTimeout) {
+            clearTimeout(this.servicesStatusCheckTimeout);
+            this.servicesStatusCheckTimeout = null;
         }
 
         this.socketSubscription = null;
@@ -284,23 +291,7 @@ export class WebSocketService {
                 case MessageAPI.GET_STATUS:
                 case MessageAPI.UPDATE_STATUS:
                     this.updateStatus(data);
-
-                    const notReadyServices = this.serviesStates.filter((item: any) => !item.states.includes(ApplicationStates.READY));
-                    const allStatesReady = notReadyServices.length === 0;
-
-                    if (!allStatesReady && !this.requiredServicesWrongStatus) {
-                        this.requiredServicesWrongStatus = true;
-                        if (!['/status', '/admin/settings', '/admin/logs', '/login'].includes(location.pathname)) {
-                            const last = location.pathname === '/status' ? null : btoa(location.href);
-                            //this.router.navigate(['/status'], { queryParams: { last } });
-                            this.dialogService.open(ServiceUnavailableDialog, {
-                                closable: true,
-                                header: 'Something went wrong',
-                                width: '500px',
-                            });
-                        }
-                    }
-                    this.servicesReady.next(allStatesReady);
+                    this.evaluateServicesStatus();
                     break;
                 case MessageAPI.UPDATE_RECORD: {
                     this.recordUpdateSubject.next(data);
@@ -583,6 +574,52 @@ export class WebSocketService {
             }
             existsService.states = serviceStatus[serviceName]
         }
+    }
+
+    private isAllServicesReady(): boolean {
+        return this.serviesStates.every((item: any) => item.states.includes(ApplicationStates.READY));
+    }
+
+    // Alert on a not-ready service, but re-check across a short grace period
+    // first so a transient blip (e.g. a service restarting) is ignored, and
+    // re-arm on recovery so a later outage is reported again.
+    private evaluateServicesStatus() {
+        const allStatesReady = this.isAllServicesReady();
+
+        if (allStatesReady) {
+            if (this.servicesStatusCheckTimeout) {
+                clearTimeout(this.servicesStatusCheckTimeout);
+                this.servicesStatusCheckTimeout = null;
+            }
+            this.requiredServicesWrongStatus = false;
+        } else if (!this.requiredServicesWrongStatus && !this.servicesStatusCheckTimeout) {
+            this.scheduleServicesStatusCheck(Date.now() + WebSocketService.SERVICES_STATUS_GRACE_MS);
+        }
+
+        this.servicesReady.next(allStatesReady);
+    }
+
+    private scheduleServicesStatusCheck(deadline: number) {
+        this.send(MessageAPI.GET_STATUS, null);
+        this.servicesStatusCheckTimeout = setTimeout(() => {
+            this.servicesStatusCheckTimeout = null;
+            if (this.isAllServicesReady()) {
+                this.requiredServicesWrongStatus = false;
+                return;
+            }
+            if (Date.now() < deadline) {
+                this.scheduleServicesStatusCheck(deadline);
+                return;
+            }
+            this.requiredServicesWrongStatus = true;
+            if (!['/status', '/admin/settings', '/admin/logs', '/login'].includes(location.pathname)) {
+                this.dialogService.open(ServiceUnavailableDialog, {
+                    closable: true,
+                    header: 'Something went wrong',
+                    width: '500px',
+                });
+            }
+        }, WebSocketService.SERVICES_STATUS_POLL_MS);
     }
 
     public IsServicesReady() {


### PR DESCRIPTION
### Description

- Fixed a false "Something went wrong" modal that appeared during long operations such as policy import or dry-run, even though the operation completed successfully.
- Root cause was in the api-gateway: it checked each service's health by asking for a status reply and ignoring anything that arrived later than 300ms. A service that is merely busy answers late, so it looked exactly like a crashed one and was reported as unavailable, triggering the modal mid-operation.
- The gateway now tracks the most recent status reply from each service, including late ones, and reports a service as unavailable only after it has been silent for longer than two heartbeats (~70s). A busy service keeps answering (late), so it is no longer mistaken for a down service, while a genuinely down service is still detected.
- The frontend re-checks status across a short grace period before showing the modal, so a brief blip (such as a service restarting) is ignored.
- The alert resets once services recover, so a later genuine outage is reported again (previously it only fired once).
- Pending checks are cancelled when the websocket connection closes, so an old timer cannot trigger the modal during a reconnect.

Resolves #6281 