### PR TITLE
fix: correct schema preview dialog header

### DIFF
--- a/frontend/src/app/views/schemas/schemas.component.ts
+++ b/frontend/src/app/views/schemas/schemas.component.ts
@@ -1144,7 +1144,7 @@ export class SchemaConfigComponent implements OnInit {
     public onOpenForm(schema: Schema, example: boolean): void {
         this.dialog.open(SchemaFormDialog, {
             showHeader: false,
-            header: 'Dry run with test data',
+            header: example ? 'Dry run with test data' : 'Preview',
             width: '90%',
             styleClass: 'guardian-dialog',
             data: {


### PR DESCRIPTION
### Description

- Schema preview dialog showed the same header as the dry run option ("Dry run with test data").
- Updated `onOpenForm` in the schemas view to set the header to "Preview" when opening the preview dialog, keeping "Dry run with test data" for the dry run case.

Resolves #6300