### PR TITLE
fix: prevent service crashes from unhandled promise rejections

### DIFF
--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -4,7 +4,7 @@ import { PolicyEngine } from './helpers/policy-engine.js';
 import { WebSocketsService } from './api/service/websockets.js';
 import { Users } from './helpers/users.js';
 import { Wallet } from './helpers/wallet.js';
-import { GenerateTLSOptionsNats, JwtServicesValidator, LargePayloadContainer, MessageBrokerChannel, OldSecretManager, PinoLogger } from '@guardian/common';
+import { GenerateTLSOptionsNats, JwtServicesValidator, LargePayloadContainer, markServiceBooted, MessageBrokerChannel, OldSecretManager, PinoLogger, setGlobalErrorLogger } from '@guardian/common';
 import { TaskManager } from './helpers/task-manager.js';
 import { AppModule } from './app.module.js';
 import { NestFactory } from '@nestjs/core';
@@ -66,6 +66,7 @@ Promise.all([
         }));
 
         const logger: PinoLogger = app.get(PinoLogger);
+        setGlobalErrorLogger(logger);
 
         app.useBodyParser('binary/octet-stream', { bodyLimit: BODY_LIMIT });
 
@@ -113,6 +114,10 @@ Promise.all([
         app.listen(PORT, '0.0.0.0', async () => {
             await logger.info(`Started on ${PORT}`, ['API_GATEWAY'], null);
         });
+
+        // Bootstrap complete: from here on, a stray unhandled rejection is logged
+        // and swallowed instead of terminating the process.
+        markServiceBooted();
     } catch (error) {
         console.error(error.message);
         process.exit(1);

--- a/api-gateway/src/helpers/register-global-error-handlers.ts
+++ b/api-gateway/src/helpers/register-global-error-handlers.ts
@@ -1,0 +1,6 @@
+import { registerGlobalErrorHandlers } from '@guardian/common';
+
+// Registered as a side effect on import so the safety nets are active before the
+// application bootstrap (imported afterwards in index.ts) can produce any
+// unhandled rejection. See process-error-handlers.ts in @guardian/common.
+registerGlobalErrorHandlers(['API_GATEWAY']);

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,2 +1,3 @@
+import './helpers/register-global-error-handlers.js';
 import './config.js';
 import './app.js';

--- a/common/src/helpers/index.ts
+++ b/common/src/helpers/index.ts
@@ -27,6 +27,7 @@ export * from './console-transport.js';
 export * from './mongo-logging-initialization.js';
 export * from './pino-logger.js';
 export * from './pino-logger-initialization.js';
+export * from './process-error-handlers.js';
 export * from './insert-variables.js';
 export * from './generate-tls-options.js';
 export * from './encrypt-vc-helper.js';

--- a/common/src/helpers/process-error-handlers.ts
+++ b/common/src/helpers/process-error-handlers.ts
@@ -1,0 +1,85 @@
+import process from 'process';
+import { PinoLogger } from './pino-logger.js';
+
+/**
+ * Logger used by the global handlers once the service has initialized one.
+ * Until {@link setGlobalErrorLogger} is called (early boot) the handlers fall
+ * back to console output only.
+ * @private
+ */
+let activeLogger: PinoLogger | null = null;
+
+/**
+ * Whether the owning service has finished bootstrapping. A stray rejection
+ * *before* boot completes leaves the service half-initialized, so we exit and
+ * let the orchestrator restart a clean instance. After boot we keep running so
+ * that a single failed operation (e.g. one policy failing to initialize) cannot
+ * take down the whole process.
+ * @private
+ */
+let booted = false;
+
+/**
+ * Attributes attached to every logged global error.
+ * @private
+ */
+let logAttributes: string[] = ['GLOBAL'];
+
+/**
+ * Route the global error handlers to a PinoLogger once one is available.
+ * @param logger initialized logger
+ */
+export function setGlobalErrorLogger(logger: PinoLogger): void {
+    activeLogger = logger;
+}
+
+/**
+ * Mark bootstrap as complete. After this, unhandled rejections are logged and
+ * swallowed instead of terminating the process.
+ */
+export function markServiceBooted(): void {
+    booted = true;
+}
+
+/**
+ * Log a global error through both the console (always) and the PinoLogger (if set).
+ * @private
+ */
+function logGlobalError(kind: string, error: Error): void {
+    // Console first: guaranteed to reach stdout even if the logger is down.
+    console.error(`[${kind}]`, error.stack || error.message);
+    // PinoLogger is async and must never itself throw from inside a handler.
+    activeLogger?.error(error, [...logAttributes, kind], null).catch(() => { /* noop */ });
+}
+
+/**
+ * Register process-level safety nets so a single stray promise rejection or
+ * uncaught exception cannot silently crash the service.
+ *
+ * - `unhandledRejection`: logged. Terminates only if it happens before boot
+ *   completes; after boot it is swallowed to keep the service available.
+ * - `uncaughtException`: process state is undefined afterwards, so we log
+ *   synchronously and exit(1) for a clean restart.
+ *
+ * Must be called as early as possible during startup (before the bootstrap that
+ * can produce rejections).
+ *
+ * @param attributes log attributes identifying the service (e.g. ['GUARDIAN_SERVICE'])
+ */
+export function registerGlobalErrorHandlers(attributes: string[]): void {
+    logAttributes = attributes;
+
+    process.on('unhandledRejection', (reason: unknown) => {
+        const error = reason instanceof Error ? reason : new Error(String(reason));
+        logGlobalError('unhandledRejection', error);
+        if (!booted) {
+            console.error('[unhandledRejection] occurred during startup - exiting for a clean restart');
+            process.exit(1);
+        }
+    });
+
+    process.on('uncaughtException', (error: Error) => {
+        logGlobalError('uncaughtException', error);
+        process.exit(1);
+    });
+}

--- a/common/src/helpers/process-error-handlers.ts
+++ b/common/src/helpers/process-error-handlers.ts
@@ -26,6 +26,28 @@ let booted = false;
 let logAttributes: string[] = ['GLOBAL'];
 
 /**
+ * Guards against registering the process listeners more than once (duplicate
+ * imports, tests, hot reload), which would fire every handler N times.
+ * @private
+ */
+let handlersRegistered = false;
+
+/**
+ * Number of post-boot unhandled rejections that have been logged and swallowed.
+ * Exposed so callers can surface it as a metric / health signal — swallowing
+ * indefinitely without observability can hide a persistently failing path.
+ * @private
+ */
+let swallowedRejections = 0;
+
+/**
+ * @returns the number of post-boot unhandled rejections swallowed so far.
+ */
+export function getSwallowedRejectionCount(): number {
+    return swallowedRejections;
+}
+
+/**
  * Route the global error handlers to a PinoLogger once one is available.
  * @param logger initialized logger
  */
@@ -69,12 +91,21 @@ function logGlobalError(kind: string, error: Error): void {
 export function registerGlobalErrorHandlers(attributes: string[]): void {
     logAttributes = attributes;
 
+    // Idempotent: keep the latest attributes but attach the listeners only once.
+    if (handlersRegistered) {
+        return;
+    }
+    handlersRegistered = true;
+
     process.on('unhandledRejection', (reason: unknown) => {
         const error = reason instanceof Error ? reason : new Error(String(reason));
         logGlobalError('unhandledRejection', error);
         if (!booted) {
             console.error('[unhandledRejection] occurred during startup - exiting for a clean restart');
             process.exit(1);
+        } else {
+            swallowedRejections += 1;
+            console.error(`[unhandledRejection] swallowed post-boot (total: ${swallowedRejections})`);
         }
     });
 

--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -87,7 +87,18 @@ export abstract class NatsService {
                     const serviceToken = msg.headers?.get('serviceToken');
                     const fn = this.responseCallbacksMap.get(messageId);
                     if (fn) {
-                        const message = (await this.codec.decode(msg.data)) as IMessageResponse<any>;
+                        let message: IMessageResponse<any>;
+                        try {
+                            message = (await this.codec.decode(msg.data)) as IMessageResponse<any>;
+                        } catch (e: any) {
+                            // Decode may fetch a large-payload directLink; a failure here (e.g.
+                            // ECONNREFUSED when the responder died mid-request) must fail this
+                            // request rather than throw out of the async callback and crash the process.
+                            console.error('Reply decode failed:', e.message);
+                            fn(null, e.message, 500);
+                            this.responseCallbacksMap.delete(messageId);
+                            return;
+                        }
                         if (!message) {
                             fn(null)
                         } else {

--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -94,8 +94,10 @@ export abstract class NatsService {
                             // Decode may fetch a large-payload directLink; a failure here (e.g.
                             // ECONNREFUSED when the responder died mid-request) must fail this
                             // request rather than throw out of the async callback and crash the process.
+                            // Log the detail server-side; return a generic message to the caller so
+                            // internal exception text (e.g. the directLink URL) is not leaked.
                             console.error('Reply decode failed:', e.message);
-                            fn(null, e.message, 500);
+                            fn(null, 'Failed to decode reply payload', 500);
                             this.responseCallbacksMap.delete(messageId);
                             return;
                         }
@@ -204,7 +206,7 @@ export abstract class NatsService {
     public sendMessage<T>(subject: string, data?: unknown, isResponseCallback: boolean = true, externalMessageId?: string): Promise<T> {
         const messageId = externalMessageId ?? GenerateUUIDv4();
 
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const head = headers();
             head.append('messageId', messageId);
             if (isResponseCallback) {
@@ -218,13 +220,22 @@ export abstract class NatsService {
             } else {
                 resolve(null);
             }
-            const token = await JwtServicesValidator.sign(subject);
-            head.append('serviceToken', token);
+            // Run the async work outside the Promise executor: a rejection from
+            // sign/encode/publish inside an async executor is neither caught nor
+            // settles this promise (it becomes an unhandledRejection and the
+            // caller hangs). Route it to reject and clean up the callback instead.
+            (async () => {
+                const token = await JwtServicesValidator.sign(subject);
+                head.append('serviceToken', token);
 
-            this.connection.publish(subject, await this.codec.encode(data), {
-                reply: this.replySubject,
-                headers: head
-            })
+                this.connection.publish(subject, await this.codec.encode(data), {
+                    reply: this.replySubject,
+                    headers: head
+                })
+            })().catch((e) => {
+                this.responseCallbacksMap.delete(messageId);
+                reject(e instanceof Error ? e : new Error(String(e)));
+            });
         });
     }
 
@@ -256,7 +267,7 @@ export abstract class NatsService {
      */
     public sendRawMessage<T>(subject: string, data?: unknown): Promise<T> {
         const messageId = GenerateUUIDv4();
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const head = headers();
             head.append('messageId', messageId);
             // head.append('rawMessage', 'true');
@@ -267,15 +278,23 @@ export abstract class NatsService {
                 } else {
                     resolve(body);
                 }
-            })
+            });
 
-            const token = await JwtServicesValidator.sign(subject);
-            head.append('serviceToken', token);
+            // See sendMessage: keep async work out of the Promise executor so a
+            // sign/encode/publish failure rejects this promise (and clears the
+            // callback) instead of becoming an unhandledRejection.
+            (async () => {
+                const token = await JwtServicesValidator.sign(subject);
+                head.append('serviceToken', token);
 
-            this.connection.publish(subject, await this.codec.encode(data), {
-                reply: this.replySubject,
-                headers: head
-            })
+                this.connection.publish(subject, await this.codec.encode(data), {
+                    reply: this.replySubject,
+                    headers: head
+                })
+            })().catch((e) => {
+                this.responseCallbacksMap.delete(messageId);
+                reject(e instanceof Error ? e : new Error(String(e)));
+            });
         });
     }
 

--- a/common/tests/unit-tests/nats-service-reply-decode.test.mjs
+++ b/common/tests/unit-tests/nats-service-reply-decode.test.mjs
@@ -53,9 +53,10 @@ describe('NatsService reply handler decode failure', () => {
         // Must resolve (not reject) — that is the whole point of the fix.
         await getReplyCallback()(null, makeMsg('mid-1', 'test-reply'));
 
+        // The caller receives a generic message; internal detail stays server-side.
         assert.deepEqual(result, {
             body: null,
-            error: 'connect ECONNREFUSED 10.0.0.1:55427',
+            error: 'Failed to decode reply payload',
             code: 500
         });
         assert.equal(svc.responseCallbacksMap.has('mid-1'), false, 'callback must be cleaned up');
@@ -84,5 +85,35 @@ describe('NatsService reply handler decode failure', () => {
         );
         await getReplyCallback()(null, makeMsg('unknown-id', 'test-reply'));
         assert.equal(svc.responseCallbacksMap.size, 0);
+    });
+});
+
+/**
+ * sendMessage/sendRawMessage must not use an async Promise executor: a
+ * sign/encode/publish failure there becomes an unhandledRejection and leaves the
+ * caller's promise pending forever. The fix must reject the promise and clean up
+ * the pending response callback instead.
+ */
+describe('NatsService send failure handling', () => {
+    afterEach(() => sinon.restore());
+
+    it('sendMessage rejects (and clears its callback) when encode fails, instead of hanging', async () => {
+        sinon.stub(JwtServicesValidator, 'sign').resolves('token');
+        const { svc } = await buildService(async () => ({}));
+        svc.connection.publish = () => { };
+        svc.codec.encode = async () => { throw new Error('encode boom'); };
+
+        await assert.rejects(svc.sendMessage('subject', { x: 1 }), /encode boom/);
+        assert.equal(svc.responseCallbacksMap.size, 0, 'pending callback must be cleaned up');
+    });
+
+    it('sendRawMessage rejects (and clears its callback) when sign fails, instead of hanging', async () => {
+        sinon.stub(JwtServicesValidator, 'sign').rejects(new Error('sign boom'));
+        const { svc } = await buildService(async () => ({}));
+        svc.connection.publish = () => { };
+        svc.codec.encode = async (d) => d;
+
+        await assert.rejects(svc.sendRawMessage('subject', { x: 1 }), /sign boom/);
+        assert.equal(svc.responseCallbacksMap.size, 0, 'pending callback must be cleaned up');
     });
 });

--- a/common/tests/unit-tests/nats-service-reply-decode.test.mjs
+++ b/common/tests/unit-tests/nats-service-reply-decode.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { NatsService } from '../../dist/mq/nats-service.js';
+import { JwtServicesValidator } from '../../dist/security/index.js';
+
+/**
+ * A failure while decoding a reply (e.g. a large-payload directLink fetch
+ * throwing ECONNREFUSED when the responder died mid-request) must fail only
+ * that request instead of throwing out of the async subscribe callback and
+ * crashing the process.
+ */
+class TestNats extends NatsService {
+    messageQueueName = 'test-queue';
+    replySubject = 'test-reply';
+}
+
+async function buildService(decodeImpl) {
+    const svc = new TestNats();
+    let replyCallback;
+    // connection/codec are TS-protected; accessible at runtime in JS tests.
+    svc.connection = {
+        subscribe: (_subject, opts) => {
+            replyCallback = opts.callback;
+            return {};
+        }
+    };
+    svc.codec = { decode: decodeImpl, encode: async (d) => d };
+    await svc.init();
+    return { svc, getReplyCallback: () => replyCallback };
+}
+
+function makeMsg(messageId, subject) {
+    return {
+        subject,
+        data: new Uint8Array(),
+        headers: { get: (key) => (key === 'messageId' ? messageId : 'token') }
+    };
+}
+
+describe('NatsService reply handler decode failure', () => {
+    afterEach(() => sinon.restore());
+
+    it('routes a decode failure to the caller as code 500 without throwing out of the callback', async () => {
+        const { svc, getReplyCallback } = await buildService(
+            async () => { throw new Error('connect ECONNREFUSED 10.0.0.1:55427'); }
+        );
+
+        let result;
+        svc.responseCallbacksMap.set('mid-1', (body, error, code) => {
+            result = { body, error, code };
+        });
+
+        // Must resolve (not reject) — that is the whole point of the fix.
+        await getReplyCallback()(null, makeMsg('mid-1', 'test-reply'));
+
+        assert.deepEqual(result, {
+            body: null,
+            error: 'connect ECONNREFUSED 10.0.0.1:55427',
+            code: 500
+        });
+        assert.equal(svc.responseCallbacksMap.has('mid-1'), false, 'callback must be cleaned up');
+    });
+
+    it('still delivers a successful reply body to the waiting caller', async () => {
+        sinon.stub(JwtServicesValidator, 'verify').resolves();
+        const { svc, getReplyCallback } = await buildService(
+            async () => ({ body: { ok: true }, error: undefined, code: 200 })
+        );
+
+        let result;
+        svc.responseCallbacksMap.set('mid-2', (body, error, code) => {
+            result = { body, error, code };
+        });
+
+        await getReplyCallback()(null, makeMsg('mid-2', 'test-reply'));
+
+        assert.deepEqual(result, { body: { ok: true }, error: undefined, code: 200 });
+        assert.equal(svc.responseCallbacksMap.has('mid-2'), false, 'callback must be cleaned up');
+    });
+
+    it('ignores replies with no registered callback (no throw)', async () => {
+        const { svc, getReplyCallback } = await buildService(
+            async () => { throw new Error('should not be called'); }
+        );
+        await getReplyCallback()(null, makeMsg('unknown-id', 'test-reply'));
+        assert.equal(svc.responseCallbacksMap.size, 0);
+    });
+});

--- a/common/tests/unit-tests/process-error-handlers.test.mjs
+++ b/common/tests/unit-tests/process-error-handlers.test.mjs
@@ -3,57 +3,69 @@ import sinon from 'sinon';
 import {
     registerGlobalErrorHandlers,
     setGlobalErrorLogger,
-    markServiceBooted
+    markServiceBooted,
+    getSwallowedRejectionCount
 } from '../../dist/helpers/process-error-handlers.js';
 
 /**
  * A stray promise rejection must not silently crash the whole service. The
- * module keeps process-global state (booted flag), so tests are ordered: all
- * pre-boot expectations run before the boot flag is set, and the post-boot
- * expectation runs last.
+ * module keeps process-global state (booted flag, registration guard), so the
+ * listeners can only be attached once — we capture them via a stubbed
+ * process.on and drive them directly. Pre-boot expectations run before the boot
+ * flag is set; the post-boot expectation runs last.
  */
 describe('global process error handlers', () => {
-    let handlers;
-    let exitStub;
+    const handlers = {};
+    let onStub;
 
-    beforeEach(() => {
-        handlers = {};
-        // Capture registered handlers instead of attaching real process listeners
-        // (so invoking them can't interfere with the test runner).
-        sinon.stub(process, 'on').callsFake((event, fn) => {
+    before(() => {
+        // Capture the (single) registered handlers instead of attaching real listeners.
+        onStub = sinon.stub(process, 'on').callsFake((event, fn) => {
             handlers[event] = fn;
             return process;
         });
-        exitStub = sinon.stub(process, 'exit');
+        registerGlobalErrorHandlers(['GUARDIAN_SERVICE']);
+    });
+
+    after(() => {
+        onStub.restore();
+    });
+
+    beforeEach(() => {
+        sinon.stub(process, 'exit');
         sinon.stub(console, 'error');
     });
 
     afterEach(() => {
-        sinon.restore();
+        process.exit.restore();
+        console.error.restore();
     });
 
     it('registers both unhandledRejection and uncaughtException handlers', () => {
-        registerGlobalErrorHandlers(['TEST']);
         assert.equal(typeof handlers.unhandledRejection, 'function');
         assert.equal(typeof handlers.uncaughtException, 'function');
     });
 
+    it('is idempotent: a second call does not attach more listeners', () => {
+        const before = onStub.callCount;
+        registerGlobalErrorHandlers(['GUARDIAN_SERVICE']);
+        assert.equal(onStub.callCount, before);
+    });
+
     it('exits(1) on an unhandledRejection that happens before boot completes', () => {
-        registerGlobalErrorHandlers(['TEST']);
         handlers.unhandledRejection(new Error('boom'));
-        assert.ok(exitStub.calledOnceWithExactly(1));
+        assert.ok(process.exit.calledOnceWithExactly(1));
     });
 
     it('normalizes a non-Error rejection reason and still exits before boot', () => {
-        registerGlobalErrorHandlers(['TEST']);
         handlers.unhandledRejection('a string reason');
-        assert.ok(exitStub.calledOnceWithExactly(1));
+        assert.ok(process.exit.calledOnceWithExactly(1));
     });
 
     it('routes errors to the logger (with kind + service attributes) once set', () => {
+        registerGlobalErrorHandlers(['GUARDIAN_SERVICE']); // attributes update even when idempotent
         const logger = { error: sinon.stub().resolves() };
         setGlobalErrorLogger(logger);
-        registerGlobalErrorHandlers(['GUARDIAN_SERVICE']);
 
         handlers.unhandledRejection(new Error('boom'));
 
@@ -65,16 +77,18 @@ describe('global process error handlers', () => {
     });
 
     it('exits(1) on uncaughtException', () => {
-        registerGlobalErrorHandlers(['TEST']);
         handlers.uncaughtException(new Error('fatal'));
-        assert.ok(exitStub.calledOnceWithExactly(1));
+        assert.ok(process.exit.calledOnceWithExactly(1));
     });
 
     // Must be last: flips the module-global boot flag for good.
-    it('swallows unhandledRejection after markServiceBooted (does not exit)', () => {
+    it('swallows unhandledRejection after markServiceBooted and counts it', () => {
         markServiceBooted();
-        registerGlobalErrorHandlers(['TEST']);
+        const before = getSwallowedRejectionCount();
+
         handlers.unhandledRejection(new Error('late, post-boot'));
-        assert.ok(exitStub.notCalled);
+
+        assert.ok(process.exit.notCalled);
+        assert.equal(getSwallowedRejectionCount(), before + 1);
     });
 });

--- a/common/tests/unit-tests/process-error-handlers.test.mjs
+++ b/common/tests/unit-tests/process-error-handlers.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {
+    registerGlobalErrorHandlers,
+    setGlobalErrorLogger,
+    markServiceBooted
+} from '../../dist/helpers/process-error-handlers.js';
+
+/**
+ * A stray promise rejection must not silently crash the whole service. The
+ * module keeps process-global state (booted flag), so tests are ordered: all
+ * pre-boot expectations run before the boot flag is set, and the post-boot
+ * expectation runs last.
+ */
+describe('global process error handlers', () => {
+    let handlers;
+    let exitStub;
+
+    beforeEach(() => {
+        handlers = {};
+        // Capture registered handlers instead of attaching real process listeners
+        // (so invoking them can't interfere with the test runner).
+        sinon.stub(process, 'on').callsFake((event, fn) => {
+            handlers[event] = fn;
+            return process;
+        });
+        exitStub = sinon.stub(process, 'exit');
+        sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('registers both unhandledRejection and uncaughtException handlers', () => {
+        registerGlobalErrorHandlers(['TEST']);
+        assert.equal(typeof handlers.unhandledRejection, 'function');
+        assert.equal(typeof handlers.uncaughtException, 'function');
+    });
+
+    it('exits(1) on an unhandledRejection that happens before boot completes', () => {
+        registerGlobalErrorHandlers(['TEST']);
+        handlers.unhandledRejection(new Error('boom'));
+        assert.ok(exitStub.calledOnceWithExactly(1));
+    });
+
+    it('normalizes a non-Error rejection reason and still exits before boot', () => {
+        registerGlobalErrorHandlers(['TEST']);
+        handlers.unhandledRejection('a string reason');
+        assert.ok(exitStub.calledOnceWithExactly(1));
+    });
+
+    it('routes errors to the logger (with kind + service attributes) once set', () => {
+        const logger = { error: sinon.stub().resolves() };
+        setGlobalErrorLogger(logger);
+        registerGlobalErrorHandlers(['GUARDIAN_SERVICE']);
+
+        handlers.unhandledRejection(new Error('boom'));
+
+        assert.ok(logger.error.calledOnce);
+        const [errArg, attrs, userId] = logger.error.firstCall.args;
+        assert.ok(errArg instanceof Error);
+        assert.deepEqual(attrs, ['GUARDIAN_SERVICE', 'unhandledRejection']);
+        assert.equal(userId, null);
+    });
+
+    it('exits(1) on uncaughtException', () => {
+        registerGlobalErrorHandlers(['TEST']);
+        handlers.uncaughtException(new Error('fatal'));
+        assert.ok(exitStub.calledOnceWithExactly(1));
+    });
+
+    // Must be last: flips the module-global boot flag for good.
+    it('swallows unhandledRejection after markServiceBooted (does not exit)', () => {
+        markServiceBooted();
+        registerGlobalErrorHandlers(['TEST']);
+        handlers.unhandledRejection(new Error('late, post-boot'));
+        assert.ok(exitStub.notCalled);
+    });
+});

--- a/guardian-service/src/app.ts
+++ b/guardian-service/src/app.ts
@@ -32,7 +32,9 @@ import {
     Wallet,
     Workers,
     JwtServicesValidator,
-    NotificationEvents
+    NotificationEvents,
+    markServiceBooted,
+    setGlobalErrorLogger
 } from '@guardian/common';
 import { entities } from '@guardian/common/dist/entities.js';
 import { ApplicationStates, PolicyEvents, PolicyStatus, WorkerTaskType } from '@guardian/interfaces';
@@ -152,6 +154,7 @@ Promise.all([
     const channel = new MessageBrokerChannel(cn, 'guardians');
 
     const logger: PinoLogger = pinoLoggerInitialization(loggerMongo);
+    setGlobalErrorLogger(logger);
     NotificationEvents.init(new GuardiansService());
 
     const state = new ApplicationState();
@@ -434,6 +437,10 @@ Promise.all([
     initMathjs();
 
     startMetricsServer();
+
+    // Bootstrap complete: from here on, a stray unhandled rejection is logged and
+    // swallowed instead of terminating the service.
+    markServiceBooted();
 }, (reason) => {
     console.log(reason);
     process.exit(0);

--- a/guardian-service/src/helpers/register-global-error-handlers.ts
+++ b/guardian-service/src/helpers/register-global-error-handlers.ts
@@ -1,0 +1,6 @@
+import { registerGlobalErrorHandlers } from '@guardian/common';
+
+// Registered as a side effect on import so the safety nets are active before the
+// application bootstrap (imported afterwards in index.ts) can produce any
+// unhandled rejection. See process-error-handlers.ts in @guardian/common.
+registerGlobalErrorHandlers(['GUARDIAN_SERVICE']);

--- a/guardian-service/src/index.ts
+++ b/guardian-service/src/index.ts
@@ -1,3 +1,4 @@
 import './prototypes/date-prototype.js';
+import './helpers/register-global-error-handlers.js';
 import './config.js';
 import './app.js';

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -2127,12 +2127,15 @@ export class PolicyEngine extends NatsService {
             if (confirmed) {
                 return new Promise((resolve, reject) => {
                     this.policyReadyCallbacks.set(policyId, (data, error) => {
+                        // Always clean up first so the callback settles exactly once,
+                        // even if a duplicate ready-event arrives.
+                        this.policyReadyCallbacks.delete(policyId);
                         if (error) {
                             this.policyInitializationErrors.set(policyId, error);
                             reject(new Error(error));
+                            return;
                         }
                         resolve(data);
-                        this.policyReadyCallbacks.delete(policyId);
                     })
                 });
             } else {


### PR DESCRIPTION
## Problem

No service registers a process-level error handler, so a single stray promise rejection terminates the whole Node process (exit 1). We hit this in production: `guardian-service` crashed and cascaded to `api-gateway`.

Two concrete paths trigger it:

1. **NATS reply handler** — in `common/src/mq/nats-service.ts`, the reply-subject callback awaits `this.codec.decode(msg.data)` **outside** a try/catch. For large payloads, `ZipCodec.decode` fetches a `directLink` over HTTP; if the responding service died mid-request, that fetch throws `ECONNREFUSED` out of the async subscribe callback → `unhandledRejection` → process exit.
2. **PolicyEngine.generateModel** — the ready-callback settles its promise more than once (no `return` after `reject`) and only cleans up on the resolve path.

Because there is no `process.on('unhandledRejection' | 'uncaughtException')` anywhere in the codebase, either path crashes the service.

## Changes

**Global safety net**
- New shared helper `common/src/helpers/process-error-handlers.ts` (`registerGlobalErrorHandlers` / `setGlobalErrorLogger` / `markServiceBooted`).
- Registered before bootstrap in `guardian-service` and `api-gateway` (via a side-effect module imported ahead of `app.js`, so handlers are active before any bootstrap rejection).
- After boot, `unhandledRejection` is logged and swallowed so one failed operation cannot take down the process; before boot it exits(1) for a clean restart. `uncaughtException` always logs and exits(1).

**NATS reply decode guard**
- Wrap `codec.decode()` in the reply handler so a failed reply (e.g. a large-payload `directLink` fetch failure) fails just that request — the caller's `sendMessage` promise settles with an error — instead of throwing out of the async callback. The rest of the handler is unchanged; validation still returns `401`.

**generateModel ready-callback**
- Delete the callback first and settle exactly once (`return` after `reject`), so a duplicate ready-event can't double-settle.

## Tests

New unit tests in `common/tests/unit-tests/`:
- `process-error-handlers.test.mjs` — pre-boot exit vs post-boot swallow, non-Error reason normalization, logger routing, `uncaughtException` exit.
- `nats-service-reply-decode.test.mjs` — decode failure routed to caller as `500` without throwing; happy path still delivers the body; unknown-callback replies don't throw.

`interfaces`, `common`, `guardian-service`, and `api-gateway` all build clean; the new tests pass.