### PR TITLE
fix(guardian-service): strip stale discontinuedDate on policy import/new-version (#6369)

### DIFF
--- a/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
@@ -122,6 +122,7 @@ export class PolicyImport {
             delete policy.version;
             delete policy.previousVersion;
             delete policy.createDate;
+            delete policy.discontinuedDate;
             policy.uuid = GenerateUUIDv4();
             policy.creator = user.creator;
             policy.owner = user.owner;
@@ -155,6 +156,7 @@ export class PolicyImport {
             delete policy.version;
             delete policy.previousVersion;
             delete policy.createDate;
+            delete policy.discontinuedDate;
             policy.uuid = GenerateUUIDv4();
             policy.creator = user.creator;
             policy.owner = user.owner;

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -461,6 +461,7 @@ export class PolicyEngine extends NatsService {
             delete data.owner;
             delete data.version;
             delete data.messageId;
+            delete data.discontinuedDate;
         }
         const model = DatabaseServer.createPolicy(data);
         model.creator = user.creator;

--- a/guardian-service/tests/unit/policy-import-strip-discontinued.test.mjs
+++ b/guardian-service/tests/unit/policy-import-strip-discontinued.test.mjs
@@ -1,0 +1,42 @@
+import { assert } from 'chai';
+import { PolicyImport } from '../../dist/helpers/import-helpers/policy/policy-import.js';
+import { ImportMode } from '../../dist/helpers/import-helpers/common/import.interface.js';
+
+/**
+ * Regression guard for #6369: a policy exported while DISCONTINUED carries a stale
+ * `discontinuedDate`. If import / new-version create doesn't strip it, publishing
+ * sets status=PUBLISH while discontinuedDate is in the past, and the hourly
+ * `policy-discontinue` task immediately flips it to DISCONTINUED.
+ *
+ * dataPreparation() is private but dependency-light (pure field manipulation, no
+ * DB/await in body), so we drive it via the prototype with only `mode` set.
+ */
+describe('PolicyImport.dataPreparation strips stale discontinuedDate (#6369)', () => {
+    const user = { creator: 'did:creator', owner: 'did:owner' };
+    const pastDate = new Date('2024-01-01T00:00:00.000Z');
+
+    const run = async (mode) => {
+        const importer = Object.create(PolicyImport.prototype);
+        importer.mode = mode;
+        const policy = {
+            id: '6a567ce0c7892208461c1128',
+            uuid: '16e4b361-07fd-493c-92e0-1bb0ae1831de',
+            name: 'Sample Policy',
+            version: '1.0',
+            status: 'DISCONTINUED',
+            discontinuedDate: pastDate,
+            config: {}
+        };
+        return importer.dataPreparation(policy, user, null);
+    };
+
+    it('COMMON (normal import) mode removes discontinuedDate', async () => {
+        const result = await run(ImportMode.COMMON);
+        assert.notProperty(result, 'discontinuedDate');
+    });
+
+    it('DEMO mode removes discontinuedDate', async () => {
+        const result = await run(ImportMode.DEMO);
+        assert.notProperty(result, 'discontinuedDate');
+    });
+});


### PR DESCRIPTION
Fixes #6369

## Problem

A policy exported while **DISCONTINUED** carries a past `discontinuedDate` in its `.policy` file. On import (`PolicyImport.dataPreparation`) and new-version create (`createPolicy`), Guardian strips `status`/`version`/`id`/`messageId`/etc. but **not** `discontinuedDate`, and publish never clears it. The hourly `policy-discontinue` `SynchronizationTask` (`guardian-service/src/app.ts`) then matches `discontinuedDate <= now && status === PUBLISH` and flips the freshly published policy straight to **DISCONTINUED** — no user action, no error.

## Fix

- `delete policy.discontinuedDate` in `dataPreparation` — **COMMON** (normal import) and **DEMO** branches. `VIEW` is intentionally left alone (it preserves the record as a read-only view of a possibly-discontinued remote policy).
- `delete data.discontinuedDate` in `createPolicy` field-stripping (new version).
- Regression test that drives the private `dataPreparation` via the prototype (dependency-light, pure field manipulation) and asserts `discontinuedDate` is removed for COMMON and DEMO.

## Notes

Verified against the equivalent change in a downstream mirror (build + test green). A full build in this fork checkout is blocked by unrelated pre-existing dependency drift in files this PR does not touch; the change itself is trivial field-stripping identical to the adjacent lines.

Present on both `main` and `develop`; this PR targets `develop`.