### PR TITLE
fix: draft file action buttons layout in request document dialog

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
@@ -274,6 +274,7 @@
       {{ minutesAgo$ | async }}
     </div>
   }
+  @if (!loading) {
     <request-draft-file-actions
       [schema]="schema"
       [policyId]="policyId"
@@ -281,5 +282,6 @@
       [dataForm]="dataForm"
       (draftImported)="onDraftImported($event)">
     </request-draft-file-actions>
+  }
   </div>
 </div>

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
@@ -268,6 +268,12 @@
       </button>
     </div>
   }
+    <div class="action-buttons-spacer"></div>
+  @if (lastSavedAt) {
+    <div class="last-autosave">
+      {{ minutesAgo$ | async }}
+    </div>
+  }
     <request-draft-file-actions
       [schema]="schema"
       [policyId]="policyId"
@@ -275,10 +281,5 @@
       [dataForm]="dataForm"
       (draftImported)="onDraftImported($event)">
     </request-draft-file-actions>
-  @if (lastSavedAt) {
-    <div class="last-autosave">
-      {{ minutesAgo$ | async }}
-    </div>
-  }
   </div>
 </div>

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
@@ -76,28 +76,28 @@ form {
 
 .action-buttons {
     display: flex;
+    align-items: center;
     user-select: none;
-    justify-content: flex-start !important;
+    gap: 16px;
 
-    &>div {
-        margin-left: 0px;
-        margin-right: 16px;
-    }
-
-    request-draft-file-actions {
-        margin-right: 16px;
+    .action-buttons-spacer {
+        order: 2;
+        flex: 1 1 auto;
     }
 
     .dialog-button {
         display: none;
+        margin: 0;
     }
 
     .dialog-button[id="cancel"] {
         display: block;
+        order: 0;
     }
 
     .dialog-button[id="submit"] {
         display: block;
+        order: 1;
 
         button {
             padding-left: 16px;
@@ -105,10 +105,17 @@ form {
         }
     }
 
+    .last-autosave {
+        order: 3;
+    }
+
+    request-draft-file-actions {
+        order: 4;
+    }
+
     .dialog-button[id="save"] {
         display: block;
-        margin-left: auto;
-        margin-right: 0px;
+        order: 5;
 
         &[visible="false"] {
             display: none !important;
@@ -121,22 +128,12 @@ form {
             padding-right: 16px;
         }
     }
-
-    .dialog-button[id="save"][visible="false"]+.last-autosave {
-        right: 52px;
-    }
-
-    .dialog-button[id="save"][visible="true"]+.last-autosave {
-        right: 182px;
-    }
 }
 
 .last-autosave {
-    position: absolute;
-    right: 182px;
-    bottom: 42px;
     font-size: 14px;
     color: #8E8E8E;
+    white-space: nowrap;
 }
 
 .close-icon-color {

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/draft-file-actions/draft-file-actions.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/draft-file-actions/draft-file-actions.component.html
@@ -10,7 +10,7 @@
             svgClass="icon-color-primary"
         ></svg-icon>
     </div>
-    <div class="guardian-button-label">Save draft to file</div>
+    <div class="guardian-button-label">Save Draft To File</div>
 </button>
 <button
     (click)="triggerImportDraft()"
@@ -24,7 +24,7 @@
             svgClass="icon-color-primary"
         ></svg-icon>
     </div>
-    <div class="guardian-button-label">Restore from draft file</div>
+    <div class="guardian-button-label">Restore From Draft File</div>
 </button>
 <input
     #draftFileInput

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/draft-file-actions/draft-file-actions.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/draft-file-actions/draft-file-actions.component.scss
@@ -3,3 +3,19 @@
     align-items: center;
     gap: 8px;
 }
+
+.guardian-button {
+    height: 40px;
+    padding: 1px 16px;
+
+    .guardian-button-icon {
+        width: 20px;
+        height: 20px;
+
+        svg-icon,
+        svg {
+            width: 20px;
+            height: 20px;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix the layout and behavior of the draft file action buttons in the request document dialog footer.

- Size the "Save Draft To File" and "Restore From Draft File" buttons to match the other footer buttons.
- Place the draft file buttons to the left of the Save Draft button and stop the autosave label from overlapping them.
- Render the draft file buttons only once the dialog content has loaded, matching the other footer buttons.
- Title-case the button labels to align with the rest of the UI.
