### PR TITLE
feat: collapsed menu tooltips and profile logout

### DIFF
--- a/frontend/src/app/views/new-header/new-header.component.html
+++ b/frontend/src/app/views/new-header/new-header.component.html
@@ -49,7 +49,9 @@
           (click)="onRouter(barItem)"
           [class.current]="isCurrent(barItem, activeLink)"
           [class.parent-active]="hasActiveChild(barItem)"
+          [pTooltip]="(menuCollapsed && !barItem.childItems) ? barItem.title : ''"
           class="item clickable"
+          tooltipPosition="right"
           >
           @if (barItem.icon) {
             <i class="{{ barItem.icon }} item-icon"></i>
@@ -104,8 +106,10 @@
 <ng-template #footerActions>
   <div
     [class.current]="activeLink.startsWith('/notifications')"
+    [pTooltip]="(menuCollapsed && layout === 'vertical') ? 'Notifications' : ''"
     [routerLink]="'/notifications'"
     class="item cursor-pointer notification-item"
+    tooltipPosition="right"
     >
     <i class="pi pi-bell item-icon"></i>
     @if (menuCollapsed && layout === 'vertical') {
@@ -157,7 +161,11 @@
     </div>
   }
 
-  <div class="user-box">
+  <div
+    [class.has-flyout]="menuCollapsed && layout === 'vertical'"
+    [class.item-block]="menuCollapsed && layout === 'vertical'"
+    class="user-box"
+    >
     <div
       (click)="goToHomePage()"
       [class.clickable]="!user.AUDITOR"
@@ -186,5 +194,19 @@
         ></i>
       }
     </div>
+
+    @if (menuCollapsed && layout === 'vertical') {
+      <div class="flyout">
+        <div class="flyout-title">{{ username }}</div>
+        @if (!user.AUDITOR) {
+          <div (click)="goToHomePage()" class="flyout-item clickable">
+            <span>Open Profile</span>
+          </div>
+        }
+        <div (click)="logOut(); $event.stopPropagation()" class="flyout-item clickable">
+          <span>Logout</span>
+        </div>
+      </div>
+    }
   </div>
 </ng-template>

--- a/frontend/src/app/views/new-header/new-header.component.scss
+++ b/frontend/src/app/views/new-header/new-header.component.scss
@@ -357,6 +357,13 @@
     border-top: 1px solid var(--sidebar-border);
 }
 
+/* Profile flyout lives in the footer, so anchor it to the bottom of the box and
+   let it grow upward instead of dropping off the bottom of the viewport. */
+.user-box.has-flyout .flyout {
+    top: auto;
+    bottom: 0;
+}
+
 /* The profile row is a footer control, not a nav target — give it a soft active
    state instead of the solid brand pill used for menu items. */
 .user-item.current {


### PR DESCRIPTION
### Description

Improve usability of the collapsed navigation rail so users can identify items and log out without expanding it.

- Add right-anchored tooltips to collapsed nav leaf items (e.g. Relayer Accounts); items with children keep their existing hover flyout.
- Add a tooltip to the Notifications action when the rail is collapsed.
- Add a hover flyout on the collapsed Profile box exposing Open Profile and Logout, so logout is reachable without expanding the menu.