### PR TITLE
fix: HttpRequestUIAddon params in createUrl

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/code/http-request-ui-addon.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/code/http-request-ui-addon.ts
@@ -41,7 +41,7 @@ export class HttpRequestUIAddonCode {
             history: any[]
         }
     ) {
-        const url = this.createUrl(data.document);
+        const url = this.createUrl({ ...data.document, ...data.params });
         const headers = await this.createHeaders();
         if (this.mockId) {
             return this.mockRequest(this.mockId, this.type, url, data, headers);


### PR DESCRIPTION
**Description**:
* Fixed createUrl ignoring data.params in favour of data.document which is overwritten by each HTTP response
