### PR TITLE
chore: update MongoDB image version to 6.0.28

### DIFF
--- a/docker-compose-analytics-build.yml
+++ b/docker-compose-analytics-build.yml
@@ -68,7 +68,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-analytics.yml
+++ b/docker-compose-analytics.yml
@@ -62,7 +62,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -160,7 +160,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-indexer-build.yml
+++ b/docker-compose-indexer-build.yml
@@ -98,7 +98,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-indexer.yml
+++ b/docker-compose-indexer.yml
@@ -90,7 +90,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-production-build.yml
+++ b/docker-compose-production-build.yml
@@ -164,7 +164,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -151,7 +151,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-quickstart-build.yml
+++ b/docker-compose-quickstart-build.yml
@@ -113,7 +113,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     # command: "--setParameter allowDiskUseByDefault=true"
     command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -107,7 +107,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     # command: "--setParameter allowDiskUseByDefault=true"
     command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
     init: true
 
   mongo:
-    image: mongo:6.0.26
+    image: mongo:6.0.28
     command: "--setParameter allowDiskUseByDefault=true"
     # command: "--setParameter allowDiskUseByDefault=true --quiet --logpath /dev/null" # use this command to reduce log noise
     restart: always


### PR DESCRIPTION
Upgrade MongoDB Docker image from 6.0.26 to 6.0.28 across all docker-compose configuration files. This patch update includes bug fixes and security improvements.