### PR TITLE
fix(api-gateway): cached @Response() endpoints hang on cache hit; preserve response headers

### DIFF
--- a/api-gateway/src/api/service/contract.ts
+++ b/api-gateway/src/api/service/contract.ts
@@ -104,9 +104,10 @@ export class ContractsApi {
         example: { statusCode: 500, message: 'Error message' }
     })
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async getContracts(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Response() res: any,
         @Query('type') type?: ContractType,
         @Query('pageIndex') pageIndex?: number,
@@ -121,6 +122,7 @@ export class ContractsApi {
                 pageIndex,
                 pageSize
             );
+            req.locals = contracts;
             return res.header('X-Total-Count', count).send(contracts);
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -465,9 +465,10 @@ export class SchemaApi {
     })
     @ApiExtraModels(SchemaDTO, InternalServerErrorDTO)
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async getSchemasPage(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Response() res: any,
         @Query('pageIndex') pageIndex?: number,
         @Query('pageSize') pageSize?: number,
@@ -502,6 +503,7 @@ export class SchemaApi {
             }
             const { items, count } = await guardians.getSchemasByOwner(options, owner);
             SchemaHelper.updatePermission(items, owner);
+            req.locals = SchemaUtils.toOld(items);
             return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -752,9 +754,10 @@ export class SchemaApi {
     })
     @ApiExtraModels(SchemaDTO, InternalServerErrorDTO)
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async getSchemasPageByTopicId(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Response() res: any,
         @Param('topicId') topicId: string,
         @Query('pageIndex') pageIndex?: number,
@@ -777,6 +780,7 @@ export class SchemaApi {
             }
             const { items, count } = await guardians.getSchemasByOwner(options, owner);
             SchemaHelper.updatePermission(items, owner);
+            req.locals = SchemaUtils.toOld(items);
             return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -2720,9 +2724,10 @@ export class SchemaApi {
     })
     @ApiExtraModels(SchemaDTO, InternalServerErrorDTO)
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async getSystemSchema(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Response() res: any,
         @Param('username') username: string,
         @Query('pageIndex') pageIndex?: number,
@@ -2733,6 +2738,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const { items, count } = await guardians.getSystemSchemas(user, pageIndex, pageSize);
             items.forEach((s) => { s.readonly = s.readonly || s.owner !== owner.owner });
+            req.locals = SchemaUtils.toOld(items);
             return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/api/service/themes.ts
+++ b/api-gateway/src/api/service/themes.ts
@@ -367,9 +367,10 @@ export class ThemesApi {
         }
     })
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async exportTheme(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Param('themeId') themeId: string,
         @Response() res: any
     ): Promise<any> {
@@ -379,6 +380,7 @@ export class ThemesApi {
             const file: any = await guardian.exportThemeFile(themeId, owner);
             res.header('Content-disposition', `attachment; filename=theme_${Date.now()}`);
             res.header('Content-type', 'application/zip');
+            req.locals = file;
             return res.send(file);
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/api/service/tool.ts
+++ b/api-gateway/src/api/service/tool.ts
@@ -184,9 +184,10 @@ export class ToolsApi {
         example: { statusCode: 500, message: 'Error message' }
     })
     @HttpCode(HttpStatus.OK)
-    @UseCache()
+    @UseCache({ isFastify: true })
     async getTools(
         @AuthUser() user: IAuthUser,
+        @Req() req,
         @Response() res: any,
         @Query('pageIndex') pageIndex?: number,
         @Query('pageSize') pageSize?: number
@@ -198,6 +199,7 @@ export class ToolsApi {
                 pageIndex,
                 pageSize
             }, owner);
+            req.locals = items;
             return res.header('X-Total-Count', count).send(items);
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/helpers/interceptors/cache.ts
+++ b/api-gateway/src/helpers/interceptors/cache.ts
@@ -17,6 +17,9 @@ import { CACHE, CACHE_PREFIXES, META_DATA } from '#constants';
 
 @Injectable()
 export class CacheInterceptor implements NestInterceptor {
+    // Response headers re-applied on a cache hit (a hit replays only the body).
+    private static readonly CACHED_HEADERS = ['X-Total-Count', 'Content-Disposition', 'Content-Type'];
+
     constructor(
         private readonly cacheService: CacheService
     ) {
@@ -52,24 +55,35 @@ export class CacheInterceptor implements NestInterceptor {
                 const cachedResponse: string = await this.cacheService.get(cacheKey);
 
                 if (cachedResponse) {
-                    let result = JSON.parse(cachedResponse);
+                    const envelope = JSON.parse(cachedResponse);
+                    const headers = envelope.headers;
+                    let value;
 
-                    if (result.type === 'StreamableFile') {
-                        const buffer = Buffer.from(result.data, 'base64');
-                        result = new StreamableFile(buffer);
+                    if (envelope.type === 'StreamableFile') {
+                        value = new StreamableFile(Buffer.from(envelope.data, 'base64'));
                     }
-                    else if (result.type === 'buffer') {
-                        result = Buffer.from(result.data, 'base64');
+                    else if (envelope.type === 'buffer') {
+                        value = Buffer.from(envelope.data, 'base64');
                     } else  {
-                        result = result.data;
+                        value = envelope.data;
                     }
 
-                    return result;
+                    return { cached: true, value, headers };
                 }
+
+                return null;
             }),
-            switchMap(resultResponse => {
-                if (resultResponse) {
+            switchMap(cacheHit => {
+                if (cacheHit) {
+                    const resultResponse = cacheHit.value;
                     if (isFastify) {
+                        // A hit never runs the handler, so re-apply the headers it
+                        // set (e.g. X-Total-Count, download filename/MIME).
+                        if (cacheHit.headers && typeof responseContext.header === 'function') {
+                            for (const [name, value] of Object.entries(cacheHit.headers)) {
+                                responseContext.header(name, value);
+                            }
+                        }
                         return of(responseContext.send(resultResponse));
                     }
 
@@ -94,6 +108,19 @@ export class CacheInterceptor implements NestInterceptor {
                             result = { type: 'json', data: result };
                         } else {
                             result = { type: 'string', data: result };
+                        }
+
+                        if (isFastify && typeof responseContext.getHeader === 'function') {
+                            const headers: Record<string, string> = {};
+                            for (const name of CacheInterceptor.CACHED_HEADERS) {
+                                const value = responseContext.getHeader(name);
+                                if (value !== undefined && value !== null) {
+                                    headers[name] = String(value);
+                                }
+                            }
+                            if (Object.keys(headers).length) {
+                                result.headers = headers;
+                            }
                         }
 
                         await this.cacheService.set(cacheKey, JSON.stringify(result), ttl, cacheTag);

--- a/api-gateway/tests/cache-fastify-response.invariant.test.js
+++ b/api-gateway/tests/cache-fastify-response.invariant.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// A @UseCache() handler that manages its own response via @Response()/@Res
+// hangs on a cache hit unless it passes { isFastify: true }: the hit never runs
+// the handler, and without the flag the interceptor returns a value Fastify's
+// manual-response mode drops, so reply.send() is never called.
+
+const SERVICE_DIR = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../src/api/service'
+);
+
+function matchParen(src, open) {
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        if (src[i] === '(') depth++;
+        else if (src[i] === ')') {
+            depth--;
+            if (depth === 0) return i;
+        }
+    }
+    return -1;
+}
+
+function findViolations(src, file) {
+    const out = [];
+    const re = /@UseCache\s*\(/g;
+    let m;
+    while ((m = re.exec(src))) {
+        const argOpen = m.index + m[0].length - 1;
+        const argClose = matchParen(src, argOpen);
+        if (argClose < 0) continue;
+        const isFastify = /isFastify\s*:\s*true/.test(src.slice(argOpen + 1, argClose));
+
+        const rest = src.slice(argClose);
+        const sigM = rest.match(/async\s+([A-Za-z0-9_]+)\s*\(/);
+        if (!sigM) continue;
+        const paramOpen = argClose + sigM.index + sigM[0].length - 1;
+        const params = src.slice(paramOpen + 1, matchParen(src, paramOpen));
+        const usesRes = /@Response\s*\(|@Res\s*\(/.test(params);
+
+        if (usesRes && !isFastify) {
+            out.push(`${file}::${sigM[1]}`);
+        }
+    }
+    return out;
+}
+
+describe('@UseCache Fastify response contract', () => {
+    const files = fs.readdirSync(SERVICE_DIR).filter((f) => f.endsWith('.ts'));
+
+    it('has service sources to scan', () => {
+        assert.ok(files.length > 0);
+    });
+
+    it('never pairs @UseCache (without isFastify:true) with a @Response()/@Res handler', () => {
+        const violations = files.flatMap((f) =>
+            findViolations(fs.readFileSync(path.join(SERVICE_DIR, f), 'utf8'), f)
+        );
+        assert.deepEqual(
+            violations,
+            [],
+            `Cache hits on these @Response() handlers never call res.send() and hang:\n` +
+                violations.map((v) => `  - ${v}`).join('\n')
+        );
+    });
+});

--- a/api-gateway/tests/cache-interceptor-headers.test.js
+++ b/api-gateway/tests/cache-interceptor-headers.test.js
@@ -81,7 +81,7 @@ describe('CacheInterceptor header preservation (fastify)', () => {
         const sent = [];
         const req = { headers: {}, url: '/dl', locals: Buffer.from('zipbytes') };
         const res = {
-            getHeader: (k) => hdr[k],
+            getHeader: (k) => hdr[k.toLowerCase()],
             header: (k, v) => { applied[k] = v; },
             send: (x) => { sent.push(x); return 'SENT'; },
         };

--- a/api-gateway/tests/cache-interceptor-headers.test.js
+++ b/api-gateway/tests/cache-interceptor-headers.test.js
@@ -1,0 +1,103 @@
+import 'reflect-metadata';
+import assert from 'node:assert/strict';
+import { firstValueFrom, of } from 'rxjs';
+
+import { CacheInterceptor } from '../dist/helpers/interceptors/cache.js';
+
+function makeStore(initial = {}) {
+    const data = { ...initial };
+    const sets = [];
+    return {
+        data,
+        sets,
+        service: {
+            get: async (k) => (k in data ? data[k] : null),
+            set: async (k, v) => { sets.push({ k, v }); data[k] = v; },
+            addTags: async () => {},
+        },
+    };
+}
+
+function makeContext(request, response) {
+    const handler = function handlerFn() {};
+    return {
+        switchToHttp: () => ({ getRequest: () => request, getResponse: () => response }),
+        getHandler: () => handler,
+        getClass: () => function classFn() {},
+    };
+}
+
+function fastify(ctx) {
+    Reflect.defineMetadata('fastify', true, ctx.getHandler());
+}
+
+async function run(it, ctx, next) {
+    return firstValueFrom(await it.intercept(ctx, next));
+}
+
+describe('CacheInterceptor header preservation (fastify)', () => {
+    it('captures X-Total-Count on a miss', async () => {
+        const store = makeStore();
+        const req = { headers: {}, url: '/paged', locals: [{ a: 1 }] };
+        const res = { getHeader: (k) => (k === 'X-Total-Count' ? 42 : undefined) };
+        const ctx = makeContext(req, res);
+        fastify(ctx);
+        const it = new CacheInterceptor(store.service);
+        await run(it, ctx, { handle: () => of(undefined) });
+        const envelope = JSON.parse(store.sets[0].v);
+        assert.deepEqual(envelope.data, [{ a: 1 }]);
+        assert.deepEqual(envelope.headers, { 'X-Total-Count': '42' });
+    });
+
+    it('re-applies X-Total-Count via response.header on a hit', async () => {
+        const store = makeStore();
+        const applied = {};
+        const sent = [];
+        const req = { headers: {}, url: '/paged', locals: [{ a: 1 }] };
+        const res = {
+            getHeader: (k) => (k === 'X-Total-Count' ? 7 : undefined),
+            header: (k, v) => { applied[k] = v; },
+            send: (x) => { sent.push(x); return 'SENT'; },
+        };
+        const ctx = makeContext(req, res);
+        fastify(ctx);
+        const it = new CacheInterceptor(store.service);
+        // miss populates the cache, second call is served from it
+        await run(it, ctx, { handle: () => of(undefined) });
+        delete res.getHeader;
+        const result = await run(it, ctx, { handle: () => of('fresh') });
+        assert.equal(applied['X-Total-Count'], '7');
+        assert.deepEqual(sent, [[{ a: 1 }]]);
+        assert.equal(result, 'SENT');
+    });
+
+    it('captures and replays download headers for a buffer body', async () => {
+        const store = makeStore();
+        const hdr = {
+            'Content-Disposition': 'attachment; filename=template.xlsx',
+            'Content-Type': 'application/zip',
+        };
+        const applied = {};
+        const sent = [];
+        const req = { headers: {}, url: '/dl', locals: Buffer.from('zipbytes') };
+        const res = {
+            getHeader: (k) => hdr[k],
+            header: (k, v) => { applied[k] = v; },
+            send: (x) => { sent.push(x); return 'SENT'; },
+        };
+        const ctx = makeContext(req, res);
+        fastify(ctx);
+        const it = new CacheInterceptor(store.service);
+        await run(it, ctx, { handle: () => of(undefined) });
+        const envelope = JSON.parse(store.sets[0].v);
+        assert.equal(envelope.type, 'buffer');
+        assert.deepEqual(envelope.headers, hdr);
+
+        delete res.getHeader;
+        await run(it, ctx, { handle: () => of('fresh') });
+        assert.equal(applied['Content-Disposition'], hdr['Content-Disposition']);
+        assert.equal(applied['Content-Type'], hdr['Content-Type']);
+        assert.ok(Buffer.isBuffer(sent[0]));
+        assert.equal(sent[0].toString(), 'zipbytes');
+    });
+});


### PR DESCRIPTION
## Problem

A `@UseCache()` route whose handler manages its own response via `@Response() res` (Fastify manual-response mode) **hangs on every cache hit**.

The api-gateway runs on Fastify, and these handlers send the body themselves via `res.send(...)`. In that mode Nest does not auto-send the interceptor's emitted value — it waits for `res.send()`.

On a cache **hit** the real handler never runs, so nobody calls `res.send()`. The `CacheInterceptor` only sends on the `isFastify` branch (`responseContext.send(...)`); without the flag it returns `of(value)`, which Fastify's `@Res` mode drops → the reply is never written → the request hangs until the client times out.

- First load (cache **miss**) → handler runs → `res.send()` → works.
- Reload within TTL (cache **hit**) → interceptor returns a value nobody sends → **hang**.

## Affected handlers

Six handlers use `@UseCache()` + `@Res` without `isFastify:true`, so each hangs on a cache hit:

| file | handler |
|---|---|
| `schema.ts` | `getSchemasPage`, `getSchemasPageByTopicId`, `getSystemSchema` |
| `contract.ts` | `getContracts` |
| `tool.ts` | `getTools` |
| `themes.ts` | `exportTheme` |

## Fix

**1.** Each handler is fixed to the existing working pattern (`getModuleSchemas`): `@Req() req` + `req.locals = <body>` + `@UseCache({ isFastify: true })`. `req.locals` is required — a `@Res` handler emits `undefined` to the interceptor, so without it the miss caches an empty body and the hit serves nothing.

**2.** The interceptor now **preserves response headers across a cache hit**. A hit replays only the cached body, so headers the client relies on were lost:
- **`X-Total-Count`** — paginated list endpoints (`observe: 'response'`) silently fell back to the current page length, undercounting pagination on cached responses.
- **`Content-Disposition` / `Content-Type`** — cached file downloads (`exportTemplate` is already `@UseCache({ isFastify: true })`) arrived with **no filename and wrong MIME** on cache hits.

The interceptor captures an allowlist (`X-Total-Count`, `Content-Disposition`, `Content-Type`) on the miss and re-applies them via `reply.header()` before `reply.send()` on the hit. Only allowlisted headers survive a hit (auth/set-cookie/etc. must not be replayed across users).

## Tests

- `cache-fastify-response.invariant.test.js` — fails if any `@UseCache` handler uses `@Response()`/`@Res` without `isFastify: true`; guards the six and any future regression.
- `cache-interceptor-headers.test.js` — `X-Total-Count` and download-header (`Content-Disposition`/`Content-Type`) capture-on-miss / replay-on-hit round-trips.

`tsc` build clean.

## Note

Cached file downloads are stored base64 in the cache store; fine for the small templates here, but caching large downloads through this JSON cache would be a memory-growth concern (pre-existing, out of scope).
