### PR TITLE
fix: 6423 surface unreachable IPFS data on remote policy/tool import

### DIFF
--- a/common/src/hedera-modules/message/index.ts
+++ b/common/src/hedera-modules/message/index.ts
@@ -5,6 +5,7 @@ export { VCMessage } from './vc-message.js';
 export { MessageType } from './message-type.js';
 export { MessageAction } from './message-action.js';
 export { MessageServer } from './message-server.js';
+export { MessageIpfsError } from './message-load.error.js';
 export { PolicyMessage } from './policy-message.js';
 export { UrlType } from './url.interface.js';
 export { TopicMessage } from './topic-message.js';

--- a/common/src/hedera-modules/message/message-load.error.ts
+++ b/common/src/hedera-modules/message/message-load.error.ts
@@ -1,0 +1,16 @@
+/**
+ * Message found on Hedera but its IPFS documents could not be loaded (unpinned,
+ * offline, or timed out). Carries code 422 so it surfaces as an actionable 4xx
+ * rather than a generic 500 / null.
+ */
+export class MessageIpfsError extends Error {
+    public readonly code: number;
+    public readonly messageId?: string;
+
+    constructor(messageId?: string) {
+        super(`IPFS_UNAVAILABLE: IPFS data for message ${messageId} could not be retrieved. It may be unpinned or the source node is offline.`);
+        this.name = 'MessageIpfsError';
+        this.code = 422;
+        this.messageId = messageId;
+    }
+}

--- a/common/src/hedera-modules/message/message-server.ts
+++ b/common/src/hedera-modules/message/message-server.ts
@@ -7,6 +7,7 @@ import { MessageMemo } from '../memo-mappings/message-memo.js';
 import { DatabaseServer } from '../../database-modules/index.js';
 import { TopicConfig } from '../topic.js';
 import { Message } from './message.js';
+import { MessageIpfsError } from './message-load.error.js';
 import { MessageType } from './message-type.js';
 import { MessageAction } from './message-action.js';
 import { VCMessage } from './vc-message.js';
@@ -836,11 +837,20 @@ export class MessageServer {
             } else {
                 let message = await MessageServer.getTopicMessage<T>(messageId, type, options);
                 if (loadIPFS) {
-                    message = await MessageServer.loadIPFS(message, options.encryptKey, options);
+                    try {
+                        message = await MessageServer.loadIPFS(message, options.encryptKey, options);
+                    } catch (ipfsError) {
+                        // Distinguish unreachable IPFS from a missing message.
+                        new PinoLogger().error(ipfsError, ['GUARDIAN_SERVICE'], options?.userId);
+                        throw new MessageIpfsError(messageId);
+                    }
                 }
                 return message;
             }
         } catch (error) {
+            if (error instanceof MessageIpfsError) {
+                throw error;
+            }
             new PinoLogger().error(error, ['GUARDIAN_SERVICE'], options?.userId);
             return null;
         }
@@ -870,11 +880,20 @@ export class MessageServer {
             } else {
                 let message = await this.getTopicMessage<T>(messageId, type, options);
                 if (loadIPFS) {
-                    message = await this.loadIPFS(message, options);
+                    try {
+                        message = await this.loadIPFS(message, options);
+                    } catch (ipfsError) {
+                        // Distinguish unreachable IPFS from a missing message.
+                        new PinoLogger().error(ipfsError, ['GUARDIAN_SERVICE'], options?.userId);
+                        throw new MessageIpfsError(messageId);
+                    }
                 }
                 return message as T;
             }
         } catch (error) {
+            if (error instanceof MessageIpfsError) {
+                throw error;
+            }
             new PinoLogger().error(error, ['GUARDIAN_SERVICE'], options?.userId);
             return null;
         }

--- a/common/tests/unit-tests/hedera-modules/message/message-ipfs-error.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/message/message-ipfs-error.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { MessageIpfsError } from '../../../../dist/hedera-modules/message/message-load.error.js';
+
+describe('@unit MessageIpfsError', () => {
+    it('carries a 422 status', () => {
+        assert.equal(new MessageIpfsError('1.2.3').code, 422);
+    });
+
+    it('is an Error and preserves the message id', () => {
+        const e = new MessageIpfsError('1.2.3');
+        assert.ok(e instanceof Error);
+        assert.equal(e.name, 'MessageIpfsError');
+        assert.equal(e.messageId, '1.2.3');
+    });
+
+    it('embeds the IPFS_UNAVAILABLE token and the message id', () => {
+        const e = new MessageIpfsError('1.2.3');
+        assert.match(e.message, /^IPFS_UNAVAILABLE:/);
+        assert.match(e.message, /1\.2\.3/);
+        assert.match(e.message, /unpinned|offline/i);
+    });
+});

--- a/common/tests/unit-tests/hedera-modules/message/message-server-getmessage-ipfs.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/message/message-server-getmessage-ipfs.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { MessageServer } from '../../../../dist/hedera-modules/message/message-server.js';
+import { MessageIpfsError } from '../../../../dist/hedera-modules/message/message-load.error.js';
+
+// getMessage() must distinguish a missing header (returns null) from a found
+// header whose IPFS documents fail to load (throws MessageIpfsError). Driven via
+// .call() on a minimal stub so no real MessageServer / Hedera creds are needed.
+
+function fakeThis(overrides) {
+    return {
+        dryRun: false,
+        getTopicMessage: async () => ({ type: 'InstancePolicy', document: {} }),
+        loadIPFS: async (m) => m,
+        ...overrides
+    };
+}
+
+const invoke = (self, options) => MessageServer.prototype.getMessage.call(self, options);
+
+describe('@unit MessageServer.getMessage() IPFS failure handling', () => {
+    it('throws MessageIpfsError(422) when the header loads but IPFS load fails', async () => {
+        const self = fakeThis({ loadIPFS: async () => { throw new Error('gateway timeout'); } });
+        await assert.rejects(invoke(self, { messageId: '1.2.3', loadIPFS: true }), (e) => {
+            assert.ok(e instanceof MessageIpfsError);
+            assert.equal(e.code, 422);
+            assert.equal(e.messageId, '1.2.3');
+            return true;
+        });
+    });
+
+    it('returns null (not a throw) for a non-IPFS failure', async () => {
+        const self = fakeThis({ getTopicMessage: async () => { throw new Error('topic lookup failed'); } });
+        assert.equal(await invoke(self, { messageId: '1.2.3', loadIPFS: true }), null);
+    });
+
+    it('does not run the IPFS step when loadIPFS is false', async () => {
+        let called = false;
+        const self = fakeThis({ loadIPFS: async () => { called = true; throw new Error('x'); } });
+        const result = await invoke(self, { messageId: '1.2.3', loadIPFS: false });
+        assert.equal(called, false);
+        assert.deepEqual(result, { type: 'InstancePolicy', document: {} });
+    });
+
+    it('returns the loaded message on success', async () => {
+        const loaded = { type: 'InstancePolicy', document: { ok: true } };
+        const self = fakeThis({ loadIPFS: async () => loaded });
+        assert.equal(await invoke(self, { messageId: '1.2.3', loadIPFS: true }), loaded);
+    });
+});

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -383,7 +383,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
         }
 
         // Show the failure before the redirect branches below navigate away.
-        this.informService.processAsyncError(error);
+        this.toastService.processAsyncError(error);
 
         if (this.last) {
             this.redirect(this.last);

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -382,6 +382,9 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             return;
         }
 
+        // Show the failure before the redirect branches below navigate away.
+        this.informService.processAsyncError(error);
+
         if (this.last) {
             this.redirect(this.last);
             return;

--- a/guardian-service/src/api/tool.service.ts
+++ b/guardian-service/src/api/tool.service.ts
@@ -1121,7 +1121,8 @@ export async function toolsAPI(logger: PinoLogger): Promise<void> {
                 return new MessageResponse(item);
             } catch (error) {
                 await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
-                return new MessageError(error);
+                // Forward error.code (422 for MessageIpfsError) instead of a generic 500.
+                return new MessageError(error, error?.code);
             }
         });
 
@@ -1188,7 +1189,8 @@ export async function toolsAPI(logger: PinoLogger): Promise<void> {
                     });
                 }
             }, async (error) => {
-                notifier.fail(error);
+                // Forward error.code (422 for MessageIpfsError) instead of a generic 500.
+                notifier.fail(error, (error as any)?.code);
             });
             return new MessageResponse(task);
         });

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -2074,7 +2074,8 @@ export class PolicyEngineService {
                     return new MessageResponse(true);
                 } catch (error) {
                     await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
-                    return new MessageError(error);
+                    // Forward error.code (422 for MessageIpfsError) instead of a generic 500.
+                    return new MessageError(error, error?.code);
                 }
             });
 
@@ -2156,7 +2157,8 @@ export class PolicyEngineService {
                         }
                     } catch (error) {
                         await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
-                        notifier.fail(error);
+                        // Forward error.code (422 for MessageIpfsError) instead of a generic 500.
+                        notifier.fail(error, error?.code);
                     }
                 });
                 return new MessageResponse(task);


### PR DESCRIPTION
## Issues

Addresses #6423 (unhelpful error when a remote import fails on missing IPFS data). Related to #6424 (IPFS pinning durability) - this PR handles the *reporting* side, not pinning.

## Problem

Importing a remote policy or tool by Hedera message id fails with no meaningful feedback when the referenced IPFS data is unpinned or offline. `MessageServer.getMessage()` catches every failure and returns `null`, so callers cannot distinguish "message not found on Hedera" from "message found but its IPFS payload is unreachable":

- Policy import dereferences the `null` and throws a generic error.
- Tool import reports a generic "Invalid Message".
- On the frontend, a failed push-import task is swallowed on the full-page `/task/:id` route (it redirects without showing anything).

## Changes

- **`common`**: new `MessageIpfsError` (HTTP code `422`). `getMessage()` now wraps the IPFS load step and throws it instead of collapsing to `null` when the message header was retrieved but its documents could not be loaded. A genuinely missing message still returns `null`, so the existing contract is preserved.
- **`guardian-service`**: forward `error.code` across NATS in the policy and tool import handlers (sync + async), so the `422` reaches the client instead of a generic `500`. (Matches the many handlers that already do `new MessageError(error, error?.code)`.)
- **`frontend`**: `AsyncProgressComponent.setError()` surfaces the failure via `InformService.processAsyncError` (which shows the task code + message) before redirecting, so push-task failures are no longer silently swallowed. This covers all push-task errors, not only import.

## Result

- Unreachable IPFS -> `422 IPFS_UNAVAILABLE: IPFS data for message <id> could not be retrieved. It may be unpinned or the source node is offline.`
- Message genuinely absent -> unchanged not-found behaviour.
- The message is shown at the preview step (where the IPFS fetch first happens) and on import execution if it fails there.

## Tests

- `common`: `MessageIpfsError` class; `getMessage()` IPFS-failure handling (throws on IPFS load failure, returns null on non-IPFS failure / empty id, skips the IPFS step when `loadIPFS=false`, returns the loaded message on success).