### PR TITLE
perf(policy-service): parallelize bulk DID generation in customLogicBlock and reuse batch setup (#6346)

### DIFF
--- a/configs/.env..guardian.system
+++ b/configs/.env..guardian.system
@@ -92,6 +92,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/configs/.env.develop.guardian.system
+++ b/configs/.env.develop.guardian.system
@@ -92,6 +92,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/configs/.env.quickstart.guardian.system
+++ b/configs/.env.quickstart.guardian.system
@@ -113,6 +113,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/configs/.env.template.guardian.system
+++ b/configs/.env.template.guardian.system
@@ -109,6 +109,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/docs/available-policy-workflow-blocks/customlogicblock.md
+++ b/docs/available-policy-workflow-blocks/customlogicblock.md
@@ -13,3 +13,7 @@ This block supports two types of artifacts : JSON (.json) and Executable Code (.
 **JSON** :  will be added to the “artifacts” variable which is array in specific order (for example artifacts\[0] is e\_grid\_mapping json object).
 
 **Executable Code** :  will be executed before main function.
+
+## Bulk processing
+
+When the block code returns an array, the output documents are processed with bounded concurrency (10 in parallel by default). The limit is configured with the `CUSTOM_LOGIC_CONCURRENCY` environment variable (provided by the `configs/.env.*.guardian.system` templates). During policy recording or replay, processing is always sequential so that recorded UUID/DID sequences stay deterministic. If processing of one document fails, no further documents are started; documents already in flight complete before the error is reported.

--- a/policy-service/configs/.env.policy
+++ b/policy-service/configs/.env.policy
@@ -23,6 +23,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/policy-service/configs/.env.policy.develop
+++ b/policy-service/configs/.env.policy.develop
@@ -23,6 +23,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/policy-service/configs/.env.policy.template
+++ b/policy-service/configs/.env.policy.template
@@ -23,6 +23,7 @@ BBS_SIGNATURES_MODE="WASM"
 # PYTHON_SANDBOX_MODE="pyodide" # "pyodide" (default) or "docker"
 PYTHON_SANDBOX_TIMEOUT_MS="120000" # Custom Logic block Python execution timeout (default 120000)
 DRY_RUN_BLOCK_TIMEOUT_MS="180000" # Policy Editor 'Test' dialog overall timeout (default 180000)
+CUSTOM_LOGIC_CONCURRENCY="10" # Custom Logic block: max concurrent output-document processing for array results (default 10; forced to 1 during policy recording/replay)
 # Sandbox-mode resource cap (only used when PYTHON_SANDBOX_MODE="pyodide", the default; ignored in docker mode):
 # PYTHON_SANDBOX_HEAP_MB="512" # Pyodide worker heap cap in MB (default 512)
 # Docker-mode resource caps (only used when PYTHON_SANDBOX_MODE="docker"):

--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -13,6 +13,7 @@ import { PolicyUtils } from '../helpers/utils.js';
 import { ExternalDocuments, ExternalEvent, ExternalEventType } from '../interfaces/external-event.js';
 import { fileURLToPath } from 'node:url';
 import { PolicyActionsUtils } from '../policy-actions/utils.js';
+import { IGenerateDidBatch } from '../policy-actions/generate-did.js';
 import { BlockActionError } from '../errors/index.js';
 import { collectTablesPack, hydrateTablesInObject, loadFileTextById } from '../helpers/table-field.js';
 import { RecordActionStep } from '../record-action-step.js';
@@ -219,6 +220,7 @@ export class CustomLogicBlock {
                     }
                     metadata = await this.aggregateMetadata(documents, user, ref, userId);
                 }
+                const didBatch: IGenerateDidBatch = {};
                 const done = async (result: any | any[], final: boolean) => {
                     if (!result) {
                         await triggerEvents(null);
@@ -240,14 +242,11 @@ export class CustomLogicBlock {
                         if (options.unsigned) {
                             return await this.createUnsignedDocument(json, ref, actionStatus?.id);
                         } else {
-                            return await this.createDocument(json, metadata, ref, userId, actionStatus?.id, user);
+                            return await this.createDocument(json, metadata, ref, userId, actionStatus?.id, user, didBatch);
                         }
                     }
                     if (Array.isArray(result)) {
-                        const items: IPolicyDocument[] = [];
-                        for (const r of result) {
-                            items.push(await processing(r))
-                        }
+                        const items = await this.processItems(result, processing, ref);
                         await triggerEvents(items);
                         if (final) {
                             try {
@@ -490,6 +489,39 @@ export class CustomLogicBlock {
     }
 
     /**
+     * Process result items with bounded concurrency
+     * @param items
+     * @param task
+     * @param ref
+     */
+    private async processItems(
+        items: any[],
+        task: (json: any) => Promise<IPolicyDocument>,
+        ref: IPolicyCalculateBlock
+    ): Promise<IPolicyDocument[]> {
+        // Recording and replay consume UUID/DID sequences in order, so they require sequential processing.
+        let limit = 1;
+        if (!ref.components.runAndRecordController) {
+            const configured = parseInt(process.env.CUSTOM_LOGIC_CONCURRENCY, 10);
+            limit = Number.isFinite(configured) && configured > 0 ? configured : 10;
+        }
+        limit = Math.min(limit, items.length);
+        const results = new Array<IPolicyDocument>(items.length);
+        let index = 0;
+        const workers: Promise<void>[] = [];
+        for (let i = 0; i < limit; i++) {
+            workers.push((async () => {
+                while (index < items.length) {
+                    const current = index++;
+                    results[current] = await task(items[current]);
+                }
+            })());
+        }
+        await Promise.all(workers);
+        return results;
+    }
+
+    /**
      * Generate document metadata
      * @param documents
      * @param user
@@ -576,7 +608,8 @@ export class CustomLogicBlock {
         ref: IPolicyCalculateBlock,
         userId: string | null,
         actionStatusId: string,
-        user?: PolicyUser
+        user?: PolicyUser,
+        didBatch?: IGenerateDidBatch
     ): Promise<IPolicyDocument> {
         const {
             owner,
@@ -623,7 +656,7 @@ export class CustomLogicBlock {
             user: owner,
             relayerAccount,
             userId
-        }, actionStatusId);
+        }, actionStatusId, didBatch);
         if (newId) {
             vcSubject.id = newId;
         }

--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -508,16 +508,26 @@ export class CustomLogicBlock {
         limit = Math.min(limit, items.length);
         const results = new Array<IPolicyDocument>(items.length);
         let index = 0;
+        let failed = false;
         const workers: Promise<void>[] = [];
         for (let i = 0; i < limit; i++) {
             workers.push((async () => {
-                while (index < items.length) {
+                while (!failed && index < items.length) {
                     const current = index++;
-                    results[current] = await task(items[current]);
+                    try {
+                        results[current] = await task(items[current]);
+                    } catch (error) {
+                        failed = true;
+                        throw error;
+                    }
                 }
             })());
         }
-        await Promise.all(workers);
+        const settled = await Promise.allSettled(workers);
+        const failure = settled.find((s) => s.status === 'rejected');
+        if (failure) {
+            throw (failure as PromiseRejectedResult).reason;
+        }
         return results;
     }
 

--- a/policy-service/src/policy-engine/policy-actions/generate-did.ts
+++ b/policy-service/src/policy-engine/policy-actions/generate-did.ts
@@ -1,10 +1,16 @@
-import { DIDMessage, HederaDidDocument, MessageServer, MessageAction, PolicyAction } from '@guardian/common';
+import { DIDMessage, HederaDidDocument, MessageServer, MessageAction, PolicyAction, TopicConfig } from '@guardian/common';
 import { GenerateUUIDv4 } from '@guardian/interfaces';
 import { PolicyUtils } from '../helpers/utils.js';
 import { PolicyComponentsUtils } from './../policy-components-utils.js';
 import { AnyBlockType } from '../policy-engine.interface.js';
-import { PolicyUser } from '../policy-user.js';
+import { PolicyUser, UserCredentials } from '../policy-user.js';
 import { PolicyActionType } from './policy-action.type.js';
+
+export interface IGenerateDidBatch {
+    topic?: Promise<TopicConfig>;
+    userCred?: Promise<UserCredentials>;
+    client?: Promise<MessageServer>;
+}
 
 export class GenerateDID {
     public static async local(options: {
@@ -12,19 +18,32 @@ export class GenerateDID {
         user: PolicyUser,
         relayerAccount: string,
         userId: string | null
-    }, actionStatusId?: string): Promise<string> {
+    }, actionStatusId?: string, batch?: IGenerateDidBatch): Promise<string> {
         const { ref, user, relayerAccount, userId } = options;
-        const topic = await PolicyUtils.getOrCreateTopic(ref, 'root', null, null, userId);
-        const userCred = await PolicyUtils.getUserCredentials(ref, user.did, userId);
-        const userHederaCred = await userCred.loadHederaCredentials(ref, userId);
-        const userRelayerAccount = await userCred.loadRelayerAccount(ref, relayerAccount, userId);
-        const client = new MessageServer({
-            operatorId: userRelayerAccount.hederaAccountId,
-            operatorKey: userRelayerAccount.hederaAccountKey,
-            signOptions: userRelayerAccount.signOptions,
-            encryptKey: userHederaCred.hederaAccountKey,
-            dryRun: ref.dryRun
-        });
+        const context: IGenerateDidBatch = batch || {};
+        if (!context.topic) {
+            context.topic = PolicyUtils.getOrCreateTopic(ref, 'root', null, null, userId);
+        }
+        if (!context.userCred) {
+            context.userCred = PolicyUtils.getUserCredentials(ref, user.did, userId);
+        }
+        if (!context.client) {
+            context.client = (async () => {
+                const cred = await context.userCred;
+                const userHederaCred = await cred.loadHederaCredentials(ref, userId);
+                const userRelayerAccount = await cred.loadRelayerAccount(ref, relayerAccount, userId);
+                return new MessageServer({
+                    operatorId: userRelayerAccount.hederaAccountId,
+                    operatorKey: userRelayerAccount.hederaAccountKey,
+                    signOptions: userRelayerAccount.signOptions,
+                    encryptKey: userHederaCred.hederaAccountKey,
+                    dryRun: ref.dryRun
+                });
+            })();
+        }
+        const topic = await context.topic;
+        const userCred = await context.userCred;
+        const client = await context.client;
 
         const didObject = await ref.components.generateDID(topic.topicId, actionStatusId);
         const message = new DIDMessage(MessageAction.CreateDID);

--- a/policy-service/src/policy-engine/policy-actions/utils.ts
+++ b/policy-service/src/policy-engine/policy-actions/utils.ts
@@ -6,7 +6,7 @@ import { PolicyComponentsUtils } from '../policy-components-utils.js';
 import { PolicyUser } from '../policy-user.js';
 import { BlockActionError } from '../errors/index.js';
 import { SignAndSendRole } from './sign-and-send-role.js';
-import { GenerateDID } from './generate-did.js';
+import { GenerateDID, IGenerateDidBatch } from './generate-did.js';
 import { SignVC } from './sign-vc.js';
 import { PolicyActionType } from './policy-action.type.js';
 import { SendMessage } from './send-message.js';
@@ -209,7 +209,7 @@ export class PolicyActionsUtils {
         user: PolicyUser,
         relayerAccount: string,
         userId: string | null
-    }, actionStatusId?: string): Promise<string> {
+    }, actionStatusId?: string, batch?: IGenerateDidBatch): Promise<string> {
         const { ref, type, user, userId } = options;
         try {
             if (type === 'UUID') {
@@ -224,7 +224,7 @@ export class PolicyActionsUtils {
             if (type === 'DID') {
                 const userCred = await PolicyUtils.getUserCredentials(ref, user.did, userId);
                 if (userCred.location === LocationType.LOCAL) {
-                    return await GenerateDID.local(options, actionStatusId);
+                    return await GenerateDID.local(options, actionStatusId, batch);
                 } else {
                     const data = await GenerateDID.request(options);
                     return new Promise((resolve, reject) => {

--- a/policy-service/tests/unit-tests/blocks/custom-logic-bulk-did.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/custom-logic-bulk-did.test.mjs
@@ -1,0 +1,342 @@
+import assert from 'node:assert/strict';
+import { makeUser, restoreHarness } from './_block-exec-harness.mjs';
+import { CustomLogicBlock } from '../../../dist/policy-engine/blocks/custom-logic-block.js';
+import { GenerateDID } from '../../../dist/policy-engine/policy-actions/generate-did.js';
+import { PolicyActionsUtils } from '../../../dist/policy-engine/policy-actions/utils.js';
+import { PolicyUtils } from '../../../dist/policy-engine/helpers/utils.js';
+import { MessageServer } from '@guardian/common';
+import { LocationType } from '@guardian/interfaces';
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+describe('@unit customLogicBlock bulk processing (#6346)', () => {
+    const processItems = (items, task, ref = { components: {} }) =>
+        CustomLogicBlock.prototype.processItems(items, task, ref);
+
+    let envBackup;
+
+    beforeEach(() => {
+        envBackup = process.env.CUSTOM_LOGIC_CONCURRENCY;
+        delete process.env.CUSTOM_LOGIC_CONCURRENCY;
+    });
+
+    afterEach(() => {
+        if (envBackup === undefined) {
+            delete process.env.CUSTOM_LOGIC_CONCURRENCY;
+        } else {
+            process.env.CUSTOM_LOGIC_CONCURRENCY = envBackup;
+        }
+    });
+
+    after(() => restoreHarness());
+
+    function trackedTasks(count) {
+        const gates = [];
+        const started = [];
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const task = async (json) => {
+            started.push(json.i);
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            const gate = deferred();
+            gates.push(gate);
+            await gate.promise;
+            inFlight--;
+            return { processed: json.i };
+        };
+        const items = Array.from({ length: count }, (_, i) => ({ i }));
+        return {
+            items,
+            task,
+            started,
+            gates,
+            maxInFlight: () => maxInFlight,
+            releaseAll: async () => {
+                while (gates.some((g) => g)) {
+                    for (let i = 0; i < gates.length; i++) {
+                        if (gates[i]) {
+                            gates[i].resolve();
+                            gates[i] = null;
+                        }
+                    }
+                    await flush();
+                }
+            },
+        };
+    }
+
+    it('preserves input order in the results regardless of completion order', async () => {
+        const t = trackedTasks(5);
+        const pending = processItems(t.items, t.task);
+        await flush();
+        for (let i = t.gates.length - 1; i >= 0; i--) {
+            t.gates[i].resolve();
+            t.gates[i] = null;
+            await flush();
+        }
+        const results = await pending;
+        assert.deepEqual(results.map((r) => r.processed), [0, 1, 2, 3, 4]);
+    });
+
+    it('runs at most 10 items concurrently by default', async () => {
+        const t = trackedTasks(25);
+        const pending = processItems(t.items, t.task);
+        await flush();
+        assert.equal(t.started.length, 10, 'only the first 10 items start immediately');
+        await t.releaseAll();
+        const results = await pending;
+        assert.equal(results.length, 25);
+        assert.equal(t.maxInFlight(), 10);
+    });
+
+    it('honours CUSTOM_LOGIC_CONCURRENCY', async () => {
+        process.env.CUSTOM_LOGIC_CONCURRENCY = '3';
+        const t = trackedTasks(9);
+        const pending = processItems(t.items, t.task);
+        await flush();
+        assert.equal(t.started.length, 3);
+        await t.releaseAll();
+        await pending;
+        assert.equal(t.maxInFlight(), 3);
+    });
+
+    it('falls back to the default limit when CUSTOM_LOGIC_CONCURRENCY is invalid', async () => {
+        for (const bad of ['0', '-2', 'abc']) {
+            process.env.CUSTOM_LOGIC_CONCURRENCY = bad;
+            const t = trackedTasks(12);
+            const pending = processItems(t.items, t.task);
+            await flush();
+            assert.equal(t.started.length, 10, `invalid value "${bad}" falls back to 10`);
+            await t.releaseAll();
+            await pending;
+        }
+    });
+
+    it('processes sequentially and in order while recording or replaying', async () => {
+        process.env.CUSTOM_LOGIC_CONCURRENCY = '10';
+        const t = trackedTasks(6);
+        const ref = { components: { runAndRecordController: {} } };
+        const pending = processItems(t.items, t.task, ref);
+        for (let i = 0; i < 6; i++) {
+            await flush();
+            t.gates[i].resolve();
+            t.gates[i] = null;
+        }
+        const results = await pending;
+        assert.equal(t.maxInFlight(), 1, 'no overlap under record/replay');
+        assert.deepEqual(t.started, [0, 1, 2, 3, 4, 5], 'items start strictly in order');
+        assert.deepEqual(results.map((r) => r.processed), [0, 1, 2, 3, 4, 5]);
+    });
+
+    it('rejects when any item fails', async () => {
+        const items = [{ i: 0 }, { i: 1 }, { i: 2 }];
+        const task = async (json) => {
+            if (json.i === 1) {
+                throw new Error('boom on item 1');
+            }
+            return json;
+        };
+        await assert.rejects(() => processItems(items, task), /boom on item 1/);
+    });
+});
+
+describe('@unit GenerateDID.local batch reuse (#6346)', () => {
+    const origGetOrCreateTopic = PolicyUtils.getOrCreateTopic;
+    const origGetUserCredentials = PolicyUtils.getUserCredentials;
+    const origSendMessage = MessageServer.prototype.sendMessage;
+
+    let calls;
+    let userCred;
+    let ref;
+    let user;
+
+    beforeEach(() => {
+        calls = {
+            getOrCreateTopic: 0,
+            getUserCredentials: 0,
+            loadHederaCredentials: 0,
+            loadRelayerAccount: 0,
+            sendMessage: 0,
+            generateDID: 0,
+            saveSubDidDocument: 0,
+        };
+        userCred = {
+            location: LocationType.LOCAL,
+            loadHederaCredentials: async () => {
+                calls.loadHederaCredentials++;
+                return { hederaAccountId: '0.0.2', hederaAccountKey: 'op-key' };
+            },
+            loadRelayerAccount: async () => {
+                calls.loadRelayerAccount++;
+                return { hederaAccountId: '0.0.2', hederaAccountKey: 'op-key', signOptions: {} };
+            },
+            saveSubDidDocument: async () => {
+                calls.saveSubDidDocument++;
+            },
+        };
+        PolicyUtils.getOrCreateTopic = async () => {
+            calls.getOrCreateTopic++;
+            return { topicId: '0.0.111', submitKey: null };
+        };
+        PolicyUtils.getUserCredentials = async () => {
+            calls.getUserCredentials++;
+            return userCred;
+        };
+        MessageServer.prototype.sendMessage = async function () {
+            calls.sendMessage++;
+            return { getId: () => `msg-${calls.sendMessage}`, getTopicId: () => '0.0.111' };
+        };
+        let didSeq = 0;
+        ref = {
+            policyId: 'policy-1',
+            tag: 'tag-1',
+            dryRun: null,
+            mockId: null,
+            components: {
+                generateDID: async () => {
+                    calls.generateDID++;
+                    const seq = ++didSeq;
+                    return {
+                        getDid: () => `did:hedera:testnet:device-${seq}`,
+                        getDocument: () => ({ id: `did:hedera:testnet:device-${seq}` }),
+                    };
+                },
+            },
+        };
+        user = makeUser({ did: 'did:owner', group: null });
+    });
+
+    afterEach(() => {
+        PolicyUtils.getOrCreateTopic = origGetOrCreateTopic;
+        PolicyUtils.getUserCredentials = origGetUserCredentials;
+        MessageServer.prototype.sendMessage = origSendMessage;
+    });
+
+    const options = () => ({ ref, user, relayerAccount: null, userId: null });
+
+    it('resolves topic, credentials and client once for a shared batch (sequential calls)', async () => {
+        const batch = {};
+        const dids = [];
+        for (let i = 0; i < 3; i++) {
+            dids.push(await GenerateDID.local(options(), undefined, batch));
+        }
+        assert.equal(new Set(dids).size, 3, 'every device gets a distinct DID');
+        assert.equal(calls.getOrCreateTopic, 1);
+        assert.equal(calls.getUserCredentials, 1);
+        assert.equal(calls.loadHederaCredentials, 1);
+        assert.equal(calls.loadRelayerAccount, 1);
+        assert.equal(calls.generateDID, 3);
+        assert.equal(calls.sendMessage, 3);
+        assert.equal(calls.saveSubDidDocument, 3);
+    });
+
+    it('resolves the shared setup once under concurrent calls (no duplicate in-flight setup)', async () => {
+        const batch = {};
+        const dids = await Promise.all([
+            GenerateDID.local(options(), undefined, batch),
+            GenerateDID.local(options(), undefined, batch),
+            GenerateDID.local(options(), undefined, batch),
+            GenerateDID.local(options(), undefined, batch),
+        ]);
+        assert.equal(new Set(dids).size, 4);
+        assert.equal(calls.getOrCreateTopic, 1);
+        assert.equal(calls.getUserCredentials, 1);
+        assert.equal(calls.loadHederaCredentials, 1);
+        assert.equal(calls.loadRelayerAccount, 1);
+        assert.equal(calls.sendMessage, 4);
+    });
+
+    it('keeps per-call setup when no batch is provided (back-compat)', async () => {
+        await GenerateDID.local(options());
+        await GenerateDID.local(options());
+        assert.equal(calls.getOrCreateTopic, 2);
+        assert.equal(calls.getUserCredentials, 2);
+        assert.equal(calls.loadHederaCredentials, 2);
+        assert.equal(calls.loadRelayerAccount, 2);
+        assert.equal(calls.sendMessage, 2);
+    });
+
+    it('uses a pre-seeded batch context without re-resolving anything', async () => {
+        const client = new MessageServer({
+            operatorId: '0.0.2',
+            operatorKey: 'op-key',
+            encryptKey: 'op-key',
+            signOptions: {},
+            dryRun: null,
+        });
+        const batch = {
+            topic: Promise.resolve({ topicId: '0.0.111', submitKey: null }),
+            userCred: Promise.resolve(userCred),
+            client: Promise.resolve(client),
+        };
+        const did = await GenerateDID.local(options(), undefined, batch);
+        assert.match(did, /^did:hedera:testnet:device-/);
+        assert.equal(calls.getOrCreateTopic, 0);
+        assert.equal(calls.getUserCredentials, 0);
+        assert.equal(calls.loadHederaCredentials, 0);
+        assert.equal(calls.loadRelayerAccount, 0);
+        assert.equal(calls.sendMessage, 1);
+    });
+});
+
+describe('@unit PolicyActionsUtils.generateId batch threading (#6346)', () => {
+    const origLocal = GenerateDID.local;
+    const origGetUserCredentials = PolicyUtils.getUserCredentials;
+
+    afterEach(() => {
+        GenerateDID.local = origLocal;
+        PolicyUtils.getUserCredentials = origGetUserCredentials;
+    });
+
+    it('passes the batch through to GenerateDID.local for DID ids', async () => {
+        let receivedBatch;
+        let receivedActionStatusId;
+        GenerateDID.local = async (opts, actionStatusId, batch) => {
+            receivedActionStatusId = actionStatusId;
+            receivedBatch = batch;
+            return 'did:hedera:testnet:generated';
+        };
+        PolicyUtils.getUserCredentials = async () => ({ location: LocationType.LOCAL });
+        const batch = {};
+        const ref = { policyId: 'policy-1', components: {}, error: () => {} };
+        const id = await PolicyActionsUtils.generateId({
+            ref,
+            type: 'DID',
+            user: makeUser(),
+            relayerAccount: null,
+            userId: null,
+        }, 'action-1', batch);
+        assert.equal(id, 'did:hedera:testnet:generated');
+        assert.equal(receivedActionStatusId, 'action-1');
+        assert.equal(receivedBatch, batch, 'the exact batch object reaches GenerateDID.local');
+    });
+
+    it('ignores the batch for UUID ids', async () => {
+        let generateUUIDCalls = 0;
+        const ref = {
+            components: {
+                generateUUID: async () => {
+                    generateUUIDCalls++;
+                    return 'uuid-1';
+                },
+            },
+        };
+        const id = await PolicyActionsUtils.generateId({
+            ref,
+            type: 'UUID',
+            user: makeUser(),
+            relayerAccount: null,
+            userId: null,
+        }, 'action-1', {});
+        assert.equal(id, 'uuid-1');
+        assert.equal(generateUUIDCalls, 1);
+    });
+});

--- a/policy-service/tests/unit-tests/blocks/custom-logic-bulk-did.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/custom-logic-bulk-did.test.mjs
@@ -146,6 +146,43 @@ describe('@unit customLogicBlock bulk processing (#6346)', () => {
         };
         await assert.rejects(() => processItems(items, task), /boom on item 1/);
     });
+
+    it('stops scheduling new items after a failure', async () => {
+        process.env.CUSTOM_LOGIC_CONCURRENCY = '2';
+        const started = [];
+        const gates = new Map();
+        const task = (json) => new Promise((resolve, reject) => {
+            started.push(json.i);
+            gates.set(json.i, { resolve: () => resolve(json), reject });
+        });
+        const items = Array.from({ length: 6 }, (_, i) => ({ i }));
+        const pending = processItems(items, task);
+        await flush();
+        assert.deepEqual(started, [0, 1], 'two items in flight');
+        gates.get(0).reject(new Error('boom on item 0'));
+        await flush();
+        gates.get(1).resolve();
+        await assert.rejects(() => pending, /boom on item 0/);
+        assert.deepEqual(started, [0, 1], 'no new items start after the failure');
+    });
+
+    it('awaits in-flight items before rejecting', async () => {
+        process.env.CUSTOM_LOGIC_CONCURRENCY = '2';
+        const gates = new Map();
+        const task = (json) => new Promise((resolve, reject) => {
+            gates.set(json.i, { resolve: () => resolve(json), reject });
+        });
+        const items = Array.from({ length: 4 }, (_, i) => ({ i }));
+        let settled = false;
+        const pending = processItems(items, task);
+        pending.catch(() => { settled = true; });
+        await flush();
+        gates.get(0).reject(new Error('boom on item 0'));
+        await flush();
+        assert.equal(settled, false, 'pool keeps waiting for the in-flight item');
+        gates.get(1).resolve();
+        await assert.rejects(() => pending, /boom on item 0/);
+    });
 });
 
 describe('@unit GenerateDID.local batch reuse (#6346)', () => {


### PR DESCRIPTION
Fixes #6346

## Problem

When a `customLogicBlock` returns an array of documents with **Document Id Type = DID**, the engine processes them strictly sequentially and repeats invariant setup (root topic fetch, credential loading, `MessageServer` construction) for every item. Each item then pays an IPFS upload + a Hedera consensus wait in series. Registering a few hundred devices this way takes hours; the target use case (metered-device MRV) needs tens of thousands.

## Changes

**`custom-logic-block.ts`** — replaces the serial `for … await` loop over array results with `processItems()`, a bounded-concurrency pool:
- default 10 in flight, tunable via `CUSTOM_LOGIC_CONCURRENCY`
- falls back to strictly sequential, in-order processing when a recording/replay controller is active (`ref.components.runAndRecordController`) — record/replay consume UUID/DID sequences positionally, so concurrent generation would break deterministic replay
- result order matches input order
- on the first failure no further items are scheduled; items already in flight complete (awaited via `Promise.allSettled`) before the first error is rethrown, so no side effects continue in the background after rejection. Note this differs from the old serial loop, which never started items after the failed one — with concurrency, up to `limit - 1` already-started items may still complete.

**`policy-actions/generate-did.ts`** — `GenerateDID.local()` accepts an optional `IGenerateDidBatch` context holding promise-memoized batch invariants (root topic, user credentials, `MessageServer`). Concurrent callers share the in-flight promise, so setup is resolved once per batch instead of once per item. Without a batch the behavior is unchanged.

**`policy-actions/utils.ts`** — `generateId()` threads the batch through to `GenerateDID.local` on the LOCAL path only. The remote request/response path and the other `generateId` callers (`request-vc-document-block`, `request-vc-document-block-addon`) are untouched.

## Safety

- Hedera has no per-account nonce ordering — each transaction carries its own transactionId/valid-start, so concurrent submits from one operator account are safe.
- Shared `MessageServer` under concurrency: the constructor is pure field assignment and `setTopicObject` always re-sets the same root topic; `sendMessage` holds no per-call instance state.
- Produced artifacts are unchanged: one DID message + one signed VC per item.
- Record/replay determinism is preserved via the sequential fallback.

## Tests

New `policy-service/tests/unit-tests/blocks/custom-logic-bulk-did.test.mjs` (14 cases, all passing):
- pool: order preservation under out-of-order completion, default cap of 10 verified via in-flight tracking, `CUSTOM_LOGIC_CONCURRENCY` override, invalid-value fallback, sequential + in-order under record/replay, rejection propagation, no new items scheduled after a failure, in-flight items awaited before rejection
- batch reuse: setup resolved exactly once across sequential and concurrent calls, distinct DIDs per item, per-call setup preserved without a batch, pre-seeded context honored
- threading: batch object identity reaches `GenerateDID.local` for DID ids; UUID path ignores it
