### PR TITLE
test(e2e): drop dead waits in account setup

### DIFF
--- a/e2e-tests/cypress/e2e/api-tests/000_accounts_creating/create_accounts.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/000_accounts_creating/create_accounts.cy.js
@@ -51,121 +51,72 @@ context("Prepare accounts for future tests", { tags: ['preparing', 'smoke', 'all
             });
     });
 
-    //If SR doesn't have hedera credentials, creating them
-    it("Generate hedera credentials for SR, if there're no creds", () => {
-        Authorization.getAccessToken(SRUsername).then((authorization) => {
+    // Set hedera credentials for a Standard Registry, if there're no creds
+    const generateSRCredentials = (username) => {
+        Authorization.getAccessToken(username).then((authorization) => {
             cy.request({
                 method: METHOD.GET,
-                url: API.ApiServer + "profiles/" + SRUsername,
+                url: API.ApiServer + "profiles/" + username,
                 headers: {
                     authorization,
                 },
             }).then((response) => {
-                if (!response.body.confirmed) {
-                    cy.request({
-                        method: METHOD.GET,
-                        url: API.ApiServer + API.RandomKey,
-                        headers: { authorization },
-                        timeout: 600000
-                    }).then((response) => {
-                        cy.wait(3000)
-                        let hederaAccountId = response.body.id
-                        let hederaAccountKey = response.body.key
-                        cy.request({
-                            method: METHOD.PUT,
-                            url: API.ApiServer + "profiles/" + SRUsername,
-                            headers: {
-                                authorization,
-                            },
-                            body: {
-                                didDocument: null,
-                                useFireblocksSigning: false,
-                                fireblocksConfig:
-                                {
-                                    fireBlocksVaultId: "",
-                                    fireBlocksAssetId: "",
-                                    fireBlocksApiKey: "",
-                                    fireBlocksPrivateiKey: ""
-                                },
-                                didKeys: [],
-                                hederaAccountId: hederaAccountId,
-                                hederaAccountKey: hederaAccountKey,
-                                vcDocument: {
-                                    geography: "testGeography",
-                                    law: "testLaw",
-                                    tags: "testTags",
-                                    type: "StandardRegistry",
-                                    "@context": [],
-                                },
-                            },
-                            timeout: 400000,
-                        }).then(() => {
-                            cy.log("hedera credentials was created");
-                        });
-                    })
-                } else {
+                if (response.body.confirmed) {
                     cy.log("User has hedera credentials");
+                    return;
                 }
+                cy.request({
+                    method: METHOD.GET,
+                    url: API.ApiServer + API.RandomKey,
+                    headers: { authorization },
+                    timeout: 600000
+                }).then((response) => {
+                    let hederaAccountId = response.body.id
+                    let hederaAccountKey = response.body.key
+                    cy.request({
+                        method: METHOD.PUT,
+                        url: API.ApiServer + "profiles/" + username,
+                        headers: {
+                            authorization,
+                        },
+                        body: {
+                            didDocument: null,
+                            useFireblocksSigning: false,
+                            fireblocksConfig:
+                            {
+                                fireBlocksVaultId: "",
+                                fireBlocksAssetId: "",
+                                fireBlocksApiKey: "",
+                                fireBlocksPrivateiKey: ""
+                            },
+                            didKeys: [],
+                            hederaAccountId: hederaAccountId,
+                            hederaAccountKey: hederaAccountKey,
+                            vcDocument: {
+                                geography: "testGeography",
+                                law: "testLaw",
+                                tags: "testTags",
+                                type: "StandardRegistry",
+                                "@context": [],
+                            },
+                        },
+                        timeout: 400000,
+                    }).then(() => {
+                        cy.log("hedera credentials was created");
+                    });
+                })
             });
         })
+    };
+
+    //If SR doesn't have hedera credentials, creating them
+    it("Generate hedera credentials for SR, if there're no creds", () => {
+        generateSRCredentials(SRUsername);
     });
 
     //If SR2 doesn't have hedera credentials, creating them
     it("Generate hedera credentials for SR2, if there're no creds", () => {
-        Authorization.getAccessToken(SR2Username).then((authorization) => {
-            cy.request({
-                method: METHOD.GET,
-                url: API.ApiServer + "profiles/" + SR2Username,
-                headers: {
-                    authorization,
-                },
-            }).then((response) => {
-                if (!response.body.confirmed) {
-                    cy.request({
-                        method: METHOD.GET,
-                        url: API.ApiServer + API.RandomKey,
-                        headers: { authorization },
-                    }).then((response) => {
-                        cy.wait(3000)
-                        let hederaAccountId = response.body.id
-                        let hederaAccountKey = response.body.key
-                        cy.request({
-                            method: METHOD.PUT,
-                            url: API.ApiServer + "profiles/" + SR2Username,
-                            headers: {
-                                authorization,
-                            },
-                            body: {
-                                didDocument: null,
-                                useFireblocksSigning: false,
-                                fireblocksConfig:
-                                {
-                                    fireBlocksVaultId: "",
-                                    fireBlocksAssetId: "",
-                                    fireBlocksApiKey: "",
-                                    fireBlocksPrivateiKey: ""
-                                },
-                                didKeys: [],
-                                hederaAccountId: hederaAccountId,
-                                hederaAccountKey: hederaAccountKey,
-                                vcDocument: {
-                                    geography: "testGeography",
-                                    law: "testLaw",
-                                    tags: "testTags",
-                                    type: "StandardRegistry",
-                                    "@context": [],
-                                },
-                            },
-                            timeout: 400000,
-                        }).then(() => {
-                            cy.log("hedera credentials was created");
-                        });
-                    })
-                } else {
-                    cy.log("User has hedera credentials");
-                }
-            });
-        })
+        generateSRCredentials(SR2Username);
     });
 
     //If User doesn't have hedera credentials, creating them
@@ -194,8 +145,8 @@ context("Prepare accounts for future tests", { tags: ['preparing', 'smoke', 'all
                             method: METHOD.GET,
                             url: API.ApiServer + API.RandomKey,
                             headers: { authorization },
+                            timeout: 600000
                         }).then((response) => {
-                            cy.wait(3000)
                             let hederaAccountId = response.body.id
                             let hederaAccountKey = response.body.key
                             cy.request({

--- a/e2e-tests/cypress/e2e/api-tests/005_profiles/setCredsAndLinkToSRByInstaller.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/005_profiles/setCredsAndLinkToSRByInstaller.cy.js
@@ -20,11 +20,10 @@ context('Profiles', { tags: ['profiles', 'thirdPool', 'all'] }, () => {
                     method: METHOD.GET,
                     url: API.ApiServer + API.RandomKey,
                     headers: { authorization },
+                    timeout: 600000
                 }).then((response) => {
-                    cy.wait(3000)
                     let hederaAccountId = response.body.id
                     let hederaAccountKey = response.body.key
-                    cy.wait(3000)
                     cy.request({
                         method: 'PUT',
                         url: API.ApiServer + 'profiles/' + Installer,

--- a/e2e-tests/cypress/e2e/api-tests/009_policies/VM033.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/009_policies/VM033.cy.js
@@ -25,8 +25,8 @@ context("Policies", { tags: ['policies', 'secondPool', 'VM0033'] }, () => {
                     method: METHOD.GET,
                     url: API.ApiServer + API.RandomKey,
                     headers: { authorization },
+                    timeout: 600000
                 }).then((response) => {
-                    cy.wait(3000)
                     cy.request({
                         method: METHOD.PUT,
                         url: API.ApiServer + "profiles/" + PPUser,
@@ -55,8 +55,8 @@ context("Policies", { tags: ['policies', 'secondPool', 'VM0033'] }, () => {
                     method: METHOD.GET,
                     url: API.ApiServer + API.RandomKey,
                     headers: { authorization },
+                    timeout: 600000
                 }).then((response) => {
-                    cy.wait(3000)
                     cy.request({
                         method: METHOD.PUT,
                         url: API.ApiServer + "profiles/" + VVBUser,

--- a/e2e-tests/cypress/e2e/api-tests/026_remote_policy/00_remotePolicyUserPreparing.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/026_remote_policy/00_remotePolicyUserPreparing.cy.js
@@ -66,7 +66,6 @@ context("Policies", { tags: ['remote_policy', 'secondPool', 'all'] }, () => {
                         headers: { authorization },
                         timeout: 600000
                     }).then((response) => {
-                        cy.wait(3000)
                         let hederaAccountId = response.body.id
                         let hederaAccountKey = response.body.key
                         cy.request({
@@ -131,8 +130,8 @@ context("Policies", { tags: ['remote_policy', 'secondPool', 'all'] }, () => {
                             method: METHOD.GET,
                             url: API.ApiServer + API.RandomKey,
                             headers: { authorization },
+                            timeout: 600000
                         }).then((response) => {
-                            cy.wait(3000)
                             let hederaAccountId = response.body.id
                             let hederaAccountKey = response.body.key
                             cy.request({
@@ -224,8 +223,8 @@ context("Policies", { tags: ['remote_policy', 'secondPool', 'all'] }, () => {
                                 method: METHOD.GET,
                                 url: API.ApiServer + API.RandomKey,
                                 headers: { authorization },
+                                timeout: 600000
                             }).then((response) => {
-                                cy.wait(3000)
                                 let hederaAccountId = response.body.id
                                 let hederaAccountKey = response.body.key
                                 Authorization.getAccessTokenMGS(MainSRUsername, tenantId).then((authorization) => {


### PR DESCRIPTION
### Description

Speed up and stabilize the account/credential-setup api-tests by removing fixed delays and normalizing request timeouts.

- Remove `cy.wait(3000)` calls that followed the `randomKey` request; the response is already available in the callback, so the wait is pure dead time.
- Normalize the `randomKey` request timeout to `600000` across the SR, SR2 and User profile setups so slow Hedera provisioning does not hit the 30s default and fail.
- Deduplicate the identical SR/SR2 credential blocks in `create_accounts.cy.js` into a shared helper, preserving test titles, tags and the confirmed-check short-circuit.
- Apply the same wait removal and timeout normalization to the sibling specs sharing the `randomKey` pattern (`setCredsAndLinkToSRByInstaller`, `00_remotePolicyUserPreparing`, `VM033`).