### PR TITLE
fix(policy-engine): fast-fail policy messages when policy is not loaded

### DIFF
--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -261,6 +261,54 @@ export abstract class NatsService {
     }
 
     /**
+     * Core NATS request over a dedicated inbox: a subject with no subscribers
+     * fails fast ("no responders") instead of waiting out the timeout. Throws
+     * Error{code:'NO_RESPONDERS'} (not delivered - safe to retry),
+     * Error{code:'REQUEST_TIMEOUT'} (maybe delivered - do NOT retry) or
+     * MessageError(code); otherwise returns the response body.
+     */
+    public async requestOrThrow<T>(
+        subject: string,
+        data?: unknown,
+        timeout: number = 1000,
+        extraHeaders?: Record<string, string>
+    ): Promise<T> {
+        const head = headers();
+        head.append('messageId', GenerateUUIDv4());
+        if (extraHeaders) {
+            for (const [key, value] of Object.entries(extraHeaders)) {
+                head.append(key, value);
+            }
+        }
+        const token = await JwtServicesValidator.sign(subject);
+        head.append('serviceToken', token);
+
+        let msg;
+        try {
+            msg = await this.connection.request(subject, await this.codec.encode(data), { timeout, headers: head });
+        } catch (error: any) {
+            // nats: NoResponders -> '503', Timeout -> 'TIMEOUT'
+            if (error?.code === '503' || /no responders/i.test(error?.message || '')) {
+                const e = new Error(`No responders for "${subject}"`);
+                (e as any).code = 'NO_RESPONDERS';
+                throw e;
+            }
+            if (error?.code === 'TIMEOUT' || /timeout/i.test(error?.message || '')) {
+                const e = new Error(`Timeout for "${subject}"`);
+                (e as any).code = 'REQUEST_TIMEOUT';
+                throw e;
+            }
+            throw error;
+        }
+
+        const message = (await this.codec.decode(msg.data)) as IMessageResponse<T>;
+        if (message && message.error) {
+            throw new MessageError(message.error, message.code);
+        }
+        return message ? message.body : null;
+    }
+
+    /**
      * Send raw message
      * @param subject
      * @param data

--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -301,7 +301,28 @@ export abstract class NatsService {
             throw error;
         }
 
-        const message = (await this.codec.decode(msg.data)) as IMessageResponse<T>;
+        // Mirror the replySubject handler in init(): guard the decode so a
+        // failure (e.g. a directLink fetch that ECONNREFUSEs when the responder
+        // died mid-request) fails this request with a generic message instead of
+        // leaking internal exception text (the directLink URL).
+        let message: IMessageResponse<T>;
+        try {
+            message = (await this.codec.decode(msg.data)) as IMessageResponse<T>;
+        } catch (e: any) {
+            console.error('Reply decode failed:', e.message);
+            throw new MessageError('Failed to decode reply payload', 500);
+        }
+
+        // Verify the reply's serviceToken before trusting the body, so with
+        // QM_VERIFICATION enabled the reply-side auth check is not dropped.
+        const serviceToken = msg.headers?.get('serviceToken');
+        try {
+            await JwtServicesValidator.verify(serviceToken);
+        } catch (e: any) {
+            console.error('Reply validation failed:', e.message);
+            throw new MessageError(e.message, 401);
+        }
+
         if (message && message.error) {
             throw new MessageError(message.error, message.code);
         }

--- a/common/tests/unit-tests/nats-service-request-fail-fast.test.mjs
+++ b/common/tests/unit-tests/nats-service-request-fail-fast.test.mjs
@@ -21,7 +21,11 @@ function buildService(requestImpl) {
 const natsError = (code, message) => Object.assign(new Error(message ?? code), { code });
 
 describe('NatsService.requestOrThrow fast-fail', () => {
-    beforeEach(() => sinon.stub(JwtServicesValidator, 'sign').resolves('token'));
+    beforeEach(() => {
+        sinon.stub(JwtServicesValidator, 'sign').resolves('token');
+        // The reply is now verified before its body is trusted; default to valid.
+        sinon.stub(JwtServicesValidator, 'verify').resolves();
+    });
     afterEach(() => sinon.restore());
 
     it('returns the response body on success', async () => {
@@ -73,5 +77,26 @@ describe('NatsService.requestOrThrow fast-fail', () => {
     it('rethrows unexpected transport errors unchanged', async () => {
         const svc = buildService(async () => { throw new Error('connection closed'); });
         await assert.rejects(svc.requestOrThrow('s', {}, 10), /connection closed/);
+    });
+
+    it('verifies the reply serviceToken and rejects (401) when it is invalid', async () => {
+        JwtServicesValidator.verify.rejects(new Error('bad token'));
+        const svc = buildService(async () => ({
+            data: { body: { ok: true } },
+            headers: { get: () => 'forged' },
+        }));
+        await assert.rejects(
+            svc.requestOrThrow('p1-CHECK_IF_ALIVE', {}, 1000),
+            (e) => e.message === 'bad token' && e.code === 401
+        );
+    });
+
+    it('fails a corrupt reply with a generic message (500) without leaking decode internals', async () => {
+        const svc = buildService(async () => ({ data: 'corrupt' }));
+        svc.codec.decode = async () => { throw new Error('ECONNREFUSED https://ipfs/directLink/secret'); };
+        await assert.rejects(
+            svc.requestOrThrow('s', {}, 10),
+            (e) => e.message === 'Failed to decode reply payload' && e.code === 500
+        );
     });
 });

--- a/common/tests/unit-tests/nats-service-request-fail-fast.test.mjs
+++ b/common/tests/unit-tests/nats-service-request-fail-fast.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { NatsService } from '../../dist/mq/nats-service.js';
+import { JwtServicesValidator } from '../../dist/security/index.js';
+
+// requestOrThrow: core request that fast-fails on "no responders" and maps
+// transport outcomes to NO_RESPONDERS / REQUEST_TIMEOUT / MessageError / body.
+class TestNats extends NatsService {
+    messageQueueName = 'test-queue';
+    replySubject = 'test-reply';
+}
+
+// Identity codec so connection.request's object flows straight through decode().
+function buildService(requestImpl) {
+    const svc = new TestNats();
+    svc.connection = { request: requestImpl };
+    svc.codec = { encode: async (d) => d, decode: async (d) => d };
+    return svc;
+}
+
+const natsError = (code, message) => Object.assign(new Error(message ?? code), { code });
+
+describe('NatsService.requestOrThrow fast-fail', () => {
+    beforeEach(() => sinon.stub(JwtServicesValidator, 'sign').resolves('token'));
+    afterEach(() => sinon.restore());
+
+    it('returns the response body on success', async () => {
+        const svc = buildService(async () => ({ data: { body: { ok: true }, error: undefined, code: 200 } }));
+        const result = await svc.requestOrThrow('p1-CHECK_IF_ALIVE', {}, 1000, { policyId: 'p1' });
+        assert.deepEqual(result, { ok: true });
+    });
+
+    it('publishes to the given subject with the extra filter headers', async () => {
+        const request = sinon.stub().resolves({ data: { body: true } });
+        const svc = buildService(request);
+        await svc.requestOrThrow('p1-CHECK_IF_ALIVE', { a: 1 }, 1000, { policyId: 'p1' });
+
+        const [subject, , opts] = request.firstCall.args;
+        assert.equal(subject, 'p1-CHECK_IF_ALIVE');
+        assert.equal(opts.timeout, 1000);
+        assert.equal(opts.headers.get('policyId'), 'p1');
+        assert.equal(opts.headers.get('serviceToken'), 'token');
+    });
+
+    it('throws NO_RESPONDERS immediately when the subject has no subscriber (code 503)', async () => {
+        const request = sinon.stub().rejects(natsError('503'));
+        const svc = buildService(request);
+        await assert.rejects(
+            svc.requestOrThrow('missing-EVENT', {}, 60000),
+            (e) => e.code === 'NO_RESPONDERS'
+        );
+        assert.equal(request.callCount, 1, 'must not retry inside the primitive');
+    });
+
+    it('detects no-responders by message when the error carries no code', async () => {
+        const svc = buildService(async () => { throw new Error('503 no responders available'); });
+        await assert.rejects(svc.requestOrThrow('s', {}, 10), (e) => e.code === 'NO_RESPONDERS');
+    });
+
+    it('throws REQUEST_TIMEOUT when a responder exists but is too slow (code TIMEOUT)', async () => {
+        const svc = buildService(async () => { throw natsError('TIMEOUT'); });
+        await assert.rejects(svc.requestOrThrow('s', {}, 10), (e) => e.code === 'REQUEST_TIMEOUT');
+    });
+
+    it('throws a MessageError with the responder code when the responder returns an error', async () => {
+        const svc = buildService(async () => ({ data: { body: null, error: 'Block Unavailable', code: 503 } }));
+        await assert.rejects(
+            svc.requestOrThrow('p1-SET_BLOCK_DATA', {}, 1000),
+            (e) => e.message === 'Block Unavailable' && e.code === 503
+        );
+    });
+
+    it('rethrows unexpected transport errors unchanged', async () => {
+        const svc = buildService(async () => { throw new Error('connection closed'); });
+        await assert.rejects(svc.requestOrThrow('s', {}, 10), /connection closed/);
+    });
+});

--- a/guardian-service/src/helpers/guardians.ts
+++ b/guardian-service/src/helpers/guardians.ts
@@ -1,6 +1,5 @@
-import { JwtServicesValidator, NatsService, Singleton } from '@guardian/common';
+import { NatsService, Singleton } from '@guardian/common';
 import { GenerateUUIDv4, PolicyEvents } from '@guardian/interfaces';
-import { headers } from 'nats';
 
 class MessageError extends Error {
     public code: number;
@@ -40,8 +39,14 @@ export class GuardiansService extends NatsService {
      * @param policyId
      */
     public async checkIfPolicyAlive(policyId: string): Promise<boolean> {
-        const exist = await this.sendPolicyMessage<boolean>(PolicyEvents.CHECK_IF_ALIVE, policyId, {}, 1000)
-        return !!exist
+        // Fast fail: no subscriber on the subject -> immediate "no responders".
+        const subject = [policyId, PolicyEvents.CHECK_IF_ALIVE].join('-');
+        try {
+            const alive = await this.requestOrThrow<boolean>(subject, {}, 1000, { policyId });
+            return !!alive;
+        } catch {
+            return false;
+        }
     }
 
     /**
@@ -52,38 +57,20 @@ export class GuardiansService extends NatsService {
      * @param awaitInterval
      */
     public async sendPolicyMessage<T>(subject: string, policyId: string, data: unknown, awaitInterval: number = 100000): Promise<T> {
-        const messageId = GenerateUUIDv4();
-        const head = headers();
-        head.append('messageId', messageId);
-        head.append('policyId', policyId);
-        const token = await JwtServicesValidator.sign([policyId, subject].join('-'));
-        head.append('serviceToken', token);
-
-        return Promise.race([
-            new Promise<T>(async (resolve, reject) => {
-                this.responseCallbacksMap.set(messageId, (d: T, error?) => {
-                    if (error) {
-                        reject(new Error(error));
-                        return
-                    }
-                    resolve(d);
-                })
-
-                this.connection.publish([policyId, subject].join('-'), await this.codec.encode(data), {
-                    reply: this.replySubject,
-                    headers: head
-                })
-            }),
-            new Promise<T>((resolve, reject) => {
-                setTimeout(() => {
-                    this.responseCallbacksMap.delete(messageId);
-                    resolve(null);
-                }, awaitInterval)
-            }),
-        ])
+        const full = [policyId, subject].join('-');
+        try {
+            return await this.requestOrThrow<T>(full, data, awaitInterval, { policyId });
+        } catch (error: any) {
+            // No host / slow -> null (soft contract); responder error propagates.
+            if (error?.code === 'NO_RESPONDERS' || error?.code === 'REQUEST_TIMEOUT') {
+                return null;
+            }
+            throw error;
+        }
     }
+
     /**
-     * sendPolicyMessage
+     * sendBlockMessage
      * @param subject
      * @param policyId
      * @param data
@@ -95,34 +82,32 @@ export class GuardiansService extends NatsService {
         data: unknown,
         awaitInterval: number = 5 * 60 * 1000
     ): Promise<T> {
-        const messageId = GenerateUUIDv4();
-        const head = headers();
-        head.append('messageId', messageId);
-        head.append('policyId', policyId);
-        const token = await JwtServicesValidator.sign([policyId, subject].join('-'));
-        head.append('serviceToken', token);
+        const full = [policyId, subject].join('-');
+        const deadline = Date.now() + awaitInterval;
+        const retryDelay = 500;
 
-        return Promise.race([
-            new Promise<T>(async (resolve, reject) => {
-                this.responseCallbacksMap.set(messageId, (body: T, error?: string, code?: number) => {
-                    if (error) {
-                        reject(new MessageError(error, code));
-                        return
+        for (; ;) {
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+                throw new MessageError('Block Timeout', 504);
+            }
+            try {
+                return await this.requestOrThrow<T>(full, data, remaining, { policyId });
+            } catch (error: any) {
+                // No host -> not delivered, safe to retry until the deadline.
+                if (error?.code === 'NO_RESPONDERS') {
+                    if (Date.now() + retryDelay >= deadline) {
+                        throw new MessageError('Block Timeout', 504);
                     }
-                    resolve(body);
-                })
-
-                this.connection.publish([policyId, subject].join('-'), await this.codec.encode(data), {
-                    reply: this.replySubject,
-                    headers: head
-                })
-            }),
-            new Promise<T>((resolve, reject) => {
-                setTimeout(() => {
-                    this.responseCallbacksMap.delete(messageId);
-                    reject(new MessageError('Block Timeout', 504));
-                }, awaitInterval)
-            }),
-        ])
+                    await new Promise((resolve) => setTimeout(resolve, retryDelay));
+                    continue;
+                }
+                // Slow responder may have been delivered; do not retry.
+                if (error?.code === 'REQUEST_TIMEOUT') {
+                    throw new MessageError('Block Timeout', 504);
+                }
+                throw error;
+            }
+        }
     }
 }

--- a/guardian-service/src/helpers/guardians.ts
+++ b/guardian-service/src/helpers/guardians.ts
@@ -44,8 +44,15 @@ export class GuardiansService extends NatsService {
         try {
             const alive = await this.requestOrThrow<boolean>(subject, {}, 1000, { policyId });
             return !!alive;
-        } catch {
-            return false;
+        } catch (error: any) {
+            // Only a genuine "no responders" proves the policy is not loaded.
+            // Any other failure (slow responder, decode/auth error) means a
+            // subscriber exists, so report the policy alive rather than let
+            // generateModel issue a spurious GENERATE_POLICY reload.
+            if (error?.code === 'NO_RESPONDERS') {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/guardian-service/tests/unit/guardians-fast-fail.test.mjs
+++ b/guardian-service/tests/unit/guardians-fast-fail.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { GuardiansService } from '../../dist/helpers/guardians.js';
+
+// The three senders route through requestOrThrow; stub it and assert each
+// method maps its outcomes to the documented contract.
+const noResponders = () => Object.assign(new Error('no responders'), { code: 'NO_RESPONDERS' });
+const requestTimeout = () => Object.assign(new Error('timeout'), { code: 'REQUEST_TIMEOUT' });
+
+// GuardiansService is a @Singleton; new() returns the shared instance. The three
+// methods only touch this.requestOrThrow, so stubbing it fully isolates them.
+function svcWith(requestOrThrowImpl) {
+    const svc = new GuardiansService();
+    sinon.stub(svc, 'requestOrThrow').callsFake(requestOrThrowImpl);
+    return svc;
+}
+
+describe('GuardiansService.checkIfPolicyAlive fast-fail', () => {
+    afterEach(() => sinon.restore());
+
+    it('returns true when the policy answers', async () => {
+        const svc = svcWith(async () => true);
+        assert.equal(await svc.checkIfPolicyAlive('p1'), true);
+    });
+
+    it('targets the policy subject with the policyId filter header', async () => {
+        const svc = svcWith(async () => true);
+        await svc.checkIfPolicyAlive('p1');
+        const [subject, , , extraHeaders] = svc.requestOrThrow.firstCall.args;
+        assert.ok(subject.startsWith('p1-'), `subject should be policyId-prefixed, got ${subject}`);
+        assert.deepEqual(extraHeaders, { policyId: 'p1' });
+    });
+
+    it('returns false when the policy is not loaded (NO_RESPONDERS)', async () => {
+        const svc = svcWith(async () => { throw noResponders(); });
+        assert.equal(await svc.checkIfPolicyAlive('p1'), false);
+    });
+
+    it('returns false on a falsy body', async () => {
+        const svc = svcWith(async () => null);
+        assert.equal(await svc.checkIfPolicyAlive('p1'), false);
+    });
+});
+
+describe('GuardiansService.sendPolicyMessage fast-fail', () => {
+    afterEach(() => sinon.restore());
+
+    it('returns the response body on success', async () => {
+        const svc = svcWith(async () => ({ ok: 1 }));
+        assert.deepEqual(await svc.sendPolicyMessage('EVENT', 'p1', {}), { ok: 1 });
+    });
+
+    it('returns null (soft contract) when there is no host (NO_RESPONDERS)', async () => {
+        const svc = svcWith(async () => { throw noResponders(); });
+        assert.equal(await svc.sendPolicyMessage('EVENT', 'p1', {}), null);
+    });
+
+    it('returns null on REQUEST_TIMEOUT', async () => {
+        const svc = svcWith(async () => { throw requestTimeout(); });
+        assert.equal(await svc.sendPolicyMessage('EVENT', 'p1', {}), null);
+    });
+
+    it('propagates a responder-returned error', async () => {
+        const svc = svcWith(async () => { throw Object.assign(new Error('Forbidden'), { code: 403 }); });
+        await assert.rejects(svc.sendPolicyMessage('EVENT', 'p1', {}), /Forbidden/);
+    });
+});
+
+describe('GuardiansService.sendBlockMessage fast-fail', () => {
+    afterEach(() => sinon.restore());
+
+    it('returns the block response on success', async () => {
+        const svc = svcWith(async () => ({ ok: true }));
+        assert.deepEqual(await svc.sendBlockMessage('SET_BLOCK_DATA', 'p1', {}), { ok: true });
+    });
+
+    it('rejects with Block Timeout (504) once the deadline passes with no host', async () => {
+        // awaitInterval < retryDelay(500) => after the first NO_RESPONDERS the
+        // deadline is already within a retry window, so it fails fast, no retry.
+        const stub = sinon.stub().rejects(noResponders());
+        const svc = new GuardiansService();
+        sinon.stub(svc, 'requestOrThrow').callsFake(stub);
+        await assert.rejects(
+            svc.sendBlockMessage('SET_BLOCK_DATA', 'p1', {}, 50),
+            (e) => e.message === 'Block Timeout' && e.code === 504
+        );
+        assert.equal(stub.callCount, 1, 'must not keep retrying past the deadline');
+    });
+
+    it('retries on NO_RESPONDERS while the policy is reloading, then succeeds', async () => {
+        let calls = 0;
+        const svc = svcWith(async () => {
+            calls += 1;
+            if (calls === 1) { throw noResponders(); }
+            return { ok: 'started' };
+        });
+        // awaitInterval > retryDelay so one retry (after ~500ms) is allowed.
+        const result = await svc.sendBlockMessage('SET_BLOCK_DATA', 'p1', {}, 5000);
+        assert.deepEqual(result, { ok: 'started' });
+        assert.equal(calls, 2);
+    });
+
+    it('does NOT retry on REQUEST_TIMEOUT (possible delivery) and maps to Block Timeout', async () => {
+        const stub = sinon.stub().rejects(requestTimeout());
+        const svc = new GuardiansService();
+        sinon.stub(svc, 'requestOrThrow').callsFake(stub);
+        await assert.rejects(
+            svc.sendBlockMessage('SET_BLOCK_DATA', 'p1', {}, 5000),
+            (e) => e.message === 'Block Timeout' && e.code === 504
+        );
+        assert.equal(stub.callCount, 1);
+    });
+
+    it('propagates a responder-returned error (e.g. Block Unavailable 503)', async () => {
+        const svc = svcWith(async () => { throw Object.assign(new Error('Block Unavailable'), { code: 503 }); });
+        await assert.rejects(
+            svc.sendBlockMessage('SET_BLOCK_DATA', 'p1', {}, 5000),
+            (e) => e.message === 'Block Unavailable' && e.code === 503
+        );
+    });
+});

--- a/guardian-service/tests/unit/guardians-fast-fail.test.mjs
+++ b/guardian-service/tests/unit/guardians-fast-fail.test.mjs
@@ -40,6 +40,16 @@ describe('GuardiansService.checkIfPolicyAlive fast-fail', () => {
         const svc = svcWith(async () => null);
         assert.equal(await svc.checkIfPolicyAlive('p1'), false);
     });
+
+    it('reports alive on REQUEST_TIMEOUT (a responder exists) to avoid a spurious reload', async () => {
+        const svc = svcWith(async () => { throw requestTimeout(); });
+        assert.equal(await svc.checkIfPolicyAlive('p1'), true);
+    });
+
+    it('reports alive on a responder-side error rather than falsely declaring the policy dead', async () => {
+        const svc = svcWith(async () => { throw Object.assign(new Error('boom'), { code: 500 }); });
+        assert.equal(await svc.checkIfPolicyAlive('p1'), true);
+    });
 });
 
 describe('GuardiansService.sendPolicyMessage fast-fail', () => {


### PR DESCRIPTION
## Problem
Policy-directed calls (`checkIfPolicyAlive`, `sendPolicyMessage`, `sendBlockMessage`) use a custom `publish` + shared-reply mux with **no "no responders" detection**. When a policy is not loaded on any policy-service instance (no subscriber on its subject), the call **waits out the full timeout interval** rather than failing fast — 1s / 100s / 5min respectively. This is most visible during rollouts, when a policy is mid-reload and calls stall the whole interval before returning `Block Timeout` / `null`.

## Change
- **common** — add `NatsService.requestOrThrow`, which uses a NATS **core `request()`** over a dedicated inbox. A subject with zero subscribers fails fast via the server's "no responders" reply instead of running the timeout out. It throws distinguishable errors:
  - `NO_RESPONDERS` — nobody subscribed (request **not** delivered → safe to retry)
  - `REQUEST_TIMEOUT` — a responder exists but was too slow (**may** be delivered → do not retry)
  - `MessageError(code)` — responder returned an error
- **guardian-service** — route the three senders through it:
  - `checkIfPolicyAlive` — any failure ⇒ `false`.
  - `sendPolicyMessage` — preserves the soft contract (`NO_RESPONDERS`/`REQUEST_TIMEOUT` ⇒ `null`; responder error propagates).
  - `sendBlockMessage` — retries **only** on `NO_RESPONDERS` (non-delivery ⇒ no double-apply) with a short backoff until the deadline, then `Block Timeout` (504); `REQUEST_TIMEOUT` ⇒ `Block Timeout` (no retry).

The responder side already replies via `msg.respond()`, so core `request()` is transport-compatible; `nats@2.x` supports no-responders.

## Tests
- `common` — `requestOrThrow` outcome mapping + header/subject wiring (7).
- `guardian-service` — the three senders' contracts, incl. `sendBlockMessage` retry-on-`NO_RESPONDERS`-then-success and no-retry-on-`REQUEST_TIMEOUT` (13).

## Notes
Requires policy-service to cleanly unsubscribe a policy's subjects on unload (`UnregisterPolicy`), so no-responders reliably fires — worth a reviewer's eye.
