### PR TITLE
chore: Dependabot patterns update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,8 @@ updates:
       micro-orm:
         patterns:
           - "@mikro-orm/*"
+          - "mongodb"
+      langchain:
+        patterns:
+          - "langchain"
+          - "@langchain/*"


### PR DESCRIPTION
Update `.github/dependabot.yml` to include `mongodb` in the mikro-orm patterns so Dependabot tracks MongoDB packages, and add a new `langchain` entry with patterns `langchain` and `@langchain/*` to enable Dependabot updates for LangChain-related packages.