### PR TITLE
chore: rename Tokens & Contracts nav group to Hedera

### DIFF
--- a/api-gateway/src/api/service/policy-data.ts
+++ b/api-gateway/src/api/service/policy-data.ts
@@ -1,5 +1,9 @@
 import { IAuthUser, PinoLogger } from '@guardian/common';
-import { Permissions } from '@guardian/interfaces';
+import {
+    Permissions,
+    POLICY_DATA_MAX_PAGE_SIZE,
+    POLICY_DATA_DEFAULT_PAGE_SIZE,
+} from '@guardian/interfaces';
 import {
     Controller,
     Get,
@@ -28,10 +32,6 @@ import {
     PolicyDataQueryResponseDTO,
     UnauthorizedErrorDTO,
 } from '#middlewares';
-import {
-    POLICY_DATA_MAX_PAGE_SIZE,
-    POLICY_DATA_DEFAULT_PAGE_SIZE,
-} from '@guardian/interfaces';
 import { AuthUser, Auth } from '#auth';
 import { EntityOwner, Guardians, InternalException } from '#helpers';
 

--- a/frontend/src/app/views/new-header/menu.model.ts
+++ b/frontend/src/app/views/new-header/menu.model.ts
@@ -52,7 +52,7 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
         ],
     },
     {
-        title: 'Tokens & Contracts',
+        title: 'Hedera',
         icon: 'icon-hbar',
         allowedUserRoles: [UserRole.STANDARD_REGISTRY],
         active: false,
@@ -65,14 +65,11 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
                 title: 'Retirement Contracts',
                 routerLink: '/contracts'
             },
+            {
+                title: 'Relayer Accounts',
+                routerLink: '/relayer-accounts'
+            },
         ],
-    },
-    {
-        title: 'Relayer Accounts',
-        icon: 'pi pi-wallet',
-        allowedUserRoles: [UserRole.STANDARD_REGISTRY],
-        active: false,
-        routerLink: '/relayer-accounts'
     },
     {
         title: 'Administration',
@@ -279,7 +276,7 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
             }
         }
         menu.push({
-            title: 'Tokens & Contracts',
+            title: 'Hedera',
             icon: 'icon-hbar',
             allowedUserRoles: [UserRole.STANDARD_REGISTRY],
             active: false,

--- a/guardian-service/src/api/policy-data.service.ts
+++ b/guardian-service/src/api/policy-data.service.ts
@@ -244,7 +244,7 @@ export async function handlePolicyDataQuery(
         if (normalisedSortField) {
             sortOptions[normalisedSortField] = sortDescending ? 'DESC' : 'ASC';
         } else {
-            sortOptions['createDate'] = 'DESC';
+            sortOptions.createDate = 'DESC';
         }
 
         const queryOptions: any = {


### PR DESCRIPTION
### Description

Rename the "Tokens & Contracts" navigation group to "Hedera" in the new header.

- Rename the "Tokens & Contracts" group to "Hedera" in the Standard Registry and permission-based menus.
- Move "Relayer Accounts" under the Hedera group as its last item in the Standard Registry menu.
- Apply the change across the expanded, compact, and horizontal header layouts.

Delivers #6485