### PR TITLE
chore: more stale azure/image-size resolutions

### DIFF
--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -55,10 +55,6 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "name": "auth-service",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "cp environments/environment.demo.ts src/environment.ts && tsc",
         "build:demo": "cp environments/environment.demo.ts src/environment.ts && tsc",

--- a/guardian-service/package.json
+++ b/guardian-service/package.json
@@ -58,10 +58,6 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "name": "guardian-service",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",

--- a/logger-service/package.json
+++ b/logger-service/package.json
@@ -28,10 +28,6 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "name": "logger-service",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",

--- a/notification-service/package.json
+++ b/notification-service/package.json
@@ -29,10 +29,6 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "name": "notification-service",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",

--- a/policy-service/package.json
+++ b/policy-service/package.json
@@ -56,10 +56,6 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "name": "policy-service",
-    "resolutions": {
-        "@azure/core-rest-pipeline": "1.12.1",
-        "image-size": "1.0.2"
-    },
     "scripts": {
         "build": "tsc",
         "build:prod": "tsc --project tsconfig.production.json",


### PR DESCRIPTION
Remove the resolutions field from package.json files across services (auth, guardian, logger, notification, and policy).