### PR TITLE
fix: 6404 keep other nav groups expanded on navigate

### DIFF
--- a/frontend/src/app/views/new-header/new-header.component.ts
+++ b/frontend/src/app/views/new-header/new-header.component.ts
@@ -270,14 +270,14 @@ export class NewHeaderComponent implements OnInit, OnDestroy, AfterViewChecked {
         }
     }
 
-    /** Open the group whose child matches the current route (and close the others). */
+    /** Open the group whose child matches the current route, leaving other groups as-is. */
     private syncActiveGroups() {
         if (!this.menuItems) {
             return;
         }
         for (const item of this.menuItems) {
-            if (item.childItems) {
-                item.active = this.hasActiveChild(item);
+            if (item.childItems && this.hasActiveChild(item)) {
+                item.active = true;
             }
         }
     }


### PR DESCRIPTION
### Description

Prevent the vertical navigation panel from collapsing expanded groups when an item inside another group is clicked.

- Change `syncActiveGroups` to only open the group containing the active route, leaving other groups in their current state.

Resolves #6404