### PR TITLE
fix: 6315 clear stale test data on field type change

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.spec.ts
@@ -56,6 +56,22 @@ describe('SchemaFieldConfigurationComponent', () => {
         });
     });
 
+    describe('clearFieldPresetControls', () => {
+
+        it('clears default/suggest/example when field type changes', () => {
+            const component = Object.create(SchemaFieldConfigurationComponent.prototype);
+            component.field = {
+                controlDefault: new UntypedFormControl('old'),
+                controlSuggest: new UntypedFormControl('old'),
+                controlExample: new UntypedFormControl('example'),
+            };
+            component['clearFieldPresetControls']();
+            expect(component.field.controlDefault.value).toBeNull();
+            expect(component.field.controlSuggest.value).toBeNull();
+            expect(component.field.controlExample.value).toBeNull();
+        });
+    });
+
     describe('onEditExpression help context', () => {
 
         it('should include all documented operators as valid JS operators', () => {

--- a/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.ts
@@ -154,6 +154,12 @@ export class SchemaFieldConfigurationComponent implements OnInit, OnDestroy {
             });
     }
 
+    private clearFieldPresetControls(): void {
+        this.field.controlDefault.setValue(null, { emitEvent: false });
+        this.field.controlSuggest.setValue(null, { emitEvent: false });
+        this.field.controlExample.setValue(null, { emitEvent: false });
+    }
+
     ngOnInit(): void {
         if (this.fieldsForm && this.buildField) {
             const onFieldChange = (value: any) => {
@@ -206,6 +212,10 @@ export class SchemaFieldConfigurationComponent implements OnInit, OnDestroy {
                     JSON.stringify(oldField?.controlEnum) !==
                     JSON.stringify(newField?.controlEnum)
                 ) {
+                    if (oldField?.fieldType !== newField?.fieldType) {
+                        this.clearFieldPresetControls();
+                    }
+
                     this.presetValues =
                         JSON.stringify(newField?.controlEnum) !==
                             JSON.stringify(oldField?.controlEnum)


### PR DESCRIPTION
### Description

When a schema field's type is changed in the editor, the previously entered Default/Suggested/Test values were kept, so the dry-run ("Test") generator fed leftover, type-incompatible data to the new field type and failed.

- Clear the field's default, suggest and example values when its type actually changes.
- Rely on the existing document generator to supply a valid default for the new type once stale data is removed.
- Add a unit test covering the reset.

Fixes #6315