### PR TITLE
fix: dry run active virtual user per session

### DIFF
--- a/common/src/database-modules/database-server.ts
+++ b/common/src/database-modules/database-server.ts
@@ -4134,6 +4134,13 @@ export class DatabaseServer extends AbstractDatabaseServer {
      * Get All Virtual Users
      * @param policyId
      * @param savepointIds
+     * @param virtualKey
+     * @param document
+     * @param userId Real (authenticated) user requesting the list. When
+     * provided, each returned user's `active` field is recomputed against
+     * that real user's own selected persona (`ActiveVirtualUser` pointer)
+     * instead of the legacy shared `active` column, so concurrent dry-run
+     * testers each see their own persona highlighted.
      * @virtual
      */
     public static async getVirtualUsers(
@@ -4141,6 +4148,7 @@ export class DatabaseServer extends AbstractDatabaseServer {
         savepointIds?: string[],
         virtualKey?: boolean,
         document?: boolean,
+        userId?: string | null,
     ): Promise<DryRun[]> {
         const filter: any = {
             dryRunId: policyId,
@@ -4167,6 +4175,17 @@ export class DatabaseServer extends AbstractDatabaseServer {
                 createDate: 1
             }
         });
+
+        if (userId) {
+            const pointer = await new DataBaseHelper(DryRun).findOne({
+                dryRunId: policyId,
+                dryRunClass: 'ActiveVirtualUser',
+                userId
+            });
+            for (const user of users) {
+                user.active = !!pointer?.did && pointer.did === user.did;
+            }
+        }
 
         if (virtualKey) {
             for (const user of users) {

--- a/common/src/database-modules/database-server.ts
+++ b/common/src/database-modules/database-server.ts
@@ -4085,7 +4085,36 @@ export class DatabaseServer extends AbstractDatabaseServer {
      *
      * @virtual
      */
-    public static async getVirtualUser(policyId: string): Promise<DryRun | null> {
+    public static async getVirtualUser(policyId: string, userId?: string | null): Promise<DryRun | null> {
+        if (userId) {
+            const pointer = await new DataBaseHelper(DryRun).findOne({
+                dryRunId: policyId,
+                dryRunClass: 'ActiveVirtualUser',
+                userId
+            });
+            if (!pointer?.did) {
+                return null;
+            }
+            return await new DataBaseHelper(DryRun).findOne({
+                dryRunId: policyId,
+                dryRunClass: 'VirtualUsers',
+                did: pointer.did
+            }, {
+                fields: [
+                    'id',
+                    'did',
+                    'username',
+                    'hederaAccountId',
+                    'active'
+                ]
+            } as unknown as FindOptions<object>);
+        }
+        // Legacy fallback: single shared active pointer. Used only when no
+        // real (authenticated) user context is available, e.g. background
+        // jobs. Callers resolving a request on behalf of a real user should
+        // always pass `userId`, so that each real user driving a dry-run
+        // policy keeps their own independently selected virtual persona
+        // instead of sharing one global pointer with every other tester.
         return await new DataBaseHelper(DryRun).findOne({
             dryRunId: policyId,
             dryRunClass: 'VirtualUsers',
@@ -5087,7 +5116,25 @@ export class DatabaseServer extends AbstractDatabaseServer {
      *
      * @virtual
      */
-    public static async setVirtualUser(policyId: string, did: string): Promise<void> {
+    public static async setVirtualUser(policyId: string, did: string, userId?: string | null): Promise<void> {
+        if (userId) {
+            const pointer = await new DataBaseHelper(DryRun).findOne({
+                dryRunId: policyId,
+                dryRunClass: 'ActiveVirtualUser',
+                userId
+            });
+            if (pointer) {
+                pointer.did = did;
+                await new DataBaseHelper(DryRun).save(pointer);
+            } else {
+                await new DataBaseHelper(DryRun).save(DatabaseServer.addDryRunId({
+                    did,
+                    userId
+                }, policyId, 'ActiveVirtualUser', false));
+            }
+            return;
+        }
+        // Legacy fallback: see getVirtualUser() above.
         const items = (await new DataBaseHelper(DryRun).find({
             dryRunId: policyId,
             dryRunClass: 'VirtualUsers'

--- a/common/tests/unit-tests/database-server/database-server.test.mjs
+++ b/common/tests/unit-tests/database-server/database-server.test.mjs
@@ -415,5 +415,66 @@ describe('DatabaseServer', function () {
 				assert.equal(pointerB.did, 'did:b');
 			});
 		});
+
+		describe('getVirtualUsers', function () {
+			it('recomputes active per real user instead of trusting the stored shared flag when userId is given', async function () {
+				const users = [
+					{did: 'did:a', active: true},
+					{did: 'did:b', active: false},
+				];
+				findStub.resolves(users);
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-b'})).resolves({did: 'did:b'});
+
+				const result = await DatabaseServer.getVirtualUsers('policy-1', undefined, false, false, 'user-b');
+
+				assert.equal(result[0].active, false);
+				assert.equal(result[1].active, true);
+			});
+
+			it('marks every persona inactive for a real user with no pointer yet', async function () {
+				const users = [
+					{did: 'did:a', active: true},
+					{did: 'did:b', active: false},
+				];
+				findStub.resolves(users);
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-c'})).resolves(null);
+
+				const result = await DatabaseServer.getVirtualUsers('policy-1', undefined, false, false, 'user-c');
+
+				assert.equal(result[0].active, false);
+				assert.equal(result[1].active, false);
+			});
+
+			it('keeps two real users seeing independently highlighted personas for the same policy', async function () {
+				const usersForA = [{did: 'did:a', active: false}, {did: 'did:b', active: false}];
+				const usersForB = [{did: 'did:a', active: false}, {did: 'did:b', active: false}];
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-a'})).resolves({did: 'did:a'});
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-b'})).resolves({did: 'did:b'});
+
+				findStub.resolves(usersForA);
+				const resultA = await DatabaseServer.getVirtualUsers('policy-1', undefined, false, false, 'user-a');
+				assert.equal(resultA.find((u) => u.did === 'did:a').active, true);
+				assert.equal(resultA.find((u) => u.did === 'did:b').active, false);
+
+				findStub.resolves(usersForB);
+				const resultB = await DatabaseServer.getVirtualUsers('policy-1', undefined, false, false, 'user-b');
+				assert.equal(resultB.find((u) => u.did === 'did:a').active, false);
+				assert.equal(resultB.find((u) => u.did === 'did:b').active, true);
+			});
+
+			it('falls back to the raw stored active flag when userId is omitted (legacy/background callers)', async function () {
+				const users = [
+					{did: 'did:a', active: false},
+					{did: 'did:b', active: true},
+				];
+				findStub.resolves(users);
+
+				const result = await DatabaseServer.getVirtualUsers('policy-1');
+
+				assert.equal(result[0].active, false);
+				assert.equal(result[1].active, true);
+				assert.equal(findOneStub.called, false);
+			});
+		});
 	});
 });

--- a/common/tests/unit-tests/database-server/database-server.test.mjs
+++ b/common/tests/unit-tests/database-server/database-server.test.mjs
@@ -1,5 +1,6 @@
 import {assert, expect} from 'chai';
 import esmock from 'esmock';
+import sinon from 'sinon';
 
 //mocks
 import {DataBaseHelper, ormMock} from '../database-helper/mocks-database-helper.mjs';
@@ -272,6 +273,147 @@ describe('DatabaseServer', function () {
 			assert.lengthOf(updatedSchemas, 2);
 			assert.equal(updatedSchemas[0].name, 'updatedSchema1');
 			assert.equal(updatedSchemas[1].name, 'updatedSchema2');
+		});
+	});
+
+	describe('Active virtual user pointer (dry-run)', function () {
+		let findOneStub;
+		let saveStub;
+		let findStub;
+
+		beforeEach(() => {
+			findOneStub = sinon.stub(DataBaseHelper.prototype, 'findOne');
+			saveStub = sinon.stub(DataBaseHelper.prototype, 'save').resolvesArg(0);
+			findStub = sinon.stub(DataBaseHelper.prototype, 'find');
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		describe('getVirtualUser', function () {
+			it('reads the legacy shared active-flag pointer when no userId is given', async function () {
+				findOneStub.resolves({did: 'did:shared', active: true});
+
+				const result = await DatabaseServer.getVirtualUser('policy-1');
+
+				assert.equal(result.did, 'did:shared');
+				assert.equal(findOneStub.callCount, 1);
+				assert.deepEqual(findOneStub.firstCall.args[0], {
+					dryRunId: 'policy-1',
+					dryRunClass: 'VirtualUsers',
+					active: true,
+				});
+			});
+
+			it('resolves the per-user pointer and then the matching persona when userId is given', async function () {
+				findOneStub.onCall(0).resolves({did: 'did:persona-a'});
+				findOneStub.onCall(1).resolves({did: 'did:persona-a', username: 'persona-a'});
+
+				const result = await DatabaseServer.getVirtualUser('policy-1', 'real-user-a');
+
+				assert.equal(result.username, 'persona-a');
+				assert.equal(findOneStub.callCount, 2);
+				assert.deepEqual(findOneStub.firstCall.args[0], {
+					dryRunId: 'policy-1',
+					dryRunClass: 'ActiveVirtualUser',
+					userId: 'real-user-a',
+				});
+				assert.deepEqual(findOneStub.secondCall.args[0], {
+					dryRunId: 'policy-1',
+					dryRunClass: 'VirtualUsers',
+					did: 'did:persona-a',
+				});
+			});
+
+			it('returns null without a second lookup when the real user has no pointer yet', async function () {
+				findOneStub.onCall(0).resolves(null);
+
+				const result = await DatabaseServer.getVirtualUser('policy-1', 'real-user-b');
+
+				assert.isNull(result);
+				assert.equal(findOneStub.callCount, 1);
+			});
+
+			it('returns null when the pointer exists but has no did', async function () {
+				findOneStub.onCall(0).resolves({userId: 'real-user-b'});
+
+				const result = await DatabaseServer.getVirtualUser('policy-1', 'real-user-b');
+
+				assert.isNull(result);
+				assert.equal(findOneStub.callCount, 1);
+			});
+
+			it('keeps two real users on independently selected personas for the same policy', async function () {
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-a'})).resolves({did: 'did:a'});
+				findOneStub.withArgs(sinon.match({dryRunClass: 'ActiveVirtualUser', userId: 'user-b'})).resolves({did: 'did:b'});
+				findOneStub.withArgs(sinon.match({dryRunClass: 'VirtualUsers', did: 'did:a'})).resolves({did: 'did:a', username: 'persona-a'});
+				findOneStub.withArgs(sinon.match({dryRunClass: 'VirtualUsers', did: 'did:b'})).resolves({did: 'did:b', username: 'persona-b'});
+
+				const userA = await DatabaseServer.getVirtualUser('policy-1', 'user-a');
+				const userB = await DatabaseServer.getVirtualUser('policy-1', 'user-b');
+
+				assert.equal(userA.username, 'persona-a');
+				assert.equal(userB.username, 'persona-b');
+			});
+		});
+
+		describe('setVirtualUser', function () {
+			it('updates the existing per-user pointer in place instead of touching the shared active flag', async function () {
+				const pointer = {id: 'ptr-1', did: 'did:old', userId: 'user-a'};
+				findOneStub.resolves(pointer);
+
+				await DatabaseServer.setVirtualUser('policy-1', 'did:new', 'user-a');
+
+				assert.equal(pointer.did, 'did:new');
+				assert.equal(saveStub.callCount, 1);
+				assert.strictEqual(saveStub.firstCall.args[0], pointer);
+				assert.equal(findStub.called, false);
+			});
+
+			it('creates a new per-user pointer when none exists yet', async function () {
+				findOneStub.resolves(null);
+
+				await DatabaseServer.setVirtualUser('policy-1', 'did:new', 'user-a');
+
+				assert.equal(saveStub.callCount, 1);
+				const saved = saveStub.firstCall.args[0];
+				assert.equal(saved.did, 'did:new');
+				assert.equal(saved.userId, 'user-a');
+				assert.equal(saved.dryRunClass, 'ActiveVirtualUser');
+				assert.equal(saved.dryRunId, 'policy-1');
+			});
+
+			it('falls back to the legacy shared active-flag behavior when userId is omitted', async function () {
+				const users = [
+					{did: 'did:x', active: false},
+					{did: 'did:y', active: true},
+				];
+				findStub.resolves(users);
+
+				await DatabaseServer.setVirtualUser('policy-1', 'did:x');
+
+				assert.deepEqual(findStub.firstCall.args[0], {
+					dryRunId: 'policy-1',
+					dryRunClass: 'VirtualUsers',
+				});
+				assert.equal(users[0].active, true);
+				assert.equal(users[1].active, false);
+				assert.equal(saveStub.callCount, 2);
+				assert.equal(findOneStub.called, false);
+			});
+
+			it('does not let one real user switching personas affect another real user', async function () {
+				const pointerA = {id: 'ptr-a', did: 'did:a-old', userId: 'user-a'};
+				const pointerB = {id: 'ptr-b', did: 'did:b', userId: 'user-b'};
+				findOneStub.withArgs(sinon.match({userId: 'user-a'})).resolves(pointerA);
+				findOneStub.withArgs(sinon.match({userId: 'user-b'})).resolves(pointerB);
+
+				await DatabaseServer.setVirtualUser('policy-1', 'did:a-new', 'user-a');
+
+				assert.equal(pointerA.did, 'did:a-new');
+				assert.equal(pointerB.did, 'did:b');
+			});
 		});
 	});
 });

--- a/guardian-service/src/policy-engine/policy-components-utils.ts
+++ b/guardian-service/src/policy-engine/policy-components-utils.ts
@@ -59,7 +59,7 @@ export class PolicyComponentsUtils {
             result.userGroup = null;
 
             if (PolicyHelper.isDryRunMode(policy)) {
-                const activeUser = await DatabaseServer.getVirtualUser(policyId);
+                const activeUser = await DatabaseServer.getVirtualUser(policyId, user.id);
                 if (activeUser && did !== activeUser.did) {
                     did = activeUser.did;
                     permissions = [];
@@ -126,7 +126,7 @@ export class PolicyComponentsUtils {
         let permissions = user.permissions || [];
         if (did) {
             if (PolicyHelper.isDryRunMode(policy)) {
-                const activeUser = await DatabaseServer.getVirtualUser(policyId);
+                const activeUser = await DatabaseServer.getVirtualUser(policyId, user.id);
                 if (activeUser && did !== activeUser.did) {
                     did = activeUser.did;
                     permissions = [];

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -2483,7 +2483,7 @@ export class PolicyEngineService {
                         throw new Error(`Policy is not in Dry Run`);
                     }
 
-                    await DatabaseServer.setVirtualUser(policyId, virtualDID)
+                    await DatabaseServer.setVirtualUser(policyId, virtualDID, owner?.id)
                     const users = await DatabaseServer.getVirtualUsers(policyId);
 
                     await (new GuardiansService())
@@ -2514,7 +2514,7 @@ export class PolicyEngineService {
                     await DatabaseServer.clearAllSavepointData(policyId);
 
                     const users = await DatabaseServer.getVirtualUsers(policyId);
-                    await DatabaseServer.setVirtualUser(policyId, users[0]?.did);
+                    await DatabaseServer.setVirtualUser(policyId, users[0]?.did, owner?.id);
                     const filters = await this.policyEngine.addAccessFilters({}, owner);
                     const policies = (await DatabaseServer.getListOfPolicies(filters));
                     return new MessageResponse({ policies });
@@ -4115,7 +4115,7 @@ export class PolicyEngineService {
                     await DatabaseServer.clearDryRun(policyId, false);
                     PolicyDataMigrator.clearRunCacheByPolicyId(policyId);
                     const users = await DatabaseServer.getVirtualUsers(policyId);
-                    await DatabaseServer.setVirtualUser(policyId, users[0]?.did);
+                    await DatabaseServer.setVirtualUser(policyId, users[0]?.did, owner?.id);
 
                     const options = { mode: 'test' };
                     const recordToImport = await RecordImportExport.parseZipFile(Buffer.from(zip));

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -2323,7 +2323,7 @@ export class PolicyEngineService {
                     if (!PolicyHelper.isDryRunMode(model)) {
                         throw new Error(`Policy is not in Dry Run`);
                     }
-                    const users = await DatabaseServer.getVirtualUsers(policyId, savepointIds);
+                    const users = await DatabaseServer.getVirtualUsers(policyId, savepointIds, false, false, owner?.id);
                     return new MessageResponse(users);
                 } catch (error) {
                     return new MessageError(error);
@@ -2399,7 +2399,7 @@ export class PolicyEngineService {
                             }
                         });
 
-                    const users = await DatabaseServer.getVirtualUsers(policyId, savepointIds);
+                    const users = await DatabaseServer.getVirtualUsers(policyId, savepointIds, false, false, owner?.id);
                     return new MessageResponse(users);
                 } catch (error) {
                     return new MessageError(error);
@@ -2484,7 +2484,7 @@ export class PolicyEngineService {
                     }
 
                     await DatabaseServer.setVirtualUser(policyId, virtualDID, owner?.id)
-                    const users = await DatabaseServer.getVirtualUsers(policyId);
+                    const users = await DatabaseServer.getVirtualUsers(policyId, undefined, false, false, owner?.id);
 
                     await (new GuardiansService())
                         .sendPolicyMessage(PolicyEvents.SET_VIRTUAL_USER, policyId, { did: virtualDID });

--- a/policy-service/src/policy-engine/helpers/decorators/basic-block.ts
+++ b/policy-service/src/policy-engine/helpers/decorators/basic-block.ts
@@ -663,7 +663,7 @@ export function BasicBlock<T>(options: Partial<PolicyBlockDecoratorOptions>) {
             public async allAvailableUsers(currentUser: PolicyUser, userId: string | null): Promise<Map<string, PolicyUser>> {
                 const result: Map<string, PolicyUser> = new Map<string, PolicyUser>();
                 if (this.dryRun) {
-                    const virtualUser = await PolicyComponentsUtils.GetActiveVirtualUser(this as any);
+                    const virtualUser = await PolicyComponentsUtils.GetActiveVirtualUser(this as any, userId);
                     if (virtualUser) {
                         result.set(virtualUser.did, virtualUser);
                     }

--- a/policy-service/src/policy-engine/policy-components-utils.ts
+++ b/policy-service/src/policy-engine/policy-components-utils.ts
@@ -1341,7 +1341,7 @@ export class PolicyComponentsUtils {
         let userFull: PolicyUser;
         const virtual = !!instance.dryRun;
         if (virtual) {
-            const virtualUser = await DatabaseServer.getVirtualUser(instance.policyId);
+            const virtualUser = await DatabaseServer.getVirtualUser(instance.policyId, userId);
             userFull = new VirtualUser(virtualUser || regUser, instance);
         } else {
             userFull = new PolicyUser(regUser, instance);
@@ -1435,9 +1435,10 @@ export class PolicyComponentsUtils {
     }
 
     public static async GetActiveVirtualUser(
-        instance: IPolicyInstance | AnyBlockType
+        instance: IPolicyInstance | AnyBlockType,
+        userId?: string | null
     ): Promise<PolicyUser> {
-        const virtualUser = await DatabaseServer.getVirtualUser(instance.policyId);
+        const virtualUser = await DatabaseServer.getVirtualUser(instance.policyId, userId);
         if (virtualUser) {
             const userFull = new VirtualUser(virtualUser, instance);
             const group = await instance


### PR DESCRIPTION
**Description**:

This PR scopes the active dry-run virtual user (persona) per real user instead of per policy, in order to support concurrent dry-run testing by multiple users on the same policy without them interfering with each other's selected persona.

* Add optional `userId` parameter to `DatabaseServer.getVirtualUser`/`setVirtualUser`
* When `userId` is provided, read/write a new per-real-user pointer (`dryRunClass: 'ActiveVirtualUser'`, keyed by `dryRunId` + `userId`) instead of the single shared `active` flag on `VirtualUsers`
* Fall back to the previous shared-flag behavior when `userId` is omitted (e.g. background jobs)
* Pass `user.id`/`owner?.id`/`userId` through call sites: `PolicyComponentsUtils` (guardian-service and policy-service), `PolicyEngineService` (`SET_VIRTUAL_USER`, `RESTART_DRY_RUN`, `START_POLICY_TEST` handlers), and `BasicBlock.allAvailableUsers`
* Add unit tests for `DatabaseServer.getVirtualUser`/`setVirtualUser` covering both the new per-user pointer path and the legacy shared-flag fallback

**Related issue(s)**:

Fixes #6327 

**Notes for reviewer**:

Root cause: `getVirtualUser`/`setVirtualUser` resolved the "currently active" dry-run persona keyed only by `policyId`, via a single shared `active` flag. When two or more real users opened the same policy in dry-run mode at the same time, switching persona as one user silently reassigned the acting identity for every other user viewing that policy — causing block submissions to fail with `422 Unprocessable Entity` ("Block Unavailable"), and a hard refresh could land a user on a completely different persona than the one they were using.

No schema migration needed: the `DryRun` entity already had an unused `userId` field.

Out of scope (flagging for discussion, not fixed in this PR):
* Two real users deliberately selecting the *same* persona will still share it (this reads as a product decision, not a bug).
* "Restart dry run" still clears all personas for the whole policy, affecting every concurrent tester (pre-existing, unrelated behavior).

Added unit tests in `common/tests/unit-tests/database-server/database-server.test.mjs` (new `Active virtual user pointer (dry-run)` describe block) covering:
* `getVirtualUser`/`setVirtualUser` fall back to the legacy shared `active` flag when `userId` is omitted
* `getVirtualUser` resolves the per-user pointer then the matching persona, returns `null` when no pointer exists or the pointer has no `did`, and keeps two real users on independently selected personas
* `setVirtualUser` updates an existing per-user pointer in place, creates one when none exists, and doesn't let one real user's persona switch affect another's

Verified these tests fail against the pre-fix code (6 of 9 fail without the `userId` branch) and pass with it, so they're a genuine regression guard and not vacuous. No integration test was added for two concurrent dry-run sessions end-to-end — flagging in case reviewers want that as a follow-up.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
