### PR TITLE
fix: request document dialog navigation layout

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
@@ -2,6 +2,30 @@
   <div class="header-container">
     <div class="header-text">{{dialogTitle}}</div>
   </div>
+  @if (restoreData) {
+    <button
+      class="guardian-button guardian-button-secondary header-action"
+      (click)="onRestoreClick()"
+      title="Restore the latest saved values">
+      <svg-icon class="icon-btn svg-icon"
+        src="/assets/images/icons/16/refresh.svg"
+        svgClass="icon-color-primary">
+      </svg-icon>
+      <span>Restore values</span>
+    </button>
+  }
+  @if (dryRun) {
+    <button
+      class="guardian-button guardian-button-secondary header-action"
+      (click)="onDryRun()"
+      title="Fill this document with test data">
+      <svg-icon class="icon-btn svg-icon"
+        src="/assets/images/icons/16/refresh.svg"
+        svgClass="icon-color-primary">
+      </svg-icon>
+      <span>Fill with test data</span>
+    </button>
+  }
   <div class="header-icon resize" (click)="toggleSize()" [title]="isLargeSize ? 'The size 50%' : 'The size 90%'">
     <i [class]="isLargeSize ? 'pi pi-window-minimize' : 'pi pi-window-maximize'"></i>
   </div>
@@ -16,46 +40,6 @@
     </div>
   }
   <div class="dialog-body-container">
-    @if (restoreData) {
-      <div class="restore-data">
-        <svg-icon class="svg-icon"
-          src="/assets/images/icons/info.svg"
-          svgClass="icon-color-primary">
-        </svg-icon>
-        <b>There is some data to restore. You can restore latest values:</b>
-        <button
-          (click)="onRestoreClick()"
-          class="guardian-button guardian-button-primary">
-          <div class="guardian-button-icon">
-            <svg-icon class="icon-btn svg-icon"
-              src="/assets/images/icons/16/refresh.svg"
-              svgClass="icon-color-secondary">
-            </svg-icon>
-          </div>
-          <div class="guardian-button-label">Restore Values</div>
-        </button>
-      </div>
-    }
-    @if (dryRun) {
-      <div class="restore-data">
-        <svg-icon class="svg-icon"
-          src="/assets/images/icons/info.svg"
-          svgClass="icon-color-primary">
-        </svg-icon>
-        <b>Dry run mode. You can fill this document with test data:</b>
-        <button
-          (click)="onDryRun()"
-          class="guardian-button guardian-button-primary">
-          <div class="guardian-button-icon">
-            <svg-icon class="icon-btn svg-icon"
-              src="/assets/images/icons/16/refresh.svg"
-              svgClass="icon-color-secondary">
-            </svg-icon>
-          </div>
-          <div class="guardian-button-label">Test</div>
-        </button>
-      </div>
-    }
     @if (relayerAccount || enableAdditionalData) {
       <div class="relayer-account-steps">
         <div class="guardian-step-container">

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
@@ -20,6 +20,7 @@
         position: static;
         right: auto;
         top: auto;
+        padding-left: 0;
         flex: 1 1 auto;
         min-width: 0;
     }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
@@ -11,6 +11,34 @@
 
 .dialog-header {
     padding: 32px 32px 24px 32px !important;
+    align-items: center;
+    gap: 12px;
+
+    // Let the title flow so the compact header actions and icons align to
+    // the right without overlapping it.
+    .header-container {
+        position: static;
+        right: auto;
+        top: auto;
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .header-action {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        height: 32px;
+        padding: 0 14px;
+        white-space: nowrap;
+
+        .svg-icon {
+            display: inline-flex;
+            width: 16px;
+            height: 16px;
+        }
+    }
 
     .header-item {
         padding: 6px 12px;
@@ -155,37 +183,6 @@ form {
         .dialog-button[visible="true"] {
             display: block !important;
         }
-    }
-}
-
-.restore-data {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--primary-color);
-    background: var(--guardian-grey-background, #F9FAFC);
-    border: 1px solid var(--guardian-border-color);
-    height: 52px;
-    min-height: 52px;
-    border-radius: 8px;
-    margin-bottom: 16px;
-    margin-right: 32px;
-
-    svg-icon {
-        height: 30px;
-        padding: 2px;
-        width: 36px;
-    }
-
-    b {
-        height: 30px;
-        line-height: 30px;
-        padding-right: 16px;
-    }
-
-    button {
-        height: 30px;
-        padding: 0px 30px 0px 12px;
     }
 }
 

--- a/frontend/src/app/modules/schema-engine/_nav-collapse.scss
+++ b/frontend/src/app/modules/schema-engine/_nav-collapse.scss
@@ -11,7 +11,9 @@
     gap: 8px;
     height: 32px;
     min-height: 32px;
-    padding: 0 4px 0 8px;
+    // Left padding matches the tree row start (schema-nav 8px + nav-node 6px)
+    // so the title aligns with the section rows below it.
+    padding: 0 14px;
     background: var(--guardian-background, #fff);
     border-bottom: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
 }
@@ -55,13 +57,15 @@
 
 .nav-collapse-rail {
     flex: 0 0 auto;
-    align-self: flex-start;
-    position: sticky;
-    top: 0;
+    align-self: stretch;
     display: flex;
-    justify-content: center;
-    padding-top: 4px;
-    border: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
-    border-radius: 6px;
-    background: var(--guardian-background, #fff);
+    flex-direction: column;
+    padding: 4px 8px 0 0;
+    // Thin separator line between the collapsed rail and the form.
+    border-right: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
+
+    .nav-collapse-btn {
+        position: sticky;
+        top: 0;
+    }
 }

--- a/frontend/src/app/modules/schema-engine/_nav-collapse.scss
+++ b/frontend/src/app/modules/schema-engine/_nav-collapse.scss
@@ -1,0 +1,67 @@
+// Shared chrome for the collapsible schema navigation panel.
+// Used by schema-form-root and document-view so both dialogs share one
+// collapse/expand mechanism.
+
+.nav-collapse-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 32px;
+    min-height: 32px;
+    padding: 0 4px 0 8px;
+    background: var(--guardian-background, #fff);
+    border-bottom: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
+}
+
+.nav-collapse-title {
+    flex: 1 1 auto;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--guardian-disabled-color, #848fa9);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.nav-collapse-btn {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    color: var(--guardian-disabled-color, #848fa9);
+    transition: background 0.2s ease, color 0.2s ease;
+
+    &:hover {
+        background: rgba(65, 105, 226, 0.08);
+        color: var(--primary-color);
+    }
+
+    i {
+        font-size: 12px;
+    }
+}
+
+.nav-collapse-rail {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    position: sticky;
+    top: 0;
+    display: flex;
+    justify-content: center;
+    padding-top: 4px;
+    border: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
+    border-radius: 6px;
+    background: var(--guardian-background, #fff);
+}

--- a/frontend/src/app/modules/schema-engine/document-view/document-view.component.html
+++ b/frontend/src/app/modules/schema-engine/document-view/document-view.component.html
@@ -1,6 +1,29 @@
 <div class="content" #contentContainer>
+  @if (type !== 'VP' && navCollapsed) {
+    <div class="nav-collapse-rail">
+      <button
+        class="nav-collapse-btn"
+        type="button"
+        title="Expand panel"
+        aria-label="Expand panel"
+        (click)="toggleNav()">
+        <i class="pi pi-chevron-right"></i>
+      </button>
+    </div>
+  }
   @if (type !== 'VP') {
-    <div class="schema-form-view-nav" #navContainer [class.nav-collapsed]="navCollapsed">
+    <div class="schema-form-view-nav" #navContainer [hidden]="navCollapsed">
+      <div class="nav-collapse-header">
+        <span class="nav-collapse-title">Sections</span>
+        <button
+          class="nav-collapse-btn"
+          type="button"
+          title="Collapse panel"
+          aria-label="Collapse panel"
+          (click)="toggleNav()">
+          <i class="pi pi-chevron-left"></i>
+        </button>
+      </div>
       <app-schema-form-view-navigation #schemaNav
         [subjects]="subjects"
         [schemaMap]="schemaMap"
@@ -12,7 +35,7 @@
       </app-schema-form-view-navigation>
     </div>
   }
-  @if (type !== 'VP') {
+  @if (type !== 'VP' && !navCollapsed) {
     <div
       class="resize-handler"
       (mousedown)="onResizeStart($event)"

--- a/frontend/src/app/modules/schema-engine/document-view/document-view.component.scss
+++ b/frontend/src/app/modules/schema-engine/document-view/document-view.component.scss
@@ -1,3 +1,5 @@
+@import '../nav-collapse';
+
 form {
     display: flex;
     flex-direction: column;
@@ -266,19 +268,20 @@ form {
     position: sticky;
     top: 0;
     max-height: calc(100vh - 230px);
-    overflow-y: auto;
     box-sizing: border-box;
+    overflow-y: auto;
+    border: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
+    border-radius: 6px;
     transition: width 0.2s ease;
 
-    &.nav-collapsed {
-        width: 0 !important;
-        min-width: 0 !important;
-        overflow: hidden;
+    // The panel now owns the border and the scroll; the sticky collapse
+    // header stays pinned while the tree scrolls underneath it.
+    ::ng-deep .schema-nav {
+        max-height: none !important;
+        overflow: visible;
+        border: none;
+        border-radius: 0;
     }
-}
-
-.schema-form-view-nav.nav-collapsed + .resize-handler {
-    display: none;
 }
 
 .schema-form-content {

--- a/frontend/src/app/modules/schema-engine/document-view/document-view.component.ts
+++ b/frontend/src/app/modules/schema-engine/document-view/document-view.component.ts
@@ -21,7 +21,6 @@ import { SchemaFormViewNavigationComponent } from '../schema-form-view-navigatio
 })
 export class DocumentViewComponent implements OnInit {
     @Input() dialogContext?: 'fullscreen' | 'viewer';
-    @Input() navCollapsed: boolean = false;
     @Input('getByUser') getByUser: boolean = false;
     @Input('document') document: any;
     @Input('formulas') formulas: FormulasTree | null;
@@ -64,6 +63,7 @@ export class DocumentViewComponent implements OnInit {
     public formulasResults: any | null;
     public link: string | undefined;
     public accordionLink: string | undefined;
+    public navCollapsed: boolean = false;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
@@ -299,6 +299,11 @@ export class DocumentViewComponent implements OnInit {
     public openField(id?: string): void {
         const path = id?.split('/');
         this.link = path && path.length > 1 ? path[path.length - 1] : undefined;
+        this.ref.detectChanges();
+    }
+
+    public toggleNav(): void {
+        this.navCollapsed = !this.navCollapsed;
         this.ref.detectChanges();
     }
 

--- a/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.html
@@ -1,6 +1,29 @@
 <div class="schema-form-root" #contentContainer>
+  @if (model && hasNavigation && navCollapsed) {
+    <div class="nav-collapse-rail">
+      <button
+        class="nav-collapse-btn"
+        type="button"
+        title="Expand panel"
+        aria-label="Expand panel"
+        (click)="toggleNav()">
+        <i class="pi pi-chevron-right"></i>
+      </button>
+    </div>
+  }
   @if (model) {
-    <div class="schema-form-view-nav" [hidden]="!hasNavigation" #navContainer>
+    <div class="schema-form-view-nav" [hidden]="!hasNavigation || navCollapsed" #navContainer>
+      <div class="nav-collapse-header">
+        <span class="nav-collapse-title">Sections</span>
+        <button
+          class="nav-collapse-btn"
+          type="button"
+          title="Collapse panel"
+          aria-label="Collapse panel"
+          (click)="toggleNav()">
+          <i class="pi pi-chevron-left"></i>
+        </button>
+      </div>
       <app-schema-form-navigation
         #schemaNav
         [schemaFields]="navFields"
@@ -10,7 +33,7 @@
       </app-schema-form-navigation>
     </div>
   }
-  @if (model && hasNavigation) {
+  @if (model && hasNavigation && !navCollapsed) {
     <div
       class="resize-handler"
       (mousedown)="onResizeStart($event)"

--- a/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.scss
+++ b/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.scss
@@ -1,3 +1,5 @@
+@import '../nav-collapse';
+
 .schema-form-root {
     display: flex;
     gap: 8px;
@@ -5,14 +7,26 @@
 }
 
 .schema-form-view-nav {
-    width: 25%; 
-    max-width: 75%; 
+    width: 25%;
+    max-width: 75%;
     align-self: flex-start;
     position: sticky;
     top: 0;
     max-height: calc(100vh - 440px);
-    overflow-y: auto;
     box-sizing: border-box;
+    overflow-y: auto;
+    border: 1px solid var(--guardian-border-color, rgba(0, 0, 0, 0.06));
+    border-radius: 6px;
+    transition: width 0.2s ease;
+
+    // The panel now owns the border and the scroll; the sticky collapse
+    // header stays pinned while the tree scrolls underneath it.
+    ::ng-deep .schema-nav {
+        max-height: none;
+        overflow: visible;
+        border: none;
+        border-radius: 0;
+    }
 }
 
 .schema-form-content {

--- a/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.ts
@@ -19,6 +19,7 @@ export class SchemaFormRootComponent implements OnInit, AfterViewInit {
     public model: FieldForm | null;
     public loading: boolean = true;
     public hasNavigation = true;
+    public navCollapsed = false;
     public navFields: IFieldControl<any>[] = [];
 
     private startX: number = 0;
@@ -217,6 +218,11 @@ export class SchemaFormRootComponent implements OnInit, AfterViewInit {
     public preset(data: any) {
         this.presetDocument = data;
         this.buildFields();
+        this.changeDetectorRef.detectChanges();
+    }
+
+    public toggleNav(): void {
+        this.navCollapsed = !this.navCollapsed;
         this.changeDetectorRef.detectChanges();
     }
 

--- a/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-root/schema-form-root.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { SchemaFormComponent } from '../schema-form/schema-form.component';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Schema, SchemaField, SchemaRuleValidateResult } from '@guardian/interfaces';
@@ -14,7 +14,7 @@ import { SchemaFormNavigationComponent } from '../schema-form-navigation/schema-
     styleUrls: ['./schema-form-root.component.scss'],
     standalone: false
 })
-export class SchemaFormRootComponent implements OnInit {
+export class SchemaFormRootComponent implements OnInit, AfterViewInit {
     public group: UntypedFormGroup;
     public model: FieldForm | null;
     public loading: boolean = true;
@@ -27,6 +27,8 @@ export class SchemaFormRootComponent implements OnInit {
     private readonly MIN_WIDTH_PERCENT = 0;
     private readonly MAX_WIDTH_PERCENT = 75;
     private rafId: number | null = null;
+    private navScrollParent: HTMLElement | null = null;
+    private navResizeObserver: ResizeObserver | null = null;
 
     @ViewChild('childForm') private childForm?: SchemaFormComponent;
     @ViewChild('schemaNav') private schemaNav?: SchemaFormNavigationComponent;
@@ -82,6 +84,48 @@ export class SchemaFormRootComponent implements OnInit {
     ngOnInit(): void {
     }
 
+    ngAfterViewInit(): void {
+        // Inside a dialog the navigation panel is sticky within a scrollable
+        // body whose height depends on the dialog size and the banners shown
+        // above the form. Sync its height to that container so it fills the
+        // available space instead of relying on a fixed viewport calculation.
+        if (this.comesFromDialog) {
+            setTimeout(() => this.setupNavHeightSync(), 0);
+        }
+    }
+
+    private setupNavHeightSync(): void {
+        if (!this.navContainerRef) {
+            return;
+        }
+        this.navScrollParent = this.getScrollParent(this.navContainerRef.nativeElement);
+        if (!this.navScrollParent) {
+            return;
+        }
+        this.navResizeObserver = new ResizeObserver(() => this.updateNavHeight());
+        this.navResizeObserver.observe(this.navScrollParent);
+        this.updateNavHeight();
+    }
+
+    private updateNavHeight(): void {
+        if (!this.navContainerRef || !this.navScrollParent) {
+            return;
+        }
+        this.navContainerRef.nativeElement.style.maxHeight = `${this.navScrollParent.clientHeight}px`;
+    }
+
+    private getScrollParent(element: HTMLElement): HTMLElement | null {
+        let node: HTMLElement | null = element.parentElement;
+        while (node) {
+            const overflowY = getComputedStyle(node).overflowY;
+            if (overflowY === 'auto' || overflowY === 'scroll') {
+                return node;
+            }
+            node = node.parentElement;
+        }
+        return null;
+    }
+
     ngOnChanges(changes: SimpleChanges) {
         this.loading = true;
         if (
@@ -109,6 +153,11 @@ export class SchemaFormRootComponent implements OnInit {
         }
         document.removeEventListener('mousemove', this.onResizeMove);
         document.removeEventListener('mouseup', this.onResizeEnd);
+
+        if (this.navResizeObserver) {
+            this.navResizeObserver.disconnect();
+            this.navResizeObserver = null;
+        }
 
         if (this.rafId) {
             cancelAnimationFrame(this.rafId);

--- a/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.html
+++ b/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.html
@@ -18,11 +18,6 @@
       </div>
     }
   </div>
-  @if (viewDocument === true && isVcDocument) {
-    <div class="header-icon nav-panel" (click)="toggleNavPanel()" [title]="navPanelCollapsed ? 'Expand panel' : 'Collapse panel'">
-      <i [class]="navPanelCollapsed ? 'pi pi-chevron-right' : 'pi pi-chevron-left'"></i>
-    </div>
-  }
   <div class="header-icon resize" (click)="toggleSize()" [title]="isLargeSize ? 'The size 50%' : 'The size 90%'">
     <i [class]="isLargeSize ? 'pi pi-window-minimize' : 'pi pi-window-maximize'"></i>
   </div>
@@ -97,7 +92,6 @@
             [getByUser]="getByUser"
             [schema]="schema"
             [type]="type"
-            [navCollapsed]="navPanelCollapsed"
           [dialogContext]="'viewer'"></app-document-view>
         }
       }

--- a/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.scss
+++ b/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.scss
@@ -151,13 +151,6 @@
     right: 165px;
 }
 
-.header-icon.nav-panel {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-right: 16px;
-}
-
 :host ::ng-deep {
     .version-dropdown {
         .p-select {

--- a/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.ts
+++ b/frontend/src/app/modules/schema-engine/vc-dialog/vc-dialog.component.ts
@@ -59,7 +59,6 @@ export class VCViewerDialog {
     public selectedVersionIndex: number = 0;
 
     public isLargeSize: boolean = true;
-    public navPanelCollapsed: boolean = false;
     @ViewChild('dialogHeader', { static: false }) dialogHeader!: ElementRef<HTMLDivElement>;
 
     constructor(
@@ -294,10 +293,6 @@ export class VCViewerDialog {
                 dryRun: this.dryRun
             }
         });
-    }
-
-    public toggleNavPanel(): void {
-        this.navPanelCollapsed = !this.navPanelCollapsed;
     }
 
     public toggleSize(): void {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -760,37 +760,17 @@ svg-icon.svg-icon-32 {
 }
 
 .resize-handler {
-    width: 6px;
-    background: #ddd;
+    width: 4px;
+    background: var(--guardian-border-color, #E1E7EF);
     cursor: col-resize;
     position: relative;
     flex-shrink: 0;
     transition: background-color 0.2s;
-    border-radius: 3px;
-    
-    &:hover {
-        background: #2196F3;
-    }
-    
-    &:active, &.resizing {
-        background: #1976D2;
-    }
-    
-    &::before {
-        content: '⋮';
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        color: #666;
-        font-size: 16px;
-        line-height: 1;
-        opacity: 0.5;
-    }
-    
-    &:hover::before {
-        opacity: 1;
-        color: white;
+
+    &:hover,
+    &:active,
+    &.resizing {
+        background: var(--color-primary, #4169E2);
     }
 }
 


### PR DESCRIPTION
### Description

Improve the layout and navigation of the request document block dialog.

- Fill the navigation panel to the full vertical height of the dialog, removing the bottom padding gap.
- Add a self-contained collapse/expand control to the navigation panel, and reuse the same mechanism in the document view and VC dialog so there is a single collapse pattern across the app.
- Move the restore values and fill-with-test-data controls into the dialog header as compact buttons.
- Thin the resize divider and match its color to the policy configuration delimiter; add a separator line between the collapsed rail and the form.
- Align the dialog header title with the navigation panel.