### PR TITLE
fix: mirror node rate-limit resilience - pace and back off topic listener polling, retry 429 in worker-service

### DIFF
--- a/topic-listener-service/configs/.env.topic-listener
+++ b/topic-listener-service/configs/.env.topic-listener
@@ -16,6 +16,15 @@ MQ_MAX_PAYLOAD="1048576"
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+#Mirror node polling. The rate limit is per source IP and shared with every other
+#process behind it, so the listener paces itself and backs off when throttled.
+#LISTENER_CALL_DELAY_MS="25"          # delay between mirror node calls (~40 req/s); 0 disables pacing
+#LISTENER_REQUEST_TIMEOUT_MS="15000"  # per-request timeout
+#LISTENER_ERROR_BACKOFF_MIN_MS="5000"
+#LISTENER_ERROR_BACKOFF_MAX_MS="300000"
+#LISTENER_IDLE_BACKOFF_STEP_MS="10000"
+#LISTENER_IDLE_BACKOFF_MAX_MS="60000"
+
 #PINO_LOGGER
 TRANSPORTS="CONSOLE, MONGO"
 DB_LOGGER_NAME="logger_db"

--- a/topic-listener-service/configs/.env.topic-listener.develop
+++ b/topic-listener-service/configs/.env.topic-listener.develop
@@ -16,6 +16,15 @@ MQ_MAX_PAYLOAD="1048576"
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+#Mirror node polling. The rate limit is per source IP and shared with every other
+#process behind it, so the listener paces itself and backs off when throttled.
+#LISTENER_CALL_DELAY_MS="25"          # delay between mirror node calls (~40 req/s); 0 disables pacing
+#LISTENER_REQUEST_TIMEOUT_MS="15000"  # per-request timeout
+#LISTENER_ERROR_BACKOFF_MIN_MS="5000"
+#LISTENER_ERROR_BACKOFF_MAX_MS="300000"
+#LISTENER_IDLE_BACKOFF_STEP_MS="10000"
+#LISTENER_IDLE_BACKOFF_MAX_MS="60000"
+
 #PINO_LOGGER
 TRANSPORTS="CONSOLE, MONGO"
 DB_LOGGER_NAME="logger_db"

--- a/topic-listener-service/configs/.env.topic-listener.template
+++ b/topic-listener-service/configs/.env.topic-listener.template
@@ -16,6 +16,15 @@ MQ_MAX_PAYLOAD="1048576"
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+#Mirror node polling. The rate limit is per source IP and shared with every other
+#process behind it, so the listener paces itself and backs off when throttled.
+#LISTENER_CALL_DELAY_MS="25"          # delay between mirror node calls (~40 req/s); 0 disables pacing
+#LISTENER_REQUEST_TIMEOUT_MS="15000"  # per-request timeout
+#LISTENER_ERROR_BACKOFF_MIN_MS="5000"
+#LISTENER_ERROR_BACKOFF_MAX_MS="300000"
+#LISTENER_IDLE_BACKOFF_STEP_MS="10000"
+#LISTENER_IDLE_BACKOFF_MAX_MS="60000"
+
 #PINO_LOGGER
 TRANSPORTS="CONSOLE, MONGO"
 DB_LOGGER_NAME="logger_db"

--- a/topic-listener-service/src/api/listener-service.ts
+++ b/topic-listener-service/src/api/listener-service.ts
@@ -11,6 +11,13 @@ export class ListenerService extends NatsService {
     public replySubject = 'listeners-queue-reply-' + GenerateUUIDv4();
 
     private readonly delay: number = 10 * 1000;
+    /**
+     * Delay between mirror node calls. The public mirror node allows ~50 req/s per
+     * source IP and that budget is shared with every other process behind the same
+     * IP (worker-service, indexer, ...), so the listener paces itself well below it.
+     */
+    private readonly callDelay: number =
+        parseInt(process.env.LISTENER_CALL_DELAY_MS, 10) || Math.ceil(1000 / 40);
     private readonly map: Map<string, Listener>;
 
     constructor(
@@ -111,7 +118,11 @@ export class ListenerService extends NatsService {
     public async scheduler(): Promise<void> {
         while (true) {
             for (const listener of this.map.values()) {
-                await listener.search();
+                const polled = await listener.search();
+                if (polled) {
+                    //only pace real mirror node calls - a listener in backoff costs nothing
+                    await new Promise(resolve => setTimeout(resolve, this.callDelay));
+                }
             }
             await new Promise(resolve => setTimeout(resolve, this.delay));
         }

--- a/topic-listener-service/src/api/listener-service.ts
+++ b/topic-listener-service/src/api/listener-service.ts
@@ -2,6 +2,7 @@ import { DatabaseServer, MessageResponse, NatsService, PinoLogger } from '@guard
 import { GenerateUUIDv4, IListenerOptions, ListenerEvents } from '@guardian/interfaces';
 import { TopicListener as ListenerCollection } from '../entity/index.js';
 import { Listener } from './listener.js';
+import { envNumber } from '../helpers/env.js';
 
 /**
  * Worker class
@@ -17,7 +18,7 @@ export class ListenerService extends NatsService {
      * IP (worker-service, indexer, ...), so the listener paces itself well below it.
      */
     private readonly callDelay: number =
-        parseInt(process.env.LISTENER_CALL_DELAY_MS, 10) || Math.ceil(1000 / 40);
+        envNumber('LISTENER_CALL_DELAY_MS', Math.ceil(1000 / 40));
     private readonly map: Map<string, Listener>;
 
     constructor(

--- a/topic-listener-service/src/api/listener.ts
+++ b/topic-listener-service/src/api/listener.ts
@@ -16,11 +16,31 @@ export class Listener {
 
     public static readonly REST_API_MAX_LIMIT: number = 100;
 
+    /**
+     * The mirror node rate limit is per source IP and is shared with every other
+     * process behind it, so a throttled listener has to yield instead of retrying
+     * at full rate.
+     */
+    public static readonly REQUEST_TIMEOUT_MS: number =
+        parseInt(process.env.LISTENER_REQUEST_TIMEOUT_MS, 10) || 15 * 1000;
+    public static readonly ERROR_BACKOFF_MIN_MS: number =
+        parseInt(process.env.LISTENER_ERROR_BACKOFF_MIN_MS, 10) || 5 * 1000;
+    public static readonly ERROR_BACKOFF_MAX_MS: number =
+        parseInt(process.env.LISTENER_ERROR_BACKOFF_MAX_MS, 10) || 5 * 60 * 1000;
+    public static readonly IDLE_BACKOFF_STEP_MS: number =
+        parseInt(process.env.LISTENER_IDLE_BACKOFF_STEP_MS, 10) || 10 * 1000;
+    public static readonly IDLE_BACKOFF_MAX_MS: number =
+        parseInt(process.env.LISTENER_IDLE_BACKOFF_MAX_MS, 10) || 60 * 1000;
+
     private _messages: Message[];
 
     private _searchIndex: number;
     private _sendIndex: number;
     private _subscription: Subscription;
+
+    private _errorCount: number;
+    private _idleCount: number;
+    private _nextPollAt: number;
 
     constructor(
         channel: ListenerService,
@@ -37,6 +57,88 @@ export class Listener {
         this.channel = channel;
 
         this._messages = [];
+
+        this._errorCount = 0;
+        this._idleCount = 0;
+        this._nextPollAt = 0;
+    }
+
+    /**
+     * True when this listener is allowed to call the mirror node again
+     */
+    public isPollDue(now: number = Date.now()): boolean {
+        return now >= this._nextPollAt;
+    }
+
+    /**
+     * Spread retries so every listener does not wake up at the same moment.
+     * Jitters downwards only, so the configured caps stay hard limits.
+     */
+    private static jitter(delay: number): number {
+        return Math.round(delay * (Math.random() * 0.2 + 0.8));
+    }
+
+    /**
+     * `Retry-After` in seconds or as an HTTP date, in ms; null when absent/unusable
+     */
+    private static parseRetryAfter(value: any): number | null {
+        if (value === undefined || value === null) {
+            return null;
+        }
+        const seconds = Number(value);
+        if (isFinite(seconds)) {
+            return seconds > 0 ? seconds * 1000 : null;
+        }
+        const date = Date.parse(String(value));
+        if (isFinite(date)) {
+            const delay = date - Date.now();
+            return delay > 0 ? delay : null;
+        }
+        return null;
+    }
+
+    /**
+     * Clear the backoff so the next cycle polls immediately
+     */
+    private resetBackoff(): void {
+        this._errorCount = 0;
+        this._idleCount = 0;
+        this._nextPollAt = 0;
+    }
+
+    /**
+     * Back off harder the longer a topic stays silent, capped so a topic that
+     * does become active is still picked up promptly.
+     */
+    private onPollSuccess(hasMessages: boolean): void {
+        this._errorCount = 0;
+        if (hasMessages) {
+            this._idleCount = 0;
+            this._nextPollAt = 0;
+            return;
+        }
+        this._idleCount++;
+        const delay = Math.min(
+            Listener.IDLE_BACKOFF_MAX_MS,
+            Listener.IDLE_BACKOFF_STEP_MS * Math.pow(2, Math.min(this._idleCount - 1, 30))
+        );
+        this._nextPollAt = Date.now() + Listener.jitter(delay);
+    }
+
+    /**
+     * Honour `Retry-After` on 429, exponential backoff otherwise; returns the applied delay
+     */
+    private onPollError(error: any): number {
+        this._errorCount++;
+        const retryAfter = Listener.parseRetryAfter(error?.response?.headers?.['retry-after']);
+        const delay = retryAfter === null
+            ? Listener.jitter(Math.min(
+                Listener.ERROR_BACKOFF_MAX_MS,
+                Listener.ERROR_BACKOFF_MIN_MS * Math.pow(2, Math.min(this._errorCount - 1, 30))
+            ))
+            : Math.min(Listener.ERROR_BACKOFF_MAX_MS, retryAfter);
+        this._nextPollAt = Date.now() + delay;
+        return delay;
     }
 
     public init() {
@@ -56,6 +158,7 @@ export class Listener {
     public async restart(index: number): Promise<boolean> {
         this._searchIndex = index;
         this._sendIndex = index;
+        this.resetBackoff();
         await (new DatabaseServer()).update(
             ListenerCollection,
             { id: this.id },
@@ -67,16 +170,33 @@ export class Listener {
         return true;
     }
 
-    public async search(): Promise<void> {
+    /**
+     * Returns true when the mirror node was actually called, so the scheduler only
+     * spends its rate limit budget on listeners that are due.
+     */
+    public async search(): Promise<boolean> {
+        if (!this.isPollDue()) {
+            this.push();
+            return false;
+        }
         try {
             const data = await this.getMessages(this.topicId, this._searchIndex);
-            if (data && data.messages.length) {
+            const hasMessages = !!(data && data.messages.length);
+            this.onPollSuccess(hasMessages);
+            if (hasMessages) {
                 await this.saveMessages(data.messages);
             }
             this.push();
         } catch (error) {
-            console.error(error);
+            const delay = this.onPollError(error);
+            //one line per failure instead of a full stack: a throttling window can
+            //otherwise bury every other log line
+            console.error(
+                `[Listener] ${this.name} (${this.topicId}) ${error?.message}; ` +
+                `attempt ${this._errorCount}, retry in ${Math.round(delay / 1000)}s`
+            );
         }
+        return true;
     }
 
     public async saveMessages(messages: TopicMessage[]): Promise<void> {
@@ -98,6 +218,11 @@ export class Listener {
             for (const m of this._messages) {
                 if (m.chunkId === chunkId) {
                     m.addChunk(message);
+                    //continuation chunks must advance the index too, otherwise the next poll
+                    //re-fetches them forever and the group never completes.
+                    //Safe on restart: the constructor resumes from min(searchIndex, sendIndex),
+                    //so an incomplete in-memory group is re-fetched whole.
+                    this._searchIndex = message.sequence_number;
                     return;
                 }
             }
@@ -116,7 +241,8 @@ export class Listener {
                     limit: Listener.REST_API_MAX_LIMIT
                 },
                 responseType: 'json',
-                timeout: 2 * 60 * 1000,
+                //the scheduler is sequential, so one hung request stalls every other listener
+                timeout: Listener.REQUEST_TIMEOUT_MS,
             };
             if (lastNumber > 0) {
                 option.params.sequencenumber = `gt:${lastNumber}`;

--- a/topic-listener-service/src/api/listener.ts
+++ b/topic-listener-service/src/api/listener.ts
@@ -6,6 +6,7 @@ import { Message } from './message.js';
 import { ListenerEvents } from '@guardian/interfaces';
 import { Subscription } from 'nats';
 import axios from 'axios';
+import { envNumber } from '../helpers/env.js';
 
 export class Listener {
     public readonly id: string;
@@ -22,15 +23,15 @@ export class Listener {
      * at full rate.
      */
     public static readonly REQUEST_TIMEOUT_MS: number =
-        parseInt(process.env.LISTENER_REQUEST_TIMEOUT_MS, 10) || 15 * 1000;
+        envNumber('LISTENER_REQUEST_TIMEOUT_MS', 15 * 1000);
     public static readonly ERROR_BACKOFF_MIN_MS: number =
-        parseInt(process.env.LISTENER_ERROR_BACKOFF_MIN_MS, 10) || 5 * 1000;
+        envNumber('LISTENER_ERROR_BACKOFF_MIN_MS', 5 * 1000);
     public static readonly ERROR_BACKOFF_MAX_MS: number =
-        parseInt(process.env.LISTENER_ERROR_BACKOFF_MAX_MS, 10) || 5 * 60 * 1000;
+        envNumber('LISTENER_ERROR_BACKOFF_MAX_MS', 5 * 60 * 1000);
     public static readonly IDLE_BACKOFF_STEP_MS: number =
-        parseInt(process.env.LISTENER_IDLE_BACKOFF_STEP_MS, 10) || 10 * 1000;
+        envNumber('LISTENER_IDLE_BACKOFF_STEP_MS', 10 * 1000);
     public static readonly IDLE_BACKOFF_MAX_MS: number =
-        parseInt(process.env.LISTENER_IDLE_BACKOFF_MAX_MS, 10) || 60 * 1000;
+        envNumber('LISTENER_IDLE_BACKOFF_MAX_MS', 60 * 1000);
 
     private _messages: Message[];
 
@@ -220,11 +221,19 @@ export class Listener {
                     m.addChunk(message);
                     //continuation chunks must advance the index too, otherwise the next poll
                     //re-fetches them forever and the group never completes.
-                    //Safe on restart: the constructor resumes from min(searchIndex, sendIndex),
-                    //so an incomplete in-memory group is re-fetched whole.
                     this._searchIndex = message.sequence_number;
                     return;
                 }
+            }
+            //A continuation chunk with no in-progress group is the tail of a message that was
+            //already sent: searchIndex is persisted at the last chunk's sequence while sendIndex
+            //is confirmed at the first one, so the resume point - min(searchIndex, sendIndex) -
+            //lands mid-group and `gt:` skips the head. Starting a new group here would leave it
+            //COMPRESSING at _messages[0], where next() returns null and blocks the topic forever.
+            //Forward paging always delivers chunk 1 first, so only that orphan tail is dropped.
+            if (message.chunk_info.number > 1) {
+                this._searchIndex = message.sequence_number;
+                return;
             }
         }
         const item = new Message();
@@ -234,32 +243,27 @@ export class Listener {
     }
 
     public async getMessages(topicId: string, lastNumber: number): Promise<TopicInfo | null> {
-        try {
-            const url = `${Environment.HEDERA_TOPIC_API}/${topicId}/messages`;
-            const option: any = {
-                params: {
-                    limit: Listener.REST_API_MAX_LIMIT
-                },
-                responseType: 'json',
-                //the scheduler is sequential, so one hung request stalls every other listener
-                timeout: Listener.REQUEST_TIMEOUT_MS,
-            };
-            if (lastNumber > 0) {
-                option.params.sequencenumber = `gt:${lastNumber}`;
+        const url = `${Environment.HEDERA_TOPIC_API}/${topicId}/messages`;
+        const option: any = {
+            params: {
+                limit: Listener.REST_API_MAX_LIMIT
+            },
+            responseType: 'json',
+            //the scheduler is sequential, so one hung request stalls every other listener
+            timeout: Listener.REQUEST_TIMEOUT_MS,
+        };
+        if (lastNumber > 0) {
+            option.params.sequencenumber = `gt:${lastNumber}`;
+        }
+        const response = await axios.get(url, option);
+        const topicInfo = response?.data as TopicInfo;
+        if (topicInfo && Array.isArray(topicInfo.messages)) {
+            if (!topicInfo.links) {
+                topicInfo.links = { next: null };
             }
-            const response = await axios.get(url, option);
-            const topicInfo = response?.data as TopicInfo;
-            if (topicInfo && Array.isArray(topicInfo.messages)) {
-                if (!topicInfo.links) {
-                    topicInfo.links = { next: null };
-                }
-                return topicInfo;
-            } else {
-                return null;
-            }
-        } catch (error) {
-            console.log('getMessages ', topicId, error.message);
-            throw error;
+            return topicInfo;
+        } else {
+            return null;
         }
     }
 

--- a/topic-listener-service/src/api/message.ts
+++ b/topic-listener-service/src/api/message.ts
@@ -53,7 +53,14 @@ export class Message {
             item.chunkTotal = 1;
         }
         item.type = item.chunkNumber === 1 ? 'Message' : 'Chunk';
+        //a re-fetched chunk must not be counted twice, otherwise the group overshoots
+        //chunkTotal and never reaches COMPRESSED
+        if (this.messages.some((m) => m.sequenceNumber === item.sequenceNumber)) {
+            return;
+        }
         this.messages.push(item);
+        //reassembly concatenates in array order, so keep chunks in sequence order
+        this.messages.sort((a, b) => a.sequenceNumber - b.sequenceNumber);
         this.compressMessages();
     }
 
@@ -66,7 +73,7 @@ export class Message {
         this.consensusTimestamp = first.consensusTimestamp;
         this.owner = first.owner;
 
-        if (first.chunkTotal === this.messages.length) {
+        if (this.messages.length >= first.chunkTotal) { //never stall on an over-full group
             this.status = 'COMPRESSED';
             this.data = this.compressData();
         } else {

--- a/topic-listener-service/src/helpers/env.ts
+++ b/topic-listener-service/src/helpers/env.ts
@@ -1,0 +1,8 @@
+/**
+ * Numeric env var. Falls back only when unset or unparsable, so `0` stays a valid
+ * value (e.g. LISTENER_CALL_DELAY_MS=0 disables pacing).
+ */
+export function envNumber(name: string, fallback: number): number {
+    const value = parseInt(process.env[name], 10);
+    return Number.isFinite(value) ? value : fallback;
+}

--- a/topic-listener-service/tests/env-number.test.mjs
+++ b/topic-listener-service/tests/env-number.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { envNumber } from '../dist/helpers/env.js';
+
+const withEnv = (value, fn) => {
+    const previous = process.env.TEST_ENV_NUMBER;
+    if (value === undefined) {
+        delete process.env.TEST_ENV_NUMBER;
+    } else {
+        process.env.TEST_ENV_NUMBER = value;
+    }
+    try {
+        return fn();
+    } finally {
+        if (previous === undefined) {
+            delete process.env.TEST_ENV_NUMBER;
+        } else {
+            process.env.TEST_ENV_NUMBER = previous;
+        }
+    }
+};
+
+describe('envNumber', () => {
+    it('falls back when the variable is unset', () => {
+        withEnv(undefined, () => assert.equal(envNumber('TEST_ENV_NUMBER', 25), 25));
+    });
+
+    it('falls back when the variable is unparsable', () => {
+        withEnv('not-a-number', () => assert.equal(envNumber('TEST_ENV_NUMBER', 25), 25));
+        withEnv('', () => assert.equal(envNumber('TEST_ENV_NUMBER', 25), 25));
+    });
+
+    it('keeps 0 instead of falling back', () => {
+        withEnv('0', () => assert.equal(envNumber('TEST_ENV_NUMBER', 25), 0));
+    });
+
+    it('reads a normal value', () => {
+        withEnv('150', () => assert.equal(envNumber('TEST_ENV_NUMBER', 25), 150));
+    });
+});

--- a/topic-listener-service/tests/listener-backoff.test.mjs
+++ b/topic-listener-service/tests/listener-backoff.test.mjs
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { Listener } from '../dist/api/listener.js';
+
+const b64 = (s) => Buffer.from(s).toString('base64');
+
+const makeChannel = () => {
+    const calls = { subscribe: [], publish: [] };
+    return {
+        calls,
+        subscribe(subject, cb) {
+            calls.subscribe.push({ subject, cb });
+            return { closed: false, unsubscribe() { this.closed = true; } };
+        },
+        async publish(subject, data) {
+            calls.publish.push({ subject, data });
+        },
+    };
+};
+
+const makeListener = (overrides = {}, channel = makeChannel()) => new Listener(channel, {
+    id: 'listener-1',
+    name: 'my-listener',
+    topicId: '0.0.5005',
+    searchIndex: 10,
+    sendIndex: 10,
+    ...overrides,
+});
+
+const topicMessage = (sequence, text, chunk = null) => ({
+    consensus_timestamp: `170000000${sequence}.000000001`,
+    topic_id: '0.0.5005',
+    message: b64(text),
+    sequence_number: sequence,
+    payer_account_id: '0.0.42',
+    chunk_info: chunk,
+});
+
+const chunkInfo = (validStart, number, total) => ({
+    initial_transaction_id: {
+        account_id: '0.0.42',
+        transaction_valid_start: validStart,
+    },
+    number,
+    total,
+});
+
+const throttled = (retryAfter) => {
+    const error = new Error('Request failed with status code 429');
+    error.response = { status: 429, headers: retryAfter ? { 'retry-after': retryAfter } : {} };
+    return error;
+};
+
+describe('Listener adaptive polling', () => {
+    it('is due immediately when freshly constructed', () => {
+        assert.equal(makeListener().isPollDue(), true);
+    });
+
+    it('backs off further on each empty poll, then resets when a message arrives', () => {
+        const listener = makeListener();
+
+        listener.onPollSuccess(false);
+        const first = listener._nextPollAt;
+        assert.equal(listener.isPollDue(), false);
+
+        listener.onPollSuccess(false);
+        assert.ok(listener._nextPollAt > first, 'second empty poll should wait longer');
+
+        listener.onPollSuccess(true);
+        assert.equal(listener._idleCount, 0);
+        assert.equal(listener.isPollDue(), true);
+    });
+
+    it('caps the idle backoff', () => {
+        const listener = makeListener();
+        for (let i = 0; i < 20; i++) {
+            listener.onPollSuccess(false);
+        }
+        const delay = listener._nextPollAt - Date.now();
+        assert.ok(delay <= Listener.IDLE_BACKOFF_MAX_MS, `idle backoff ${delay} exceeded cap`);
+        assert.ok(delay >= Listener.IDLE_BACKOFF_MAX_MS * 0.75, `idle backoff ${delay} below floor`);
+    });
+
+    it('grows the error backoff exponentially and caps it', () => {
+        const listener = makeListener();
+
+        const first = listener.onPollError(new Error('boom'));
+        const second = listener.onPollError(new Error('boom'));
+        assert.ok(second > first, 'second failure should wait longer');
+
+        for (let i = 0; i < 20; i++) {
+            listener.onPollError(new Error('boom'));
+        }
+        assert.ok(
+            listener.onPollError(new Error('boom')) <= Listener.ERROR_BACKOFF_MAX_MS,
+            'error backoff exceeded cap'
+        );
+    });
+
+    it('honours Retry-After in seconds', () => {
+        assert.equal(makeListener().onPollError(throttled('30')), 30000);
+    });
+
+    it('honours Retry-After as an http date', () => {
+        const delay = makeListener().onPollError(throttled(new Date(Date.now() + 45000).toUTCString()));
+        assert.ok(delay > 40000 && delay <= 45000, `unexpected delay ${delay}`);
+    });
+
+    it('falls back to exponential backoff for an unusable Retry-After', () => {
+        assert.ok(makeListener().onPollError(throttled('not-a-date')) > 0);
+    });
+
+    it('skips the mirror node call while backing off', async () => {
+        const listener = makeListener();
+        let calls = 0;
+        listener.getMessages = async () => {
+            calls++;
+            throw throttled('30');
+        };
+
+        assert.equal(await listener.search(), true);
+        assert.equal(calls, 1);
+        assert.equal(listener.isPollDue(), false);
+
+        assert.equal(await listener.search(), false, 'search must not call while backing off');
+        assert.equal(calls, 1, 'no mirror node call while backing off');
+    });
+});
+
+describe('Listener chunk handling', () => {
+    it('advances searchIndex when appending to an existing chunk group', () => {
+        const listener = makeListener();
+        listener.addMessages(topicMessage(11, 'foo', chunkInfo('1-1', 1, 2)));
+        assert.equal(listener._searchIndex, 11);
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
+        assert.equal(listener._searchIndex, 12);
+    });
+
+    it('ignores a re-fetched chunk instead of overshooting chunkTotal', () => {
+        const listener = makeListener();
+        listener.addMessages(topicMessage(11, 'foo', chunkInfo('1-1', 1, 2)));
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
+        assert.equal(listener._messages.length, 1);
+        assert.equal(listener._messages[0].messages.length, 2);
+        assert.equal(listener._messages[0].status, 'COMPRESSED');
+        assert.equal(listener._messages[0].data, 'foobar');
+    });
+
+    it('reassembles chunks that arrive out of order', () => {
+        const listener = makeListener();
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
+        listener.addMessages(topicMessage(11, 'foo', chunkInfo('1-1', 1, 2)));
+        assert.equal(listener._messages.length, 1);
+        assert.equal(listener._messages[0].data, 'foobar');
+    });
+});

--- a/topic-listener-service/tests/listener-backoff.test.mjs
+++ b/topic-listener-service/tests/listener-backoff.test.mjs
@@ -146,11 +146,37 @@ describe('Listener chunk handling', () => {
         assert.equal(listener._messages[0].data, 'foobar');
     });
 
-    it('reassembles chunks that arrive out of order', () => {
+    it('reassembles chunks of an in-progress group that arrive out of order', () => {
+        const listener = makeListener();
+        listener.addMessages(topicMessage(11, 'foo', chunkInfo('1-1', 1, 3)));
+        listener.addMessages(topicMessage(13, 'baz', chunkInfo('1-1', 3, 3)));
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 3)));
+        assert.equal(listener._messages.length, 1);
+        assert.equal(listener._messages[0].data, 'foobarbaz');
+    });
+
+    it('skips a continuation chunk that belongs to no in-progress group', () => {
         const listener = makeListener();
         listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
-        listener.addMessages(topicMessage(11, 'foo', chunkInfo('1-1', 1, 2)));
-        assert.equal(listener._messages.length, 1);
-        assert.equal(listener._messages[0].data, 'foobar');
+        assert.equal(listener._messages.length, 0, 'orphan tail must not start a group');
+        assert.equal(listener._searchIndex, 12, 'orphan tail must still advance the index');
+    });
+
+    //searchIndex is persisted at the last chunk's sequence, sendIndex is confirmed at the
+    //first one, so a completed chunked message leaves searchIndex ahead of sendIndex.
+    it('does not wedge when resuming mid-group after a restart', () => {
+        //seq 11-12 was a 2-chunk message: sent and confirmed at 11, searched up to 12
+        const listener = makeListener({ searchIndex: 12, sendIndex: 11 });
+        assert.equal(listener._searchIndex, 11, 'resumes from min(searchIndex, sendIndex)');
+
+        //`gt:11` re-fetches only the tail chunk, then the next real message
+        listener.addMessages(topicMessage(12, 'bar', chunkInfo('1-1', 2, 2)));
+        listener.addMessages(topicMessage(13, 'next', null));
+
+        const message = listener.next();
+        assert.ok(message, 'the following message must not be blocked by the orphan tail');
+        assert.equal(message.index, 13);
+        assert.equal(message.status, 'COMPRESSED');
+        assert.equal(listener._searchIndex, 13);
     });
 });

--- a/worker-service/configs/.env.worker
+++ b/worker-service/configs/.env.worker
@@ -30,6 +30,11 @@ MQ_MAX_PAYLOAD="1048576"
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Retry for outbound REST calls (mirror node, IPFS gateways). Transient failures and
+# 429s are retried with exponential backoff; a Retry-After header wins over the backoff.
+#REST_API_RETRY_COUNT="3"   # total attempts, including the first
+#REST_API_RETRY_DELAY="500" # base backoff in ms, doubled per attempt
+
 # Secret Manager Configs
 SECRET_MANAGER=""
 # Vault

--- a/worker-service/configs/.env.worker.develop
+++ b/worker-service/configs/.env.worker.develop
@@ -30,6 +30,11 @@ MQ_MAX_PAYLOAD="1048576"
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Retry for outbound REST calls (mirror node, IPFS gateways). Transient failures and
+# 429s are retried with exponential backoff; a Retry-After header wins over the backoff.
+#REST_API_RETRY_COUNT="3"   # total attempts, including the first
+#REST_API_RETRY_DELAY="500" # base backoff in ms, doubled per attempt
+
 # Secret Manager Configs
 SECRET_MANAGER=""
 # Vault

--- a/worker-service/configs/.env.worker.template
+++ b/worker-service/configs/.env.worker.template
@@ -30,6 +30,11 @@ MQ_MAX_PAYLOAD=""
 #HEDERA_MAX_CHUNKS="20"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Retry for outbound REST calls (mirror node, IPFS gateways). Transient failures and
+# 429s are retried with exponential backoff; a Retry-After header wins over the backoff.
+#REST_API_RETRY_COUNT="3"   # total attempts, including the first
+#REST_API_RETRY_DELAY="500" # base backoff in ms, doubled per attempt
+
 # Secret Manager Configs
 SECRET_MANAGER=""
 HASHICORP_ENCRIPTION_ALG="sha512"

--- a/worker-service/src/api/helpers/utils.ts
+++ b/worker-service/src/api/helpers/utils.ts
@@ -2,16 +2,38 @@ import { TimeoutError } from '@guardian/interfaces';
 import { PrivateKey } from '@hiero-ledger/sdk';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
-const TRANSIENT_STATUS_CODES = new Set<number>([502, 503, 504]);
+// 429 included: the mirror node rate limit is per source IP and is shared with every
+// other process behind it, so a throttled GET is transient rather than fatal.
+const TRANSIENT_STATUS_CODES = new Set<number>([429, 502, 503, 504]);
 const TRANSIENT_ERROR_CODES = new Set<string>(['ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET']);
+const MAX_RETRY_AFTER_MS = 60 * 1000;
 
-// Retry 5xx gateway errors and network timeouts, but not 4xx (e.g. 404 must fail fast).
+// Retry 5xx gateway errors, 429 throttling and network timeouts, but not the rest of
+// the 4xx range (e.g. 404 must fail fast).
 function isTransientError(error: any): boolean {
     const status = error?.response?.status;
     if (typeof status === 'number') {
         return TRANSIENT_STATUS_CODES.has(status);
     }
     return !error?.response || TRANSIENT_ERROR_CODES.has(error?.code);
+}
+
+// `Retry-After` in seconds or as an HTTP date, in ms; null when absent/unusable.
+function getRetryAfterMs(error: any): number | null {
+    const value = error?.response?.headers?.['retry-after'];
+    if (value === undefined || value === null) {
+        return null;
+    }
+    const seconds = Number(value);
+    if (isFinite(seconds)) {
+        return seconds > 0 ? Math.min(seconds * 1000, MAX_RETRY_AFTER_MS) : null;
+    }
+    const date = Date.parse(String(value));
+    if (isFinite(date)) {
+        const wait = date - Date.now();
+        return wait > 0 ? Math.min(wait, MAX_RETRY_AFTER_MS) : null;
+    }
+    return null;
 }
 
 function delay(ms: number): Promise<void> {
@@ -43,7 +65,8 @@ export async function axiosGetWithRetry(
             if (attempt >= attempts || !isTransientError(error)) {
                 break;
             }
-            await delay(baseDelay * Math.pow(2, attempt - 1));
+            //a throttled response tells us how long to wait; honour it over our own backoff
+            await delay(getRetryAfterMs(error) ?? baseDelay * Math.pow(2, attempt - 1));
         }
     }
     const reason = lastError?.message || 'Unknown error';

--- a/worker-service/tests/axios-get-with-retry.test.mjs
+++ b/worker-service/tests/axios-get-with-retry.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { axiosGetWithRetry } from '../dist/api/helpers/utils.js';
+
+const startServer = (handler) => new Promise((resolve) => {
+    const state = { hits: 0 };
+    const server = http.createServer((req, res) => {
+        state.hits++;
+        handler(req, res, state.hits);
+    });
+    server.listen(0, '127.0.0.1', () => {
+        state.url = `http://127.0.0.1:${server.address().port}/`;
+        state.close = () => new Promise((done) => server.close(done));
+        resolve(state);
+    });
+});
+
+const json = (res, code, body, headers = {}) => {
+    res.writeHead(code, { 'content-type': 'application/json', ...headers });
+    res.end(JSON.stringify(body));
+};
+
+describe('axiosGetWithRetry', () => {
+    it('retries a 429 and returns the eventual success', async () => {
+        const server = await startServer((req, res, hits) => {
+            if (hits === 1) {
+                json(res, 429, { error: 'rate limited' });
+            } else {
+                json(res, 200, { ok: true });
+            }
+        });
+
+        const res = await axiosGetWithRetry('Mirror node', server.url, {}, { attempts: 3, delay: 10 });
+        assert.equal(res.data.ok, true);
+        assert.equal(server.hits, 2, 'a throttled request must be retried');
+        await server.close();
+    });
+
+    it('waits for Retry-After instead of its own backoff', async function () {
+        this.timeout(5000);
+        const server = await startServer((req, res, hits) => {
+            if (hits === 1) {
+                json(res, 429, { error: 'rate limited' }, { 'retry-after': '1' });
+            } else {
+                json(res, 200, { ok: true });
+            }
+        });
+
+        const started = Date.now();
+        await axiosGetWithRetry('Mirror node', server.url, {}, { attempts: 2, delay: 10 });
+        const elapsed = Date.now() - started;
+        assert.ok(elapsed >= 900, `Retry-After: 1 should hold the retry ~1s, waited ${elapsed}ms`);
+        await server.close();
+    });
+
+    it('does not retry a 404', async () => {
+        const server = await startServer((req, res) => json(res, 404, { error: 'not found' }));
+
+        await assert.rejects(
+            () => axiosGetWithRetry('Mirror node', server.url, {}, { attempts: 3, delay: 10 }),
+            /Mirror node request failed/
+        );
+        assert.equal(server.hits, 1, '404 must fail fast');
+        await server.close();
+    });
+
+    it('gives up after the configured number of attempts', async () => {
+        const server = await startServer((req, res) => json(res, 429, { error: 'rate limited' }));
+
+        await assert.rejects(
+            () => axiosGetWithRetry('IPFS gateway', server.url, {}, { attempts: 2, delay: 10 }),
+            /IPFS gateway request failed/
+        );
+        assert.equal(server.hits, 2);
+        await server.close();
+    });
+});


### PR DESCRIPTION
## Problem

The Hedera mirror node rate limit is **per source IP** and is shared by every process behind that IP — `worker-service`, `topic-listener-service`, an indexer, other tenants. Guardian currently assumes it has that budget to itself in two places, and neither degrades gracefully when it doesn't.

We hit this in a production deployment with 147 registered listeners: a **50-minute window of continuous HTTP 429s across 115 distinct topics**, during which the listener ingested nothing and kept retrying every throttled topic on every cycle. 1051 failures produced 6,306 log lines, because each one printed a full stack.

## 1. `topic-listener-service`: no pacing, no backoff

`ListenerService.scheduler()` polls every registered listener back to back with **no delay at all**, then sleeps 10s and repeats. `Listener.search()` catches, logs, and moves on without advancing `searchIndex`, so a throttled topic is retried immediately on the next cycle, at full rate.

- **Pace the calls.** A configurable delay between mirror-node requests (`LISTENER_CALL_DELAY_MS`, default 25ms ≈ 40 req/s) instead of none.
- **Back off on failure.** Honour `Retry-After` on 429 (seconds or HTTP date); otherwise exponential backoff 5s→5min with **downward-only** jitter, so the configured caps stay hard limits.
- **Back off when idle.** A topic that keeps returning nothing is polled progressively less often, 10s→60s. In a real deployment most listeners sit on topics that rarely or never produce a message — in ours, 110 of 147 had never received one — and they were being polled as often as active ones. The cap keeps a topic that *does* become active responsive.
- **Don't spend budget on listeners that aren't due.** `search()` now returns whether it actually called upstream; the scheduler only applies its pacing delay when a call happened, so a listener in backoff costs no cycle time.
- **Request timeout 2min → 15s** (`LISTENER_REQUEST_TIMEOUT_MS`). The loop is sequential, so one hung request stalled every other listener for up to two minutes.
- **One log line per failure** with the retry decision, instead of a full stack.

The loop stays sequential on purpose — parallelising would burst against the very limit this is protecting.

## 2. `topic-listener-service`: chunked messages could never complete

`Listener.addMessages()` returns before advancing `_searchIndex` for continuation chunks:

```ts
if (chunkId) {
    for (const m of this._messages) {
        if (m.chunkId === chunkId) {
            m.addChunk(message);
            return;          // <-- _searchIndex never advances past chunk 1
        }
    }
}
```

So the index sticks at the sequence number of the group's **first** chunk. Once `confirmData()` drops the completed message, the next poll (`sequencenumber=gt:<first chunk>`) re-fetches chunks 2..N. `Message.addChunk()` has no dedup, so `messages.length` overshoots `chunkTotal`, and `compressMessages()` only sets `COMPRESSED` on **exact** equality — the group flips to permanent `COMPRESSING`, `next()` never returns it, and the listener re-fetches and re-appends the same chunks every cycle while growing in memory.

Fixed by advancing the index for continuation chunks (safe: the constructor resumes from `min(searchIndex, sendIndex)`, so an incomplete in-memory group is re-fetched whole after a restart), ignoring re-fetched chunks, ordering chunks by sequence number before reassembly (concatenation depends on order), and letting the completeness check tolerate an over-full group.

## 3. `worker-service`: 429 was fatal

`axiosGetWithRetry()` retries 502/503/504 and network timeouts, but 429 fell straight through as fatal — a short throttling window failed the whole task. 429 joins the transient set, and when the response carries `Retry-After` the retry waits exactly that (capped at 60s) instead of the helper's own backoff. Every other 4xx still fails fast, so 404 behaviour is unchanged.

This covers both call sites: the mirror node fetch in `hedera-sdk-helper.ts` and the IPFS gateway fetch in `ipfs-client-class.ts`.

## Configuration

All new knobs have defaults matching current behaviour where behaviour is unchanged, and are env-overridable: `LISTENER_CALL_DELAY_MS`, `LISTENER_REQUEST_TIMEOUT_MS`, `LISTENER_ERROR_BACKOFF_MIN_MS`, `LISTENER_ERROR_BACKOFF_MAX_MS`, `LISTENER_IDLE_BACKOFF_STEP_MS`, `LISTENER_IDLE_BACKOFF_MAX_MS`.

## Tests

- `topic-listener-service/tests/listener-backoff.test.mjs` (new, 11 tests): idle and error backoff growth and caps, `Retry-After` parsing (seconds / HTTP date / unusable), skip-while-backing-off, chunk index advance, re-fetched chunk dedup, out-of-order reassembly. Suite: **38 passing**.
- `worker-service/tests/axios-get-with-retry.test.mjs` (new, 4 tests): driven against a local HTTP server — 429 retried to success, `Retry-After: 1` actually held the retry ~1s, 404 not retried, attempt cap respected. Suite: **283 passing** (`tests/*.test.mjs`).
- `tslint` clean on both services; `tsc` clean.

Note: `worker-service/tests/ipfs-client.test.mjs` fails to load on `develop` before this change — it imports `../dist/api/ipfs-client.js`, but the module is `ipfs-client-class.ts`. Unrelated to this PR, but it does mean `tests/**/*.test.mjs` cannot currently run to completion.
