### PR TITLE
fix(policy-service): surface customLogic script exceptions instead of silent stall

### DIFF
--- a/policy-service/src/policy-engine/blocks/custom-logic-block.ts
+++ b/policy-service/src/policy-engine/blocks/custom-logic-block.ts
@@ -468,6 +468,13 @@ export class CustomLogicBlock {
                         reject(error);
                     });
                     worker.on('message', async (data) => {
+                        // A thrown script posts an 'error' sentinel; reject so runAction's catch
+                        // surfaces it (BlockErrorFn + log) instead of silently parking the step.
+                        if (data?.error) {
+                            cleanup();
+                            reject(new Error(data.error));
+                            return;
+                        }
                         try {
                             if (data?.type === 'done') {
                                 await done(data.result, data.final);

--- a/policy-service/src/policy-engine/helpers/workers/custom-logic-worker.ts
+++ b/policy-service/src/policy-engine/helpers/workers/custom-logic-worker.ts
@@ -68,8 +68,13 @@ function execute(): void {
     try {
         vm.runInContext(execFunc, context, { timeout: 30000 });
     } catch (error) {
-        parentPort.postMessage({ type: 'debug', message: `Sandbox error: ${error.message}` });
-        parentPort.postMessage({ type: 'done', result: null, final: true });
+        // A thrown script is a failure, not a successful empty result. Emit an 'error'
+        // sentinel so the block surfaces it (ref.error + BlockErrorFn + ErrorEvent),
+        // instead of the previous silent `done(null, final: true)` which fired no event
+        // and left the workflow step parked on this non-UI block with no diagnostics.
+        const message = (error as Error)?.message ?? String(error);
+        parentPort.postMessage({ type: 'debug', message: `Sandbox error: ${message}` });
+        parentPort.postMessage({ type: 'error', error: `Custom logic error: ${message}` });
     }
 }
 

--- a/policy-service/tests/unit-tests/blocks/custom-logic-worker-error.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/custom-logic-worker-error.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { Worker } from 'node:worker_threads';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A customLogic script that throws must emit a real 'error' sentinel, not a silent
+ * `done(null, final: true)`.
+ *
+ * Previously the worker's catch swallowed the exception into a suppressed `debug`
+ * message and posted `done(null, final: true)`, which the block turned into a no-op
+ * (triggerEvents(null) -> no RefreshEvent) -> the workflow step parked on this non-UI
+ * block with zero diagnostics.
+ */
+const filename = fileURLToPath(import.meta.url);
+const WORKER = path.join(
+    path.dirname(filename),
+    '../../../dist/policy-engine/helpers/workers/custom-logic-worker.js'
+);
+
+function runWorker(execFunc) {
+    return new Promise((resolve, reject) => {
+        const messages = [];
+        const worker = new Worker(WORKER, {
+            workerData: { execFunc, user: {}, artifacts: [], documents: [{ document: {} }], sources: [], tablesPack: {} },
+        });
+        const timer = setTimeout(() => { worker.terminate(); reject(new Error('worker timeout')); }, 15000);
+        worker.on('message', (m) => messages.push(m));
+        worker.on('error', (e) => { clearTimeout(timer); reject(e); });
+        worker.on('exit', () => { clearTimeout(timer); resolve(messages); });
+    });
+}
+
+describe('@unit customLogic worker error signalling', () => {
+    it('emits an "error" message when the script throws', async () => {
+        const messages = await runWorker('documents[0].missing.field.value;');
+        const err = messages.find((m) => m?.type === 'error');
+        assert.ok(err, 'worker posts a { type: "error" } message on a thrown script');
+        assert.match(err.error, /Custom logic error/);
+    });
+
+    it('does NOT fake a successful done(null) on a thrown script', async () => {
+        const messages = await runWorker('throw new Error("boom");');
+        const fakeDone = messages.find(
+            (m) => m?.type === 'done' && m?.result === null && m?.final === true
+        );
+        assert.equal(fakeDone, undefined, 'no silent done(null, final: true) is emitted');
+        assert.ok(messages.some((m) => m?.type === 'error'), 'an error is emitted instead');
+    });
+
+    it('still returns the script result on the success path', async () => {
+        const messages = await runWorker('done({ ok: 1 });');
+        const done = messages.find((m) => m?.type === 'done');
+        assert.ok(done, 'a done message is emitted');
+        assert.deepEqual(done.result, { ok: 1 });
+        assert.equal(messages.some((m) => m?.type === 'error'), false, 'no error on the success path');
+    });
+});


### PR DESCRIPTION
Closes #6419.

## Problem
When a `customLogicBlock` JavaScript script throws at runtime, the failure is **silently swallowed**: the worker downgrades the exception to a suppressed `debug` message and posts `done(null, final: true)`. The block turns that into a no-op (`triggerEvents(null)` → `if (!documents) return;` → no `RefreshEvent`), so the workflow step **parks indefinitely** on the block with **no diagnostics** — no UI error, no server-side error log, no console output. If the block is a non-UI child of an `interfaceStepBlock`, the viewer shows the generic "This step isn't available to you right now", masking a failed calculation as a normal role/state gate.

The JS worker branch's `worker.on('message')` also doesn't handle an error signal, unlike the Python worker branch which already checks `data?.error`.

## Fix
- **Worker** (`custom-logic-worker.ts`): on `catch`, emit `{ type: 'error', error }` instead of the fake `done(null, final: true)`.
- **Block** (`custom-logic-block.ts`, JS worker branch): reject on the `error` sentinel — mirroring the Python branch — so `runAction`'s existing catch surfaces it via `ref.error()` + `PolicyComponentsUtils.BlockErrorFn()` (UI) + `ErrorEvent`.

A legitimate `done(null)` / empty result from the script is unchanged — only a *thrown* script signals an error.

## Behavior

| Script | Before | After |
|---|---|---|
| throws | suppressed `debug` + `done(null, final: true)` → silent parked step | `error` sentinel → block error surfaced (UI + log) + `ErrorEvent` |
| `done(null)` / empty | no-op | no-op (unchanged) |
| `done(result)` | result propagates | result propagates (unchanged) |

## Tests
New `custom-logic-worker-error.test.mjs` spawns the real worker:
- thrown script → emits `error` sentinel (not `done(null, final: true)`)
- success path → result preserved, no error

`3 passing`. Build (`gulp`) clean.
