### PR TITLE
feat: redesign policy configurator

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -468,34 +468,12 @@ body {
     z-index: 9999 !important;
 }
 
-::ng-deep p-selectitem li {
-    min-height: 38px !important;
-}
-
-::ng-deep .grid-setting td.propRowCell {
-    height: 39px !important;
-}
-
 ::ng-deep .propRowCell .pi-trash {
     margin: 4px 4px
 }
 
-::ng-deep .propRowCell .readonly-prop {
-    min-height: 36px;
-    padding-top: 12px;
-}
-
-::ng-deep td.propRowCell.cellName,
-::ng-deep .propRow .propRowCell {
-    align-content: center;
-}
-
 ::ng-deep p-progressspinner svg circle {
     stroke: var(--button-primary-color) !important;
-}
-
-::ng-deep p-select .p-select-label-empty {
-    min-height: 36px;
 }
 
 ::ng-deep .p-tabs .p-tab.p-tab-active,

--- a/frontend/src/app/modules/policy-engine/helpers/document-path/document-path.component.html
+++ b/frontend/src/app/modules/policy-engine/helpers/document-path/document-path.component.html
@@ -17,7 +17,6 @@
     </option>
     <option value="option." title="option.">Attributes</option>
   </select>
-  <div></div>
   <input [(ngModel)]="endPath" [readonly]="readonly" class="input-end" (input)="onInput()">
   @if (displayTooltip) {
     <i class="pi pi-ellipsis-h input-end-tooltip"

--- a/frontend/src/app/modules/policy-engine/helpers/document-path/document-path.component.scss
+++ b/frontend/src/app/modules/policy-engine/helpers/document-path/document-path.component.scss
@@ -1,20 +1,46 @@
-.container {
-    height: 38px;
-    overflow: hidden;
-    padding: 2px;
-    display: grid;
-    grid-template-columns: 130px 8px 1fr fit-content(24px);
+:host {
+    display: block;
+    width: 100%;
+}
 
-    .select,
+.container {
+    width: 100%;
+    box-sizing: border-box;
+    height: var(--pc-control-height, 30px);
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr) auto;
+    gap: 6px;
+    align-items: center;
+
+    .select {
+        width: 100%;
+        min-width: 0;
+        height: var(--pc-control-height, 30px);
+        box-sizing: border-box;
+        padding: 0 6px;
+        font-size: 13px;
+        font-family: var(--pc-row-font-family, 'Inter', sans-serif);
+        color: var(--guardian-font-color, #23252E);
+        background: var(--guardian-background, #fff);
+        border: 1px solid var(--guardian-border-color, #E1E7EF);
+        border-radius: 6px;
+        cursor: pointer;
+
+        &:hover {
+            border-color: var(--color-primary, #4169E2);
+        }
+    }
+
     input.input-end {
-        height: 34px !important;
+        width: 100%;
+        min-width: 0;
+        height: var(--pc-control-height, 30px) !important;
     }
 }
 
-.input-end {
-    min-width: 0;
-}
-
 .input-end-tooltip {
-    margin-left: 2px;
+    color: var(--guardian-font-color-secondary, #848FA9);
+    cursor: pointer;
+    font-size: 14px;
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/calculate-config/calculate-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/calculate-config/calculate-config.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Input Documents</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/calculate-math-config/calculate-math-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/calculate-math-config/calculate-math-config.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'equationsGroup')"
         [attr.collapse]="propHidden.equationsGroup">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/custom-logic-config/custom-logic-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/custom-logic-config/custom-logic-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Output Schema</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/data-transformation-config/data-transformation-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/data-transformation-config/data-transformation-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Expression</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/math-config/math-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/math-config/math-config.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Expression</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/aggregate-config/aggregate-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/aggregate-config/aggregate-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'options')"
         [attr.collapse]="propHidden.options">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-validator-config/document-validator-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-validator-config/document-validator-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Document Type</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-viewer-config/document-viewer-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-viewer-config/document-viewer-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/external-data-config/external-data-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/external-data-config/external-data-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Entity Type</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/filters-addon-config/filters-addon-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/filters-addon-config/filters-addon-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Type</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/reassigning-config/reassigning-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/reassigning-config/reassigning-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Issuer</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/request-addon-config/request-addon-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/request-addon-config/request-addon-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName"><span class="required-fields">*</span> Button Name</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/request-config/request-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/request-config/request-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Schema</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/revoke-config/revoke-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/revoke-config/revoke-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Update previous document status</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/send-config/send-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/send-config/send-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     @if (properties.dataType) {
       <tr class="propRow" [attr.collapse]="propHidden.main">
         <td class="propRowCol"></td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/source-addon-config/source-addon-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/source-addon-config/source-addon-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Data Type</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/timer-config/timer-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/timer-config/timer-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'options')"
         [attr.collapse]="propHidden.options">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/action-config/action-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/action-config/action-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Type</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/button-config/button-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/button-config/button-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName" pTooltip="Enable Individual Filters" tooltipPosition="top" [tooltipOptions]="{showDelay: 300}">Enable Individual Filters</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/container-config/container-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/container-config/container-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     @if (properties.blockType=='interfaceStepBlock') {
       <tr class="propRow">
         <td class="propRowCol"></td>
@@ -11,11 +12,12 @@
         </td>
       </tr>
     }
-    <tr class="propHeader">
-      <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
-        <i class="pi pi-caret-down"></i>
+    <tr class="propHeader" (click)="onHide(propHidden, 'main')">
+      <td class="propRowCol"></td>
+      <td class="propHeaderCell cellName" [attr.collapse]="propHidden.main">
+        <i class="pi pi-chevron-down chevron-icon"></i>
+        <span>UI</span>
       </td>
-      <td class="propHeaderCell cellName">UI</td>
       <td class="propHeaderCell"></td>
     </tr>
     <tr class="propRow" [attr.collapse]="propHidden.main">
@@ -37,6 +39,7 @@
           optionLabel="label"
           optionValue="value"
           [appendTo]="'body'"
+          panelStyleClass="pc-select-panel"
           >
         </p-select>
       </td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/group-manager-config/group-manager-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/group-manager-config/group-manager-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Can Invite</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/http-request-config/http-request-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/http-request-config/http-request-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'options')"
         [attr.collapse]="propHidden.options">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/information-config/information-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/information-config/information-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/roles-config/roles-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/roles-config/roles-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Available Roles</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/switch-config/switch-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/main/switch-config/switch-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'options')"
         [attr.collapse]="propHidden.options">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/module/module.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/module/module.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/report/report-item-config/report-item-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/report/report-item-config/report-item-config.component.html
@@ -1,6 +1,7 @@
 <!-- Config Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'properties')"
         [attr.collapse]="propHidden.properties">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/create-token-config/create-token-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/create-token-config/create-token-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'properties')"
         [attr.collapse]="propHidden.properties">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/mint-config/mint-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/token-action-config/token-action-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/token-action-config/token-action-config.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Use Template</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/token-confirmation-config/token-confirmation-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/token-confirmation-config/token-confirmation-config.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propRow" [attr.collapse]="propHidden.main">
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Use Template</td>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tokens/wipe-config/wipe-config.component.html
@@ -1,6 +1,7 @@
 <!-- UI Prop -->
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'main')" [attr.collapse]="propHidden.main">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tool/tool.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/tool/tool.component.html
@@ -1,5 +1,6 @@
 @if (properties) {
   <table class="properties" [attr.readonly]="readonly">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
     <tr class="propHeader">
       <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'tool')" [attr.collapse]="propHidden.tool">
         <i class="pi pi-caret-down"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.html
@@ -1,19 +1,3 @@
-@if (block && type != 'Events') {
-  <div class="inspector-head">
-    <div class="inspector-head-row">
-      <span class="inspector-head-name" [title]="block.localTag">{{ block.localTag }}</span>
-      <span class="inspector-head-type">{{ block.blockType }}</span>
-    </div>
-    @if (block.parent && !block.parent.isRoot) {
-      <div class="inspector-head-parent" (click)="selectParent.emit(block.parent)"
-        title="Select parent block">
-        <span class="inspector-head-parent-label">in</span>
-        <span class="inspector-head-parent-name">{{ block.parent.localTag }}</span>
-        <i class="pi pi-arrow-up-right"></i>
-      </div>
-    }
-  </div>
-}
 @if (type != 'Events') {
   <div class="grid-setting" [attr.readonly]="readonly">
     @if (loading) {
@@ -25,12 +9,13 @@
       <div class="table-body">
         @if (block) {
           <table class="properties">
-            <tr class="propHeader">
-              <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'about')"
-                [attr.collapse]="propHidden.about">
-                <i class="pi pi-caret-down"></i>
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
+            <tr class="propHeader" (click)="onHide(propHidden, 'about')">
+              <td class="propRowCol"></td>
+              <td class="propHeaderCell cellName" [attr.collapse]="propHidden.about">
+                <i class="pi pi-chevron-down chevron-icon"></i>
+                <span>About</span>
               </td>
-              <td class="propHeaderCell cellName">About</td>
               <td class="propHeaderCell"></td>
             </tr>
             <tr class="propRow" [attr.collapse]="propHidden.about">
@@ -91,12 +76,12 @@
                 </td>
               </tr>
             }
-            <tr class="propHeader">
-              <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'metaData')"
-                [attr.collapse]="propHidden.metaData">
-                <i class="pi pi-caret-down"></i>
+            <tr class="propHeader" (click)="onHide(propHidden, 'metaData')">
+              <td class="propRowCol"></td>
+              <td class="propHeaderCell cellName" [attr.collapse]="propHidden.metaData">
+                <i class="pi pi-chevron-down chevron-icon"></i>
+                <span>Meta Data</span>
               </td>
-              <td class="propHeaderCell cellName">Meta Data</td>
               <td class="propHeaderCell"></td>
             </tr>
             <!-- Meta Data  -->
@@ -130,7 +115,7 @@
               <td class="propRowCell">
                 <p-multiSelect [(ngModel)]="block.permissions" [options]="roles" [disabled]="readonly"
                   (onChange)="onSave()" optionLabel="name" optionValue="value" placeholder="Select Roles"
-                  [appendTo]="'body'">
+                  [appendTo]="'body'" panelStyleClass="pc-select-panel">
                 </p-multiSelect>
               </td>
             </tr>
@@ -166,7 +151,7 @@
               <td class="propRowCell">
                 <p-select [(ngModel)]="block.properties.onErrorAction" [options]="errorActions"
                   [disabled]="readonly" (onChange)="onSave()" optionLabel="label" optionValue="value"
-                  placeholder="Select Action" [appendTo]="'body'">
+                  placeholder="Select Action" [appendTo]="'body'" panelStyleClass="pc-select-panel">
                 </p-select>
               </td>
             </tr>
@@ -204,12 +189,12 @@
               </tr>
             }
             @if (customProperties) {
-              <tr class="propHeader">
-                <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'customProperties')"
-                  [attr.collapse]="propHidden.customProperties">
-                  <i class="pi pi-caret-down"></i>
+              <tr class="propHeader" (click)="onHide(propHidden, 'customProperties')">
+                <td class="propRowCol"></td>
+                <td class="propHeaderCell cellName" [attr.collapse]="propHidden.customProperties">
+                  <i class="pi pi-chevron-down chevron-icon"></i>
+                  <span>Properties</span>
                 </td>
-                <td class="propHeaderCell cellName">Properties</td>
                 <td class="propHeaderCell"></td>
               </tr>
               @for (property of customProperties; track property) {
@@ -233,14 +218,13 @@
       <div class="table-body">
         @if (block) {
           <table class="properties">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
             @if (defaultEvent) {
-              <tr class="propHeader">
-                <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'defaultEvent')"
-                  [attr.collapse]="propHidden.defaultEvent">
-                  <i class="pi pi-caret-own"></i>
-                </td>
-                <td class="propHeaderCell cellName fullCell">
-                  <div style="height: 20px;" [attr.disabled]="block.properties.stopPropagation">
+              <tr class="propHeader" (click)="onHide(propHidden, 'defaultEvent')">
+                <td class="propRowCol"></td>
+                <td class="propHeaderCell cellName fullCell" [attr.collapse]="propHidden.defaultEvent">
+                  <div class="event-header-row" [attr.disabled]="block.properties.stopPropagation">
+                    <i class="pi pi-chevron-down chevron-icon"></i>
                     <span class="prop-icon prop-icon-event">
                       <svg-icon src="/assets/images/icons/flash_on.svg"
                       svgClass="icon-style-flash_on"></svg-icon>
@@ -312,13 +296,11 @@
             }
             @for (item of module.allEvents; track item) {
               @if (isOutputEvent(item) || isInputEvent(item)) {
-                <tr class="propHeader">
-                  <td class="propRowCol cellCollapse" (click)="onHide(propHidden.eventsGroup, item.id)"
-                    [attr.collapse]="propHidden.eventsGroup[item.id]">
-                    <i class="pi pi-caret-down"></i>
-                  </td>
-                  <td class="propHeaderCell cellName fullCell">
-                    <div style="height: 20px;" [attr.disabled]="item.disabled">
+                <tr class="propHeader" (click)="onHide(propHidden.eventsGroup, item.id)">
+                  <td class="propRowCol"></td>
+                  <td class="propHeaderCell cellName fullCell" [attr.collapse]="propHidden.eventsGroup[item.id]">
+                    <div class="event-header-row" [attr.disabled]="item.disabled">
+                      <i class="pi pi-chevron-down chevron-icon"></i>
                       <span class="prop-icon prop-icon-event" [attr.invalid]="isInvalid(item)">
                         <svg-icon src="/assets/images/icons/flash_on.svg"
                         svgClass="icon-style-flash_on"></svg-icon>
@@ -342,7 +324,7 @@
                     </div>
                   </td>
                   <td class="propHeaderCell">
-                    <span class="remove-prop" [attr.readonly]="readonly" (click)="onRemoveEvent(item)">
+                    <span class="remove-prop" [attr.readonly]="readonly" (click)="$event.stopPropagation(); onRemoveEvent(item)">
                       <i class="pi pi-trash"></i>
                     </span>
                   </td>
@@ -358,7 +340,7 @@
                       (onChange)="chanceType($event.value, item)"
                       [disabled]="readonly"
                       placeholder="Select Event Type"
-                      [appendTo]="'body'">
+                      [appendTo]="'body'" panelStyleClass="pc-select-panel">
                     </p-select>
                   </td>
                 </tr>
@@ -393,7 +375,7 @@
                   <td class="propRowCell cellName source-elm">Output Event</td>
                   <td class="propRowCell">
                     <p-select [(ngModel)]="item.output" [options]="getOutputEvents(item)"
-                      [disabled]="readonly" (onChange)="onSave()" [appendTo]="'body'"
+                      [disabled]="readonly" (onChange)="onSave()" [appendTo]="'body'" panelStyleClass="pc-select-panel"
                       placeholder="Select an event">
                     </p-select>
                   </td>
@@ -425,7 +407,7 @@
                   <td class="propRowCell">
                     <p-select [(ngModel)]="item.input" [options]="getPreparedInputEvents(item)"
                       [disabled]="readonly" (onChange)="onSave()" placeholder="Select Input"
-                      [appendTo]="'body'">
+                      [appendTo]="'body'" panelStyleClass="pc-select-panel">
                     </p-select>
                   </td>
                 </tr>
@@ -443,7 +425,7 @@
                       (onChange)="onSave()"
                       [disabled]="readonly"
                       placeholder="Select Actor"
-                      [appendTo]="'body'">
+                      [appendTo]="'body'" panelStyleClass="pc-select-panel">
                     </p-select>
                   </td>
                 </tr>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.html
@@ -1,3 +1,19 @@
+@if (block && type != 'Events') {
+  <div class="inspector-head">
+    <div class="inspector-head-row">
+      <span class="inspector-head-name" [title]="block.localTag">{{ block.localTag }}</span>
+      <span class="inspector-head-type">{{ block.blockType }}</span>
+    </div>
+    @if (block.parent && !block.parent.isRoot) {
+      <div class="inspector-head-parent" (click)="selectParent.emit(block.parent)"
+        title="Select parent block">
+        <span class="inspector-head-parent-label">in</span>
+        <span class="inspector-head-parent-name">{{ block.parent.localTag }}</span>
+        <i class="pi pi-arrow-up-right"></i>
+      </div>
+    }
+  </div>
+}
 @if (type != 'Events') {
   <div class="grid-setting" [attr.readonly]="readonly">
     @if (loading) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.scss
@@ -1,3 +1,61 @@
+.inspector-head {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+
+    .inspector-head-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .inspector-head-name {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--guardian-font-color, #23252E);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .inspector-head-type {
+        flex: 0 0 auto;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #e1e7fa);
+    }
+
+    .inspector-head-parent {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        cursor: pointer;
+        font-size: 12px;
+        color: var(--guardian-disabled-color, #848FA9);
+
+        .inspector-head-parent-name {
+            color: var(--color-primary, #4169E2);
+            font-weight: 500;
+        }
+
+        i {
+            font-size: 11px;
+            color: var(--color-primary, #4169E2);
+        }
+
+        &:hover .inspector-head-parent-name {
+            text-decoration: underline;
+        }
+    }
+}
+
 .block-name {
     padding-left: 32px;
     position: relative;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.scss
@@ -1,3 +1,8 @@
+:host {
+    display: block;
+    width: 100%;
+}
+
 .inspector-head {
     display: flex;
     flex-direction: column;
@@ -13,6 +18,8 @@
     }
 
     .inspector-head-name {
+        flex: 1 1 auto;
+        min-width: 0;
         font-size: 15px;
         font-weight: 600;
         color: var(--guardian-font-color, #23252E);
@@ -78,48 +85,35 @@
     user-select: none;
 }
 
-.prop-input-event {
-    color: #35a307;
-    height: 16px !important;
-    width: 20px !important;
-    line-height: 14px !important;
+.prop-input-event,
+.prop-output-icon {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 18px !important;
+    height: 18px !important;
+    border-radius: 4px;
     overflow: visible !important;
-    display: inline-block !important;
-    border-left: 2px solid #35a307;
-    margin: 0px 8px 0px 8px;
-    position: relative;
-    top: -1px;
 }
 
-.prop-input-event i,
-.prop-input-event svg {
-    position: relative !important;
-    font-size: 16px !important;
-    height: 20px;
-    width: 20px;
-    top: -1px;
+.prop-input-event {
+    color: #35a307;
+    background: color-mix(in srgb, #35a307 12%, transparent);
 }
 
 .prop-output-icon {
     color: #c53227;
-    height: 16px !important;
-    width: 20px !important;
-    line-height: 14px !important;
-    overflow: visible !important;
-    display: inline-block !important;
-    border-left: 2px solid #c53227;
-    margin: 0px 8px 0px 8px;
-    position: relative;
-    top: -1px;
+    background: color-mix(in srgb, #c53227 12%, transparent);
 }
 
+.prop-input-event i,
+.prop-input-event svg,
 .prop-output-icon i,
 .prop-output-icon svg {
-    position: relative !important;
-    font-size: 16px !important;
-    height: 20px;
-    width: 20px;
-    top: -1px;
+    position: static !important;
+    font-size: 10px !important;
+    height: auto;
+    width: auto;
 }
 
 .source-elm {
@@ -140,14 +134,14 @@
 .current-elm {
     color: #5161e1 !important;
     font-weight: 500;
-    height: 30px;
-    padding-top: 6px;
-    font-size: 16px;
-    font-family: 'Roboto', sans-serif;
+    height: 21px;
+    padding-top: 2px;
+    font-size: 13px;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
 }
 
 .propRowCell {
-    height: 40px;
+    min-height: 27px;
 }
 
 .tags-display {
@@ -176,12 +170,12 @@
 }
 
 ::ng-deep .propRowCell input.prop-input {
-    min-height: 38px;
-    font-size: 16px !important;
+    min-height: 30px;
+    font-size: 13px;
     color: var(--guardian-font-color, var(--color-grey-6));
     background: var(--guardian-background, #fff);
-    border-color: var(--guardian-border-color, #bdbdbd);
-    font-family: "Roboto", sans-serif;
+    border-color: var(--guardian-border-color, #E1E7EF);
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
 }
 
 ::ng-deep p-select .p-select,

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-properties/common-properties.component.ts
@@ -30,6 +30,7 @@ export class CommonPropertiesComponent implements OnInit {
 
     @Output() onInit = new EventEmitter();
     @Output('onEditTags') onEditTags = new EventEmitter();
+    @Output('selectParent') selectParent = new EventEmitter<PolicyItem>();
 
     loading: boolean = true;
     propHidden: any = {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.html
@@ -1,12 +1,13 @@
 @if (property.type === 'Group' && visible(property.visible)) {
-  <tr class="propHeader" [attr.collapse]="collapse">
-    <td class="propRowCol cellCollapse" (click)="onHide()" [attr.collapse]="groupCollapse">
-      <i class="pi pi-caret-down"></i>
-    </td>
-    <td class="propHeaderCell cellName" [title]="property.title">
-      @if (property.required) {
-        <span class="required-fields">*</span>
-        } {{ property.label }}
+  <tr class="propHeader" [attr.collapse]="collapse" (click)="onHide()">
+    <td class="propRowCol"></td>
+    <td class="propHeaderCell cellName" [attr.collapse]="groupCollapse" [title]="property.title">
+      <i class="pi pi-chevron-down chevron-icon"></i>
+      <span>
+        @if (property.required) {
+          <span class="required-fields">*</span>
+          } {{ property.label }}
+        </span>
       </td>
       <td class="propHeaderCell"></td>
     </tr>
@@ -22,36 +23,35 @@
   }
 
   @if (property.type === 'Array' && visible(property.visible)) {
-    <tr class="propHeader" [attr.collapse]="collapse">
-      <td class="propRowCol cellCollapse" (click)="onHide()" [attr.collapse]="groupCollapse">
-        <i class="pi pi-caret-down"></i>
-      </td>
-      <td class="propHeaderCell cellName" [title]="property.title">
-        @if (property.required) {
-          <span class="required-fields">*</span>
-          } {{ property.label }}
+    <tr class="propHeader" [attr.collapse]="collapse" (click)="onHide()">
+      <td class="propRowCol"></td>
+      <td class="propHeaderCell cellName" [attr.collapse]="groupCollapse" [title]="property.title">
+        <i class="pi pi-chevron-down chevron-icon"></i>
+        <span>
+          @if (property.required) {
+            <span class="required-fields">*</span>
+            } {{ property.label }}
+          </span>
         </td>
         <td class="propHeaderCell">
-          <div class="propAdd" (click)="addItems()">
+          <div class="propAdd" (click)="$event.stopPropagation(); addItems()">
             <i class="pi pi-plus"></i>
             <span>Add {{ property.items.label }}</span>
           </div>
         </td>
       </tr>
       @for (item of value; track item; let i = $index) {
-        <tr class="propRow" [attr.collapse]="collapse || groupCollapse">
-          <td class="propRowCol cellCollapse" (click)="onHideItem(i)"
-            [attr.collapse]="groupCollapse || itemCollapse[i]">
-            <i class="pi pi-caret-down"></i>
-          </td>
-          <td class="propRowCell cellName">
-            {{ property.items.label }} {{ i }}
+        <tr class="propRow" [attr.collapse]="collapse || groupCollapse" (click)="onHideItem(i)">
+          <td class="propRowCol"></td>
+          <td class="propRowCell cellName" [attr.collapse]="groupCollapse || itemCollapse[i]">
+            <i class="pi pi-chevron-down chevron-icon"></i>
+            <span>{{ property.items.label }} {{ i }}</span>
           </td>
           <td class="propRowCell">
             <span class="not-editable-text">
               {{ getArrayItemText(property.items, item) }}
             </span>
-            <span class="remove-prop" [attr.readonly]="readonly" (click)="removeItems(i)">
+            <span class="remove-prop" [attr.readonly]="readonly" (click)="$event.stopPropagation(); removeItems(i)">
               <i class="pi pi-times"></i>
             </span>
           </td>
@@ -140,7 +140,7 @@
                         [disabled]="readonly"
                         placeholder="Select a role"
                         (onChange)="onSave()"
-                        [appendTo]="'body'"
+                        [appendTo]="'body'" panelStyleClass="pc-select-panel"
                         >
                       </p-select>
                     }
@@ -153,7 +153,7 @@
                         [disabled]="readonly"
                         placeholder="Select an option"
                         (onChange)="onSave()"
-                        [appendTo]="'body'"
+                        [appendTo]="'body'" panelStyleClass="pc-select-panel"
                         >
                       </p-select>
                     }
@@ -182,7 +182,7 @@
                             [disabled]="readonly"
                             placeholder="Select schemas"
                             (onChange)="onSave()"
-                            [appendTo]="'body'"
+                            [appendTo]="'body'" panelStyleClass="pc-select-panel"
                             >
                             <ng-template let-schema pTemplate="item">
                               <div
@@ -207,7 +207,7 @@
                             [disabled]="readonly"
                             placeholder="Select blocks"
                             (onChange)="onSave()"
-                            [appendTo]="'body'"
+                            [appendTo]="'body'" panelStyleClass="pc-select-panel"
                             >
                             <ng-template pTemplate="selectedItems" let-selectedItems>
                               <span class="select-custom">{{ getSelectedItemsDisplay(selectedItems) }}</span>
@@ -231,7 +231,7 @@
                             [disabled]="readonly"
                             placeholder="Select children blocks"
                             (onChange)="onSave()"
-                            [appendTo]="'body'"
+                            [appendTo]="'body'" panelStyleClass="pc-select-panel"
                             >
                             <ng-template pTemplate="selectedItems" let-selectedItems>
                               <span class="select-custom">{{ getSelectedItemsDisplay(selectedItems) }}</span>
@@ -255,7 +255,7 @@
                             optionLabel="name"
                             optionValue="value"
                             placeholder="Select Roles"
-                            [appendTo]="'body'"
+                            [appendTo]="'body'" panelStyleClass="pc-select-panel"
                             >
                           </p-multiSelect>
                         }
@@ -268,7 +268,7 @@
                             optionLabel="label"
                             optionValue="value"
                             placeholder="Select Items"
-                            [appendTo]="'body'"
+                            [appendTo]="'body'" panelStyleClass="pc-select-panel"
                             >
                           </p-multiSelect>
                         }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.scss
@@ -1,22 +1,25 @@
 .select-block-name {
-    padding-left: 32px;
+    padding-left: 26px;
     position: relative;
-    height: 42px;
+    height: 22px;
+    line-height: 22px;
+    font-size: 13px;
 }
 
 .select-block-icon {
     position: absolute;
     left: 0px;
     top: 0px;
-    height: 42px;
-    width: 40px;
+    height: 22px;
+    width: 20px;
 }
 
 .select-block-icon i,
 .select-block-icon svg {
     position: absolute;
     left: 1px;
-    top: 9px;
+    top: 3px;
+    font-size: 14px;
 }
 
 .select-custom {
@@ -31,7 +34,7 @@
     width: 8px !important;
     max-width: 8px !important;
     display: inline !important;
-    color: #f00 !important;
+    color: var(--pc-required-color, #FF432A) !important;
 }
 
 .prop-checkbox {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.html
@@ -5,11 +5,11 @@
     </div>
   }
   <div class="toolbar">
-    <div class="toolbar-btn toolbar__save-btn" [attr.readonly]="readonly" (click)="onSave()">
+    <div class="toolbar-btn toolbar__save-btn" [attr.readonly]="readonly || !dirty" (click)="onSave()">
       <i class="pi pi-save"></i>
       <span>Save</span>
     </div>
-    <div class="toolbar-btn toolbar__close-btn" [attr.readonly]="readonly" (click)="onClose()">
+    <div class="toolbar-btn toolbar__close-btn" [attr.readonly]="readonly || !dirty" (click)="onClose()">
       <i class="pi pi-times"></i>
       <span>Cancel</span>
     </div>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.scss
@@ -1,7 +1,7 @@
 .textarea-code {
     position: absolute;
     left: 0px;
-    top: 32px;
+    top: 44px;
     bottom: 0px;
     right: 0px;
     resize: none;
@@ -10,6 +10,10 @@
     margin: 0px;
     border: none;
     padding: 0;
+
+    ::ng-deep .CodeMirror {
+        font-size: 12px;
+    }
 }
 
 .toolbar {
@@ -17,57 +21,68 @@
     left: 0px;
     top: 0px;
     right: 0px;
-    height: 31px;
+    height: 44px;
     overflow: hidden;
-    background: var(--guardian-grey-background, #f7f7f7);
+    background: var(--guardian-background, #fff);
     display: flex;
     flex-direction: row;
-    border-bottom: 1px solid var(--guardian-border-color, #ddd);
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 0 10px;
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
 }
 
 .toolbar__save-btn[readonly="true"],
 .toolbar__close-btn[readonly="true"] {
     pointer-events: none;
-    filter: grayscale(1);
-    opacity: 0.6;
-}
-
-.toolbar__save-btn {
-    color: #3f51b5
-}
-
-.toolbar-btn.toolbar__close-btn {
-    width: 80px;
-}
-
-.toolbar__close-btn {
-    color: #c90000;
+    cursor: not-allowed;
+    opacity: 0.45;
 }
 
 .toolbar-btn {
     cursor: pointer;
-    margin: 2px 6px 2px 3px;
-    position: relative;
-    height: 27px;
-    padding: 1px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 30px;
+    padding: 0 14px;
     box-sizing: border-box;
-    width: 70px;
-    border: 1px solid #e7e7e7;
-    border-radius: 4px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    transition: opacity 0.12s ease;
 
     .pi {
-        margin: 4px;
+        font-size: 14px;
     }
 }
 
-.toolbar-btn:hover {
-    background: var(--guardian-grey-background, #f0f0f0);
+.toolbar-btn span {
+    position: static;
 }
 
-.toolbar-btn span {
-    position: absolute;
-    left: 28px;
-    top: 4px;
+.toolbar__close-btn {
+    order: 1;
+    color: var(--guardian-font-color, #23252E);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #fff);
+
+    &:hover {
+        background: var(--guardian-grey-background, #f1f3f9);
+    }
+}
+
+.toolbar__save-btn {
+    order: 2;
+    color: #fff;
+    background: var(--color-primary, #4169E2);
+    border: 1px solid var(--color-primary, #4169E2);
+
+    &:hover {
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 88%, #000);
+    }
 }
 
 .json-errors {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/json-properties/json-properties.component.ts
@@ -52,8 +52,13 @@ export class JsonPropertiesComponent implements OnInit {
     };
 
     code!: string;
+    originalCode: string = '';
     errors: any[] = [];
     loading: boolean = false;
+
+    get dirty(): boolean {
+        return this.code !== this.originalCode;
+    }
 
     constructor(
         private componentFactoryResolver: ComponentFactoryResolver
@@ -88,6 +93,7 @@ export class JsonPropertiesComponent implements OnInit {
         } else {
             this.code = '';
         }
+        this.originalCode = this.code;
     }
 
     onClose() {
@@ -99,6 +105,7 @@ export class JsonPropertiesComponent implements OnInit {
             this.loading = true;
             const block = JSON.parse(this.code);
             this.block.rebuild(block);
+            this.originalCode = this.code;
             setTimeout(() => {
                 this.loading = false;
             }, 250);

--- a/frontend/src/app/modules/policy-engine/policy-configuration/module-properties/module-properties.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/module-properties/module-properties.component.html
@@ -11,6 +11,7 @@
   <div class="table">
     <div class="table-body" #body>
       <table class="properties">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
 
         @if (type == 'Main') {
           <tr class="propHeader">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/module-properties/module-properties.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/module-properties/module-properties.component.scss
@@ -1,3 +1,8 @@
+:host {
+    display: block;
+    width: 100%;
+}
+
 .errors-properties  {
     max-height: 200px;
     overflow: auto;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -21,6 +21,19 @@
             <i class="pi pi-arrow-left"></i>
             <span>Back</span>
           </div>
+          <div (click)="identityMenu.toggle($event)" class="policy-identity all-status"
+            title="Policy details">
+            <div class="policy-identity-icon">
+              <svg-icon src="/assets/images/icons/article.svg"
+                svgClass="icon-style-article action-color"></svg-icon>
+            </div>
+            <div class="policy-identity-text">
+              <span class="policy-identity-name">{{ policyTemplate.name || 'Untitled policy' }}</span>
+              <span class="policy-identity-meta">Policy details</span>
+            </div>
+            <i class="pi pi-chevron-down policy-identity-caret"></i>
+          </div>
+          <div class="delimiter"></div>
           <div (click)="savePolicy()" class="top-toolbar-btn readonly-status" title="Save Policy">
             <i class="pi pi-save"></i>
             <span>Save</span>
@@ -243,9 +256,9 @@
               <span>Copy Mode</span>
             </div>
             @if (rootTemplate.isPublishError) {
-              <div class="btn-new-block btn-label">
-                <i class="pi pi-times" style="color: #572424"></i>
-                <span style="color: #572424">Not published</span>
+              <div class="btn-new-block btn-label not-published-label">
+                <i class="pi pi-times"></i>
+                <span>Not published</span>
               </div>
             }
             <div class="delimiter"></div>
@@ -375,6 +388,14 @@
           <i class="pi pi-sliders-h"></i>
           <span>Parameters</span>
         </div>
+        @if (rootType === 'Policy') {
+          <div class="delimiter"></div>
+          <div (click)="toggleCommandPalette()" class="top-toolbar-btn all-status command-palette-btn"
+            title="Command palette (⌘K)">
+            <i class="pi pi-search"></i>
+            <span>⌘K</span>
+          </div>
+        }
       </div>
       <div (cdkDropListDropped)="onDroppedSection($event)" [cdkDropListData]="options.configurationOrder" cdkDropList
         cdkDropListOrientation="horizontal" class="main-container">
@@ -1050,6 +1071,21 @@
             </ng-template>
             <ng-template #propertiesBlock let-id="id" let-size="size">
               @if (this.selectedBlocks && this.selectedBlocks.size <= 1) {
+                @if (!currentBlock && rootType === 'Policy') {
+                  <div [ngStyle]="{ height: size, 'flex-basis': size }"
+                    class="right-bottom-toolbar inspector-empty">
+                    <i class="pi pi-hand-point-left inspector-empty-icon"></i>
+                    <div class="inspector-empty-title">No block selected</div>
+                    <div class="inspector-empty-text">
+                      Select a block on the canvas to edit its settings.
+                    </div>
+                    <button type="button" class="inspector-empty-btn"
+                      (click)="openPolicySettingsDrawer()">
+                      <i class="pi pi-cog"></i>
+                      <span>Policy settings</span>
+                    </button>
+                  </div>
+                }
                 @if (currentBlock && !isRootModule) {
                   <div
                     cdkDrag
@@ -1121,6 +1157,7 @@
                             [module]="openFolder"
                             [readonly]="readonly"
                             (onEditTags)="onAddTag()"
+                            (selectParent)="onSelect({ block: $event, isMultiSelect: false })"
                             class="readonly-status"
                           type="Common"></common-properties>
                         </div>
@@ -1193,9 +1230,72 @@
           </div>
         </ng-template>
       </div>
+      @if (rootType === 'Policy') {
+        <policy-settings-drawer
+          [(visible)]="openPolicySettings"
+          [policy]="policyTemplate"
+          [readonly]="readonly"
+          [allCategories]="allCategories"
+          [policyCategories]="policyCategoriesMapped"
+          [wipeContracts]="wipeContracts"></policy-settings-drawer>
+      }
     </div>
   }
 </div>
+
+<p-dialog [(visible)]="commandPaletteVisible" [modal]="true" [dismissableMask]="true"
+  [showHeader]="false" [style]="{ width: '520px' }" styleClass="command-palette-dialog"
+  [draggable]="false" [resizable]="false">
+  <div class="command-palette">
+    <div class="command-palette-search">
+      <i class="pi pi-search"></i>
+      <input type="text" pInputText [(ngModel)]="commandQuery" placeholder="Type a command…"
+        class="command-palette-input" autofocus />
+    </div>
+    <div class="command-palette-list">
+      @for (command of filteredCommands; track command.label) {
+        <div class="command-palette-item" (click)="runCommand(command)">
+          <i [class]="command.icon"></i>
+          <span>{{ command.label }}</span>
+        </div>
+      }
+      @if (filteredCommands.length === 0) {
+        <div class="command-palette-empty">No matching commands</div>
+      }
+    </div>
+  </div>
+</p-dialog>
+
+<p-popover #identityMenu>
+  <div class="identity-popover">
+    <div class="identity-popover-title">{{ policyTemplate.name || 'Untitled policy' }}</div>
+    @if (policyTemplate.version) {
+      <div class="identity-popover-version">Version {{ policyTemplate.version }}</div>
+    }
+    <div class="identity-row" (click)="copyIdentity('id', policyId, $event)" title="Copy policy ID">
+      <div class="identity-row-label">Policy ID</div>
+      <div class="identity-row-value">
+        <span class="identity-row-mono">{{ policyId || '—' }}</span>
+        @if (policyId) {
+          <i class="pi" [ngClass]="copiedField === 'id' ? 'pi-check' : 'pi-copy'"></i>
+        }
+      </div>
+    </div>
+    <div class="identity-row" (click)="copyIdentity('tag', policyTemplate.policyTag, $event)" title="Copy policy tag">
+      <div class="identity-row-label">Tag</div>
+      <div class="identity-row-value">
+        <span class="identity-row-mono">{{ policyTemplate.policyTag || '—' }}</span>
+        @if (policyTemplate.policyTag) {
+          <i class="pi" [ngClass]="copiedField === 'tag' ? 'pi-check' : 'pi-copy'"></i>
+        }
+      </div>
+    </div>
+    <div class="identity-action" (click)="openPolicySettingsDrawer(); identityMenu.hide()">
+      <i class="pi pi-cog"></i>
+      <span>Policy settings</span>
+    </div>
+  </div>
+</p-popover>
 
 <p-popover #publishMenu>
   @if (user.POLICIES_POLICY_REVIEW) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -335,6 +335,10 @@
         @if (isTree) {
           <div (click)="eventMenu.toggle($event)" class="top-toolbar-group all-status event-color"
             style="width: 80px">
+            @if (eventVisible =='Selected') {
+              <svg-icon class="event-color" src="/assets/images/icons/flash_on.svg"
+              svgClass="icon-style-flash_on event-color"></svg-icon>
+            }
             @if (eventVisible =='All') {
               <svg-icon class="event-color" src="/assets/images/icons/flash_on.svg"
               svgClass="icon-style-flash_on event-color"></svg-icon>
@@ -352,6 +356,9 @@
             @if (eventVisible =='None') {
               <svg-icon class="event-color" src="/assets/images/icons/flash_off.svg"
               svgClass="icon-style-flash_off event-color"></svg-icon>
+            }
+            @if (eventVisible =='Selected') {
+              <span class="event-color">Selected</span>
             }
             @if (eventVisible =='All') {
               <span class="event-color">All Events</span>
@@ -422,27 +429,33 @@
         }
         <ng-template #configurationBlocks let-id="id" let-size="size">
           <div (cdkDragDropped)="onDropSection($event)" (cdkDragStarted)="onDragSection($event)"
-            [attr.resizing-id]="id" [cdkDragStartDelay]="100" [ngStyle]="{ width: size, 'flex-basis': size }"
+            [attr.resizing-id]="id" [cdkDragStartDelay]="100"
+            [ngStyle]="{ width: options.libraryCollapsed ? '44px' : size, 'flex-basis': options.libraryCollapsed ? '44px' : size }"
+            [class.collapsed]="options.libraryCollapsed"
             cdkDrag class="left-toolbar">
             <i *cdkDragPreview class="pi pi-list"></i>
             <div class="pc-tabs">
               <div cdkDragHandle class="pc-tabs-headers">
-                <div (click)="select('components')" [attr.selected]="options.components"
-                  class="tab-header tab-header-min">
+                <div (click)="selectLibrary('components')" [attr.selected]="options.components"
+                  class="tab-header tab-header-min" title="Blocks">
                   <svg-icon class="icon-style-article action-color" src="/assets/images/icons/article.svg"
                   svgClass="icon-style-article action-color"></svg-icon>
                   <span>Blocks</span>
                 </div>
-                <div (click)="select('moduleLibrary')" [attr.selected]="options.moduleLibrary"
-                  class="tab-header tab-header-min">
+                <div (click)="selectLibrary('moduleLibrary')" [attr.selected]="options.moduleLibrary"
+                  class="tab-header tab-header-min" title="Modules">
                   <svg-icon class="action-color" src="/assets/images/icons/policy-module.svg"></svg-icon>
                   <span>Modules</span>
                 </div>
-                <div (click)="select('toolLibrary')" [attr.selected]="options.toolLibrary"
-                  class="tab-header tab-header-min">
+                <div (click)="selectLibrary('toolLibrary')" [attr.selected]="options.toolLibrary"
+                  class="tab-header tab-header-min" title="Tools">
                   <svg-icon class="icon-style-handyman" src="/assets/images/icons/handyman.svg"
                   svgClass="icon-style-handyman"></svg-icon>
                   <span>Tools</span>
+                </div>
+                <div (click)="toggleLibrary()" class="library-collapse-toggle"
+                  [title]="options.libraryCollapsed ? 'Expand library' : 'Collapse library'">
+                  <i [ngClass]="options.libraryCollapsed ? 'pi pi-angle-double-right' : 'pi pi-angle-double-left'"></i>
                 </div>
               </div>
               <div #menuList="cdkDropList" (cdkDropListDropped)="drop($event)"
@@ -844,6 +857,19 @@
                           <div class="theme-rule-description">{{ theme.default.description || '-' }}</div>
                         </div>
                       }
+                      <div class="theme-legends-divider"></div>
+                      <div class="theme-rule">
+                        <div class="theme-rule-prev">
+                          <div class="action-event-icon"></div>
+                        </div>
+                        <div class="theme-rule-description">Action event</div>
+                      </div>
+                      <div class="theme-rule">
+                        <div class="theme-rule-prev">
+                          <div class="refresh-event-icon"></div>
+                        </div>
+                        <div class="theme-rule-description">Refresh event</div>
+                      </div>
                     </div>
                   }
                   @if (!isTree) {
@@ -884,6 +910,7 @@
                     (search)="onBlockSearch($event)"
                     (select)="onSelect($event)"
                     (test)="onTest($event)"
+                    (addChild)="blockPickerQuery=''; blockPicker.toggle($event)"
                     [(currentBlock)]="currentBlock"
                     [active]="eventVisible"
                     [blocks]="openFolder.dataSource"
@@ -927,15 +954,17 @@
             @for (properties of options.propertiesOrder; track properties; let last = $last) {
               @switch (properties.id) {
                 @case ('policy') {
-                  <ng-container
-                  *ngTemplateOutlet="propertiesPolicy; context: { size: properties.size, id: properties.id }"></ng-container>
+                  @if (rootType !== 'Policy') {
+                    <ng-container
+                    *ngTemplateOutlet="propertiesPolicy; context: { size: properties.size, id: properties.id }"></ng-container>
+                  }
                 }
                 @case ('block') {
                   <ng-container
                   *ngTemplateOutlet="propertiesBlock; context: { size: properties.size, id: properties.id }"></ng-container>
                 }
               }
-              @if (!last) {
+              @if (!last && !(properties.id === 'policy' && rootType === 'Policy')) {
                 <div (onStopResizing)="stopResizingProperties($event)"
                   [ngStyle]="{ visibility: (!options.rightTopMenu && !options.rightBottomMenu) ? 'visible' : 'hidden' }"
                   [vertical]="true" class="resizing-vertical" resizing>
@@ -1376,7 +1405,31 @@
   </div>
 </p-popover>
 
+<p-popover #blockPicker>
+  <div class="block-picker">
+    <div class="block-picker-search">
+      <i class="pi pi-search"></i>
+      <input [(ngModel)]="blockPickerQuery" placeholder="Search blocks" autofocus>
+    </div>
+    <div class="block-picker-list">
+      @for (item of pickerBlocks; track item.type) {
+        <div (click)="addPickedBlock(item, blockPicker)" class="block-picker-item">
+          <i [ngClass]="'pi pi-' + item.icon" class="block-picker-item-icon"></i>
+          <span>{{ item.name }}</span>
+        </div>
+      } @empty {
+        <div class="block-picker-empty">No blocks found</div>
+      }
+    </div>
+  </div>
+</p-popover>
+
 <p-popover #eventMenu>
+  <div (click)="onShowEvent('Selected'); eventMenu.hide()" class="toolbar-menu all-status event-color">
+    <svg-icon class="icon-style-flash_on event-color" src="/assets/images/icons/flash_on.svg"
+    svgClass="icon-style-flash_on event-color"></svg-icon>
+    <span class="action-color">Selected Block Only</span>
+  </div>
   <div (click)="onShowEvent('All'); eventMenu.hide()" class="toolbar-menu all-status event-color">
     <svg-icon class="icon-style-flash_on event-color" src="/assets/images/icons/flash_on.svg"
     svgClass="icon-style-flash_on event-color"></svg-icon>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -16,13 +16,12 @@
   @if (isModuleValid) {
     <div [attr.readonly]="readonly" class="policy-configuration">
       <div class="top-toolbar">
+        <!-- ============ LEFT ZONE: identity + status ============ -->
         @if (rootType === 'Policy') {
-          <div (click)="backToPolicies()" class="top-toolbar-btn all-status" title="Back">
+          <div (click)="backToPolicies()" class="top-toolbar-btn icon-only all-status" title="Back">
             <i class="pi pi-arrow-left"></i>
-            <span>Back</span>
           </div>
-          <div (click)="identityMenu.toggle($event)" class="policy-identity all-status"
-            title="Policy details">
+          <div (click)="identityMenu.toggle($event)" class="policy-identity all-status">
             <div class="policy-identity-icon">
               <svg-icon src="/assets/images/icons/article.svg"
                 svgClass="icon-style-article action-color"></svg-icon>
@@ -33,66 +32,114 @@
             </div>
             <i class="pi pi-chevron-down policy-identity-caret"></i>
           </div>
-          <div class="delimiter"></div>
-          <div (click)="savePolicy()" class="top-toolbar-btn readonly-status" title="Save Policy">
-            <i class="pi pi-save"></i>
-            <span>Save</span>
-          </div>
-          @if (user.POLICIES_POLICY_CREATE) {
-            <div (click)="saveAsPolicy()"
-              [class.readonly-status]="policyTemplate.isDemo" class="top-toolbar-btn all-status"
-              title="Save Policy">
-              <i class="pi pi-save"></i>
-              <span>Save As</span>
-            </div>
-          }
-          <div (click)="openPolicyWizardDialog()" class="top-toolbar-btn readonly-status wizard-btn"
-            title="Policy Wizard">
-            <svg-icon src="/assets/images/icons/auto_awesome.svg" svgClass="icon-style-auto_awesome"></svg-icon>
-            <span>Wizard</span>
-          </div>
-          <div class="delimiter"></div>
           @if (policyTemplate.isDraft) {
-            <div (click)="publishMenu.toggle($event)"
-              class="top-toolbar-group all-status">
-              <i class="pi pi-pencil edit-color"></i>
-              <span class="edit-color">Draft</span>
-              <div class="expand-group">
-                <i class="pi pi-sort-down-fill"></i>
-              </div>
+            <div class="status-badge status-badge--draft">
+              <i class="pi pi-pencil"></i>
+              <span>Draft</span>
             </div>
           }
           @if (policyTemplate.isDryRun) {
-            <div (click)="dryRunMenu.toggle($event)"
-              class="top-toolbar-group all-status" style="width: 80px">
+            <div (click)="dryRunMenu.toggle($event)" class="status-badge status-badge--dryrun" title="Dry Run">
               <svg-icon src="/assets/images/icons/build.svg" svgClass="icon-style-build"></svg-icon>
-              <span class="dry-run-color font-size-xs">
-                In Dry Run
-              </span>
-              <div class="expand-group">
-                <i class="pi pi-sort-down-fill"></i>
-              </div>
+              <span>In Dry Run</span>
+              <i class="pi pi-sort-down-fill status-badge-caret"></i>
             </div>
           }
           @if (policyTemplate.isPublished) {
-            <div class="top-toolbar-btn top-toolbar-label">
-              <i class="pi pi-globe publish-color"></i>
-              <span class="publish-color">Published</span>
+            <div class="status-badge status-badge--published">
+              <i class="pi pi-globe"></i><span>Published</span>
             </div>
           }
           @if (policyTemplate.isDemo) {
-            <div class="top-toolbar-btn top-toolbar-label">
-              <i class="pi pi-globe demo-color"></i>
-              <span class="demo-color">Demo</span>
+            <div class="status-badge status-badge--demo">
+              <i class="pi pi-globe"></i><span>Demo</span>
             </div>
           }
           @if (policyTemplate.isView) {
-            <div class="top-toolbar-btn top-toolbar-label">
-              <i class="pi pi-globe demo-color"></i>
-              <span class="demo-color">View</span>
+            <div class="status-badge status-badge--demo">
+              <i class="pi pi-globe"></i><span>View</span>
             </div>
           }
-          <div class="delimiter"></div>
+        }
+        @if (rootType === 'Module') {
+          <div (click)="backToModules()" class="top-toolbar-btn icon-only all-status" title="Back">
+            <i class="pi pi-arrow-left"></i>
+          </div>
+          @if (moduleTemplate.isDraft && user.MODULES_MODULE_REVIEW) {
+            <div (click)="publishMenu2.toggle($event)" class="status-badge status-badge--draft">
+              <i class="pi pi-pencil"></i><span>Draft</span>
+              <i class="pi pi-sort-down-fill status-badge-caret"></i>
+            </div>
+          }
+          @if (moduleTemplate.isPublished) {
+            <div class="status-badge status-badge--published">
+              <i class="pi pi-globe"></i><span>Published</span>
+            </div>
+          }
+        }
+        @if (rootType === 'Tool') {
+          <div (click)="backToTools()" class="top-toolbar-btn icon-only all-status" title="Back">
+            <i class="pi pi-arrow-left"></i>
+          </div>
+          @if (toolTemplate.isDraft && user.TOOLS_TOOL_REVIEW) {
+            <div (click)="publishMenu3.toggle($event)" class="status-badge status-badge--draft">
+              <i class="pi pi-pencil"></i><span>Draft</span>
+              <i class="pi pi-sort-down-fill status-badge-caret"></i>
+            </div>
+          }
+          @if (toolTemplate.isDryRun) {
+            <div (click)="dryRunMenu2.toggle($event)" class="status-badge status-badge--dryrun">
+              <svg-icon src="/assets/images/icons/build.svg" svgClass="icon-style-build"></svg-icon>
+              <span>In Dry Run</span>
+              <i class="pi pi-sort-down-fill status-badge-caret"></i>
+            </div>
+          }
+          @if (toolTemplate.isPublished) {
+            <div class="status-badge status-badge--published">
+              <i class="pi pi-globe"></i><span>Published</span>
+            </div>
+          }
+        }
+
+        <div class="toolbar-spacer"></div>
+
+        <!-- ============ CENTER ZONE: view segment ============ -->
+        <div class="view-segment">
+          <div class="view-segment-item" [class.active]="currentView == 'blocks'"
+            (click)="onView('blocks')">Design</div>
+          <div class="view-segment-item" [class.active]="currentView == 'json'"
+            (click)="onView('json')">JSON</div>
+          <div class="view-segment-item" [class.active]="currentView == 'yaml'"
+            (click)="onView('yaml')">YAML</div>
+        </div>
+
+        <div class="toolbar-spacer"></div>
+
+        <!-- ============ RIGHT ZONE: actions ============ -->
+        @if (rootType === 'Policy') {
+          <div (click)="toggleCommandPalette()" class="top-toolbar-btn icon-only all-status command-palette-btn"
+            title="Command palette (⌘K)">
+            <i class="pi pi-search"></i>
+          </div>
+        }
+        @if (!readonly && isTree) {
+          <div (click)="undoPolicy()" [attr.storage-active]="storage.isUndo"
+            class="top-toolbar-btn icon-only readonly-status" title="Undo">
+            <i class="pi pi-undo"></i>
+          </div>
+          <div (click)="redoPolicy()" [attr.storage-active]="storage.isRedo"
+            class="top-toolbar-btn icon-only readonly-status" title="Redo">
+            <i class="pi pi-refresh"></i>
+          </div>
+          @if (rootTemplate.isPublishError) {
+            <div class="btn-new-block btn-label not-published-label">
+              <i class="pi pi-times"></i>
+              <span>Not published</span>
+            </div>
+          }
+        }
+        <div class="delimiter"></div>
+        @if (rootType === 'Policy') {
           @if (policyTemplate.isDraft) {
             <div
               class="top-toolbar-btn top-toolbar-group all-status validation"
@@ -104,7 +151,7 @@
               #validationBtn
               >
               <i class="pi pi-check-circle"></i>
-              <span>Validation</span>
+              <span>{{ validationCount > 0 ? 'Issues' : 'Valid' }}</span>
               @if (validationCount > 0) {
                 <div class="error-count">{{ validationCount }}</div>
               }
@@ -117,292 +164,81 @@
             </div>
           }
           @if (policyTemplate.isRun) {
-            <div
-              [routerLink]="['/policy-viewer', policyId]"
-              class="top-toolbar-btn all-status"
-              >
+            <div [routerLink]="['/policy-viewer', policyId]" class="top-toolbar-btn all-status">
               <i class="pi pi-angle-double-right"></i>
               <span>Go</span>
             </div>
           }
-          <div (click)="openApiConfigDialog()" class="top-toolbar-btn readonly-status" title="Configure API Documentation">
-            <i class="pi pi-book"></i>
-            <span>API</span>
+          <div (click)="savePolicy()" class="top-toolbar-btn readonly-status" title="Save Policy">
+            <i class="pi pi-save"></i>
+            <span>Save</span>
           </div>
-          <div class="delimiter"></div>
+          @if (policyTemplate.isDraft) {
+            @if (user.POLICIES_POLICY_REVIEW) {
+              <div (click)="tryPublishPolicy()" class="top-toolbar-group all-status publish-primary"
+                title="Publish">
+                <i class="pi pi-globe"></i>
+                <span>Publish</span>
+                <div class="expand-group" (click)="$event.stopPropagation(); publishMenu.toggle($event)">
+                  <i class="pi pi-sort-down-fill"></i>
+                </div>
+              </div>
+            } @else {
+              <div (click)="tryRunPolicy()" class="top-toolbar-btn all-status" title="Dry Run">
+                <svg-icon src="/assets/images/icons/build.svg" svgClass="icon-style-build dry-run-color"></svg-icon>
+                <span class="dry-run-color">Dry Run</span>
+              </div>
+            }
+          }
         }
         @if (rootType === 'Module') {
-          <div (click)="backToModules()" class="top-toolbar-btn all-status" title="Back">
-            <i class="pi pi-arrow-left"></i>
-            <span>Back</span>
-          </div>
+          @if (moduleTemplate.isDraft) {
+            <div (click)="validationModule()" [attr.errors-count]="errorsCount"
+              [attr.readonly]="!isTree" class="top-toolbar-btn all-status validation" title="Validation Module">
+              <i class="pi pi-check-circle"></i>
+              <span>{{ errorsCount > 0 ? 'Issues' : 'Valid' }}</span>
+              @if (errorsCount>0) {
+                <div class="error-count">{{ errorsCount }}</div>
+              }
+            </div>
+          }
           <div (click)="updateModule()" class="top-toolbar-btn readonly-status" title="Save Module">
             <i class="pi pi-save"></i>
             <span>Save</span>
           </div>
           @if (user.MODULES_MODULE_CREATE) {
-            <div (click)="saveAsModule()" class="top-toolbar-btn all-status"
-              title="Save Module">
+            <div (click)="saveAsModule()" class="top-toolbar-btn all-status" title="Save Module">
               <i class="pi pi-save"></i>
               <span>Save As</span>
             </div>
           }
-          <div class="delimiter"></div>
-          @if (moduleTemplate.isDraft && user.MODULES_MODULE_REVIEW) {
-            <div (click)="publishMenu2.toggle($event)"
-              class="top-toolbar-group all-status">
-              <i class="pi pi-pencil"></i>
-              <span class="edit-color">Draft</span>
-              <div class="expand-group">
-                <i class="pi pi-sort-down-fill"></i>
-              </div>
-            </div>
-          }
-          @if (moduleTemplate.isPublished) {
-            <div class="top-toolbar-btn top-toolbar-label">
-              <i class="pi pi-globe publish-color"></i>
-              <span class="publish-color">Published</span>
-            </div>
-          }
-          @if (moduleTemplate.isDraft) {
-            <div (click)="validationModule()" [attr.errors-count]="errorsCount"
-              [attr.readonly]="!isTree" class="top-toolbar-btn all-status" title="Validation Module">
+        }
+        @if (rootType === 'Tool') {
+          @if (toolTemplate.isDraft) {
+            <div (click)="validationTool()" [attr.errors-count]="errorsCount"
+              [attr.readonly]="!isTree" class="top-toolbar-btn all-status validation" title="Validation Tool">
               <i class="pi pi-check-circle"></i>
-              <span>Validation</span>
+              <span>{{ errorsCount > 0 ? 'Issues' : 'Valid' }}</span>
               @if (errorsCount>0) {
                 <div class="error-count">{{ errorsCount }}</div>
               }
             </div>
           }
-          <div class="delimiter"></div>
-        }
-        @if (rootType === 'Tool') {
-          <div (click)="backToTools()" class="top-toolbar-btn all-status" title="Back">
-            <i class="pi pi-arrow-left"></i>
-            <span>Back</span>
-          </div>
           <div (click)="updateTool()" class="top-toolbar-btn readonly-status" title="Save Tool">
             <i class="pi pi-save"></i>
             <span>Save</span>
           </div>
           @if (user.TOOLS_TOOL_CREATE) {
-            <div (click)="saveAsTool()" class="top-toolbar-btn"
-              title="Save Tool">
+            <div (click)="saveAsTool()" class="top-toolbar-btn" title="Save Tool">
               <i class="pi pi-save"></i>
               <span>Save As</span>
             </div>
           }
-          <div class="delimiter"></div>
-          @if (toolTemplate.isDraft && user.TOOLS_TOOL_REVIEW) {
-            <div (click)="publishMenu3.toggle($event)"
-              class="top-toolbar-group all-status">
-              <i class="pi pi-pencil edit-color"></i>
-              <span class="edit-color">Draft</span>
-              <div class="expand-group">
-                <i class="pi pi-sort-down-fill"></i>
-              </div>
-            </div>
-          }
-          @if (toolTemplate.isDryRun) {
-            <div (click)="dryRunMenu2.toggle($event)"
-              class="top-toolbar-group all-status" style="width: 80px">
-              <svg-icon src="/assets/images/icons/build.svg" svgClass="icon-style-build"></svg-icon>
-              <span class="dry-run-color font-size-xs">
-                In Dry Run
-              </span>
-              <div class="expand-group">
-                <i class="pi pi-sort-down-fill"></i>
-              </div>
-            </div>
-          }
-          @if (toolTemplate.isPublished) {
-            <div class="top-toolbar-btn top-toolbar-label">
-              <i class="pi pi-globe"></i>
-              <span class="publish-color">Published</span>
-            </div>
-          }
-          @if (toolTemplate.isDraft) {
-            <div (click)="validationTool()" [attr.errors-count]="errorsCount"
-              [attr.readonly]="!isTree" class="top-toolbar-btn all-status" title="Validation Module">
-              <i class="pi pi-check-circle"></i>
-              <span>Validation</span>
-              @if (errorsCount>0) {
-                <div class="error-count">{{ errorsCount }}</div>
-              }
-            </div>
-          }
-          <div class="delimiter"></div>
         }
-        @if (!readonly && isTree) {
-          <ng-container>
-            <div (click)="undoPolicy()" [attr.storage-active]="storage.isUndo"
-              class="top-toolbar-btn readonly-status" title="Undo">
-              <i class="pi pi-undo"></i>
-              <span>Undo</span>
-            </div>
-            <div (click)="redoPolicy()" [attr.storage-active]="storage.isRedo"
-              class="top-toolbar-btn readonly-status" title="Redo">
-              <i class="pi pi-refresh"></i>
-              <span>Redo</span>
-            </div>
-            <div (click)="onSuggestionsClick()" [ngClass]="{'btn-mode-active': isSuggestionsEnabled}"
-              class="top-toolbar-btn top-toolbar-btn__suggestions" title="Suggestions">
-              <svg-icon src="/assets/images/icons/assistant.svg" svgClass="icon-style-assistant"></svg-icon>
-              <span>Suggestions</span>
-            </div>
-            <div (click)="copyBlocksMode=!copyBlocksMode" [ngClass]="{'btn-mode-active': copyBlocksMode}"
-              class="top-toolbar-btn" title="Copy Mode">
-              <i class="pi pi-copy"></i>
-              <span>Copy Mode</span>
-            </div>
-            @if (rootTemplate.isPublishError) {
-              <div class="btn-new-block btn-label not-published-label">
-                <i class="pi pi-times"></i>
-                <span>Not published</span>
-              </div>
-            }
-            <div class="delimiter"></div>
-          </ng-container>
-          @if (
-            user.MODULES_MODULE_CREATE &&
-            rootType === 'Policy' &&
-            openType !== 'Sub' &&
-            !currentBlock?.isModule &&
-            !currentBlock?.isRoot) {
-            <div (click)="onCreateModule()" class="top-toolbar-btn readonly-status long_title_i"
-              title="Create New Module">
-              <i class="pi pi-folder-plus"></i>
-              <span>Create New Module</span>
-            </div>
-            @if (user.MODULES_MODULE_CREATE) {
-              <div (click)="onConvertToModule()"
-                class="top-toolbar-btn readonly-status long_title_svg" title="Convert to Module">
-                <svg-icon src="/assets/images/icons/move_to_inbox.svg"
-                svgClass="icon-style-move_to_inbox"></svg-icon>
-                <span>Convert to Module</span>
-              </div>
-            }
-            <div class="delimiter"></div>
-          }
-          @if (rootType === 'Policy' && currentBlock?.isModule) {
-            <div (click)="onSaveModule()" class="top-toolbar-btn readonly-status" title="Create New Module">
-              <svg-icon src="/assets/images/icons/folder_special.svg"
-              svgClass="icon-style-folder_special"></svg-icon>
-              <span>Save Module</span>
-            </div>
-            @if (openType !== 'Sub') {
-              <div (click)="onOpenModule(currentBlock)"
-                class="top-toolbar-btn readonly-status" title="Convert to Module">
-                <i class="pi pi-folder-open"></i>
-                <span>Open Module</span>
-              </div>
-            }
-            <div class="delimiter"></div>
-          }
-        }
-        <div (click)="viewMenu.toggle($event)" class="top-toolbar-group all-status event-color" style="width: 80px">
-          @if (currentView == 'blocks') {
-            <svg-icon src="/assets/images/icons/view_agenda.svg"
-            svgClass="icon-style-view_agenda"></svg-icon>
-          }
-          @if (currentView == 'json') {
-            <i class="pi pi-code"></i>
-          }
-          @if (currentView == 'yaml') {
-            <i class="pi pi-list"></i>
-          }
-          @if (currentView == 'blocks') {
-            <span>Tree</span>
-          }
-          @if (currentView == 'json') {
-            <span>JSON</span>
-          }
-          @if (currentView == 'yaml') {
-            <span>YAML</span>
-          }
-          <div class="expand-group">
-            <i class="pi pi-sort-down-fill"></i>
-          </div>
+        <div (click)="overflowMenu.toggle($event)"
+          class="top-toolbar-btn icon-only all-status overflow-btn" title="More actions">
+          <i class="pi pi-ellipsis-v"></i>
         </div>
-        <div class="delimiter"></div>
-        @if (isTree) {
-          <div (click)="onSchemas()" class="top-toolbar-btn all-status" title="Settings">
-            <svg-icon src="/assets/images/icons/dataset.svg" svgClass="icon-style-dataset"></svg-icon>
-            <span>Schemas</span>
-          </div>
-          <div class="delimiter"></div>
-        }
-        @if (isTree) {
-          <div (click)="eventMenu.toggle($event)" class="top-toolbar-group all-status event-color"
-            style="width: 80px">
-            @if (eventVisible =='Selected') {
-              <svg-icon class="event-color" src="/assets/images/icons/flash_on.svg"
-              svgClass="icon-style-flash_on event-color"></svg-icon>
-            }
-            @if (eventVisible =='All') {
-              <svg-icon class="event-color" src="/assets/images/icons/flash_on.svg"
-              svgClass="icon-style-flash_on event-color"></svg-icon>
-            }
-            @if (eventVisible == 'Action') {
-              <div class="event-color">
-                <div class="action-event-icon"></div>
-              </div>
-            }
-            @if (eventVisible == 'Refresh') {
-              <div class="event-color">
-                <div class="refresh-event-icon"></div>
-              </div>
-            }
-            @if (eventVisible =='None') {
-              <svg-icon class="event-color" src="/assets/images/icons/flash_off.svg"
-              svgClass="icon-style-flash_off event-color"></svg-icon>
-            }
-            @if (eventVisible =='Selected') {
-              <span class="event-color">Selected</span>
-            }
-            @if (eventVisible =='All') {
-              <span class="event-color">All Events</span>
-            }
-            @if (eventVisible =='Action') {
-              <span class="event-color">Action Events</span>
-            }
-            @if (eventVisible =='Refresh') {
-              <span class="event-color">Refresh Events</span>
-            }
-            @if (eventVisible =='None') {
-              <span class="event-color">Hide Events</span>
-            }
-            <div class="expand-group">
-              <i class="pi pi-sort-down-fill"></i>
-            </div>
-          </div>
-          <div class="delimiter"></div>
-        }
-        <div (click)="themesMenu.toggle($event)" class="top-toolbar-group all-status event-color"
-          style="width: 80px">
-          <i class="pi pi-palette"></i>
-          <span>Themes</span>
-          <div class="expand-group">
-            <i class="pi pi-sort-down-fill"></i>
-          </div>
-        </div>
-        <div (click)="onSettings()" class="top-toolbar-btn all-status" title="Settings">
-          <i class="pi pi-cog"></i>
-          <span>Settings</span>
-        </div>
-        <div class="delimiter"></div>
-        <div (click)="onEditableFields()" class="top-toolbar-btn all-status" title="Parameters">
-          <i class="pi pi-sliders-h"></i>
-          <span>Parameters</span>
-        </div>
-        @if (rootType === 'Policy') {
-          <div class="delimiter"></div>
-          <div (click)="toggleCommandPalette()" class="top-toolbar-btn all-status command-palette-btn"
-            title="Command palette (⌘K)">
-            <i class="pi pi-search"></i>
-            <span>⌘K</span>
-          </div>
-        }
       </div>
       <div (cdkDropListDropped)="onDroppedSection($event)" [cdkDropListData]="options.configurationOrder" cdkDropList
         cdkDropListOrientation="horizontal" class="main-container">
@@ -505,6 +341,7 @@
                     <div (click)="collapse('uiGroup')" class="components-group-name">
                       <i class="pi pi-caret-down components-group-collapse"></i>
                       <i class="pi pi-caret-right components-group-open"></i>
+                      <span class="group-dot group-dot--ui"></span>
                       <span>UI Components ({{ componentsList.uiComponents.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -533,6 +370,7 @@
                     <div (click)="collapse('serverGroup')" class="components-group-name">
                       <i class="pi pi-caret-down components-group-collapse"></i>
                       <i class="pi pi-caret-right components-group-open"></i>
+                      <span class="group-dot group-dot--server"></span>
                       <span>Server Components ({{ componentsList.serverBlocks.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -561,6 +399,7 @@
                     <div (click)="collapse('addonsGroup')" class="components-group-name">
                       <i class="pi pi-caret-down components-group-collapse"></i>
                       <i class="pi pi-caret-right components-group-open"></i>
+                      <span class="group-dot group-dot--addon"></span>
                       <span>Addons ({{ componentsList.addons.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -1129,19 +968,15 @@
                     <i *cdkDragPreview class="pi pi-align-left"></i>
                     <div class="pc-tabs">
                       <div cdkDragHandle class="pc-tabs-headers">
-                        <div (click)="select('properties')" [attr.selected]="options.properties"
+                        <div (click)="select('properties')" [attr.selected]="options.properties || options.artifacts"
                           class="tab-header">
-                          Properties
+                          Settings
                         </div>
                         <div (click)="select('events')" [attr.selected]="options.events" class="tab-header">
                           Events
                         </div>
-                        <div (click)="select('artifacts')" [attr.selected]="options.artifacts"
-                          class="tab-header">
-                          Artifacts
-                        </div>
                         <div (click)="select('json')" [attr.selected]="options.json" class="tab-header">
-                          Json
+                          JSON
                         </div>
                         <div (click)="collapse('rightBottomMenu')"
                           [attr.collapsed]="options.rightBottomMenu" class="tabs-icon">
@@ -1152,7 +987,7 @@
                         </div>
                       </div>
                       <div [attr.readonly]="!isTree" class="pc-tabs-content">
-                        <div [hidden]="!options.properties" class="prop-container">
+                        <div [hidden]="!options.properties && !options.artifacts" class="prop-container">
                           @if (errorsMap[currentBlock.id]) {
                             <div class="errors-properties">
                               @for (item of errorsMap[currentBlock.id]; track item) {
@@ -1189,6 +1024,11 @@
                             (selectParent)="onSelect({ block: $event, isMultiSelect: false })"
                             class="readonly-status"
                           type="Common"></common-properties>
+                          <div class="inspector-subsection">
+                            <div class="inspector-subsection-label">Artifacts</div>
+                            <artifact-properties [block]="currentBlock" [policyId]="policyId"
+                              [readonly]="readonly" class="readonly-status"></artifact-properties>
+                          </div>
                         </div>
                         <div [hidden]="!options.events" class="prop-container">
                           <common-properties
@@ -1198,10 +1038,6 @@
                             (onEditTags)="onAddTag()"
                             class="readonly-status"
                           type="Events"></common-properties>
-                        </div>
-                        <div [hidden]="!options.artifacts" class="prop-container">
-                          <artifact-properties [block]="currentBlock" [policyId]="policyId"
-                          [readonly]="readonly" class="readonly-status"></artifact-properties>
                         </div>
                         <div [hidden]="!options.json" class="prop-container">
                           @if (options.json) {
@@ -1297,10 +1133,7 @@
 
 <p-popover #identityMenu>
   <div class="identity-popover">
-    <div class="identity-popover-title">{{ policyTemplate.name || 'Untitled policy' }}</div>
-    @if (policyTemplate.version) {
-      <div class="identity-popover-version">Version {{ policyTemplate.version }}</div>
-    }
+    <div class="identity-popover-header">Policy details</div>
     <div class="identity-row" (click)="copyIdentity('id', policyId, $event)" title="Copy policy ID">
       <div class="identity-row-label">Policy ID</div>
       <div class="identity-row-value">
@@ -1319,22 +1152,21 @@
         }
       </div>
     </div>
+    <div class="identity-row identity-row--plain">
+      <div class="identity-row-label">Version</div>
+      <div class="identity-row-value">
+        <span class="identity-row-plain-value">{{ policyTemplate.version || '1.0' }}</span>
+      </div>
+    </div>
+    <div class="identity-divider"></div>
     <div class="identity-action" (click)="openPolicySettingsDrawer(); identityMenu.hide()">
-      <i class="pi pi-cog"></i>
-      <span>Policy settings</span>
+      <i class="pi pi-pencil"></i>
+      <span>Edit policy details</span>
     </div>
   </div>
 </p-popover>
 
 <p-popover #publishMenu>
-  @if (user.POLICIES_POLICY_REVIEW) {
-    <div (click)="tryPublishPolicy(); publishMenu.hide()"
-      class="toolbar-menu all-status publish-color" title="Release version into public domain.">
-      <i class="pi pi-globe publish-color"></i>
-      <span class="publish-color">Publish</span>
-    </div>
-  }
-
   <div (click)="tryRunPolicy(); publishMenu.hide()" class="toolbar-menu all-status dry-run-color"
     title="Run without making any persistent changes or executing transaction.">
     <svg-icon src="/assets/images/icons/build.svg" svgClass="icon-style-build dry-run-color"></svg-icon>
@@ -1476,6 +1308,114 @@
       <span [class]="t === theme ? 'action-color' : 'no-action-color'">{{ t.name }}</span>
     </div>
   }
+</p-popover>
+
+<p-popover #overflowMenu>
+  <div class="overflow-menu">
+    @if (rootType === 'Policy') {
+      @if (user.POLICIES_POLICY_CREATE) {
+        <div (click)="saveAsPolicy(); overflowMenu.hide()" class="toolbar-menu all-status"
+          [class.readonly-status]="policyTemplate.isDemo">
+          <i class="pi pi-save"></i>
+          <span>Save As</span>
+        </div>
+      }
+      <div (click)="openPolicyWizardDialog(); overflowMenu.hide()" class="toolbar-menu readonly-status">
+        <svg-icon src="/assets/images/icons/auto_awesome.svg" svgClass="icon-style-auto_awesome"></svg-icon>
+        <span>Wizard</span>
+      </div>
+      <div (click)="openApiConfigDialog(); overflowMenu.hide()" class="toolbar-menu readonly-status">
+        <i class="pi pi-book"></i>
+        <span>API</span>
+      </div>
+    }
+    @if (!readonly && isTree) {
+      <div class="overflow-menu-divider"></div>
+      <div (click)="onSuggestionsClick(); overflowMenu.hide()" class="toolbar-menu"
+        [ngClass]="{'btn-mode-active': isSuggestionsEnabled}">
+        <svg-icon src="/assets/images/icons/assistant.svg" svgClass="icon-style-assistant"></svg-icon>
+        <span>Suggestions</span>
+      </div>
+      <div (click)="copyBlocksMode=!copyBlocksMode; overflowMenu.hide()" class="toolbar-menu"
+        [ngClass]="{'btn-mode-active': copyBlocksMode}">
+        <i class="pi pi-copy"></i>
+        <span>Copy Mode</span>
+      </div>
+      @if (
+        user.MODULES_MODULE_CREATE &&
+        rootType === 'Policy' &&
+        openType !== 'Sub' &&
+        !currentBlock?.isModule &&
+        !currentBlock?.isRoot) {
+        <div (click)="onCreateModule(); overflowMenu.hide()" class="toolbar-menu readonly-status">
+          <i class="pi pi-folder-plus"></i>
+          <span>Create New Module</span>
+        </div>
+        <div (click)="onConvertToModule(); overflowMenu.hide()" class="toolbar-menu readonly-status">
+          <svg-icon src="/assets/images/icons/move_to_inbox.svg" svgClass="icon-style-move_to_inbox"></svg-icon>
+          <span>Convert to Module</span>
+        </div>
+      }
+      @if (rootType === 'Policy' && currentBlock?.isModule) {
+        <div (click)="onSaveModule(); overflowMenu.hide()" class="toolbar-menu readonly-status">
+          <svg-icon src="/assets/images/icons/folder_special.svg" svgClass="icon-style-folder_special"></svg-icon>
+          <span>Save Module</span>
+        </div>
+        @if (openType !== 'Sub') {
+          <div (click)="onOpenModule(currentBlock); overflowMenu.hide()" class="toolbar-menu readonly-status">
+            <i class="pi pi-folder-open"></i>
+            <span>Open Module</span>
+          </div>
+        }
+      }
+    }
+    @if (isTree) {
+      <div class="overflow-menu-divider"></div>
+      <div (click)="onSchemas(); overflowMenu.hide()" class="toolbar-menu all-status">
+        <svg-icon src="/assets/images/icons/dataset.svg" svgClass="icon-style-dataset"></svg-icon>
+        <span>Schemas</span>
+      </div>
+      <div class="overflow-menu-divider"></div>
+      <div class="overflow-menu-label">Event display</div>
+      <div (click)="onShowEvent('Selected'); overflowMenu.hide()" class="toolbar-menu"
+        [attr.active]="eventVisible === 'Selected' ? true : null">
+        <i class="pi pi-bolt"></i>
+        <span>Selected block only</span>
+        @if (eventVisible === 'Selected') { <i class="pi pi-check overflow-check"></i> }
+      </div>
+      <div (click)="onShowEvent('All'); overflowMenu.hide()" class="toolbar-menu"
+        [attr.active]="eventVisible === 'All' ? true : null">
+        <i class="pi pi-share-alt"></i>
+        <span>Show all events</span>
+        @if (eventVisible === 'All') { <i class="pi pi-check overflow-check"></i> }
+      </div>
+      <div (click)="onShowEvent('None'); overflowMenu.hide()" class="toolbar-menu"
+        [attr.active]="eventVisible === 'None' ? true : null">
+        <i class="pi pi-eye-slash"></i>
+        <span>Hide events</span>
+        @if (eventVisible === 'None') { <i class="pi pi-check overflow-check"></i> }
+      </div>
+    }
+    <div class="overflow-menu-divider"></div>
+    <div class="overflow-menu-label">Theme</div>
+    @for (t of themes; track t) {
+      <div (click)="setTheme(t); overflowMenu.hide()" class="toolbar-menu"
+        [attr.active]="t === theme ? true : null">
+        <i class="pi pi-palette"></i>
+        <span>{{ t.name }}</span>
+        @if (t === theme) { <i class="pi pi-check overflow-check"></i> }
+      </div>
+    }
+    <div class="overflow-menu-divider"></div>
+    <div (click)="onSettings(); overflowMenu.hide()" class="toolbar-menu all-status">
+      <i class="pi pi-cog"></i>
+      <span>Settings</span>
+    </div>
+    <div (click)="onEditableFields(); overflowMenu.hide()" class="toolbar-menu all-status">
+      <i class="pi pi-sliders-h"></i>
+      <span>Parameters</span>
+    </div>
+  </div>
 </p-popover>
 
 <ng-template #preloader>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -266,28 +266,29 @@
         <ng-template #configurationBlocks let-id="id" let-size="size">
           <div (cdkDragDropped)="onDropSection($event)" (cdkDragStarted)="onDragSection($event)"
             [attr.resizing-id]="id" [cdkDragStartDelay]="100"
-            [ngStyle]="{ width: options.libraryCollapsed ? '44px' : size, 'flex-basis': options.libraryCollapsed ? '44px' : size }"
             [class.collapsed]="options.libraryCollapsed"
             cdkDrag class="left-toolbar">
             <i *cdkDragPreview class="pi pi-list"></i>
             <div class="pc-tabs">
-              <div cdkDragHandle class="pc-tabs-headers">
-                <div (click)="selectLibrary('components')" [attr.selected]="options.components"
-                  class="tab-header tab-header-min" title="Blocks">
-                  <svg-icon class="icon-style-article action-color" src="/assets/images/icons/article.svg"
-                  svgClass="icon-style-article action-color"></svg-icon>
-                  <span>Blocks</span>
-                </div>
-                <div (click)="selectLibrary('moduleLibrary')" [attr.selected]="options.moduleLibrary"
-                  class="tab-header tab-header-min" title="Modules">
-                  <svg-icon class="action-color" src="/assets/images/icons/policy-module.svg"></svg-icon>
-                  <span>Modules</span>
-                </div>
-                <div (click)="selectLibrary('toolLibrary')" [attr.selected]="options.toolLibrary"
-                  class="tab-header tab-header-min" title="Tools">
-                  <svg-icon class="icon-style-handyman" src="/assets/images/icons/handyman.svg"
-                  svgClass="icon-style-handyman"></svg-icon>
-                  <span>Tools</span>
+              <div cdkDragHandle class="pc-tabs-headers pc-tabs-headers--library">
+                <div class="library-segment">
+                  <div (click)="selectLibrary('components')" [attr.selected]="options.components"
+                    class="tab-header tab-header-min" title="Blocks">
+                    <svg-icon class="icon-style-article action-color" src="/assets/images/icons/article.svg"
+                    svgClass="icon-style-article action-color"></svg-icon>
+                    <span>Blocks</span>
+                  </div>
+                  <div (click)="selectLibrary('moduleLibrary')" [attr.selected]="options.moduleLibrary"
+                    class="tab-header tab-header-min" title="Modules">
+                    <svg-icon class="action-color" src="/assets/images/icons/policy-module.svg"></svg-icon>
+                    <span>Modules</span>
+                  </div>
+                  <div (click)="selectLibrary('toolLibrary')" [attr.selected]="options.toolLibrary"
+                    class="tab-header tab-header-min" title="Tools">
+                    <svg-icon class="icon-style-handyman" src="/assets/images/icons/handyman.svg"
+                    svgClass="icon-style-handyman"></svg-icon>
+                    <span>Tools</span>
+                  </div>
                 </div>
                 <div (click)="toggleLibrary()" class="library-collapse-toggle"
                   [title]="options.libraryCollapsed ? 'Expand library' : 'Collapse library'">
@@ -307,12 +308,10 @@
                     <div [attr.collapsed]="options.favoritesGroup"
                       [attr.readonly]="disableComponentMenu" class="components-group">
                       <div (click)="collapse('favoritesGroup')" class="components-group-name">
-                        <i class="pi pi-caret-down components-group-collapse"></i>
-                        <i class="pi pi-caret-right components-group-open"></i>
+                        <i class="pi pi-chevron-down components-group-collapse"></i>
+                        <i class="pi pi-chevron-right components-group-open"></i>
                         <i class="pi pi-star components-group-name-icon"></i>
-                        <span style="padding-left: 24px">
-                          Favorites ({{ componentsList.favorites.length }})
-                        </span>
+                        <span>Favorites ({{ componentsList.favorites.length }})</span>
                       </div>
                       <div class="components-group-body readonly-status">
                         @for (item of componentsList.favorites; track item) {
@@ -339,8 +338,8 @@
                   <div [attr.collapsed]="options.uiGroup" [attr.readonly]="disableComponentMenu"
                     class="components-group">
                     <div (click)="collapse('uiGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span class="group-dot group-dot--ui"></span>
                       <span>UI Components ({{ componentsList.uiComponents.length }})</span>
                     </div>
@@ -368,8 +367,8 @@
                   <div [attr.collapsed]="options.serverGroup" [attr.readonly]="disableComponentMenu"
                     class="components-group">
                     <div (click)="collapse('serverGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span class="group-dot group-dot--server"></span>
                       <span>Server Components ({{ componentsList.serverBlocks.length }})</span>
                     </div>
@@ -397,8 +396,8 @@
                   <div [attr.collapsed]="options.addonsGroup" [attr.readonly]="disableComponentMenu"
                     class="components-group">
                     <div (click)="collapse('addonsGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span class="group-dot group-dot--addon"></span>
                       <span>Addons ({{ componentsList.addons.length }})</span>
                     </div>
@@ -426,8 +425,8 @@
                     <div [attr.collapsed]="options.unGroup"
                       [attr.readonly]="disableComponentMenu" class="components-group">
                       <div (click)="collapse('unGroup')" class="components-group-name">
-                        <i class="pi pi-caret-down components-group-collapse"></i>
-                        <i class="pi pi-caret-right components-group-open"></i>
+                        <i class="pi pi-chevron-down components-group-collapse"></i>
+                        <i class="pi pi-chevron-right components-group-open"></i>
                         <span>unGrouped</span>
                       </div>
                       <div class="components-group-body readonly-status">
@@ -465,11 +464,10 @@
                       [attr.collapsed]="options.favoritesModulesGroup" [attr.readonly]="disableModuleMenu"
                       class="components-group">
                       <div (click)="collapse('favoritesModulesGroup')" class="components-group-name">
-                        <i class="pi pi-caret-down components-group-collapse"></i>
-                        <i class="pi pi-caret-right components-group-open"></i>
+                        <i class="pi pi-chevron-down components-group-collapse"></i>
+                        <i class="pi pi-chevron-right components-group-open"></i>
                         <i class="pi pi-star components-group-name-icon"></i>
-                        <span style="padding-left: 22px">Favorites
-                        ({{ modulesList.favorites.length }})</span>
+                        <span>Favorites ({{ modulesList.favorites.length }})</span>
                       </div>
                       <div class="components-group-body readonly-status">
                         @for (item of modulesList.favorites; track item) {
@@ -504,8 +502,8 @@
                   <div [attr.collapsed]="options.defaultModulesGroup" [attr.readonly]="disableModuleMenu"
                     class="components-group">
                     <div (click)="collapse('defaultModulesGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span>Default Modules ({{ modulesList.defaultModules.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -541,8 +539,8 @@
                   <div [attr.collapsed]="options.customModulesGroup" [attr.readonly]="disableModuleMenu"
                     class="components-group">
                     <div (click)="collapse('customModulesGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span>Custom models ({{ modulesList.customModules.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -587,8 +585,8 @@
                   <div [attr.collapsed]="options.customToolsGroup" [attr.readonly]="disableToolMenu"
                     class="components-group">
                     <div (click)="collapse('customToolsGroup')" class="components-group-name">
-                      <i class="pi pi-caret-down components-group-collapse"></i>
-                      <i class="pi pi-caret-right components-group-open"></i>
+                      <i class="pi pi-chevron-down components-group-collapse"></i>
+                      <i class="pi pi-chevron-right components-group-open"></i>
                       <span>Tools ({{ modulesList.customTools.length }})</span>
                     </div>
                     <div class="components-group-body readonly-status">
@@ -728,6 +726,39 @@
                   }
                 </div>
               </div>
+              @if (allSubModule && allSubModule.length) {
+                <div class="canvas-breadcrumb">
+                  @if (rootType === 'Policy') {
+                    <span class="canvas-breadcrumb-item" [class.active]="openFolder===policyTemplate"
+                      (click)="onOpenRoot(policyTemplate)">
+                      <svg-icon class="action-color" src="/assets/images/icons/article.svg"></svg-icon>
+                      <span>Policy</span>
+                    </span>
+                  }
+                  @if (rootType === 'Module') {
+                    <span class="canvas-breadcrumb-item" [class.active]="openFolder===moduleTemplate"
+                      (click)="onOpenRoot(moduleTemplate)">
+                      <svg-icon class="action-color" src="/assets/images/icons/policy-module.svg"></svg-icon>
+                      <span>Module</span>
+                    </span>
+                  }
+                  @if (rootType === 'Tool') {
+                    <span class="canvas-breadcrumb-item" [class.active]="openFolder===toolTemplate"
+                      (click)="onOpenRoot(toolTemplate)">
+                      <svg-icon svgClass="tool-icon" src="/assets/images/icons/handyman.svg"></svg-icon>
+                      <span>Tool</span>
+                    </span>
+                  }
+                  @for (item of allSubModule; track item) {
+                    <i class="pi pi-chevron-right canvas-breadcrumb-sep"></i>
+                    <span class="canvas-breadcrumb-item" [class.active]="openFolder===item"
+                      (click)="onOpenModule(item)">
+                      <svg-icon class="edit-color" src="/assets/images/icons/policy-module.svg"></svg-icon>
+                      <span>{{ item.localTag }}</span>
+                    </span>
+                  }
+                </div>
+              }
                         <div [ngClass]="{
                                 'tree-container': isTree
                             }" class="pc-tabs-content">
@@ -842,13 +873,6 @@
                       <div (click)="select('tokens')" [attr.selected]="options.tokens" class="tab-header">
                         Tokens
                       </div>
-                      <div (click)="collapse('rightTopMenu')" [attr.collapsed]="options.rightTopMenu"
-                        class="tabs-icon">
-                        <i
-                        class="pi pi-arrow-up-right-and-arrow-down-left-from-center tabs-icon-full"></i>
-                        <i
-                        class="pi  pi-arrow-down-left-and-arrow-up-right-to-center tabs-icon-min"></i>
-                      </div>
                     </div>
                     <div [attr.readonly]="!isTree" class="pc-tabs-content">
                       <div [hidden]="!options.description" class="prop-container">
@@ -902,13 +926,6 @@
                       <div (click)="select('variablesModule')" [attr.selected]="options.variablesModule"
                         class="tab-header">
                         Variables
-                      </div>
-                      <div (click)="collapse('rightTopMenu')" [attr.collapsed]="options.rightTopMenu"
-                        class="tabs-icon">
-                        <i
-                        class="pi pi-arrow-up-right-and-arrow-down-left-from-center tabs-icon-full"></i>
-                        <i
-                        class="pi  pi-arrow-down-left-and-arrow-up-right-to-center tabs-icon-min"></i>
                       </div>
                     </div>
                     <div [attr.readonly]="!isTree" class="pc-tabs-content">
@@ -966,24 +983,34 @@
                     [ngStyle]="{ height: size, 'flex-basis': size }"
                     class="right-bottom-toolbar">
                     <i *cdkDragPreview class="pi pi-align-left"></i>
+                    <div cdkDragHandle class="inspector-head inspector-head--panel">
+                      <div class="inspector-head-row">
+                        <span class="inspector-head-name" [title]="currentBlock.localTag">{{ currentBlock.localTag }}</span>
+                        <span class="inspector-head-type">{{ currentBlock.blockType }}</span>
+                      </div>
+                      @if (currentBlock.parent && !currentBlock.parent.isRoot) {
+                        <div class="inspector-head-parent"
+                          (click)="onSelect({ block: currentBlock.parent, isMultiSelect: false })"
+                          title="Select parent block">
+                          <span class="inspector-head-parent-label">in</span>
+                          <span class="inspector-head-parent-name">{{ currentBlock.parent.localTag }}</span>
+                          <i class="pi pi-arrow-up-right"></i>
+                        </div>
+                      }
+                    </div>
                     <div class="pc-tabs">
-                      <div cdkDragHandle class="pc-tabs-headers">
-                        <div (click)="select('properties')" [attr.selected]="options.properties || options.artifacts"
-                          class="tab-header">
-                          Settings
-                        </div>
-                        <div (click)="select('events')" [attr.selected]="options.events" class="tab-header">
-                          Events
-                        </div>
-                        <div (click)="select('json')" [attr.selected]="options.json" class="tab-header">
-                          JSON
-                        </div>
-                        <div (click)="collapse('rightBottomMenu')"
-                          [attr.collapsed]="options.rightBottomMenu" class="tabs-icon">
-                          <i
-                          class="pi pi-arrow-up-right-and-arrow-down-left-from-center tabs-icon-full"></i>
-                          <i
-                          class="pi  pi-arrow-down-left-and-arrow-up-right-to-center tabs-icon-min"></i>
+                      <div class="pc-tabs-headers pc-tabs-headers--segment">
+                        <div class="segment-track">
+                          <div (click)="select('properties')" [attr.selected]="options.properties || options.artifacts"
+                            class="tab-header">
+                            Properties
+                          </div>
+                          <div (click)="select('events')" [attr.selected]="options.events" class="tab-header">
+                            Events
+                          </div>
+                          <div (click)="select('json')" [attr.selected]="options.json" class="tab-header">
+                            JSON
+                          </div>
                         </div>
                       </div>
                       <div [attr.readonly]="!isTree" class="pc-tabs-content">
@@ -1064,11 +1091,6 @@
                       <div cdkDragHandle class="pc-tabs-headers">
                         <div (click)="select('events')" [attr.selected]="true" class="tab-header">
                           Events
-                        </div>
-                        <div (click)="collapse('rightBottomMenu')"
-                          [attr.collapsed]="options.rightBottomMenu" class="tabs-icon">
-                          <i class="pi pi-arrow-up-right-and-arrow-down-left-from-center tabs-icon-full"></i>
-                          <i class="pi  pi-arrow-down-left-and-arrow-up-right-to-center tabs-icon-min"></i>
                         </div>
                       </div>
                       <div class="pc-tabs-content">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -1,63 +1,78 @@
 ::ng-deep body {
-    --pc-main-grid-border: var(--guardian-border-color, #b4c4cb);
-    --pc-border-color: var(--guardian-border-color, #bdbdbd);
-    --pc-active-resize-delimiter-color: #626f75;
-    --pc-active-icon-color: var(--guardian-menu-color-2, #8259ef);
-    --pc-no-active-color: var(--guardian-disabled-color, #555);
-    --pc-active-background-color: var(--guardian-primary-background, #eff0f9);
-    --pc-header-color: var(--guardian-font-color, #555555);
-    --pc-favorite-color: #f3ac0e;
-    --pc-un-favorite-color: var(--guardian-disabled-icon, #f0f0f0);
-    --pc-favorite-focus-color: var(--guardian-disabled-color, #d0d0d0);
-    --pc-component-hover: var(--guardian-hover, #fbfbfb);
-    --pc-edit-status-color: #9c27b0;
+    /* Frame / surfaces — driven entirely by the global guardian tokens so light/dark
+       parity and customer branding come for free. No hardcoded status hex below. */
+    --pc-main-grid-border: var(--guardian-border-color, #E1E7EF);
+    --pc-border-color: var(--guardian-border-color, #E1E7EF);
+    --pc-active-resize-delimiter-color: var(--color-primary, #4169E2);
+    --pc-active-icon-color: var(--color-primary, #4169E2);
+    --pc-no-active-color: var(--guardian-disabled-color, #848FA9);
+    --pc-active-background-color: var(--guardian-primary-background, #e1e7fa);
+    --pc-header-color: var(--guardian-font-color, #23252E);
+    --pc-favorite-color: var(--color-accent-yellow-1, #DA9B22);
+    --pc-un-favorite-color: var(--guardian-disabled-icon, #C4D0E1);
+    --pc-favorite-focus-color: var(--guardian-disabled-color, #848FA9);
+    --pc-component-hover: var(--guardian-hover, #F0F3FC);
+
+    /* Lifecycle status accents — semantic tokens, identical meaning in both themes */
+    --pc-edit-status-color: var(--pc-wizard-color, #9c27b0);
     --pc-dry-run-status-color: var(--pc-active-icon-color);
-    --pc-publish-status-color: #4caf50;
-    --pc-error-color: #dd0a0a;
-    --pc-error-border-strong: #b80000;
-    --pc-error-bg-strong: var(--guardian-failure-background, #fff2f2);
-    --pc-error-shadow: #b80000cc;
-    --pc-warning-border-light: #ff6b6b;
-    --pc-warning-bg-light: var(--guardian-failure-background, #ffe9ea);
-    --pc-valid-color: #00bd06;
-    --pc-btn-border-color: var(--guardian-border-color, #dcdcdc);
-    --pc-selected-btn-color: #9c27b0;
-    --pc-event-color: #bd9012;
-    --pc-event-icon-color: #ffc107;
-    --pc-prop-border-color: var(--guardian-border-color, #e5e5e5);
-    --pc-tabs-active-color: var(--guardian-background, #fff);
-    --pc-tabs-color: var(--guardian-grey-background, #e6e6e6);
-    --pc-tabs-background-color: var(--guardian-grey-color, #d0d0d0);
-    --pc-tabs-hover-color: var(--guardian-hover, #f0f0f0);
-    --pc-prop-btn-color: #6166ff;
-    --pc-del-color: #eb0303;
-    --pc-required-color: #eb0303;
+    --pc-publish-status-color: var(--color-accent-green-1, #19BE47);
+    --pc-error-color: var(--color-accent-red-1, #FF432A);
+    --pc-error-border-strong: var(--color-accent-red-1, #FF432A);
+    --pc-error-bg-strong: var(--guardian-failure-background, #FFEAEA);
+    --pc-error-shadow: var(--guardian-shadow, #00000014);
+    --pc-warning-border-light: var(--color-accent-yellow-1, #DA9B22);
+    --pc-warning-bg-light: var(--guardian-warning-background, #FFF6E3);
+    --pc-valid-color: var(--color-accent-green-1, #19BE47);
+    --pc-btn-border-color: var(--guardian-border-color, #E1E7EF);
+    --pc-selected-btn-color: var(--color-primary, #4169E2);
+    --pc-event-color: var(--color-accent-yellow-1, #DA9B22);
+    --pc-event-icon-color: var(--color-accent-yellow-1, #DA9B22);
+    --pc-prop-border-color: var(--guardian-border-color, #E1E7EF);
+
+    /* Inspector / drawer tabs — underline style, neutral surfaces */
+    --pc-tabs-active-color: var(--guardian-background, #FFFFFF);
+    --pc-tabs-color: var(--guardian-background, #FFFFFF);
+    --pc-tabs-background-color: var(--guardian-background, #FFFFFF);
+    --pc-tabs-hover-color: var(--guardian-hover, #F0F3FC);
+    --pc-prop-btn-color: var(--color-primary, #4169E2);
+    --pc-del-color: var(--color-accent-red-1, #FF432A);
+    --pc-required-color: var(--color-accent-red-1, #FF432A);
     --pc-wizard-color: #9c27b0;
-    --pc-hover-color: var(--guardian-hover, #d0d0d0);
+    --pc-hover-color: var(--guardian-hover, #F0F3FC);
 
-    --pc-ui-block-background-color: #efe5fc;
-    --pc-server-block-background-color: #e2f9fe;
-    --pc-addon-block-background-color: #ffeeda;
+    /* Block-type accents — surfaces use a soft tint of the accent on the panel
+       background so they stay legible in dark mode; the borders carry the hue. */
+    --pc-ui-block-accent: #8259ef;
+    --pc-server-block-accent: #2aa9c4;
+    --pc-addon-block-accent: #e08a1e;
+    --pc-tool-block-accent: #c37a29;
 
-    --pc-ui-block-border-color: #c396fa;
-    --pc-server-block-border-color: #7bd0e3;
-    --pc-addon-block-border-color: #f9b465;
-    --pc-tool-block-color: #c37a29;
+    --pc-ui-block-background-color: color-mix(in srgb, var(--pc-ui-block-accent) 12%, var(--guardian-background, #fff));
+    --pc-server-block-background-color: color-mix(in srgb, var(--pc-server-block-accent) 12%, var(--guardian-background, #fff));
+    --pc-addon-block-background-color: color-mix(in srgb, var(--pc-addon-block-accent) 12%, var(--guardian-background, #fff));
 
-    --pc-drag-text-color: var(--guardian-font-color, #404040);
-    --pc-readonly-text-color: var(--guardian-disabled-color, rgba(0, 0, 0, .45));
-    --pc-text-color: var(--guardian-font-color, #000);
-    --pc-background-color: var(--guardian-background, #fff);
+    --pc-ui-block-border-color: color-mix(in srgb, var(--pc-ui-block-accent) 45%, var(--guardian-border-color, #fff));
+    --pc-server-block-border-color: color-mix(in srgb, var(--pc-server-block-accent) 45%, var(--guardian-border-color, #fff));
+    --pc-addon-block-border-color: color-mix(in srgb, var(--pc-addon-block-accent) 45%, var(--guardian-border-color, #fff));
+    --pc-tool-block-color: var(--pc-tool-block-accent, #c37a29);
+
+    --pc-drag-text-color: var(--guardian-font-color, #23252E);
+    --pc-readonly-text-color: var(--guardian-disabled-color, #848FA9);
+    --pc-text-color: var(--guardian-font-color, #23252E);
+    --pc-background-color: var(--guardian-background, #FFFFFF);
+
+    /* Surface radius / elevation — replaces the old thick grid frame */
+    --pc-radius: 10px;
+    --pc-radius-sm: 8px;
+    --pc-elevation: 0 1px 2px var(--guardian-shadow, #00000014), 0 1px 1px var(--guardian-shadow, #00000014);
 }
 
 .content {
     width: 100%;
     height: 100%;
     position: relative;
-    border: 0px solid var(--pc-main-grid-border);
-    border-left-width: 4px;
-    border-right-width: 0px;
-    border-bottom-width: 2px;
+    border: none;
 }
 
 .action-color {
@@ -115,7 +130,7 @@
     top: 50%;
     transform: translate(-50%, -50%);
     font-size: 20px;
-    color: darkgrey;
+    color: var(--guardian-disabled-color, #848FA9);
 }
 
 .policy-configuration {
@@ -126,6 +141,7 @@
     height: calc(100vh - 2px);
     overflow: hidden;
     min-width: 1000px;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
 }
 
 .top-toolbar {
@@ -136,11 +152,8 @@
     height: 80px;
     display: flex;
     background: var(--pc-background-color);
-    border: 4px solid var(--pc-main-grid-border);
-    border-top-width: 7px;
-    border-left-width: 4px;
-    border-right-width: 8px;
-    border-bottom-width: 3px;
+    border: none;
+    border-bottom: 1px solid var(--pc-main-grid-border);
     box-sizing: border-box;
 }
 
@@ -150,22 +163,26 @@
     top: 80px;
     right: 0;
     bottom: 0px;
-    border: 4px solid var(--pc-main-grid-border);
+    border: none;
     box-sizing: border-box;
     display: flex;
-    gap: 2px;
-    background-color: var(--pc-main-grid-border);
+    gap: 12px;
+    padding: 12px;
+    background-color: var(--guardian-grey-background, #F9FAFC);
 }
 
 .left-toolbar {
     height: 100%;
     position: relative;
-    // border-right: 4px solid var(--pc-main-grid-border);
     box-sizing: border-box;
     background-color: var(--guardian-background, white);
     color: var(--guardian-font-color, #23252E);
     z-index: 1;
     min-width: 150px;
+    border: 1px solid var(--pc-main-grid-border);
+    border-radius: var(--pc-radius);
+    box-shadow: var(--pc-elevation);
+    overflow: hidden;
 }
 
 .center-container {
@@ -173,11 +190,13 @@
     position: relative;
     overflow: hidden;
     box-sizing: border-box;
-    // border-right: 4px solid var(--pc-main-grid-border);
     z-index: 1;
     background-color: var(--guardian-background, white);
     color: var(--guardian-font-color, #23252E);
     min-width: 275px;
+    border: 1px solid var(--pc-main-grid-border);
+    border-radius: var(--pc-radius);
+    box-shadow: var(--pc-elevation);
 }
 
 .tree-container {
@@ -186,8 +205,8 @@
     overflow: hidden;
     box-sizing: border-box;
     background: var(--guardian-grey-background, #f5f5f5);
-    background-image: radial-gradient(circle, var(--guardian-border-color, #bfbfbf) 1px, var(--guardian-grey-background, #f5f5f5) 1px);
-    background-size: 20px 20px;
+    background-image: radial-gradient(circle, color-mix(in srgb, var(--guardian-border-color, #bfbfbf) 55%, transparent) 1px, transparent 1px);
+    background-size: 24px 24px;
 }
 
 .textarea-code {
@@ -209,11 +228,14 @@
     // width: 485px;
     position: relative;
     box-sizing: border-box;
-    border-right: 4px solid var(--pc-main-grid-border);
+    border: 1px solid var(--pc-main-grid-border);
+    border-radius: var(--pc-radius);
+    box-shadow: var(--pc-elevation);
+    overflow: hidden;
     display: flex;
-    gap: 2px;
+    gap: 0;
     flex-direction: column;
-    background: var(--pc-main-grid-border);
+    background: var(--pc-background-color);
     z-index: 1;
     min-width: 280px;
 }
@@ -221,7 +243,7 @@
 .right-top-toolbar {
     position: relative;
     width: 100%;
-    border-bottom: 4px solid var(--pc-main-grid-border);
+    border-bottom: 1px solid var(--pc-main-grid-border);
     box-sizing: border-box;
     min-height: 31px;
     flex: 1;
@@ -229,9 +251,9 @@
     background: var(--pc-background-color);
 
     &[collapse-top="true"] {
-        max-height: 31px;
-        height: 31px;
-        min-height: 31px;
+        max-height: 38px;
+        height: 38px;
+        min-height: 38px;
     }
 
     &[collapse-bottom="true"] {
@@ -240,9 +262,9 @@
     }
 
     &[collapse-top="true"][collapse-bottom="true"] {
-        max-height: 31px;
-        height: 31px;
-        min-height: 31px;
+        max-height: 38px;
+        height: 38px;
+        min-height: 38px;
     }
 }
 
@@ -260,24 +282,24 @@
     }
 
     &[collapse-bottom="true"] {
-        max-height: 31px;
-        height: 31px;
-        min-height: 31px;
+        max-height: 38px;
+        height: 38px;
+        min-height: 38px;
     }
 
     &[collapse-top="true"][collapse-bottom="true"] {
-        max-height: 31px;
-        height: 31px;
-        min-height: 31px;
+        max-height: 38px;
+        height: 38px;
+        min-height: 38px;
     }
 }
 
 .top-toolbar {
     .delimiter {
-        width: 10px;
-        height: 54px;
-        border-left: 1px solid var(--pc-active-icon-color);
-        margin: 8px 0px 6px 10px;
+        width: 1px;
+        height: 36px;
+        border-left: 1px solid var(--pc-border-color);
+        margin: 22px 8px;
     }
 
     .top-toolbar-label {
@@ -312,7 +334,7 @@
         flex-direction: column;
         overflow: hidden;
         height: 60px;
-        margin: 5px 4px;
+        margin: 10px 2px;
         padding: 12px 2px 2px 2px;
         font-size: 12px;
         align-items: center;
@@ -321,13 +343,14 @@
         cursor: pointer;
         position: relative;
         user-select: none;
-        background: var(--guardian-background, #fcfcfc);
-        border: 1px solid var(--pc-btn-border-color);
-        border-radius: 6px;
+        background: transparent;
+        border: 1px solid transparent;
+        border-radius: 8px;
+        transition: background 0.15s ease, border-color 0.15s ease;
 
         &:hover {
             background: var(--guardian-hover, #f9f9fd);
-            border: 1px solid var(--pc-active-icon-color);
+            border: 1px solid transparent;
         }
 
         span {
@@ -430,18 +453,19 @@
             top: 0;
             right: 0px;
             bottom: 0;
-            width: 18px;
+            width: 16px;
             overflow: hidden;
-            background: var(--guardian-grey-background, rgb(240 240 240));
-            border-top-right-radius: 6px;
-            border-bottom-right-radius: 6px;
-            border-left: 1px solid var(--pc-btn-border-color);
+            background: transparent;
+            border-top-right-radius: 8px;
+            border-bottom-right-radius: 8px;
+            border-left: none;
 
             .pi {
                 position: absolute;
-                top: 22px;
-                left: 2px;
-                font-size: 14px;
+                top: 24px;
+                left: 1px;
+                font-size: 12px;
+                opacity: 0.6;
             }
         }
 
@@ -563,13 +587,16 @@
         }
 
         .components-group-name {
-            height: 38px;
-            border-top: 1px solid var(--pc-border-color);
+            height: 34px;
+            border-top: none;
             border-bottom: 1px solid var(--pc-border-color);
             box-sizing: border-box;
-            margin: 8px 0px;
-            font-weight: 500;
-            color: var(--pc-header-color);
+            margin: 6px 0px 2px;
+            font-weight: 600;
+            font-size: 12px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--pc-no-active-color);
             position: relative;
             padding: 9px 24px;
             cursor: pointer;
@@ -780,22 +807,23 @@
 
         .pc-tabs-headers {
             display: flex;
-            height: 31px;
+            height: 38px;
             position: absolute;
             left: 0;
             right: 0;
             top: 0;
             background: var(--pc-tabs-background-color);
+            border-bottom: 1px solid var(--pc-border-color);
             position: relative;
 
             .tab-header {
                 padding: 6px 8px;
-                font-weight: bold;
-                color: var(--pc-header-color);
+                font-weight: 500;
+                color: var(--pc-no-active-color);
                 cursor: pointer;
                 flex: 1;
-                background: var(--pc-tabs-color);
-                height: 31px;
+                background: transparent;
+                height: 38px;
                 box-sizing: border-box;
                 overflow: hidden;
                 text-align: center;
@@ -808,13 +836,18 @@
                 text-overflow: ellipsis;
                 display: grid;
                 grid-template-columns: 30px 130px;
+                border-bottom: 2px solid transparent;
+                transition: color 0.15s ease, border-color 0.15s ease;
 
                 &:hover {
                     background: var(--pc-tabs-hover-color);
+                    color: var(--pc-header-color);
                 }
 
                 &[selected="true"] {
-                    background: var(--pc-tabs-active-color) !important;
+                    background: transparent !important;
+                    color: var(--pc-active-icon-color) !important;
+                    border-bottom: 2px solid var(--pc-active-icon-color) !important;
                     cursor: default !important;
                 }
 
@@ -878,12 +911,12 @@
 
             .tabs-icon {
                 padding: 6px 8px;
-                font-weight: bold;
+                font-weight: 500;
                 color: var(--pc-header-color);
                 cursor: pointer;
                 flex: 1;
-                background: var(--pc-tabs-color);
-                height: 31px;
+                background: transparent;
+                height: 38px;
                 overflow: hidden;
                 text-align: center;
                 width: 20px;
@@ -926,7 +959,7 @@
         .pc-tabs-content {
             position: absolute;
             left: 0;
-            top: 31px;
+            top: 38px;
             right: 0;
             bottom: 0;
             overflow: auto;
@@ -985,7 +1018,7 @@
             top: 0;
             right: 0;
             width: 30px;
-            height: 31px;
+            height: 38px;
             overflow: hidden;
             cursor: pointer;
             box-sizing: border-box;
@@ -1008,14 +1041,16 @@
         .theme-legends-container {
             display: none;
             position: absolute;
-            top: 32px;
+            top: 44px;
             right: 10px;
             z-index: 5;
-            border-bottom-left-radius: 6px;
-            box-shadow: -2px 2px 4px 0px #00000020;
+            border: 1px solid var(--pc-border-color);
+            border-radius: var(--pc-radius, 10px);
+            box-shadow: var(--pc-elevation);
             background: var(--pc-background-color);
             overflow: auto;
             max-height: calc(100vh - var(--header-height) - 260px);
+            padding: 6px;
         }
 
         .theme-rule {
@@ -1027,6 +1062,7 @@
             margin-right: 0px;
             background: var(--pc-background-color);
             padding: 4px 6px;
+            border-radius: 6px;
             pointer-events: all;
         }
 
@@ -1064,7 +1100,7 @@
 
     &.cdk-drag-placeholder {
         opacity: 0.4 !important;
-        background: #e3e3e3 !important;
+        background: var(--guardian-grey-color, #e3e3e3) !important;
         height: 54px;
         display: flex;
         position: relative;
@@ -1088,10 +1124,10 @@
             cursor: pointer;
             user-select: none;
             margin: 0px 0px 0px 0px;
-            box-shadow: 4px 4px 6px 0px #00000040;
+            box-shadow: 4px 4px 6px 0px var(--guardian-shadow, #00000040);
             width: 160px;
             background: var(--pc-background-color);
-            border-color: #838383;
+            border-color: var(--guardian-grey-color-3, #838383);
 
             .drag-component-icon {
                 display: block;
@@ -1186,6 +1222,229 @@
     color: var(--pc-tool-block-color) !important;
 }
 
+.not-published-label {
+    color: var(--pc-error-color);
+
+    i,
+    span {
+        color: var(--pc-error-color);
+    }
+}
+
+.policy-identity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 44px;
+    margin: 18px 4px;
+    padding: 0 10px;
+    max-width: 240px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        background: var(--guardian-hover, #F0F3FC);
+        border-color: var(--pc-border-color);
+    }
+
+    .policy-identity-icon {
+        flex: 0 0 auto;
+        width: 22px;
+        height: 22px;
+        display: flex;
+        align-items: center;
+
+        svg {
+            width: 20px;
+            fill: var(--pc-active-icon-color);
+        }
+    }
+
+    .policy-identity-text {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        line-height: 1.2;
+    }
+
+    .policy-identity-name {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--pc-text-color);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .policy-identity-meta {
+        font-size: 11px;
+        color: var(--pc-no-active-color);
+    }
+
+    .policy-identity-caret {
+        flex: 0 0 auto;
+        font-size: 11px;
+        color: var(--pc-no-active-color);
+    }
+}
+
+.identity-popover {
+    min-width: 280px;
+    max-width: 360px;
+    padding: 4px;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+
+    .identity-popover-title {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--pc-text-color);
+        padding: 4px 8px;
+    }
+
+    .identity-popover-version {
+        font-size: 12px;
+        color: var(--pc-no-active-color);
+        padding: 0 8px 8px;
+    }
+
+    .identity-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background 0.15s ease;
+
+        &:hover {
+            background: var(--guardian-hover, #F0F3FC);
+        }
+    }
+
+    .identity-row-label {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--pc-no-active-color);
+        flex: 0 0 auto;
+    }
+
+    .identity-row-value {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        overflow: hidden;
+
+        i {
+            flex: 0 0 auto;
+            font-size: 13px;
+            color: var(--pc-active-icon-color);
+        }
+    }
+
+    .identity-row-mono {
+        font-family: 'Roboto Mono', ui-monospace, monospace;
+        font-size: 12px;
+        color: var(--pc-text-color);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .identity-action {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-top: 4px;
+        padding: 10px 8px;
+        border-top: 1px solid var(--pc-border-color);
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--pc-active-icon-color);
+
+        i {
+            font-size: 14px;
+        }
+
+        &:hover {
+            color: var(--color-primary, #4169E2);
+        }
+    }
+}
+
+.command-palette-btn span {
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.command-palette {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+
+    .command-palette-search {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 6px 12px;
+        border-bottom: 1px solid var(--pc-border-color);
+
+        i {
+            color: var(--pc-no-active-color);
+            font-size: 16px;
+        }
+
+        .command-palette-input {
+            flex: 1;
+            border: none;
+            outline: none;
+            background: transparent;
+            font-size: 16px;
+            color: var(--pc-text-color);
+
+            &::placeholder {
+                color: var(--pc-no-active-color);
+            }
+        }
+    }
+
+    .command-palette-list {
+        margin-top: 8px;
+        max-height: 360px;
+        overflow: auto;
+    }
+
+    .command-palette-item {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 12px;
+        border-radius: 8px;
+        cursor: pointer;
+        color: var(--pc-text-color);
+        transition: background 0.12s ease;
+
+        i {
+            font-size: 16px;
+            color: var(--pc-active-icon-color);
+            width: 20px;
+            text-align: center;
+        }
+
+        &:hover {
+            background: var(--guardian-hover, #F0F3FC);
+        }
+    }
+
+    .command-palette-empty {
+        padding: 16px 12px;
+        color: var(--pc-no-active-color);
+        text-align: center;
+    }
+}
+
 @media (max-width: 810px) {
     .policy-configuration {
         height: calc(100vh - var(--header-height));
@@ -1274,7 +1533,7 @@
         &.right-toolbar,
         &.right-top-toolbar,
         &.right-bottom-toolbar {
-            outline: 1px dashed black;
+            outline: 1px dashed var(--guardian-grid-color, #848FA9);
             opacity: 0.5;
         }
     }
@@ -1477,7 +1736,7 @@
     background-color: var(--color-grey-white);
     z-index: 10;
 
-    font-family: Inter;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
     font-weight: 400;
     font-style: Regular;
     font-size: 14px;
@@ -1500,7 +1759,7 @@
     background-color: var(--color-grey-white);
     z-index: 10;
 
-    font-family: Inter;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
     font-weight: 400;
     font-style: Regular;
     font-size: 14px;
@@ -1518,7 +1777,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-family: Inter;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
     font-weight: 400;
     font-style: Regular;
     font-size: 14px;
@@ -1526,4 +1785,54 @@
     vertical-align: middle;
     color: var(--color-grey-5, #848FA9);
     background-color: var(--guardian-grey-background, #EFEFEF);
+}
+
+.inspector-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px;
+    text-align: center;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    background: var(--guardian-background, #fff);
+
+    .inspector-empty-icon {
+        font-size: 28px;
+        color: var(--guardian-disabled-icon, #C4D0E1);
+        margin-bottom: 4px;
+    }
+
+    .inspector-empty-title {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--guardian-font-color, #23252E);
+    }
+
+    .inspector-empty-text {
+        font-size: 13px;
+        color: var(--pc-no-active-color);
+        max-width: 240px;
+    }
+
+    .inspector-empty-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 8px;
+        padding: 8px 16px;
+        border: 1px solid var(--color-primary, #4169E2);
+        border-radius: 8px;
+        background: transparent;
+        color: var(--color-primary, #4169E2);
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.15s ease;
+
+        &:hover {
+            background: var(--guardian-primary-background, #e1e7fa);
+        }
+    }
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -149,8 +149,11 @@
     left: 0;
     top: 0;
     right: 0;
-    height: 80px;
+    height: 64px;
     display: flex;
+    align-items: center;
+    padding: 0 12px;
+    gap: 2px;
     background: var(--pc-background-color);
     border: none;
     border-bottom: 1px solid var(--pc-main-grid-border);
@@ -160,7 +163,7 @@
 .main-container {
     position: absolute;
     left: 0;
-    top: 80px;
+    top: 64px;
     right: 0;
     bottom: 0px;
     border: none;
@@ -374,10 +377,154 @@
         margin: 22px 8px;
     }
 
+    .toolbar-spacer {
+        flex: 1 1 auto;
+    }
+
+    .top-toolbar-btn.icon-only {
+        min-width: 40px;
+        width: 40px;
+        padding: 0;
+        justify-content: center;
+
+        i {
+            font-size: 18px;
+        }
+
+        span {
+            display: none;
+        }
+    }
+
     .top-toolbar-label {
         background: var(--pc-background-color) !important;
         border: 1px solid var(--pc-background-color) !important;
         cursor: default !important;
+    }
+
+    .top-toolbar-group.publish-primary {
+        background: var(--color-primary, #4169e2);
+        border-color: var(--color-primary, #4169e2);
+        color: #fff;
+
+        i,
+        span {
+            color: #fff;
+        }
+
+        svg {
+            fill: #fff;
+        }
+
+        .expand-group {
+            border-left: 1px solid rgba(255, 255, 255, 0.3);
+
+            .pi {
+                color: #fff;
+                opacity: 0.85;
+            }
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--color-primary, #4169e2) 88%, #000);
+            border-color: color-mix(in srgb, var(--color-primary, #4169e2) 88%, #000);
+        }
+    }
+
+    .status-badge {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 6px;
+        height: 28px;
+        margin: 0 4px;
+        padding: 0 12px;
+        border-radius: 14px;
+        font-size: 12px;
+        font-weight: 600;
+        user-select: none;
+        white-space: nowrap;
+
+        i {
+            font-size: 13px;
+        }
+
+        span {
+            font-size: 12px;
+        }
+
+        .status-badge-caret {
+            font-size: 10px;
+            opacity: 0.7;
+            cursor: pointer;
+        }
+
+        &--draft {
+            color: var(--pc-edit-color, #7B61FF);
+            background: color-mix(in srgb, var(--pc-edit-color, #7B61FF) 14%, transparent);
+        }
+
+        &--dryrun {
+            color: var(--pc-dry-run-color, #E0A800);
+            background: color-mix(in srgb, var(--pc-dry-run-color, #E0A800) 16%, transparent);
+            cursor: pointer;
+
+            svg {
+                fill: var(--pc-dry-run-color, #E0A800);
+                width: 16px;
+            }
+        }
+
+        &--published {
+            color: var(--pc-publish-color, #21A66B);
+            background: color-mix(in srgb, var(--pc-publish-color, #21A66B) 14%, transparent);
+        }
+
+        &--demo {
+            color: var(--pc-demo-color, #8a8f9c);
+            background: color-mix(in srgb, var(--pc-demo-color, #8a8f9c) 14%, transparent);
+        }
+    }
+
+    .view-segment {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 2px;
+        height: 36px;
+        padding: 3px;
+        border-radius: 10px;
+        background: var(--guardian-grey-background, #f1f3f9);
+        border: 1px solid var(--pc-border-color);
+
+        .view-segment-item {
+            display: flex;
+            align-items: center;
+            height: 28px;
+            padding: 0 16px;
+            border-radius: 7px;
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--guardian-font-color-secondary, #8a8f9c);
+            cursor: pointer;
+            user-select: none;
+            transition: background 0.15s ease, color 0.15s ease;
+
+            &:hover {
+                color: var(--guardian-font-color, #23252e);
+            }
+
+            &.active {
+                color: var(--color-primary, #4169e2);
+                background: var(--guardian-background, #fff);
+                box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+                font-weight: 600;
+            }
+        }
     }
 
     .btn-mode-active {
@@ -403,14 +550,14 @@
     .top-toolbar-group,
     .top-toolbar-btn {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         overflow: hidden;
-        height: 60px;
-        margin: 10px 2px;
-        padding: 12px 2px 2px 2px;
-        font-size: 12px;
+        height: 40px;
+        margin: 0 2px;
+        padding: 0 12px;
+        gap: 8px;
+        font-size: 13px;
         align-items: center;
-        align-content: center;
         color: var(--pc-active-icon-color);
         cursor: pointer;
         position: relative;
@@ -420,25 +567,22 @@
         border-radius: 8px;
         transition: background 0.15s ease, border-color 0.15s ease;
 
+        i {
+            font-size: 18px;
+        }
+
         &:hover {
             background: var(--guardian-hover, #f9f9fd);
             border: 1px solid transparent;
         }
 
         span {
-            font-size: 12px;
-            text-align: center;
-            line-height: 14px;
+            font-size: 13px;
+            line-height: 1;
             user-select: none;
+            white-space: nowrap;
             display: flex;
-            max-width: 65px;
-            min-width: 60px;
-            height: 28px;
             align-items: center;
-            align-content: center;
-            justify-content: center;
-            justify-items: center;
-            padding-top: 2px;
         }
 
         &[active="true"] {
@@ -451,7 +595,7 @@
     }
 
     .top-toolbar-btn {
-        min-width: 60px;
+        min-width: auto;
 
         &[errors-count] {
             color: var(--pc-error-color);
@@ -504,8 +648,8 @@
     }
 
     .top-toolbar-group {
-        padding-right: 21px;
-        min-width: 52px;
+        padding-right: 28px;
+        min-width: auto;
 
         svg-icon {
             height: 20px;
@@ -516,26 +660,22 @@
             fill: var(--pc-active-icon-color);
         }
 
-        span {
-            max-width: 65px;
-        }
-
         .expand-group {
             position: absolute;
             top: 0;
             right: 0px;
             bottom: 0;
-            width: 16px;
+            width: 20px;
             overflow: hidden;
             background: transparent;
             border-top-right-radius: 8px;
             border-bottom-right-radius: 8px;
             border-left: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
 
             .pi {
-                position: absolute;
-                top: 24px;
-                left: 1px;
                 font-size: 12px;
                 opacity: 0.6;
             }
@@ -605,6 +745,122 @@
             width: 16px;
             fill: var(--pc-event-color);
         }
+    }
+}
+
+.overflow-menu {
+    display: flex;
+    flex-direction: column;
+    min-width: 236px;
+    padding: 6px;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+
+    .toolbar-menu {
+        min-width: 0;
+        height: 32px;
+        margin: 0;
+        padding: 0 10px;
+        gap: 12px;
+        border-radius: 6px;
+        color: var(--guardian-font-color, #23252e);
+
+        i,
+        svg-icon,
+        svg {
+            color: var(--guardian-font-color-secondary, #8a8f9c);
+            fill: var(--guardian-font-color-secondary, #8a8f9c);
+        }
+
+        i {
+            font-size: 16px;
+            width: 18px;
+            text-align: center;
+        }
+
+        &:hover {
+            background: var(--pc-component-hover, var(--guardian-hover, #f4f6fb));
+            border-color: transparent;
+        }
+
+        span {
+            flex: 1 1 auto;
+            text-align: left;
+            padding-left: 0;
+            font-size: 13px;
+            color: inherit;
+        }
+
+        .overflow-check {
+            flex: 0 0 auto;
+            width: auto;
+            padding-left: 8px;
+            font-size: 13px;
+            color: var(--color-primary, #4169e2);
+        }
+
+        &[active="true"] {
+            color: var(--color-primary, #4169e2);
+            font-weight: 600;
+
+            i,
+            svg-icon,
+            svg {
+                color: var(--color-primary, #4169e2);
+                fill: var(--color-primary, #4169e2);
+            }
+        }
+    }
+
+    .overflow-menu-divider {
+        height: 1px;
+        margin: 6px 8px;
+        background: var(--pc-border-color);
+    }
+
+    .overflow-menu-label {
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--guardian-font-color-secondary, #8a8f9c);
+        padding: 8px 10px 4px;
+    }
+}
+
+.group-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 8px;
+    vertical-align: middle;
+    flex: 0 0 auto;
+
+    &--ui {
+        background: var(--pc-ui-block-accent);
+    }
+
+    &--server {
+        background: var(--pc-server-block-accent);
+    }
+
+    &--addon {
+        background: var(--pc-addon-block-accent);
+    }
+}
+
+.inspector-subsection {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--pc-border-color);
+
+    .inspector-subsection-label {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--guardian-font-color-secondary, #8a8f9c);
+        padding: 0 12px 8px;
     }
 }
 
@@ -1375,17 +1631,13 @@
     padding: 4px;
     font-family: var(--font-family-inter, 'Inter', sans-serif);
 
-    .identity-popover-title {
-        font-size: 15px;
+    .identity-popover-header {
+        font-size: 11px;
         font-weight: 600;
-        color: var(--pc-text-color);
-        padding: 4px 8px;
-    }
-
-    .identity-popover-version {
-        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
         color: var(--pc-no-active-color);
-        padding: 0 8px 8px;
+        padding: 4px 8px 8px;
     }
 
     .identity-row {
@@ -1401,6 +1653,25 @@
         &:hover {
             background: var(--guardian-hover, #F0F3FC);
         }
+
+        &.identity-row--plain {
+            cursor: default;
+
+            &:hover {
+                background: transparent;
+            }
+        }
+    }
+
+    .identity-row-plain-value {
+        font-size: 13px;
+        color: var(--pc-text-color);
+    }
+
+    .identity-divider {
+        height: 1px;
+        margin: 4px 8px;
+        background: var(--pc-border-color);
     }
 
     .identity-row-label {
@@ -1435,21 +1706,31 @@
     .identity-action {
         display: flex;
         align-items: center;
-        gap: 10px;
-        margin-top: 4px;
-        padding: 10px 8px;
-        border-top: 1px solid var(--pc-border-color);
-        cursor: pointer;
+        justify-content: center;
+        gap: 8px;
+        margin-top: 2px;
+        padding: 9px 12px;
+        border-radius: 8px;
+        background: var(--guardian-grey-background, #f1f3f9);
+        color: var(--guardian-font-color, #23252e);
         font-size: 13px;
         font-weight: 500;
-        color: var(--pc-active-icon-color);
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
 
         i {
             font-size: 14px;
+            color: var(--guardian-font-color-secondary, #8a8f9c);
+            transition: color 0.15s ease;
         }
 
         &:hover {
-            color: var(--color-primary, #4169E2);
+            background: color-mix(in srgb, var(--color-primary, #4169e2) 10%, transparent);
+            color: var(--color-primary, #4169e2);
+
+            i {
+                color: var(--color-primary, #4169e2);
+            }
         }
     }
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -185,6 +185,78 @@
     overflow: hidden;
 }
 
+.library-collapse-toggle {
+    flex: 0 0 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 38px;
+    cursor: pointer;
+    color: var(--pc-no-active-color, #848FA9);
+    transition: background 0.15s ease, color 0.15s ease;
+
+    &:hover {
+        background: var(--pc-tabs-hover-color);
+        color: var(--pc-active-icon-color);
+    }
+
+    i {
+        font-size: 14px;
+    }
+}
+
+.left-toolbar.collapsed {
+    min-width: 44px;
+    width: 44px;
+
+    .pc-tabs .pc-tabs-headers {
+        flex-direction: column;
+        height: auto;
+        align-items: center;
+        background: transparent;
+        border-bottom: none;
+
+        .tab-header {
+            grid-template-columns: 1fr;
+            flex: 0 0 auto;
+            width: 36px;
+            height: 36px;
+            margin: 2px auto;
+            padding: 0;
+            border-bottom: none !important;
+            border-radius: 8px;
+
+            span {
+                display: none;
+            }
+
+            svg {
+                position: static;
+                left: auto;
+                top: auto;
+                margin: 0 auto;
+            }
+
+            &[selected="true"] {
+                background: var(--guardian-primary-background, #e1e7fa) !important;
+                border-bottom: none !important;
+            }
+        }
+
+        .library-collapse-toggle {
+            order: -1;
+            width: 36px;
+            height: 32px;
+            margin: 2px auto 4px;
+            border-radius: 8px;
+        }
+    }
+
+    .pc-tabs .pc-tabs-content {
+        display: none !important;
+    }
+}
+
 .center-container {
     flex: 1;
     position: relative;
@@ -1080,6 +1152,12 @@
             display: flex;
         }
 
+        .theme-legends-divider {
+            height: 1px;
+            margin: 6px 4px;
+            background: var(--pc-border-color);
+        }
+
         &[active="true"] {
             .theme-legends-container {
                 display: block;
@@ -1442,6 +1520,73 @@
         padding: 16px 12px;
         color: var(--pc-no-active-color);
         text-align: center;
+    }
+}
+
+.block-picker {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    width: 260px;
+
+    .block-picker-search {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 6px 10px;
+        border-bottom: 1px solid var(--pc-border-color);
+
+        i {
+            color: var(--pc-no-active-color);
+            font-size: 14px;
+        }
+
+        input {
+            flex: 1;
+            border: none;
+            outline: none;
+            background: transparent;
+            font-size: 14px;
+            color: var(--pc-text-color);
+
+            &::placeholder {
+                color: var(--pc-no-active-color);
+            }
+        }
+    }
+
+    .block-picker-list {
+        margin-top: 6px;
+        max-height: 320px;
+        overflow: auto;
+    }
+
+    .block-picker-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 10px;
+        border-radius: 8px;
+        cursor: pointer;
+        color: var(--pc-text-color);
+        font-size: 13px;
+        transition: background 0.12s ease;
+
+        .block-picker-item-icon {
+            font-size: 15px;
+            color: var(--pc-active-icon-color);
+            width: 18px;
+            text-align: center;
+        }
+
+        &:hover {
+            background: var(--guardian-hover, #F0F3FC);
+        }
+    }
+
+    .block-picker-empty {
+        padding: 14px 10px;
+        color: var(--pc-no-active-color);
+        text-align: center;
+        font-size: 13px;
     }
 }
 

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -181,11 +181,19 @@
     background-color: var(--guardian-background, white);
     color: var(--guardian-font-color, #23252E);
     z-index: 1;
-    min-width: 150px;
+    width: 264px;
+    flex: 0 0 264px;
+    min-width: 264px;
+    max-width: 264px;
     border: 1px solid var(--pc-main-grid-border);
     border-radius: var(--pc-radius);
     box-shadow: var(--pc-elevation);
     overflow: hidden;
+}
+
+// The library is a fixed-width rail; drop the resize handle that follows it.
+.main-container > .left-toolbar + .resizing {
+    display: none;
 }
 
 .library-collapse-toggle {
@@ -211,6 +219,8 @@
 .left-toolbar.collapsed {
     min-width: 44px;
     width: 44px;
+    max-width: 44px;
+    flex: 0 0 44px;
 
     .pc-tabs .pc-tabs-headers {
         flex-direction: column;
@@ -221,23 +231,38 @@
 
         .tab-header {
             grid-template-columns: 1fr;
-            flex: 0 0 auto;
-            width: 36px;
+            flex: 0 0 auto !important;
+            width: 36px !important;
+            min-width: 36px !important;
+            max-width: 36px !important;
             height: 36px;
             margin: 2px auto;
-            padding: 0;
+            padding: 0 !important;
             border-bottom: none !important;
             border-radius: 8px;
+            display: flex !important;
+            align-items: center;
+            justify-content: center;
 
             span {
                 display: none;
             }
 
+            svg-icon {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 20px;
+                height: 20px;
+            }
+
             svg {
-                position: static;
-                left: auto;
-                top: auto;
-                margin: 0 auto;
+                position: static !important;
+                left: auto !important;
+                top: auto !important;
+                margin: 0 !important;
+                width: 20px;
+                height: 20px;
             }
 
             &[selected="true"] {
@@ -258,6 +283,18 @@
     .pc-tabs .pc-tabs-content {
         display: none !important;
     }
+}
+
+// The collapsed rail icons render inside <svg-icon>, so their inner <svg>
+// belongs to the child component's encapsulation. Reach it through ::ng-deep
+// to cancel the default absolute positioning and center every icon uniformly.
+.policy-configuration::ng-deep .left-toolbar.collapsed .pc-tabs-headers .tab-header svg {
+    position: static !important;
+    left: auto !important;
+    top: auto !important;
+    margin: 0 !important;
+    width: 20px !important;
+    height: 20px !important;
 }
 
 .center-container {
@@ -300,7 +337,10 @@
 
 .right-toolbar {
     height: 100%;
-    // width: 485px;
+    width: 340px !important;
+    flex: 0 0 340px !important;
+    min-width: 340px;
+    max-width: 340px;
     position: relative;
     box-sizing: border-box;
     border: 1px solid var(--pc-main-grid-border);
@@ -312,7 +352,11 @@
     flex-direction: column;
     background: var(--pc-background-color);
     z-index: 1;
-    min-width: 280px;
+}
+
+// The inspector is a fixed-width rail; drop the resize handle in front of it.
+.main-container > .resizing:has(+ .right-toolbar) {
+    display: none;
 }
 
 .right-top-toolbar {
@@ -350,6 +394,14 @@
     min-height: 31px;
     z-index: 1;
     background: var(--pc-background-color);
+    display: flex;
+    flex-direction: column;
+
+    .pc-tabs {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: auto;
+    }
 
     &[collapse-top="true"] {
         max-height: 100%;
@@ -372,9 +424,9 @@
 .top-toolbar {
     .delimiter {
         width: 1px;
-        height: 36px;
+        height: 24px;
         border-left: 1px solid var(--pc-border-color);
-        margin: 22px 8px;
+        margin: 0 6px;
     }
 
     .toolbar-spacer {
@@ -437,7 +489,7 @@
         align-items: center;
         gap: 6px;
         height: 28px;
-        margin: 0 4px;
+        margin: 0 2px;
         padding: 0 12px;
         border-radius: 14px;
         font-size: 12px;
@@ -850,8 +902,8 @@
 }
 
 .inspector-subsection {
-    margin-top: 12px;
-    padding-top: 12px;
+    margin-top: 4px;
+    padding: 12px;
     border-top: 1px solid var(--pc-border-color);
 
     .inspector-subsection-label {
@@ -860,7 +912,74 @@
         letter-spacing: 0.04em;
         text-transform: uppercase;
         color: var(--guardian-font-color-secondary, #8a8f9c);
-        padding: 0 12px 8px;
+        padding: 0 0 8px;
+    }
+
+    ::ng-deep .artifact-container {
+        margin-top: 0;
+        height: auto;
+        align-items: stretch;
+        gap: 8px;
+    }
+
+    ::ng-deep .artifact-list {
+        width: 100%;
+        border: 1px solid var(--pc-border-color);
+        border-radius: 8px;
+        min-height: 0;
+        max-height: 220px;
+        overflow-y: auto;
+    }
+
+    ::ng-deep .artifact-row {
+        padding: 8px 10px;
+        font-size: 13px;
+        border-bottom: 1px solid var(--pc-border-color);
+        color: var(--guardian-font-color, #23252E);
+    }
+
+    ::ng-deep .artifact-row .remove-prop {
+        top: 50%;
+        right: 8px;
+        transform: translateY(-50%);
+        color: var(--pc-del-color, #FF432A);
+    }
+
+    ::ng-deep .artifact-row .remove-prop i {
+        font-size: 15px;
+    }
+
+    ::ng-deep .add-artifact-button {
+        width: 100% !important;
+        height: 36px !important;
+        min-height: 36px !important;
+        margin-bottom: 0 !important;
+        border: 1px dashed var(--pc-border-color) !important;
+        border-radius: 8px !important;
+        box-shadow: none !important;
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        color: var(--color-primary, #4169E2) !important;
+
+        &:hover {
+            border-color: var(--color-primary, #4169E2) !important;
+            background: color-mix(in srgb, var(--color-primary, #4169E2) 8%, transparent) !important;
+        }
+
+        i {
+            color: var(--color-primary, #4169E2) !important;
+            font-size: 14px !important;
+            margin: 0 !important;
+        }
+
+        &::after {
+            content: "Add artifact";
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--color-primary, #4169E2);
+        }
     }
 }
 
@@ -877,34 +996,43 @@
     box-shadow: 0px -1px 0px 0px var(--pc-border-color);
 
     .components-search {
-        height: 32px;
-        box-sizing: border-box;
-        font-weight: 500;
-        color: var(--pc-header-color);
-        padding: 6px 8px 0px 8px;
         position: relative;
+        height: 34px;
+        margin: 10px 8px 4px;
+        box-sizing: border-box;
 
         input {
             position: absolute;
-            left: 8px;
-            top: 0;
-            right: 8px;
-            height: 24px;
+            inset: 0;
+            width: 100%;
+            height: 34px;
             box-sizing: border-box;
             border: 1px solid var(--pc-border-color);
-            border-radius: 4px;
-            padding: 2px 24px 2px 7px;
+            border-radius: 8px;
+            padding: 0 32px 0 12px;
             outline: none;
+            font-size: 13px;
             background: var(--guardian-background, #fff);
             color: var(--guardian-font-color, #23252E);
+            transition: border-color 0.15s ease;
+
+            &::placeholder {
+                color: var(--pc-no-active-color);
+            }
+
+            &:focus {
+                border-color: var(--color-primary, #4169E2);
+            }
         }
 
         .components-search-icon {
             position: absolute;
-            top: 12px;
-            right: 16px;
-            color: var(--pc-border-color);
+            top: 50%;
+            right: 12px;
+            transform: translateY(-50%);
+            color: var(--pc-no-active-color);
             font-size: 14px;
+            pointer-events: none;
         }
     }
 
@@ -915,60 +1043,68 @@
         }
 
         .components-group-name {
-            height: 34px;
-            border-top: none;
-            border-bottom: 1px solid var(--pc-border-color);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            height: 32px;
             box-sizing: border-box;
-            margin: 6px 0px 2px;
+            margin: 10px 6px 2px;
             font-weight: 600;
-            font-size: 12px;
+            font-size: 11px;
             letter-spacing: 0.04em;
             text-transform: uppercase;
             color: var(--pc-no-active-color);
             position: relative;
-            padding: 9px 24px;
+            padding: 0 8px;
+            border-radius: 6px;
             cursor: pointer;
             user-select: none;
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
 
             .components-group-name-icon {
+                flex: 0 0 auto;
                 color: var(--pc-favorite-color);
-                position: absolute;
-                left: 26px;
-                top: 12px;
-                font-size: 14px;
+                font-size: 12px;
+            }
+
+            .group-dot {
+                margin-right: 0;
+            }
+
+            > span:last-child {
+                flex: 1 1 auto;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
             }
 
             &:hover {
                 background: var(--pc-component-hover);
+                color: var(--pc-header-color);
             }
         }
 
-        .components-group-collapse {
-            width: 16px;
-            position: absolute;
-            left: 4px;
-            top: 10px;
-            display: block;
+        .components-group-collapse,
+        .components-group-open {
+            flex: 0 0 auto;
+            width: 12px;
+            font-size: 11px;
+            color: var(--pc-no-active-color);
             pointer-events: all;
         }
 
+        .components-group-collapse {
+            display: block;
+        }
+
         .components-group-open {
-            width: 16px;
-            position: absolute;
-            left: 4px;
-            top: 9px;
             display: none;
-            pointer-events: all;
         }
 
         .components-group-item {
             position: relative;
             width: 100%;
             max-width: 100%;
-            height: 34px;
+            height: auto;
             overflow: hidden;
 
             .drag-btn {
@@ -1000,35 +1136,55 @@
         }
 
         .component-btn {
-            top: 5px;
-            height: 22px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            height: 32px;
             position: relative;
-            padding: 2px 32px 7px 46px;
+            margin: 1px 6px;
+            padding: 0 30px 0 18px;
             box-sizing: border-box;
-            color: var(--pc-active-icon-color);
+            border-radius: 8px;
+            color: var(--guardian-font-color, #23252E);
+            font-size: 13px;
+            font-weight: 400;
             cursor: pointer;
             user-select: none;
-            max-width: 100%;
+            max-width: calc(100% - 12px);
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
 
             .component-btn-icon {
-                position: absolute;
-                top: 3px;
-                left: 14px;
+                flex: 0 0 auto;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 20px;
+                height: 20px;
+                font-size: 16px;
                 pointer-events: none;
-                width: 24px;
-                height: 24px;
+                color: var(--pc-active-icon-color);
+            }
+
+            > span {
+                flex: 1 1 auto;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+
+            > .component-btn-favorite {
+                position: absolute;
+                top: 50%;
+                right: 10px;
+                transform: translateY(-50%);
             }
 
             .component-btn-favorite {
-                position: absolute;
-                top: 3px;
-                right: 6px;
                 color: var(--pc-background-color);
                 cursor: pointer;
-                font-size: 16px;
+                font-size: 15px;
 
                 &[favorite="true"] {
                     color: var(--pc-favorite-color) !important;
@@ -1058,15 +1214,14 @@
 
         .component-btn-toolbar {
             position: absolute;
-            top: 0px;
-            right: 0px;
+            top: 50%;
+            right: 6px;
+            transform: translateY(-50%);
 
             i,
             svg {
-                top: 3px;
-                right: 6px;
                 cursor: pointer;
-                font-size: 22px;
+                font-size: 15px;
                 position: relative !important;
             }
 
@@ -1079,8 +1234,7 @@
 
         svg.icon-style-policy-module,
         svg.icon-style-handyman {
-            width: 18px;
-            padding-bottom: 5px;
+            width: 16px;
             fill: var(--pc-event-color);
         }
     }
@@ -1095,16 +1249,15 @@
 }
 
 .prop-container {
-    border-top: 0px solid var(--pc-background-color);
-    margin: 4px 0px 0px 0px;
-    overflow: auto;
     position: absolute !important;
     left: 0;
     top: 0;
     right: 0;
-    bottom: 0px;
+    bottom: 0;
     box-sizing: border-box;
-    box-shadow: 0px -1px 0px 0px var(--pc-border-color);
+    padding: 0 12px 8px 0;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .action-event-icon {
@@ -1210,9 +1363,11 @@
                     display: grid !important;
 
                     span {
-                        font-size: 16px;
-                        margin-bottom: 4px;
+                        font-size: 14px;
+                        font-weight: 600;
+                        margin-bottom: 0;
                         padding-left: 0;
+                        align-self: center;
                     }
 
                     &[selected="false"] {
@@ -1315,55 +1470,219 @@
 
     .pc-tabs.minimized-tabs {
         .pc-tabs-headers {
+            padding: 0 44px 0 8px;
+            gap: 4px;
+            align-items: center;
+
             .tab-header {
-                padding: 6px 16px;
+                height: 28px !important;
+                box-sizing: border-box;
+                padding: 0 14px;
                 flex: none;
+                border-radius: 8px;
+                border-bottom: none !important;
+                color: var(--guardian-font-color-secondary, #8a8f9c);
+                font-family: var(--font-family-inter, 'Inter', sans-serif) !important;
+                font-size: 14px !important;
+                font-weight: 500 !important;
+                align-items: center;
+                transition: background 0.15s ease, color 0.15s ease;
+
+                span {
+                    font-family: var(--font-family-inter, 'Inter', sans-serif);
+                    font-size: 14px !important;
+                    font-weight: 500;
+                }
+
+                svg-icon,
+                svg-icon svg,
+                svg {
+                    position: static !important;
+                    top: auto !important;
+                    left: auto !important;
+                    width: 18px !important;
+                    height: 18px !important;
+                    font-size: 16px !important;
+                }
 
                 &.tab-header-icon {
-                    display: grid !important;
-                    grid-template-columns: max-content auto !important;
+                    display: flex !important;
+                    align-items: center;
+                    justify-content: center;
+                    gap: 8px;
+                    padding: 0 14px;
+                }
+
+                &:hover {
+                    background: var(--guardian-grey-background, #f1f3f9);
+                    color: var(--guardian-font-color, #23252E);
+                }
+
+                &[selected="true"] {
+                    border-bottom: none !important;
+                    background: color-mix(in srgb, var(--color-primary, #4169e2) 12%, transparent) !important;
+                    color: var(--color-primary, #4169e2) !important;
                 }
             }
         }
     }
 
     .pc-tabs-headers.right-menu {
-        padding-right: 30px;
+        padding-right: 44px;
+    }
+
+    // #6 Drop the canvas header strip; the root is already represented by the
+    // "Policy" block in the tree. Collapse the header and let the tree fill
+    // the canvas; the legend button floats onto the canvas (styled below).
+    .pc-tabs.minimized-tabs {
+        .pc-tabs-headers.right-menu {
+            height: 0 !important;
+            min-height: 0 !important;
+            padding: 0 !important;
+            border-bottom: none !important;
+            overflow: visible;
+
+            .tab-header {
+                display: none !important;
+            }
+        }
+
+        .pc-tabs-content {
+            top: 0 !important;
+        }
+    }
+
+    // #4 Floating breadcrumb for sub-module navigation (replaces the header
+    // tabs). Only shown when a module is open; offset right of the
+    // collapse-all control.
+    .canvas-breadcrumb {
+        position: absolute;
+        top: 10px;
+        right: 66px;
+        left: auto;
+        z-index: 10;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        max-width: calc(100% - 90px);
+        overflow: hidden;
+        padding: 0 5px;
+        box-sizing: border-box;
+        background: var(--guardian-background, #fff);
+        border: 1px solid var(--pc-border-color, #E1E7EF);
+        border-radius: 9px;
+        box-shadow: 0 2px 6px var(--guardian-shadow, #0000001a);
+        font-family: var(--font-family-inter, 'Inter', sans-serif);
+        font-size: 13px;
+
+        .canvas-breadcrumb-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            height: 26px;
+            padding: 0 9px;
+            border-radius: 7px;
+            line-height: 1;
+            color: var(--guardian-font-color-secondary, #848FA9);
+            cursor: pointer;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 170px;
+            transition: background 0.15s ease, color 0.15s ease;
+
+            svg-icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                flex: 0 0 auto;
+                width: 16px;
+                height: 16px;
+                line-height: 0;
+            }
+
+            svg-icon svg,
+            svg {
+                display: block;
+                width: 16px !important;
+                height: 16px !important;
+            }
+
+            span {
+                display: inline-flex;
+                align-items: center;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+
+            &:hover {
+                background: var(--guardian-grey-background, #f1f3f9);
+                color: var(--guardian-font-color, #23252E);
+            }
+
+            &.active {
+                color: var(--color-primary, #4169E2);
+                background: color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
+                font-weight: 500;
+            }
+        }
+
+        .canvas-breadcrumb-sep {
+            font-size: 10px;
+            color: var(--guardian-font-color-secondary, #848FA9);
+            flex: 0 0 auto;
+            display: inline-flex;
+            align-items: center;
+        }
     }
 }
 
 .policy-configuration::ng-deep {
     .theme-legends {
         position: absolute;
-        top: 0;
-        right: 0;
-        width: 30px;
-        height: 30px;
+        top: 10px;
+        right: 22px;
+        width: 34px;
+        height: 34px;
         overflow: visible;
+        z-index: 10;
 
         .theme-legends-icon {
             position: absolute;
             top: 0;
             right: 0;
-            width: 30px;
-            height: 38px;
+            width: 34px;
+            height: 34px;
             overflow: hidden;
             cursor: pointer;
             box-sizing: border-box;
-            border-left: 1px solid var(--pc-border-color);
-            color: var(--guardian-font-color, #555);
+            border-radius: 9px;
+            background: var(--guardian-background, #fff);
+            border: 1px solid var(--pc-border-color, #E1E7EF);
+            box-shadow: 0 2px 6px var(--guardian-shadow, #0000001a);
+            color: var(--guardian-font-color-secondary, #848FA9);
             display: grid;
             justify-content: center;
             align-content: center;
+            transition: background 0.15s ease, color 0.15s ease;
 
             &:hover {
-                background: var(--pc-tabs-hover-color);
+                background: var(--guardian-grey-background, #f1f3f9);
+                color: var(--color-primary, #4169E2);
             }
 
             i,
             svg {
-                font-size: 22px;
+                font-size: 18px;
             }
+        }
+
+        &[active="true"] .theme-legends-icon {
+            background: color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
+            color: var(--color-primary, #4169E2);
+            border-color: color-mix(in srgb, var(--color-primary, #4169E2) 40%, transparent);
         }
 
         .theme-legends-container {
@@ -1373,24 +1692,27 @@
             right: 10px;
             z-index: 5;
             border: 1px solid var(--pc-border-color);
-            border-radius: var(--pc-radius, 10px);
-            box-shadow: var(--pc-elevation);
+            border-radius: 12px;
+            box-shadow: 0 8px 24px var(--guardian-shadow, #0000001f);
             background: var(--pc-background-color);
             overflow: auto;
             max-height: calc(100vh - var(--header-height) - 260px);
-            padding: 6px;
+            min-width: 224px;
+            padding: 8px;
         }
 
         .theme-rule {
-            width: 200px;
+            width: auto;
             height: auto;
             min-height: 20px;
             display: grid;
-            grid-template-columns: 50px auto;
+            grid-template-columns: 44px auto;
+            align-items: center;
+            gap: 6px;
             margin-right: 0px;
             background: var(--pc-background-color);
-            padding: 4px 6px;
-            border-radius: 6px;
+            padding: 5px 8px;
+            border-radius: 8px;
             pointer-events: all;
         }
 
@@ -1406,6 +1728,9 @@
         .theme-rule-description {
             align-items: center;
             display: flex;
+            font-family: var(--font-family-inter, 'Inter', sans-serif);
+            font-size: 13px;
+            color: var(--guardian-font-color, #23252E);
         }
 
         .theme-legends-divider {
@@ -1420,8 +1745,8 @@
             }
 
             .theme-legends-icon {
-                background: var(--pc-background-color);
-                color: var(--pc-active-icon-color);
+                background: color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
+                color: var(--color-primary, #4169E2);
             }
         }
     }
@@ -1513,9 +1838,233 @@
     // }
 }
 
-.right-bottom-toolbar .tab-header {
-    max-width: 50%;
-    margin-right: auto;
+.right-toolbar .tab-header {
+    display: flex !important;
+    grid-template-columns: none !important;
+    align-items: center;
+    justify-content: center;
+    max-width: none;
+    margin-right: 0;
+    padding: 6px 8px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+// Block inspector: persistent title/type header above the tabs.
+.inspector-head--panel {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--pc-border-color);
+    cursor: grab;
+
+    .inspector-head-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .inspector-head-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--pc-header-color, #23252E);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .inspector-head-type {
+        flex: 0 0 auto;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #e1e7fa);
+    }
+
+    .inspector-head-parent {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        cursor: pointer;
+        font-size: 12px;
+        color: var(--guardian-disabled-color, #848FA9);
+
+        .inspector-head-parent-name {
+            color: var(--color-primary, #4169E2);
+            font-weight: 500;
+        }
+
+        i {
+            font-size: 11px;
+            color: var(--color-primary, #4169E2);
+        }
+
+        &:hover .inspector-head-parent-name {
+            text-decoration: underline;
+        }
+    }
+}
+
+// Block inspector tabs styled as a segmented control (matches the top bar).
+// Scoped through .pc-tabs to outrank the default .pc-tabs-headers .tab-header
+// rules (which set a grid layout + underline with !important).
+.policy-configuration::ng-deep .pc-tabs .pc-tabs-headers--segment {
+    height: 38px;
+    padding: 0 8px;
+    gap: 0;
+    align-items: center;
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--pc-border-color);
+    background: var(--pc-background-color);
+
+    .segment-track {
+        flex: 1 1 auto;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        height: 30px;
+        padding: 3px;
+        border-radius: 9px;
+        background: var(--guardian-grey-background, #f1f3f9);
+        border: 1px solid var(--pc-border-color);
+        box-sizing: border-box;
+    }
+
+    .tab-header {
+        flex: 1 1 0 !important;
+        height: 24px !important;
+        min-width: 0;
+        padding: 0 6px !important;
+        margin: 0 !important;
+        border-radius: 6px !important;
+        border-bottom: none !important;
+        display: flex !important;
+        grid-template-columns: none !important;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        font-weight: 500;
+        line-height: 1;
+        color: var(--guardian-font-color-secondary, #8a8f9c);
+        background: transparent !important;
+        transition: background 0.15s ease, color 0.15s ease;
+
+        &:hover {
+            background: transparent !important;
+            color: var(--guardian-font-color, #23252e) !important;
+        }
+
+        &[selected="true"] {
+            background: var(--guardian-background, #fff) !important;
+            color: var(--color-primary, #4169e2) !important;
+            font-weight: 600;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+            border-bottom: none !important;
+            cursor: default;
+        }
+    }
+}
+
+// Library switcher (Blocks / Modules / Tools) as a segmented control,
+// matching the top-bar Design/JSON/YAML pill. Expanded state only —
+// the collapsed rail keeps its vertical icon buttons.
+.policy-configuration::ng-deep .left-toolbar:not(.collapsed) .pc-tabs-headers--library {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 38px;
+    padding: 0 6px;
+    box-sizing: border-box;
+    border-bottom: 1px solid var(--pc-border-color);
+    background: var(--pc-background-color);
+
+    .library-segment {
+        flex: 1 1 auto;
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        height: 30px;
+        padding: 3px;
+        border-radius: 9px;
+        background: var(--guardian-grey-background, #f1f3f9);
+        border: 1px solid var(--pc-border-color);
+        box-sizing: border-box;
+    }
+
+    .tab-header {
+        flex: 1 1 0 !important;
+        width: auto !important;
+        min-width: 0 !important;
+        max-width: none !important;
+        height: 24px !important;
+        padding: 0 4px !important;
+        margin: 0 !important;
+        border-radius: 6px !important;
+        border-bottom: none !important;
+        display: flex !important;
+        grid-template-columns: none !important;
+        align-items: center;
+        justify-content: center;
+        background: transparent !important;
+        color: var(--guardian-font-color-secondary, #8a8f9c) !important;
+        transition: background 0.15s ease, color 0.15s ease;
+
+        svg-icon,
+        svg {
+            display: none !important;
+        }
+
+        span {
+            position: static !important;
+            display: block !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            font-size: 12px !important;
+            font-weight: 500 !important;
+            line-height: 1;
+            letter-spacing: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        &:hover {
+            background: transparent !important;
+            color: var(--guardian-font-color, #23252e) !important;
+        }
+
+        &[selected="true"] {
+            background: var(--guardian-background, #fff) !important;
+            color: var(--color-primary, #4169e2) !important;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+            cursor: default !important;
+
+            span {
+                font-weight: 600 !important;
+            }
+        }
+    }
+
+    .library-collapse-toggle {
+        flex: 0 0 26px;
+        height: 30px;
+        border-radius: 8px;
+    }
+}
+
+// Collapsed rail: unwrap the segment so the tabs become direct children
+// again and the existing vertical icon-button layout applies unchanged.
+.policy-configuration::ng-deep .left-toolbar.collapsed .pc-tabs-headers--library .library-segment {
+    display: contents;
 }
 
 .module-root-icon {
@@ -1570,7 +2119,7 @@
     align-items: center;
     gap: 8px;
     height: 44px;
-    margin: 18px 4px;
+    margin: 0 2px;
     padding: 0 10px;
     max-width: 240px;
     border: 1px solid transparent;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -97,6 +97,7 @@ export class PolicyConfigurationComponent implements OnInit {
     public validationLevel: 'error' | 'warning' | 'info' | 'success' | 'ok' = 'ok';
 
     public currentView: string = 'blocks';
+    public copiedField: string = '';
     public search: string = '';
     public searchModule: string = '';
     public storage: PolicyStorage;
@@ -1525,6 +1526,81 @@ export class PolicyConfigurationComponent implements OnInit {
             const blockData = this.currentBlock?.getJSON() || null;
             navigator.clipboard.writeText(JSON.stringify(blockData));
         }
+    }
+
+    public openPolicySettings: boolean = false;
+    public commandPaletteVisible: boolean = false;
+    public commandQuery: string = '';
+    public commands: { label: string; icon: string; action: () => void }[] = [];
+
+    @HostListener('document:keydown', ['$event'])
+    public onGlobalKeydown(event: KeyboardEvent): void {
+        if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {
+            if (this.rootType !== 'Policy') {
+                return;
+            }
+            event.preventDefault();
+            this.toggleCommandPalette();
+        } else if (event.key === 'Escape' && this.commandPaletteVisible) {
+            this.commandPaletteVisible = false;
+        }
+    }
+
+    public openPolicySettingsDrawer(): void {
+        this.openPolicySettings = true;
+    }
+
+    public toggleCommandPalette(): void {
+        this.commandPaletteVisible = !this.commandPaletteVisible;
+        if (this.commandPaletteVisible) {
+            this.commandQuery = '';
+            this.buildCommands();
+        }
+    }
+
+    public get filteredCommands(): { label: string; icon: string; action: () => void }[] {
+        const query = this.commandQuery.trim().toLowerCase();
+        if (!query) {
+            return this.commands;
+        }
+        return this.commands.filter((command) => command.label.toLowerCase().includes(query));
+    }
+
+    public runCommand(command: { action: () => void }): void {
+        this.commandPaletteVisible = false;
+        setTimeout(() => command.action(), 0);
+    }
+
+    private buildCommands(): void {
+        this.commands = [
+            { label: 'Policy settings', icon: 'pi pi-cog', action: () => this.openPolicySettingsDrawer() },
+            { label: 'Save policy', icon: 'pi pi-save', action: () => this.savePolicy() },
+            { label: 'Save as new policy', icon: 'pi pi-copy', action: () => this.saveAsPolicy() },
+            { label: 'Policy wizard', icon: 'pi pi-sparkles', action: () => this.openPolicyWizardDialog() },
+            { label: 'Validate policy', icon: 'pi pi-check-circle', action: () => this.validationPolicy() },
+            { label: 'Schemas', icon: 'pi pi-database', action: () => this.onSchemas() },
+            { label: 'Settings', icon: 'pi pi-cog', action: () => this.onSettings() },
+            { label: 'Parameters', icon: 'pi pi-sliders-h', action: () => this.onEditableFields() },
+            { label: 'API documentation', icon: 'pi pi-book', action: () => this.openApiConfigDialog() },
+            { label: 'View: Tree', icon: 'pi pi-table', action: () => this.onView('blocks') },
+            { label: 'View: JSON', icon: 'pi pi-code', action: () => this.onView('json') },
+            { label: 'View: YAML', icon: 'pi pi-list', action: () => this.onView('yaml') },
+            { label: 'Toggle suggestions', icon: 'pi pi-comment', action: () => this.onSuggestionsClick() },
+        ];
+    }
+
+    public copyIdentity(field: string, value: string | undefined, event?: Event): void {
+        event?.stopPropagation();
+        if (!value) {
+            return;
+        }
+        navigator.clipboard.writeText(value);
+        this.copiedField = field;
+        setTimeout(() => {
+            if (this.copiedField === field) {
+                this.copiedField = '';
+            }
+        }, 1500);
     }
 
     public onInitViewer(event: PolicyTreeComponent) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -102,7 +102,9 @@ export class PolicyConfigurationComponent implements OnInit {
     public searchModule: string = '';
     public storage: PolicyStorage;
     public copyBlocksMode: boolean = false;
-    public eventVisible: string = 'All';
+    public eventVisible: string = 'Selected';
+    public blockPickerQuery: string = '';
+    private _allBlocks: any[] = [];
     public blockSearchData: any = null;
     public code!: string;
     public isSuggestionsEnabled = false;
@@ -923,6 +925,7 @@ export class PolicyConfigurationComponent implements OnInit {
 
     private updateComponents() {
         const all = this.registeredService.getAll();
+        this._allBlocks = all.filter((block: any) => !block?.deprecated);
         this.componentsList.favorites = [];
         this.componentsList.uiComponents = [];
         this.componentsList.serverBlocks = [];
@@ -1431,6 +1434,18 @@ export class PolicyConfigurationComponent implements OnInit {
         this.options.save();
     }
 
+    public toggleLibrary() {
+        this.options.change('libraryCollapsed');
+        this.options.save();
+    }
+
+    public selectLibrary(name: string) {
+        if (this.options.libraryCollapsed) {
+            this.options.libraryCollapsed = false;
+        }
+        this.select(name);
+    }
+
     public collapse(name: string) {
         this.options.collapse(name);
         this.options.save();
@@ -1680,6 +1695,19 @@ export class PolicyConfigurationComponent implements OnInit {
             this.changeDetector.detectChanges();
         }
         this.updateTemporarySchemas();
+    }
+
+    public get pickerBlocks(): any[] {
+        const q = this.blockPickerQuery ? this.blockPickerQuery.toLowerCase() : '';
+        if (!q) {
+            return this._allBlocks;
+        }
+        return this._allBlocks.filter((block: any) => block.search.indexOf(q) !== -1);
+    }
+
+    public addPickedBlock(item: any, picker: any) {
+        this.onAdd(item);
+        picker?.hide();
     }
 
     public onAdd(btn: any) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-properties/policy-properties.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-properties/policy-properties.component.html
@@ -2,6 +2,7 @@
   <div class="table">
     <div class="table-body" #body>
       <table class="properties">
+  <colgroup><col class="col-toggle"><col class="col-name"><col class="col-value"></colgroup>
         @if (type == 'Main') {
           <tr class="propHeader">
             <td class="propRowCol cellCollapse" (click)="onHide(propHidden, 'metaData')"

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-properties/policy-properties.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-properties/policy-properties.component.scss
@@ -1,3 +1,8 @@
+:host {
+    display: block;
+    width: 100%;
+}
+
 .cellDivider {
     padding: 8px;
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.html
@@ -1,0 +1,35 @@
+@if (visible) {
+  <div class="psd-backdrop" (click)="close()"></div>
+}
+<div class="psd-panel" [class.open]="visible" [attr.aria-hidden]="!visible">
+  <div class="psd">
+    <div class="psd-title">
+      <i class="pi pi-cog"></i>
+      <span>Policy settings</span>
+      <button type="button" class="psd-close" (click)="close()" title="Close">
+        <i class="pi pi-times"></i>
+      </button>
+    </div>
+    <div class="psd-body">
+      <div class="psd-nav">
+        @for (s of sections; track s.id) {
+          <div class="psd-nav-item" [attr.selected]="section === s.id" (click)="selectSection(s.id)">
+            <i [class]="s.icon"></i>
+            <span>{{ s.label }}</span>
+          </div>
+        }
+      </div>
+      <div class="psd-content">
+        @if (policy && visible) {
+          <policy-properties
+            [policy]="policy"
+            [readonly]="readonly"
+            [allCategories]="allCategories"
+            [policyCategories]="policyCategories"
+            [wipeContracts]="wipeContracts"
+            [type]="section"></policy-properties>
+        }
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.scss
@@ -1,0 +1,129 @@
+:host {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+}
+
+.psd-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 40;
+    background: color-mix(in srgb, #000 32%, transparent);
+}
+
+.psd-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 41;
+    width: min(760px, 92vw);
+    background: var(--guardian-background, #fff);
+    border-left: 1px solid var(--guardian-border-color, #E1E7EF);
+    box-shadow: -8px 0 24px var(--guardian-shadow, #00000014);
+    transform: translateX(100%);
+    transition: transform 0.22s ease;
+    display: flex;
+    flex-direction: column;
+
+    &.open {
+        transform: translateX(0);
+    }
+}
+
+.psd {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    padding: 16px;
+    box-sizing: border-box;
+}
+
+.psd-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 0 16px;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--guardian-font-color, #23252E);
+
+    i {
+        font-size: 18px;
+        color: var(--color-primary, #4169E2);
+    }
+
+    .psd-close {
+        margin-left: auto;
+        width: 32px;
+        height: 32px;
+        border: none;
+        border-radius: 8px;
+        background: transparent;
+        color: var(--guardian-font-color, #23252E);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:hover {
+            background: var(--guardian-hover, #F0F3FC);
+        }
+    }
+}
+
+.psd-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    gap: 16px;
+}
+
+.psd-nav {
+    flex: 0 0 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-right: 1px solid var(--guardian-border-color, #E1E7EF);
+    padding-right: 12px;
+    overflow: auto;
+}
+
+.psd-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--guardian-font-color, #23252E);
+    transition: background 0.12s ease, color 0.12s ease;
+
+    i {
+        font-size: 16px;
+        color: var(--guardian-disabled-color, #848FA9);
+        width: 20px;
+        text-align: center;
+    }
+
+    &:hover {
+        background: var(--guardian-hover, #F0F3FC);
+    }
+
+    &[selected="true"] {
+        background: var(--guardian-primary-background, #e1e7fa);
+        color: var(--color-primary, #4169E2);
+
+        i {
+            color: var(--color-primary, #4169E2);
+        }
+    }
+}
+
+.psd-content {
+    flex: 1;
+    min-width: 0;
+    overflow: auto;
+    position: relative;
+}

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-settings-drawer/policy-settings-drawer.component.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { IContract } from '@guardian/interfaces';
+import { IPolicyCategory, PolicyTemplate } from '../../structures';
+
+/**
+ * Drawer that hosts the global policy configuration (description, roles, navigation,
+ * groups, topics, tokens). It reuses the existing `policy-properties` section views,
+ * relocating them out of the right rail so the rail can focus on the selected block.
+ */
+@Component({
+    selector: 'policy-settings-drawer',
+    templateUrl: './policy-settings-drawer.component.html',
+    styleUrls: ['./policy-settings-drawer.component.scss'],
+    standalone: false
+})
+export class PolicySettingsDrawerComponent {
+    @Input() visible: boolean = false;
+    @Output() visibleChange = new EventEmitter<boolean>();
+
+    @Input() policy!: PolicyTemplate;
+    @Input() readonly: boolean = false;
+    @Input() allCategories: any;
+    @Input() policyCategories: IPolicyCategory[] = [];
+    @Input() wipeContracts: IContract[] = [];
+
+    public section: string = 'Main';
+    public readonly sections: { id: string; label: string; icon: string }[] = [
+        { id: 'Main', label: 'Description', icon: 'pi pi-info-circle' },
+        { id: 'Role', label: 'Roles', icon: 'pi pi-users' },
+        { id: 'Navigation', label: 'Navigation', icon: 'pi pi-compass' },
+        { id: 'Groups', label: 'Groups', icon: 'pi pi-sitemap' },
+        { id: 'Topics', label: 'Topics', icon: 'pi pi-comments' },
+        { id: 'Tokens', label: 'Tokens', icon: 'pi pi-bitcoin' },
+    ];
+
+    public selectSection(id: string): void {
+        this.section = id;
+    }
+
+    public close(): void {
+        this.visible = false;
+        this.visibleChange.emit(false);
+    }
+}

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.html
@@ -96,6 +96,14 @@
                   <div class="block-item-name" theme-text>
                     {{ item.node.localTag }}
                   </div>
+                  @if (item.hasEvents) {
+                    <div class="block-event-mark"
+                      pTooltip="Has event connections"
+                      tooltipPosition="top"
+                      tooltipStyleClass="guardian-tooltip">
+                      <i class="pi pi-bolt"></i>
+                    </div>
+                  }
                   @if (isBlockSelected(item)) {
                     <div class="block-selected-mark">
                       <svg-icon
@@ -132,6 +140,12 @@
                     <button (click)="onVisibleMoreActions($event)" mat-icon-button class="action-button more-action-button">
                       <i class="pi pi-ellipsis-h"></i>
                     </button>
+                    @if (!readonly) {
+                      <button (click)="onAddChild($event)" mat-icon-button class="action-button add-child-action"
+                        title="Add block inside">
+                        <i class="pi pi-plus"></i>
+                      </button>
+                    }
                     <button (click)="onSearch($event)" mat-icon-button class="action-button">
                       <i class="pi pi-search"></i>
                     </button>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.html
@@ -93,8 +93,11 @@
                   <div class="block-item-icon">
                     <i [ngClass]="'pi pi-' + item.icon" class="theme-text"></i>
                   </div>
-                  <div class="block-item-name" theme-text>
-                    {{ item.node.localTag }}
+                  <div class="block-item-text">
+                    <div class="block-item-name" theme-text>
+                      {{ item.node.localTag }}
+                    </div>
+                    <div class="block-item-type">{{ item.node.blockType }}</div>
                   </div>
                   @if (item.hasEvents) {
                     <div class="block-event-mark"

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
@@ -413,6 +413,10 @@
     color: var(--pc-del-color, #FF432A);
 }
 
+.add-child-action {
+    color: var(--color-primary, #4169E2);
+}
+
 .move-actions-container {
     display: none;
     align-items: center;
@@ -681,6 +685,22 @@
 }
 
 .block-body
+.block-event-mark {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-warning, #E0A800);
+
+    i {
+        font-size: 13px;
+    }
+}
+
+.block-event-mark ~ .block-selected-mark {
+    margin-left: 8px;
+}
+
 .block-selected-mark {
     margin-top: 4px;
     margin-left: auto;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
@@ -65,16 +65,18 @@
     position: relative;
     min-width: 160px;
     background: var(--guardian-background, #fff);
-    border: 2px solid #000;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    border-radius: 8px;
     box-sizing: border-box;
     cursor: pointer;
     -webkit-user-select: none;
     user-select: none;
     margin: 4px 8px 4px 0px;
-    box-shadow: 4px 4px 6px 0px #00000040;
+    box-shadow: 0 1px 2px var(--guardian-shadow, #00000014);
     padding: 0px 12px;
     align-items: center;
     display: flex;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 .block-item * {
@@ -127,13 +129,13 @@
 }
 
 .block-container[selected="true"] .block-item {
-    border-color: #5161e1 !important;
-    box-shadow: 4px 4px 6px 0px #00000040, 0px 0px 4px 1px #5161e1cc !important;
+    border-color: var(--color-primary, #4169E2) !important;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary, #4169E2) 30%, transparent) !important;
 }
 
 .block-container[selected="true"] .module-body .block-item::after {
-    border-color: #5161e1 !important;
-    box-shadow: -1px -2px 2px 0px #5161e161 !important;
+    border-color: var(--color-primary, #4169E2) !important;
+    box-shadow: -1px -2px 2px 0px color-mix(in srgb, var(--color-primary, #4169E2) 38%, transparent) !important;
 }
 
 .block-container[error="true"] .block-item {
@@ -148,8 +150,8 @@
 
 .block-container[error="true"] .tool-body .block-item::after {
     background-image:
-        linear-gradient(180deg, #838383 3px, var(--pc-error-bg-strong) 3px),
-        linear-gradient(180deg, var(--pc-error-bg-strong) 3px, #838383 3px) !important;
+        linear-gradient(180deg, var(--guardian-grey-color-3, #838383) 3px, var(--pc-error-bg-strong) 3px),
+        linear-gradient(180deg, var(--pc-error-bg-strong) 3px, var(--guardian-grey-color-3, #838383) 3px) !important;
 }
 
 .block-container[error="true"][selected="true"] .block-item {
@@ -178,7 +180,7 @@
     left: 2px;
     position: relative;
     font-size: 24px;
-    color: #404fb2;
+    color: var(--color-primary, #404fb2);
 }
 
 .module-item-icon i,
@@ -191,7 +193,7 @@
 }
 
 .tool-icon {
-    color: #c37a29 !important;
+    color: var(--pc-tool-block-color, #c37a29) !important;
 }
 
 .block-item-icon i,
@@ -205,7 +207,7 @@
     max-width: 330px;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: #404040;
+    color: var(--guardian-font-color, #404040);
 }
 
 .block-container[block-type="UI Components"] .block-item {
@@ -227,7 +229,7 @@
 
 .block-container[block-type="module"] .block-item {
     background: var(--guardian-background, white);
-    border-color: #adadad;
+    border-color: var(--guardian-grey-color-3, #adadad);
 }
 
 .block-all-expand {
@@ -270,7 +272,7 @@
     content: "";
     width: 40px;
     height: 8px;
-    border: 2px solid #838383;
+    border: 2px solid var(--guardian-grey-color-3, #838383);
     top: -8px;
     left: 0px;
     border-bottom-width: 0;
@@ -294,8 +296,8 @@
     z-index: 2;
     box-sizing: border-box;
     background-image:
-        linear-gradient(180deg, #838383 3px, var(--guardian-background, #fff) 3px),
-        linear-gradient(180deg, var(--guardian-background, #fff) 3px, #838383 3px);
+        linear-gradient(180deg, var(--guardian-grey-color-3, #838383) 3px, var(--guardian-background, #fff) 3px),
+        linear-gradient(180deg, var(--guardian-background, #fff) 3px, var(--guardian-grey-color-3, #838383) 3px);
     background-position: 0 0, 3px 0;
     background-size: 3px 6px, 3px 6px;
     background-repeat: repeat-y;
@@ -305,7 +307,7 @@
 .module-body .block-item {
     height: 40px;
     background: var(--guardian-background, #fff) !important;
-    border-color: #838383 !important;
+    border-color: var(--guardian-grey-color-3, #838383) !important;
     padding: 2px 12px 2px 12px;
     margin: 8px 8px 3px 0px;
 }
@@ -343,10 +345,10 @@
     transform: translate(-50%, -100%) translate(0, -5px);
     background: var(--guardian-background, #fff);
     padding: 5px 15px;
-    border: 1px solid #7c7c7c;
-    border-radius: 4px;
+    border: 1px solid var(--guardian-border-color, #7c7c7c);
+    border-radius: 8px;
     z-index: 9999;
-    box-shadow: -1px 2px 3px 0px rgb(0 0 0 / 30%);
+    box-shadow: 0 4px 12px var(--guardian-shadow, rgb(0 0 0 / 30%));
     min-width: 250px;
     transition: opacity 0.5s;
 }
@@ -387,7 +389,7 @@
 .action-button {
     background-color: var(--guardian-background, white);
     font-size: 10px;
-    border-radius: 5px;
+    border-radius: 6px;
     width: 31px;
     height: 31px;
     line-height: 0px;
@@ -395,7 +397,7 @@
     color: var(--guardian-font-color, #3f51b5);
     z-index: 2;
     border: 1px solid var(--guardian-border-color, rgb(200 200 200));
-    box-shadow: 2px 2px 6px 1px #00000035;
+    box-shadow: 0 1px 3px var(--guardian-shadow, #00000035);
     cursor: pointer;
 
     * {
@@ -408,7 +410,7 @@
 }
 
 .delete-action {
-    color: red;
+    color: var(--pc-del-color, #FF432A);
 }
 
 .move-actions-container {
@@ -567,21 +569,21 @@
 // }
 
 .block-container[deprecated="true"] .block-item {
-    background-color: lightgray !important;
-    border-color: lightgray !important;
+    background-color: var(--guardian-disabled-background, lightgray) !important;
+    border-color: var(--guardian-disabled-color, lightgray) !important;
 }
 
 .block-container[deprecated="true"] .block-item::after {
     content: "";
     width: 110%;
     height: 3px;
-    background-color: black;
+    background-color: var(--guardian-font-color, black);
     position: absolute;
     left: -5%;
 }
 
 .block-container[selected="true"][deprecated="true"] .block-item {
-    border-color: #5161e1 !important;
+    border-color: var(--color-primary, #4169E2) !important;
 }
 
 .cdk-drag-animating {
@@ -590,7 +592,7 @@
 
 .cdk-drag-placeholder {
     opacity: 0.4 !important;
-    background: #e3e3e3 !important;
+    background: var(--guardian-grey-color, #e3e3e3) !important;
 }
 
 .cdk-drag-placeholder.block-container {
@@ -630,25 +632,25 @@
 }
 .block-container[warning="true"] .tool-body .block-item::after {
     background-image:
-        linear-gradient(180deg, #838383 3px, var(--pc-warning-bg-light) 3px),
-        linear-gradient(180deg, var(--pc-warning-bg-light) 3px, #838383 3px) !important;
+        linear-gradient(180deg, var(--guardian-grey-color-3, #838383) 3px, var(--pc-warning-bg-light) 3px),
+        linear-gradient(180deg, var(--pc-warning-bg-light) 3px, var(--guardian-grey-color-3, #838383) 3px) !important;
 }
 
 .block-container[info="true"] .block-item {
-    border-color: #35a307 !important;
-    background: #eaffea !important;
+    border-color: var(--pc-valid-color, #19BE47) !important;
+    background: var(--guardian-success-background, #eaffea) !important;
 }
 .block-container[info="true"][selected="true"] .block-item {
-    box-shadow: 4px 4px 6px 0px #00000040, 0 0 4px 1px #35a307cc !important;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--pc-valid-color, #19BE47) 35%, transparent) !important;
 }
 .block-container[info="true"] .module-body .block-item::after {
-    border-color: #35a307 !important;
-    background: #eaffea !important;
+    border-color: var(--pc-valid-color, #19BE47) !important;
+    background: var(--guardian-success-background, #eaffea) !important;
 }
 .block-container[info="true"] .tool-body .block-item::after {
     background-image:
-        linear-gradient(180deg, #838383 3px, #eaffea 3px),
-        linear-gradient(180deg, #eaffea 3px, #838383 3px) !important;
+        linear-gradient(180deg, var(--guardian-grey-color-3, #838383) 3px, var(--guardian-success-background, #eaffea) 3px),
+        linear-gradient(180deg, var(--guardian-success-background, #eaffea) 3px, var(--guardian-grey-color-3, #838383) 3px) !important;
 }
 
 .block-body
@@ -668,7 +670,7 @@
     }
 
     span {
-        font-family: Inter, sans-serif;
+        font-family: var(--font-family-inter, 'Inter', sans-serif);
         font-weight: 500;
         font-style: Medium;
         font-size: 12px;
@@ -684,7 +686,7 @@
     margin-left: auto;
 
     span {
-        font-family: Inter, sans-serif;
+        font-family: var(--font-family-inter, 'Inter', sans-serif);
         font-weight: 500;
         font-style: Medium;
         font-size: 12px;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.scss
@@ -50,7 +50,7 @@
 }
 
 .block-expand {
-    width: 40px;
+    width: 32px;
     height: 40px;
     position: relative;
     cursor: pointer;
@@ -719,4 +719,292 @@
 .block-container[selected="true"]
 .block-body .block-tag-count {
     right: 0;
+}
+
+// #6 / #3 Drop the folder-tab "hat" from module blocks (root and nested).
+// It reads as a detached rectangle; the icon + border already convey a module.
+.module-body .block-item::after {
+    display: none !important;
+}
+
+// #2 Root block: the collapse-all control already sits in the expand column,
+// so hide the root's own (redundant) caret to avoid two overlapping arrows.
+// Keep the column width so the block doesn't shift.
+.block-container[root="true"] .block-expand i {
+    display: none !important;
+}
+
+// Fit + modernize the collapse-all control inside the 32px expand column.
+.block-all-expand {
+    left: 0 !important;
+    width: 32px !important;
+}
+
+.block-all-expand i,
+.block-all-expand svg {
+    left: 4px !important;
+    top: 50% !important;
+    transform: translateY(-50%);
+    width: 24px !important;
+    height: 24px !important;
+    padding: 4px !important;
+    font-size: 15px !important;
+    border-radius: 6px;
+    background: transparent !important;
+    color: var(--guardian-font-color-secondary, #848FA9) !important;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.block-all-expand:hover i,
+.block-all-expand:hover svg {
+    background: var(--guardian-grey-background, #f1f3f9) !important;
+    color: var(--guardian-font-color, #23252E) !important;
+}
+
+// #1 Thinner block borders (theme applies 2px via --theme-border-width).
+.block-item[theme-all],
+.block-item[theme-block] {
+    border-width: 1px !important;
+}
+
+// #3 Tighter vertical rhythm between blocks (between the original and the
+// tightest pass).
+.block-container {
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.block-item:has(.block-item-text) {
+    min-height: 44px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+}
+
+.block-body:has(.block-item-text) {
+    min-height: 44px;
+}
+
+// #5 Center the root / module / tool icon vertically.
+.module-item-icon {
+    top: 50% !important;
+    transform: translateY(-50%);
+
+    i,
+    svg {
+        top: 0 !important;
+        left: 0 !important;
+    }
+}
+
+// ---- Canvas refresh: expand carets, typography, block hover ----
+
+// Modernize the expand caret: drop the grey square, use a clean chevron
+// glyph with a subtle rounded hover target.
+.block-expand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.block-expand i {
+    position: static !important;
+    top: auto !important;
+    left: auto !important;
+    width: 22px !important;
+    height: 22px !important;
+    padding: 0 !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px !important;
+    border-radius: 6px;
+    background: transparent !important;
+    color: var(--guardian-font-color-secondary, #848FA9) !important;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.block-expand:hover i {
+    background: var(--guardian-grey-background, #f1f3f9) !important;
+    color: var(--guardian-font-color, #23252E) !important;
+}
+
+.block-container[collapsed="true"] .block-expand i {
+    transform: rotate(-90deg);
+}
+
+// ---- #3 Modern blocks: icon chip + name/type stack ----
+.block-item:has(.block-item-text) {
+    height: auto;
+    min-height: 46px;
+    align-items: center;
+}
+
+.block-body:has(.block-item-text) {
+    height: auto;
+    min-height: 46px;
+    align-items: center;
+}
+
+.block-item:has(.block-item-text) .block-item-icon {
+    width: 26px;
+    height: 26px;
+    left: 8px;
+    border-radius: 7px;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    i {
+        font-size: 14px;
+    }
+}
+
+.block-item-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    padding-left: 26px;
+    padding-right: 4px;
+    overflow: hidden;
+}
+
+.block-item-type {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    font-size: 10px;
+    line-height: 1.25;
+    color: inherit;
+    opacity: 0.55;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 300px;
+}
+
+// ---- #2 Nesting connectors ----
+// Indent step is 40px/level and .block-expand is 40px wide, so each block's
+// parent-caret column is exactly 60px left of its .block-body. Draw a
+// continuous vertical guide at that column plus a horizontal branch to the
+// block, forming a proper tree.
+.block-container:not([root="true"]) .block-body {
+    &::before {
+        content: "";
+        position: absolute;
+        left: -48px;
+        top: -8px;
+        bottom: -8px;
+        width: 1px;
+        background: var(--pc-border-color, #E1E7EF);
+        pointer-events: none;
+    }
+
+    &::after {
+        content: "";
+        position: absolute;
+        left: -48px;
+        top: 50%;
+        width: 30px;
+        height: 1px;
+        background: var(--pc-border-color, #E1E7EF);
+        pointer-events: none;
+    }
+}
+
+// Typography: consistent Inter across block and module labels.
+.block-item-name {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.25;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 300px;
+}
+
+.block-item:has(.block-item-text) .block-item-name {
+    padding: 0 !important;
+}
+
+.module-item-name {
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    font-size: 14px !important;
+    font-weight: 500;
+    color: var(--guardian-font-color, #23252E) !important;
+}
+
+// Softer, more tactile hover than the flat brightness filter.
+.block-item {
+    transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.block-item:hover {
+    filter: none;
+    box-shadow: 0 2px 6px var(--guardian-shadow, #00000022);
+}
+
+// Modernize the floating block action menu (both compact and move modes).
+// Clean, smaller icon buttons with rounded hover states.
+.action-button {
+    width: 28px !important;
+    height: 28px !important;
+    border-radius: 8px !important;
+    border: 1px solid var(--pc-border-color, #E1E7EF) !important;
+    box-shadow: 0 1px 3px var(--guardian-shadow, #0000001a) !important;
+    background: var(--guardian-background, #fff);
+    color: var(--guardian-font-color-secondary, #848FA9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+
+    i {
+        font-size: 12px;
+    }
+
+    &:hover {
+        background: var(--guardian-grey-background, #f1f3f9);
+        color: var(--guardian-font-color, #23252E);
+    }
+}
+
+// The compact actions group reads as one softly-shadowed card with
+// borderless buttons inside.
+.actions-container {
+    background: var(--guardian-background, #fff) !important;
+    border: 1px solid var(--pc-border-color, #E1E7EF) !important;
+    box-shadow: 0 6px 18px var(--guardian-shadow, #0000001f) !important;
+    border-radius: 9px !important;
+    padding: 3px !important;
+    display: flex;
+    align-items: center;
+    gap: 1px;
+
+    .action-button {
+        border: none !important;
+        box-shadow: none !important;
+        width: 26px !important;
+        height: 26px !important;
+    }
+}
+
+.actions-container .add-child-action,
+.action-button.add-child-action {
+    color: var(--color-primary, #4169E2);
+
+    &:hover {
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
+        color: var(--color-primary, #4169E2);
+    }
+}
+
+.actions-container .delete-action,
+.action-button.delete-action {
+    color: var(--pc-del-color, #FF432A);
+
+    &:hover {
+        background: color-mix(in srgb, var(--pc-del-color, #FF432A) 12%, transparent);
+        color: var(--pc-del-color, #FF432A);
+    }
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.ts
@@ -58,6 +58,7 @@ export class PolicyTreeComponent implements OnInit {
     @Output('currentBlockChange') currentBlockChange = new EventEmitter();
     @Output('search') search = new EventEmitter();
     @Output('test') test = new EventEmitter();
+    @Output('addChild') addChild = new EventEmitter<MouseEvent>();
 
     @ViewChild('parent') parentRef!: ElementRef<HTMLCanvasElement>;
     @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
@@ -200,6 +201,9 @@ export class PolicyTreeComponent implements OnInit {
             this.selectedNode = this.data.find(
                 (item) => item.node === changes.currentBlock.currentValue
             );
+            if (this.active === 'Selected') {
+                this.render();
+            }
             return;
         }
         this.errorsTree = {};
@@ -260,6 +264,7 @@ export class PolicyTreeComponent implements OnInit {
     private rebuildTree(data: PolicyBlock[]) {
         this.root = data[0];
         this.data = this.convertToArray([], data, 0, null);
+        this.markEvents();
 
         if (this.currentBlock) {
             this.selectedNode = this.data.find(
@@ -267,6 +272,28 @@ export class PolicyTreeComponent implements OnInit {
             );
         }
         this.render(true);
+    }
+
+    private markEvents() {
+        const tags = new Set<string>();
+        for (const node of this.data) {
+            const events = node.node?.events;
+            if (events) {
+                for (const event of events) {
+                    if (!event.disabled) {
+                        if (event.sourceTag) {
+                            tags.add(event.sourceTag);
+                        }
+                        if (event.targetTag) {
+                            tags.add(event.targetTag);
+                        }
+                    }
+                }
+            }
+        }
+        for (const node of this.data) {
+            node.hasEvents = !!node.node?.tag && tags.has(node.node.tag);
+        }
     }
 
     private getCollapsed(node: FlatBlockNode): boolean {
@@ -753,6 +780,13 @@ export class PolicyTreeComponent implements OnInit {
         if (this.active === 'All') {
             return true;
         }
+        if (this.active === 'Selected') {
+            const tag = this.currentBlock?.tag;
+            if (!tag) {
+                return false;
+            }
+            return item.sourceTag === tag || item.targetTag === tag;
+        }
         if (this.active === 'Action') {
             return item.input !== 'RefreshEvent' && item.output !== 'RefreshEvent';
         }
@@ -828,6 +862,13 @@ export class PolicyTreeComponent implements OnInit {
         event.preventDefault();
         event.stopPropagation();
         this.search.emit(this.currentBlock);
+        return false;
+    }
+
+    public onAddChild(event: MouseEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.addChild.emit(event);
         return false;
     }
 

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-tree/policy-tree.component.ts
@@ -95,7 +95,7 @@ export class PolicyTreeComponent implements OnInit {
     private root!: PolicyBlock;
     private collapsedMap: Map<string, boolean> = new Map<string, boolean>();
     private eventsDisabled = false;
-    private paddingLeft = 40;
+    private paddingLeft = 32;
 
     private tooltip!: HTMLDivElement;
     private canvas!: EventCanvas;
@@ -997,7 +997,7 @@ export class PolicyTreeComponent implements OnInit {
         const next = items[index]?.data;
         const lvl = Math.max(1, next && next > prev ? next : prev);
         const placeholder = event.item.getPlaceholderElement()
-        placeholder.style.paddingLeft = `${40 * lvl}px`;
+        placeholder.style.paddingLeft = `${32 * lvl}px`;
     }
 
     public onDragEntered(event: any) {
@@ -1009,7 +1009,7 @@ export class PolicyTreeComponent implements OnInit {
         const next = items[index]?.data;
         const lvl = Math.max(1, next && next > prev ? next : prev);
         const placeholder = event.item.getPlaceholderElement()
-        placeholder.style.paddingLeft = `${40 * lvl}px`;
+        placeholder.style.paddingLeft = `${32 * lvl}px`;
     }
 
     public onDragSortPredicate(index: number): boolean {

--- a/frontend/src/app/modules/policy-engine/policy-engine.module.ts
+++ b/frontend/src/app/modules/policy-engine/policy-engine.module.ts
@@ -20,6 +20,7 @@ import { PolicyConfigurationComponent } from './policy-configuration/policy-conf
 import { ContainerConfigComponent } from './policy-configuration/blocks/main/container-config/container-config.component';
 import { RequestConfigComponent } from './policy-configuration/blocks/documents/request-config/request-config.component';
 import { PolicyPropertiesComponent } from './policy-configuration/policy-properties/policy-properties.component';
+import { PolicySettingsDrawerComponent } from './policy-configuration/policy-settings-drawer/policy-settings-drawer.component';
 import { MintConfigComponent } from './policy-configuration/blocks/tokens/mint-config/mint-config.component';
 import { SendConfigComponent } from './policy-configuration/blocks/documents/send-config/send-config.component';
 import { ExternalDataConfigComponent } from './policy-configuration/blocks/documents/external-data-config/external-data-config.component';
@@ -199,6 +200,7 @@ import { PolicyTestAutomationPopupComponent } from './policy-viewer/policy-test-
         ContainerConfigComponent,
         RequestConfigComponent,
         PolicyPropertiesComponent,
+        PolicySettingsDrawerComponent,
         MintConfigComponent,
         WipeConfigComponent,
         SendConfigComponent,

--- a/frontend/src/app/modules/policy-engine/structures/storage/config-options.ts
+++ b/frontend/src/app/modules/policy-engine/structures/storage/config-options.ts
@@ -78,7 +78,7 @@ export class Options {
             [
                 { id: 'blocks', size: '225px' },
                 { id: 'tree', size: 'auto' },
-                { id: 'properties', size: '465px' },
+                { id: 'properties', size: '340px' },
             ]
         );
         this._propertiesOrder = new ArrayProperty(prefix + 'PROPERTIES_ORDER', [

--- a/frontend/src/app/modules/policy-engine/structures/storage/config-options.ts
+++ b/frontend/src/app/modules/policy-engine/structures/storage/config-options.ts
@@ -35,6 +35,7 @@ export class Options {
     private readonly _favorites: ObjectProperty<boolean>;
     private readonly _favoritesModules: ObjectProperty<boolean>;
     private readonly _legendActive: BooleanProperty;
+    private readonly _libraryCollapsed: BooleanProperty;
     private readonly _configurationOrder: ArrayProperty<OrderOption>;
     private readonly _propertiesOrder: ArrayProperty<OrderOption>;
 
@@ -71,6 +72,7 @@ export class Options {
         this._favorites = new ObjectProperty(prefix + 'FAVORITES', {});
         this._favoritesModules = new ObjectProperty(prefix + 'FAVORITES_MODULES', {});
         this._legendActive = new BooleanProperty(prefix + 'LEGEND', true);
+        this._libraryCollapsed = new BooleanProperty(prefix + 'LIBRARY_COLLAPSED', false);
         this._configurationOrder = new ArrayProperty(
             prefix + 'CONFIGURATION_ORDER',
             [
@@ -116,6 +118,7 @@ export class Options {
             this.outputsModule = this._outputsModule.load();
             this.variablesModule = this._variablesModule.load();
             this.legendActive = this._legendActive.load();
+            this.libraryCollapsed = this._libraryCollapsed.load();
             this._favorites.load();
             this._favoritesModules.load();
             this._configurationOrder.load();
@@ -158,6 +161,7 @@ export class Options {
             this._outputsModule.save();
             this._variablesModule.save();
             this._legendActive.save();
+            this._libraryCollapsed.save();
             this._configurationOrder.save();
             this._propertiesOrder.save();
         } catch (error) {
@@ -279,6 +283,10 @@ export class Options {
 
     public get legendActive(): boolean {
         return this._legendActive.value;
+    }
+
+    public get libraryCollapsed(): boolean {
+        return this._libraryCollapsed.value;
     }
 
     public get configurationOrder(): OrderOption[] {
@@ -496,6 +504,10 @@ export class Options {
         this._legendActive.value = value;
     }
 
+    public set libraryCollapsed(value: boolean) {
+        this._libraryCollapsed.value = value;
+    }
+
     public set configurationOrder(value: OrderOption[]) {
         if (Array.isArray(value)) {
             this._configurationOrder.value = value;
@@ -617,6 +629,9 @@ export class Options {
         switch (name) {
             case 'legendActive':
                 this.legendActive = !this.legendActive;
+                break;
+            case 'libraryCollapsed':
+                this.libraryCollapsed = !this.libraryCollapsed;
                 break;
             default:
                 return;

--- a/frontend/src/app/modules/policy-engine/structures/tree-model/block-node.ts
+++ b/frontend/src/app/modules/policy-engine/structures/tree-model/block-node.ts
@@ -31,6 +31,7 @@ export class FlatBlockNode {
     public canDown!: boolean;
     public canLeft!: boolean;
     public canRight!: boolean;
+    public hasEvents!: boolean;
 
     constructor(node: PolicyItem) {
         this.node = node;

--- a/frontend/src/app/modules/policy-engine/structures/tree-model/event-canvas.ts
+++ b/frontend/src/app/modules/policy-engine/structures/tree-model/event-canvas.ts
@@ -161,43 +161,53 @@ export class EventCanvas {
     private drawArrow(line: BlocLine, dash: boolean = false, selected: boolean = false): void {
         const ctx = this.context;
         const points = line.points;
-        ctx.save();
-        if (selected) {
-            ctx.strokeStyle = `rgb(0,0,255)`;
-            ctx.lineWidth = 3;
-        } else {
-            ctx.strokeStyle = `rgb(${line.color[0]},${line.color[1]},${line.color[2]})`;
-            ctx.lineWidth = line.selected ? 3 : 1;
+        const n = points.length;
+        if (n < 4) {
+            return;
         }
+        ctx.save();
+        ctx.lineJoin = 'round';
+        ctx.lineCap = 'round';
+        let color: string;
+        if (selected) {
+            color = 'rgb(65, 105, 226)';
+            ctx.lineWidth = 2.5;
+        } else {
+            color = `rgb(${line.color[0]},${line.color[1]},${line.color[2]})`;
+            ctx.lineWidth = line.selected ? 2.5 : 1.5;
+        }
+        ctx.strokeStyle = color;
+        ctx.fillStyle = color;
         ctx.beginPath();
         if (dash) {
-            ctx.setLineDash([10, 5]);
+            ctx.setLineDash([8, 5]);
         } else {
             ctx.setLineDash([]);
         }
 
-        let fx: number = 0, fy: number = 0, tx: number = 0, ty: number = 0;
-        for (let i = 0; i < points.length - 3; i += 2) {
-            fx = points[i];
-            fy = points[i + 1];
-            tx = points[i + 2];
-            ty = points[i + 3];
-            ctx.moveTo(fx, fy);
-            ctx.lineTo(tx, ty);
+        // Route through the waypoints with rounded elbows instead of hard
+        // right-angle corners for a cleaner, modern connector.
+        const radius = 6;
+        ctx.moveTo(points[0], points[1]);
+        for (let i = 2; i < n - 2; i += 2) {
+            ctx.arcTo(points[i], points[i + 1], points[i + 2], points[i + 3], radius);
         }
-        const angle = Math.atan2(ty - fy, tx - fx);
-        const k = Math.PI / 7;
-        const headlen = 5;
+        ctx.lineTo(points[n - 2], points[n - 1]);
         ctx.stroke();
-        ctx.lineWidth = 3;
-        ctx.beginPath();
+
+        // Filled arrowhead at the target, aimed along the final segment.
+        const fx = points[n - 4], fy = points[n - 3];
+        const tx = points[n - 2], ty = points[n - 1];
+        const angle = Math.atan2(ty - fy, tx - fx);
+        const k = Math.PI / 6;
+        const headlen = 8;
         ctx.setLineDash([]);
+        ctx.beginPath();
         ctx.moveTo(tx, ty);
         ctx.lineTo(tx - headlen * Math.cos(angle - k), ty - headlen * Math.sin(angle - k));
         ctx.lineTo(tx - headlen * Math.cos(angle + k), ty - headlen * Math.sin(angle + k));
-        ctx.lineTo(tx, ty);
-        ctx.lineTo(tx - headlen * Math.cos(angle - k), ty - headlen * Math.sin(angle - k));
-        ctx.stroke();
+        ctx.closePath();
+        ctx.fill();
         ctx.restore();
     }
 

--- a/frontend/src/app/modules/policy-engine/styles/properties.scss
+++ b/frontend/src/app/modules/policy-engine/styles/properties.scss
@@ -1,27 +1,27 @@
 .policy-configuration::ng-deep {
     --pc-row-height: 42px;
     --pc-row-font-size: 16px;
-    --pc-row-font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    --pc-row-font-family: var(--font-family-inter, 'Inter', sans-serif);
     --pc-row-font-style: normal;
 
     --guardian-primary-color: var(--color-primary, #4169E2);
-    --pc-border-color: var(--guardian-border-color, #bdbdbd);
-    --pc-active-icon-color: var(--guardian-menu-color-2, #8259ef);
-    --pc-header-color: var(--guardian-font-color, #555555);
-    --pc-error-color: #dd0a0a;
-    --pc-error-border-strong: #b80000;
-    --pc-error-bg-strong: var(--guardian-failure-background, #ffb3b3);
-    --pc-error-shadow: #b80000cc;
-    --pc-event-color: #bd9012;
-    --pc-event-icon-color: #ffc107;
-    --pc-prop-border-color: var(--guardian-border-color, #e5e5e5);
-    --pc-del-color: #eb0303;
-    --pc-required-color: #eb0303;
-    --pc-readonly-text-color: var(--guardian-disabled-color, rgba(0, 0, 0, .45));
+    --pc-border-color: var(--guardian-border-color, #E1E7EF);
+    --pc-active-icon-color: var(--color-primary, #4169E2);
+    --pc-header-color: var(--guardian-font-color, #23252E);
+    --pc-error-color: var(--color-accent-red-1, #FF432A);
+    --pc-error-border-strong: var(--color-accent-red-1, #FF432A);
+    --pc-error-bg-strong: var(--guardian-failure-background, #FFEAEA);
+    --pc-error-shadow: var(--guardian-shadow, #00000014);
+    --pc-event-color: var(--color-accent-yellow-1, #DA9B22);
+    --pc-event-icon-color: var(--color-accent-yellow-1, #DA9B22);
+    --pc-prop-border-color: var(--guardian-border-color, #E1E7EF);
+    --pc-del-color: var(--color-accent-red-1, #FF432A);
+    --pc-required-color: var(--color-accent-red-1, #FF432A);
+    --pc-readonly-text-color: var(--guardian-disabled-color, #848FA9);
     --pc-background-color: var(--guardian-background, #fff);
-    --pc-warning-border-light: #ff6b6b;
-    --pc-warning-bg-light: var(--guardian-failure-background, #ffe9ea);
-    --pc-warning-shadow: #ff6b6bcc;
+    --pc-warning-border-light: var(--color-accent-yellow-1, #DA9B22);
+    --pc-warning-bg-light: var(--guardian-warning-background, #FFF6E3);
+    --pc-warning-shadow: var(--guardian-shadow, #00000014);
 
     .properties {
         --col-name-width: 155px;
@@ -418,7 +418,7 @@
         .remove-step {
             width: auto !important;
             text-align: end;
-            color: #e30101;
+            color: var(--pc-del-color);
             cursor: pointer;
 
             i,

--- a/frontend/src/app/modules/policy-engine/styles/properties.scss
+++ b/frontend/src/app/modules/policy-engine/styles/properties.scss
@@ -1,6 +1,6 @@
 .policy-configuration::ng-deep {
-    --pc-row-height: 42px;
-    --pc-row-font-size: 16px;
+    --pc-row-height: 30px;
+    --pc-row-font-size: 13px;
     --pc-row-font-family: var(--font-family-inter, 'Inter', sans-serif);
     --pc-row-font-style: normal;
 
@@ -22,17 +22,37 @@
     --pc-warning-border-light: var(--color-accent-yellow-1, #DA9B22);
     --pc-warning-bg-light: var(--guardian-warning-background, #FFF6E3);
     --pc-warning-shadow: var(--guardian-shadow, #00000014);
+    --pc-control-height: 30px;
 
     .properties {
-        --col-name-width: 155px;
+        --col-name-width: 116px;
         --col-value-width: 100%;
 
         width: 100%;
+        max-width: 100%;
+        table-layout: fixed;
         position: relative;
-        background: var(--pc-prop-border-color);
-        font-size: var(--pc-row-font-family);
+        background: var(--pc-background-color);
+        border-collapse: collapse;
+        font-size: var(--pc-row-font-size);
         font-family: var(--pc-row-font-family);
         font-style: var(--pc-row-font-style);
+
+        // table-layout:fixed sizes columns off whichever row the browser
+        // treats as authoritative, which is unreliable when header rows
+        // and data rows disagree on widths. An explicit colgroup removes
+        // the ambiguity regardless of row content.
+        colgroup .col-toggle {
+            width: 18px;
+        }
+
+        colgroup .col-name {
+            width: var(--col-name-width);
+        }
+
+        colgroup .col-value {
+            width: var(--col-value-width);
+        }
 
         .cellTitle {
             font-weight: 500;
@@ -47,9 +67,9 @@
         }
 
         .propRowCol {
-            background: var(--pc-prop-border-color);
-            width: 20px;
-            min-width: 20px;
+            background: transparent;
+            width: 18px;
+            min-width: 18px;
             position: relative;
             cursor: pointer;
             user-select: none;
@@ -58,34 +78,39 @@
             i,
             svg {
                 position: absolute;
-                top: 9px;
-                left: 1px;
-                height: 20px;
-                width: 20px;
+                top: 50%;
+                left: 0;
+                height: 14px;
+                width: 14px;
+                font-size: 12px;
+                line-height: 14px;
+                transform: translateY(-50%);
+                transition: transform 0.12s ease;
                 pointer-events: none;
-                color: var(--pc-header-color);
-            }
-
-            &[collapse="false"] i,
-            &[collapse="false"] svg {
-                top: 9px;
-                left: 1px;
+                color: var(--guardian-font-color-secondary, #848FA9);
             }
 
             &[collapse="true"] i,
             &[collapse="true"] svg {
-                transform: rotate(-90deg);
-                top: 4px;
-                left: 2px;
+                transform: translateY(-50%) rotate(-90deg);
             }
         }
 
         .propHeader {
-            background: var(--pc-prop-border-color);
+            background: transparent;
             color: var(--pc-header-color);
             position: relative;
-            font-weight: 500;
-            position: relative;
+            cursor: pointer;
+
+            &:hover {
+                background: color-mix(in srgb, var(--guardian-primary-color) 5%, transparent);
+            }
+
+            &:hover .propRowCol i,
+            &:hover .propRowCol svg,
+            &:hover .chevron-icon {
+                color: var(--pc-header-color);
+            }
 
             &[collapse="true"] {
                 display: none;
@@ -95,47 +120,63 @@
                 pointer-events: none;
                 position: absolute;
                 content: "";
-                top: -2px;
-                left: -2px;
-                right: -2px;
-                bottom: -1px;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
                 border-top: 1px solid var(--pc-border-color);
                 z-index: 1;
             }
 
+            &:first-child::after {
+                border-top: none;
+            }
+
             .cellName {
-                width: var(--col-name-width) !important;
-                max-width: var(--col-name-width) !important;
-                min-width: var(--col-name-width) !important;
+                display: flex;
+                align-items: flex-start;
+                gap: 6px;
+                width: auto !important;
+                max-width: none !important;
+                min-width: 0 !important;
                 overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-                padding-right: 5px;
+                white-space: normal;
                 box-sizing: border-box;
-                font-size: var(--pc-row-font-size);
-                font-weight: bold;
-                padding: 8px 6px !important;
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.06em;
+                text-transform: uppercase;
+                color: var(--pc-header-color, #23252E);
+                padding: 12px 4px 6px 4px !important;
 
                 span {
-                    width: calc(var(--col-value-width) - 10px);
-                    overflow: hidden;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
+                    white-space: normal;
+                    overflow-wrap: break-word;
                     display: block;
+                }
+
+                .chevron-icon {
+                    flex: 0 0 auto;
+                    font-size: 11px;
+                    transition: transform 0.12s ease;
+                }
+
+                &[collapse="true"] .chevron-icon {
+                    transform: rotate(-90deg);
                 }
             }
 
             .propHeaderCell {
-                width: var(--col-value-width);
-                max-width: var(--col-value-width);
-                min-width: var(--col-value-width);
+                width: auto;
+                max-width: none;
+                min-width: 0;
                 position: relative;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 box-sizing: border-box;
-                min-height: var(--pc-row-height);
-                padding: 8px 0px;
+                min-height: 20px;
+                padding: 5px 0px 3px;
             }
         }
 
@@ -145,56 +186,75 @@
             }
 
             &:nth-child(2n) .propRowCell {
-                background: var(--guardian-grey-background, #f7f7f7);
+                background: transparent;
             }
 
             .cellName {
                 width: var(--col-name-width) !important;
                 max-width: var(--col-name-width) !important;
                 min-width: var(--col-name-width) !important;
-                padding-left: 10px !important;
+                padding-left: 0 !important;
                 overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-                padding-right: 5px;
+                white-space: normal;
+                overflow-wrap: break-word;
+                padding-right: 8px;
                 box-sizing: border-box;
+                color: var(--guardian-font-color-secondary, #8a8f9c);
+                font-weight: 400;
+                font-size: var(--pc-row-font-size);
+                line-height: 1.25;
+                vertical-align: top;
+                padding-top: 6px;
 
                 span {
                     width: calc(var(--col-name-width) - 10px);
-                    overflow: hidden;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
+                    white-space: normal;
+                    overflow-wrap: break-word;
                     display: block;
                 }
 
-                .lvl[lvl="1"] {
-                    padding-left: 0px !important;
-                    width: 140px !important;
+                .lvl {
+                    --lvl-indent: 0px;
+                    padding-left: var(--lvl-indent) !important;
+                    width: calc(var(--col-name-width) - 10px - var(--lvl-indent)) !important;
                 }
 
                 .lvl[lvl="1"] {
-                    padding-left: 8px !important;
-                    width: 132px !important;
+                    --lvl-indent: 8px;
                 }
 
                 .lvl[lvl="2"] {
-                    padding-left: 16px !important;
-                    width: 124px !important;
+                    --lvl-indent: 16px;
                 }
 
                 .lvl[lvl="3"] {
-                    padding-left: 24px !important;
-                    width: 116px !important;
-                }
-
-                .lvl[lvl="3"] {
-                    padding-left: 32px !important;
-                    width: 108px !important;
+                    --lvl-indent: 24px;
                 }
 
                 .lvl[lvl="4"] {
-                    padding-left: 40px !important;
-                    width: 100px !important;
+                    --lvl-indent: 32px;
+                }
+
+                .lvl[lvl="5"] {
+                    --lvl-indent: 40px;
+                }
+            }
+
+            .cellName:has(.chevron-icon) {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding-left: 4px !important;
+
+                .chevron-icon {
+                    flex: 0 0 auto;
+                    font-size: 11px;
+                    color: var(--guardian-font-color-secondary, #848FA9);
+                    transition: transform 0.12s ease;
+                }
+
+                &[collapse="true"] .chevron-icon {
+                    transform: rotate(-90deg);
                 }
             }
 
@@ -210,32 +270,32 @@
                     top: 0;
                     bottom: 0;
                     align-items: center;
-                    padding: 11px 8px;
+                    padding: 8px 8px;
                 }
             }
 
             .propRowCell {
-                width: var(--col-value-width);
-                max-width: var(--col-value-width);
-                min-width: var(--col-value-width);
+                width: auto;
+                max-width: none;
+                min-width: 0;
                 background: var(--pc-background-color);
                 position: relative;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 box-sizing: border-box;
-                padding: 0px;
+                padding: 1px 0px;
+                vertical-align: middle;
                 font-size: var(--pc-row-font-size);
                 min-height: var(--pc-row-height);
 
                 p-select,
                 p-multiselect,
-                select-schema {
-                    position: absolute;
-                    left: 0;
-                    top: 0;
-                    bottom: 0;
-                    right: 0;
+                select-schema,
+                select-block {
+                    position: relative;
+                    display: block;
+                    width: 100%;
                 }
 
                 &.multi-line {
@@ -258,6 +318,11 @@
                 }
             }
 
+            .propRowCell.cellName {
+                white-space: normal;
+                overflow-wrap: break-word;
+            }
+
             .propRowCell:has(.remove-prop) {
                 padding-right: 34px;
             }
@@ -271,18 +336,25 @@
             }
 
             input {
-                height: 24px;
+                height: var(--pc-control-height);
                 box-sizing: border-box;
                 border: 1px solid var(--pc-border-color);
-                border-radius: 3px;
-                padding: 2px 24px 2px 6px;
+                border-radius: 6px;
+                padding: 2px 8px;
                 outline: none;
                 width: 100%;
+                font-size: 13px;
+                font-family: var(--pc-row-font-family);
                 background: var(--guardian-background, #fff);
                 color: var(--guardian-font-color, #000);
 
                 &:hover {
                     border: 1px solid var(--guardian-primary-color);
+                }
+
+                &:focus {
+                    border: 1px solid var(--guardian-primary-color);
+                    box-shadow: 0 0 0 3px color-mix(in srgb, var(--guardian-primary-color) 15%, transparent);
                 }
 
                 &[readonly] {
@@ -291,19 +363,39 @@
                     outline: none !important;
                 }
 
-                &[type="checkbox"] {
-                    width: 16px;
-                    height: 16px;
-                    box-sizing: border-box;
-                    line-height: 24px;
-                    margin: 0;
-                    border: none;
-                    display: block;
-                    margin-left: 12px;
+                &[type="checkbox"].prop-input {
+                    appearance: none;
+                    -webkit-appearance: none;
+                    flex: 0 0 auto;
+                    width: 40px;
+                    height: 20px;
+                    margin: 4px 0;
+                    padding: 0;
+                    border: none !important;
+                    border-radius: 20px;
+                    background-color: var(--pc-border-color, #E1E7EF);
+                    background-image: radial-gradient(circle at center, #fff 7px, rgba(0, 0, 0, 0) 8px);
+                    background-repeat: no-repeat;
+                    background-size: 20px 20px;
+                    background-position: left center;
                     cursor: pointer;
+                    transition: background-color 0.15s ease, background-position 0.15s ease;
+
+                    &:hover {
+                        border: none !important;
+                    }
+
+                    &:focus {
+                        box-shadow: none;
+                    }
+
+                    &:checked {
+                        background-color: var(--guardian-primary-color);
+                        background-position: right center;
+                    }
                 }
 
-                &[readonly][type="checkbox"] {
+                &[readonly][type="checkbox"].prop-input {
                     pointer-events: none;
                     filter: grayscale(1);
                 }
@@ -316,7 +408,7 @@
                 padding: 6px 24px 4px 7px;
                 outline: none;
                 width: 100% !important;
-                font-size: 16px;
+                font-size: var(--pc-row-font-size);
                 min-width: 100% !important;
                 min-height: 70px;
                 color: var(--guardian-font-color, var(--color-grey-6));
@@ -350,6 +442,104 @@
             padding-left: 50px !important;
         }
 
+        // Tree-style connector for nested rows so the hierarchy reads at a
+        // glance (mirrors the angled connector from the redesign mockup).
+        *[offset="1"] .cellName,
+        *[offset="2"] .cellName,
+        *[offset="3"] .cellName,
+        *[offset="4"] .cellName,
+        .subRow .cellName,
+        .subRow-2 .cellName,
+        .subRow-3 .cellName,
+        .subRow-4 .cellName {
+            position: relative;
+
+            &::before {
+                content: "";
+                position: absolute;
+                top: 0;
+                height: 50%;
+                width: 6px;
+                border-left: 1px solid var(--pc-border-color);
+                border-bottom: 1px solid var(--pc-border-color);
+                border-bottom-left-radius: 5px;
+                pointer-events: none;
+            }
+        }
+
+        *[offset="1"] .cellName::before,
+        .subRow .cellName::before {
+            left: 8px;
+        }
+
+        *[offset="2"] .cellName::before,
+        .subRow-2 .cellName::before {
+            left: 18px;
+        }
+
+        *[offset="3"] .cellName::before,
+        .subRow-3 .cellName::before {
+            left: 28px;
+        }
+
+        *[offset="4"] .cellName::before,
+        .subRow-4 .cellName::before {
+            left: 38px;
+        }
+
+        // Config editors that still use the old markup keep their collapse
+        // caret in the far-left toggle column, detached from the indented
+        // label. Pull each nested caret in beside its label (aligned with the
+        // tree connector) and tint it like the section chevrons. Drop the
+        // connector on those toggle rows so the caret isn't doubled up.
+        .propRowCol.cellCollapse {
+            overflow: visible;
+
+            // The caret is nudged out of this 18px cell (below), but the click
+            // handler lives on the cell. Extend a transparent hit area over the
+            // caret + label so the toggle keeps working (and the label becomes
+            // clickable to collapse too).
+            &::after {
+                content: "";
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                width: 128px;
+                cursor: pointer;
+                z-index: 3;
+            }
+
+            i {
+                position: absolute;
+                z-index: 4;
+                color: var(--guardian-font-color-secondary, #848FA9);
+                font-size: 11px;
+            }
+        }
+
+        .propHeader > .propRowCol.cellCollapse i {
+            left: 8px;
+        }
+
+        .subRow > .propRowCol.cellCollapse i {
+            left: 24px;
+        }
+
+        .subRow-2 > .propRowCol.cellCollapse i {
+            left: 34px;
+        }
+
+        .subRow-3 > .propRowCol.cellCollapse i {
+            left: 44px;
+        }
+
+        .subRow:has(> .propRowCol.cellCollapse) .cellName::before,
+        .subRow-2:has(> .propRowCol.cellCollapse) .cellName::before,
+        .subRow-3:has(> .propRowCol.cellCollapse) .cellName::before {
+            display: none;
+        }
+
         .navigation .stepRow .propRowCol {
             left: 20px !important;
             top: 2px !important;
@@ -360,14 +550,14 @@
             height: 18px;
             overflow: hidden;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 13px;
             color: var(--pc-active-icon-color);
             position: relative;
             font-weight: 500;
             user-select: none;
             width: 100%;
-            min-width: 175px;
-            padding: 2px 0px 0px 28px;
+            min-width: 0;
+            padding: 2px 0px 0px 22px;
 
             i,
             svg {
@@ -399,15 +589,25 @@
 
         .remove-prop {
             position: absolute;
-            top: 5px;
-            right: 2px;
-            color: var(--pc-del-color);
+            top: 50%;
+            right: 6px;
+            transform: translateY(-50%);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--guardian-font-color-secondary, #848FA9);
             cursor: pointer;
             padding: 2px;
+            border-radius: 6px;
 
             i,
             svg {
-                font-size: 18px;
+                font-size: 14px;
+            }
+
+            &:hover {
+                color: var(--pc-del-color);
+                background: color-mix(in srgb, var(--pc-del-color) 10%, transparent);
             }
 
             &[readonly="true"] {
@@ -433,97 +633,110 @@
 
         .propBottom {
             background: var(--pc-background-color);
-            font-weight: 500;
             position: absolute;
-            bottom: 2px;
-            height: 38px;
+            bottom: 0px;
+            height: 44px;
             left: 0px;
-            right: 4px;
-            border-left: 24px solid var(--pc-prop-border-color);
-            padding: 8px 15px;
+            right: 0px;
+            padding: 6px 12px;
             box-sizing: border-box;
-            box-shadow: 0px -2px 0 0 var(--pc-prop-border-color), 0px 0px 0 0 var(--pc-prop-border-color), 2px 0px 0 0 var(--pc-prop-border-color);
-
-            &::after {
-                pointer-events: none;
-                position: absolute;
-                content: "";
-                top: -3px;
-                left: -26px;
-                right: -4px;
-                bottom: 0px;
-                border-top: 1px solid var(--pc-border-color);
-                z-index: 1;
-            }
+            border-top: 1px solid var(--pc-border-color);
         }
 
         .propRowBottom {
-            height: 28px;
+            height: 44px;
+        }
+
+        .propBottom .propAdd {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            width: 100%;
+            height: 32px;
+            padding: 0;
+            border: 1px dashed var(--pc-border-color);
+            border-radius: 8px;
+            font-weight: 500;
+
+            &:hover {
+                text-decoration: none;
+                border-color: var(--guardian-primary-color);
+                background: color-mix(in srgb, var(--guardian-primary-color) 6%, transparent);
+            }
+
+            i,
+            svg {
+                position: static;
+                font-size: 12px;
+            }
         }
 
         .icon-event {
-            display: inline-block;
-            overflow: visible;
-            font-size: 18px;
-            line-height: 10px;
-            height: 18px;
+            display: inline-flex;
+            align-items: center;
+            font-size: 15px;
             color: var(--pc-event-icon-color);
-            width: 16px;
-            position: relative;
-            top: 4px;
         }
 
         .icon-link {
-            display: inline-block;
-            overflow: visible;
-            font-size: 18px;
-            line-height: 10px;
-            height: 18px;
+            display: inline-flex;
+            align-items: center;
+            font-size: 15px;
             color: var(--pc-active-icon-color);
-            width: 18px;
-            position: relative;
-            top: 4px;
             user-select: none;
         }
 
         .readonly-prop {
             padding-left: 6px;
-            color: var(--pc-readonly-text-color);
-            display: block;
+            color: var(--guardian-font-color, #23252E);
+            display: flex;
+            align-items: center;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
             position: absolute;
             left: 0;
             top: 0;
+            bottom: 0;
             right: 10px;
         }
 
+        .event-header-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            height: 20px;
+        }
+
         .prop-icon {
-            display: inline-block !important;
-            height: 18px !important;
+            display: inline-flex !important;
+            align-items: center;
+            height: auto !important;
             width: auto !important;
-            line-height: 18px !important;
-            overflow: hidden !important;
+            line-height: normal !important;
+            overflow: visible !important;
         }
 
         .prop-icon i,
         .prop-icon svg {
-            position: relative !important;
-            font-size: 20px !important;
+            position: static !important;
+            font-size: 15px !important;
         }
 
         .prop-icon-text {
-            display: inline-block !important;
-            height: 16px !important;
+            display: inline-flex !important;
+            align-items: center;
+            height: auto !important;
             width: auto !important;
-            line-height: 16px !important;
-            overflow: hidden !important;
+            line-height: normal !important;
+            overflow: visible !important;
+            font-size: var(--pc-row-font-size);
+            font-weight: 600;
         }
 
         .prop-icon-event {
             color: var(--pc-event-color);
-            width: 20px !important;
         }
 
         .prop-icon-event[invalid="true"] {
@@ -536,33 +749,170 @@
         }
 
         .common-properties-button {
-            width: 99%;
-            font-size: 12px;
-            line-height: 25px;
-            color: var(--pc-active-icon-color);
+            width: 100%;
+            height: 30px;
+            box-sizing: border-box;
+            font-size: 13px;
+            font-family: var(--pc-row-font-family);
+            font-weight: 500;
+            line-height: 1;
+            color: var(--guardian-primary-color);
             background-color: var(--pc-background-color);
-            border-radius: 4px;
-            border: 1px solid var(--color-primary, #4169E2);
+            border-radius: 8px;
+            border: 1px solid var(--pc-border-color);
             cursor: pointer;
+
+            &:hover {
+                border-color: var(--guardian-primary-color);
+                background: color-mix(in srgb, var(--guardian-primary-color) 6%, transparent);
+            }
         }
 
         .common-properties-button-container {
             display: flex;
             justify-content: center;
             align-self: center;
-            padding: 3px;
+            padding: 2px 0;
         }
 
         .custom-properties {
             display: contents;
         }
+
+        p-select,
+        p-multiselect {
+            width: 100%;
+            height: var(--pc-control-height);
+            min-height: var(--pc-control-height);
+            box-sizing: border-box;
+            border-radius: 6px;
+            border: 1px solid var(--pc-border-color);
+            background: var(--guardian-background, #fff);
+            box-shadow: none;
+            display: flex !important;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-items: center;
+            overflow: hidden;
+            font-size: 13px;
+            font-family: var(--pc-row-font-family);
+
+            &:not(.p-disabled):hover {
+                border-color: var(--guardian-primary-color);
+            }
+
+            &.p-focus,
+            &.p-inputwrapper-focus {
+                border-color: var(--guardian-primary-color);
+                box-shadow: 0 0 0 3px color-mix(in srgb, var(--guardian-primary-color) 15%, transparent);
+            }
+        }
+
+        p-select .p-select-label,
+        p-multiselect .p-multiselect-label {
+            flex: 1 1 auto;
+            min-width: 0;
+            height: 100%;
+            padding: 0 10px;
+            font-size: 13px;
+            color: var(--guardian-font-color, #23252E);
+            display: flex;
+            align-items: center;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        p-select .p-select-label.p-placeholder,
+        p-multiselect .p-multiselect-label.p-placeholder {
+            color: var(--guardian-font-color-secondary, #848FA9);
+        }
+
+        p-select .p-select-dropdown,
+        p-multiselect .p-multiselect-dropdown {
+            flex: 0 0 auto;
+            width: 24px;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--guardian-font-color-secondary, #848FA9);
+        }
+
+        // PrimeNG p-checkbox is used in some config editors instead of a
+        // native checkbox. Render it as the same toggle switch so the
+        // inspector controls stay consistent.
+        p-checkbox {
+            display: inline-block;
+            width: 40px;
+            height: 20px;
+            margin: 4px 0;
+
+            .p-checkbox,
+            .p-checkbox-box {
+                width: 40px !important;
+                height: 20px !important;
+                min-width: 40px;
+            }
+
+            .p-checkbox-input {
+                width: 40px;
+                height: 20px;
+                cursor: pointer;
+            }
+
+            .p-checkbox-box {
+                position: relative;
+                border-radius: 20px !important;
+                border: none !important;
+                background: var(--pc-border-color, #E1E7EF) !important;
+                box-shadow: none !important;
+                transition: background 0.15s ease;
+
+                &::after {
+                    content: "";
+                    position: absolute;
+                    top: 3px;
+                    left: 3px;
+                    width: 14px;
+                    height: 14px;
+                    border-radius: 50%;
+                    background: #fff;
+                    box-shadow: 0 1px 2px var(--guardian-shadow, #00000024);
+                    transition: transform 0.15s ease;
+                }
+            }
+
+            .p-checkbox-icon {
+                display: none !important;
+            }
+
+            &.p-checkbox-checked .p-checkbox-box {
+                background: var(--guardian-primary-color) !important;
+
+                &::after {
+                    transform: translateX(20px);
+                }
+            }
+        }
+    }
+
+    // Block-specific config editors are inserted as sibling components
+    // inside .table-body via ViewContainerRef. Their custom-element hosts
+    // default to display:inline, which shrink-wraps the .properties table
+    // inside them and defeats table-layout:fixed (columns size to content
+    // instead of filling the rail). Force the hosts to fill the width.
+    .grid-setting .table-body > *:not(table) {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
     }
 
     .grid-setting {
         position: relative;
         height: auto;
         width: 100%;
-        overflow: auto;
+        overflow: visible;
 
         .loading {
             background: color-mix(in srgb, var(--guardian-background, #fff) 70%, transparent);
@@ -587,5 +937,53 @@
             pointer-events: none;
             filter: grayscale(1);
         }
+    }
+}
+
+// PrimeNG select/multiSelect overlays render via appendTo="body" and land
+// outside .policy-configuration's DOM subtree, so ::ng-deep scoping above
+// can't reach them. panelStyleClass="pc-select-panel" tags only our own
+// overlays, so this stays global on purpose without leaking to other
+// p-select/p-multiSelect usages elsewhere in the app.
+::ng-deep .pc-select-panel {
+    font-family: 'Inter', sans-serif;
+    font-size: 13px;
+
+    .p-select-header,
+    .p-multiselect-header {
+        padding: 8px;
+    }
+
+    .p-select-filter,
+    .p-multiselect-filter {
+        height: 32px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-family: 'Inter', sans-serif;
+    }
+
+    .p-select-list,
+    .p-multiselect-list {
+        padding: 4px;
+        gap: 2px;
+    }
+
+    .p-select-option,
+    .p-multiselect-option {
+        padding: 8px 10px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-family: 'Inter', sans-serif;
+    }
+
+    .p-checkbox {
+        width: 16px;
+        height: 16px;
+    }
+
+    .p-checkbox-box {
+        width: 16px;
+        height: 16px;
+        border-radius: 4px;
     }
 }


### PR DESCRIPTION
### Description

Redesign of the policy configurator across its four zones.

- Modernized the configurator shell and chrome: refreshed visuals, a policy identity popover, a command palette, an editable settings drawer, and a block inspector header with an empty state.
- Rebuilt the canvas and block library: a collapsible, fixed-width library rail with an indentation ladder and chevrons, selection-only event arrows with rounded elbows and block markers, event styles shown in the canvas legend, a contextual add-block picker, and a rail that focuses on the selected block.
- Reworked the top bar: a zoned layout, a primary publish split-button for draft policies, tightened spacing and icon consistency, and a refined overflow menu and policy popover.
- Redesigned the inspector panel: fixed the input sizing and layout issues, and gave the Blocks/Modules/Tools switcher and the Properties/Events/JSON tabs the same segmented control used in the top bar.

Resolves #3532
