### PR TITLE
chore: remove stale azure/image-size resolutions

### DIFF
--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -6,10 +6,6 @@
         "@interfaces": "dist/interfaces",
         "@middlewares": "dist/middlewares"
     },
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
         "@guardian/common": "workspace:*",

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -55,10 +55,6 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "name": "api-gateway",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "cp environments/environment.demo.ts src/environment.ts && tsc",
         "build:demo": "cp environments/environment.demo.ts src/environment.ts && tsc",

--- a/application-events/package.json
+++ b/application-events/package.json
@@ -40,10 +40,6 @@
     "license": "Apache-2.0",
     "main": "index.js",
     "name": "application-events",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",

--- a/common/package.json
+++ b/common/package.json
@@ -81,10 +81,6 @@
         "./dist/entity/**/*.js"
     ],
     "name": "@guardian/common",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",

--- a/indexer-api-gateway/package.json
+++ b/indexer-api-gateway/package.json
@@ -7,10 +7,6 @@
         "#dto": "./dist/dto/index.js",
         "#decorators": "./dist/decorators/index.js"
     },
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "author": "Hashgraph <guardian@hashgraph.com>",
     "dependencies": {
         "@indexer/common": "workspace:*",

--- a/mrv-sender/package.json
+++ b/mrv-sender/package.json
@@ -1,9 +1,5 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "dependencies": {
         "@digitalbazaar/credentials-context": "3.2.0",
         "@digitalbazaar/ed25519-signature-2018": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "packageManager": "yarn@4.16.0",
     "private": true,
     "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2",
         "@mattrglobal/bls12381-key-pair": "2.0.0",
         "@mattrglobal/bbs-signatures": "2.0.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,15 +1145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/abort-controller@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@azure/abort-controller@npm:1.1.0"
-  dependencies:
-    tslib: "npm:^2.2.0"
-  checksum: 10c0/bb79f0faaa9e9c1ae3c4ec2523ea23ee0879cc491abb4b3ac2dd56c2cc2dfe4b7e8522ffa866d39c7145c0dd61387711368afe0d4eb6534daba7b67ed0a2a730
-  languageName: node
-  linkType: hard
-
 "@azure/abort-controller@npm:^2.0.0, @azure/abort-controller@npm:^2.1.2":
   version: 2.1.2
   resolution: "@azure/abort-controller@npm:2.1.2"
@@ -1163,7 +1154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-auth@npm:^1.10.0, @azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.9.0":
+"@azure/core-auth@npm:^1.10.0, @azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.9.0":
   version: 1.10.1
   resolution: "@azure/core-auth@npm:1.10.1"
   dependencies:
@@ -1210,24 +1201,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-rest-pipeline@npm:1.12.1":
-  version: 1.12.1
-  resolution: "@azure/core-rest-pipeline@npm:1.12.1"
+"@azure/core-rest-pipeline@npm:^1.17.0, @azure/core-rest-pipeline@npm:^1.19.0, @azure/core-rest-pipeline@npm:^1.22.0, @azure/core-rest-pipeline@npm:^1.8.0":
+  version: 1.24.0
+  resolution: "@azure/core-rest-pipeline@npm:1.24.0"
   dependencies:
-    "@azure/abort-controller": "npm:^1.0.0"
-    "@azure/core-auth": "npm:^1.4.0"
-    "@azure/core-tracing": "npm:^1.0.1"
-    "@azure/core-util": "npm:^1.3.0"
-    "@azure/logger": "npm:^1.0.0"
-    form-data: "npm:^4.0.0"
-    http-proxy-agent: "npm:^5.0.0"
-    https-proxy-agent: "npm:^5.0.0"
-    tslib: "npm:^2.2.0"
-  checksum: 10c0/0d106f10aea8902e5e7f2f45d8509b84bd8654516641aafc4a7486d8aaa591932209cf2cf5312c15aa22898e3d0142ecadfc63b1412781d019a9652cc001066f
+    "@azure/abort-controller": "npm:^2.1.2"
+    "@azure/core-auth": "npm:^1.10.0"
+    "@azure/core-tracing": "npm:^1.3.0"
+    "@azure/core-util": "npm:^1.13.0"
+    "@azure/logger": "npm:^1.3.0"
+    "@typespec/ts-http-runtime": "npm:^0.3.4"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4ae0eca54641108ad754e5e73384a74a4c1f453660c293c06f528a27fc089abfb3cbfebad8a773f4abd2e3cdb9f88163f6050d440fb834f16d557a705f63e7d9
   languageName: node
   linkType: hard
 
-"@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1, @azure/core-tracing@npm:^1.2.0, @azure/core-tracing@npm:^1.3.0":
+"@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.2.0, @azure/core-tracing@npm:^1.3.0":
   version: 1.3.1
   resolution: "@azure/core-tracing@npm:1.3.1"
   dependencies:
@@ -1236,7 +1225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-util@npm:^1.10.0, @azure/core-util@npm:^1.11.0, @azure/core-util@npm:^1.13.0, @azure/core-util@npm:^1.2.0, @azure/core-util@npm:^1.3.0":
+"@azure/core-util@npm:^1.10.0, @azure/core-util@npm:^1.11.0, @azure/core-util@npm:^1.13.0, @azure/core-util@npm:^1.2.0":
   version: 1.13.1
   resolution: "@azure/core-util@npm:1.13.1"
   dependencies:
@@ -4715,13 +4704,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.1
-  resolution: "@tootallnate/once@npm:2.0.1"
-  checksum: 10c0/23b01a341485be711c602077936d70f8e695405bb88ab4433dc6d1e6cb4556401518789574d399eded790b70b27738136c9a8f02df7ae4219f4ba28bb22d586b
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.12
   resolution: "@tsconfig/node10@npm:1.0.12"
@@ -5169,6 +5151,17 @@ __metadata:
     https-proxy-agent: "npm:^7.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/33cb3d7a38851a4144b8370c39d6ad9e77b722213cb0eafef9a9e52e35f611d88ebdfd264bb3b51147a2fa4de8d78c8cff294af9e58ebb39ab6c439588771d2b
+  languageName: node
+  linkType: hard
+
+"@typespec/ts-http-runtime@npm:^0.3.4":
+  version: 0.3.6
+  resolution: "@typespec/ts-http-runtime@npm:0.3.6"
+  dependencies:
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7e530e0272c908a1833193900bfa3ed021b090559c48498d59a0c242e3489f8fcfd3ead0fe7dd8bac6aa783c305d3668ab795a27056cb3ef8cc3b5ea45d49158
   languageName: node
   linkType: hard
 
@@ -9706,17 +9699,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
-  dependencies:
-    "@tootallnate/once": "npm:2"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/32a05e413430b2c1e542e5c74b38a9f14865301dd69dff2e53ddb684989440e3d2ce0c4b64d25eb63cf6283e6265ff979a61cf93e3ca3d23047ddfdc8df34a32
-  languageName: node
-  linkType: hard
-
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -9826,14 +9808,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"image-size@npm:1.0.2":
-  version: 1.0.2
-  resolution: "image-size@npm:1.0.2"
+"image-size@npm:^1.0.2":
+  version: 1.2.1
+  resolution: "image-size@npm:1.2.1"
   dependencies:
     queue: "npm:6.0.2"
   bin:
     image-size: bin/image-size.js
-  checksum: 10c0/df518606c75d0ee12a6d7e822a64ef50d9eabbb303dcee8c9df06bad94e49b4d4680b9003968203f239ff39a9cc51d4ff1781cd331cc0a4b3b858d9fc9836c68
+  checksum: 10c0/f8b3c19d4476513f1d7e55c3e6db80997b315444743e2040d545cbcaee59be03d2eb40c46be949a8372697b7003fdb0c04925d704390a7f606bc8181e25c0ed4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

- Removed two long-standing Yarn `resolutions` that are no longer needed:
  - `@azure/core-rest-pipeline: 1.12.1` — the current Azure SDK packages (`@azure/identity`, `@azure/keyvault-secrets`, and their dependencies) request `^1.17.0`/`^1.19.0`/`^1.22.0`, so this pin was forcing a downgrade to a version that satisfied none of those ranges. It now resolves to 1.24.0.
  - `image-size: 1.0.2` — its only consumer, `excel4node`, just requires `^1.0.2`; nothing needs the old floor. It now resolves to 1.2.1.
- Dropped the per-service copies of these resolutions across 11 workspaces. Yarn only honors `resolutions` from the root manifest, so those copies had no effect.
- Regenerated `yarn.lock` to re-resolve the affected dependencies.