### PR TITLE
fix: 6383 refresh after dry-run form submit

### DIFF
--- a/policy-service/src/policy-engine/helpers/decorators/basic-block.ts
+++ b/policy-service/src/policy-engine/helpers/decorators/basic-block.ts
@@ -667,6 +667,10 @@ export function BasicBlock<T>(options: Partial<PolicyBlockDecoratorOptions>) {
                     if (virtualUser) {
                         result.set(virtualUser.did, virtualUser);
                     }
+                    // Always notify the acting user: the pointer lookup above can miss.
+                    if (currentUser?.did) {
+                        result.set(currentUser.did, currentUser);
+                    }
                 } else {
                     const allUsers = await this.databaseServer.getAllPolicyUsers(this.policyId);
                     for (const group of allUsers) {


### PR DESCRIPTION
### Description

After submitting a document form in a dry-run policy workflow, the page did not refresh to the next state (e.g. "Waiting for approval") until a manual reload. This is a regression introduced by #6328 (dry run active virtual user per session): the block-update broadcast resolves its recipients in dry-run only through the per-session active-virtual-user pointer, which is keyed on the real authenticated user id but was queried with the acting user's id, so the lookup missed and no update event was emitted.

- Always include the acting user in the dry-run block-update recipient set so the submitting session receives the update event.

Resolves #6383 