### PR TITLE
fix: handle GridFS write errors to prevent silent file loss

### DIFF
--- a/common/src/helpers/db-helper.ts
+++ b/common/src/helpers/db-helper.ts
@@ -167,7 +167,10 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
                 };
                 stream.on('error', done);
                 stream.write(content);
-                stream.end(() => done());
+                //forward the end callback's error too: it is the only signal when a stream
+                //reports failure through the callback instead of emitting 'error', which is
+                //how saveFileWithId used to surface it via end(buffer, (err) => ...)
+                stream.end((err?: any) => done(err));
             } catch (error) {
                 reject(error);
             }

--- a/common/src/helpers/db-helper.ts
+++ b/common/src/helpers/db-helper.ts
@@ -2,7 +2,7 @@ import { MikroORM, CreateRequestContext, wrap, FilterObject, FilterQuery, FindAl
 import { MongoDriver, MongoEntityManager, MongoEntityRepository, ObjectId } from '@mikro-orm/mongodb';
 import { BaseEntity } from '../models/index.js';
 import { DataBaseNamingStrategy } from './db-naming-strategy.js';
-import { Db, GridFSBucket } from 'mongodb';
+import { Db, GridFSBucket, GridFSBucketWriteStream } from 'mongodb';
 import fixConnectionString from './fix-connection-string.js';
 import { MintTransactionStatus } from '@guardian/interfaces';
 import { AbstractDataBaseHelper, ICommonConnectionConfig, IGetAggregationFilters, IGetDocumentAggregationFilters } from '../interfaces/index.js';
@@ -136,20 +136,28 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
     }
 
     /**
-     * Save file
-     * @param uuid
-     * @param buffer
-     * @returns file ID
+     * Write content to a GridFS upload stream and resolve with the file id only
+     * after a successful finish. Registers an 'error' handler so async write
+     * failures reject instead of hanging, crashing, or leaving a phantom id.
+     * Rejects on null/undefined content (empty buffers/strings are valid).
+     * @param content file content
+     * @param label context label for error messages
+     * @param openStream opens the target upload stream
+     * @returns file Id
      */
-    public static async saveFile(uuid: string, buffer: Buffer): Promise<ObjectId> {
+    public static writeToGridFS(
+        content: string | Buffer,
+        label: string,
+        openStream: () => GridFSBucketWriteStream
+    ): Promise<ObjectId> {
         return new Promise<ObjectId>((resolve, reject) => {
             try {
-                if (buffer === null || buffer === undefined) {
-                    reject(new Error('GridFS saveFile: buffer is null/undefined'));
+                if (content === null || content === undefined) {
+                    reject(new Error(`GridFS write (${label}): content is null/undefined`));
                     return;
                 }
-                const fileStream = DataBaseHelper.gridFS.openUploadStream(uuid);
-                const fileId = fileStream.id;
+                const stream = openStream();
+                const fileId = stream.id;
                 let settled = false;
                 // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
                 const done = (err?: any) => {
@@ -157,13 +165,23 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
                     settled = true;
                     if (err) { reject(err); } else { resolve(fileId); }
                 };
-                fileStream.on('error', done);
-                fileStream.write(buffer);
-                fileStream.end(() => done());
+                stream.on('error', done);
+                stream.write(content);
+                stream.end(() => done());
             } catch (error) {
                 reject(error);
             }
         });
+    }
+
+    /**
+     * Save file
+     * @param uuid
+     * @param buffer
+     * @returns file ID
+     */
+    public static async saveFile(uuid: string, buffer: Buffer): Promise<ObjectId> {
+        return DataBaseHelper.writeToGridFS(buffer, uuid, () => DataBaseHelper.gridFS.openUploadStream(uuid));
     }
 
     /**
@@ -174,25 +192,7 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
      * @returns file ID
      */
     public static async saveFileWithId(id: ObjectId, filename: string, buffer: Buffer): Promise<ObjectId> {
-        return new Promise<ObjectId>((resolve, reject) => {
-            try {
-                if (buffer === null || buffer === undefined) {
-                    reject(new Error('GridFS saveFileWithId: buffer is null/undefined'));
-                    return;
-                }
-                const stream = DataBaseHelper.gridFS.openUploadStreamWithId(id, filename);
-                let settled = false;
-                const done = (err?: any) => {
-                    if (settled) { return; }
-                    settled = true;
-                    if (err) { reject(err); } else { resolve(id); }
-                };
-                stream.on('error', done);
-                stream.end(buffer, (err?: any) => done(err));
-            } catch (e) {
-                reject(e);
-            }
-        });
+        return DataBaseHelper.writeToGridFS(buffer, filename, () => DataBaseHelper.gridFS.openUploadStreamWithId(id, filename));
     }
 
     /**

--- a/common/src/helpers/db-helper.ts
+++ b/common/src/helpers/db-helper.ts
@@ -144,11 +144,22 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
     public static async saveFile(uuid: string, buffer: Buffer): Promise<ObjectId> {
         return new Promise<ObjectId>((resolve, reject) => {
             try {
+                if (buffer === null || buffer === undefined) {
+                    reject(new Error('GridFS saveFile: buffer is null/undefined'));
+                    return;
+                }
                 const fileStream = DataBaseHelper.gridFS.openUploadStream(uuid);
+                const fileId = fileStream.id;
+                let settled = false;
+                // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
+                const done = (err?: any) => {
+                    if (settled) { return; }
+                    settled = true;
+                    if (err) { reject(err); } else { resolve(fileId); }
+                };
+                fileStream.on('error', done);
                 fileStream.write(buffer);
-                fileStream.end(() => {
-                    resolve(fileStream.id);
-                });
+                fileStream.end(() => done());
             } catch (error) {
                 reject(error);
             }
@@ -165,8 +176,19 @@ export class DataBaseHelper<T extends BaseEntity> extends AbstractDataBaseHelper
     public static async saveFileWithId(id: ObjectId, filename: string, buffer: Buffer): Promise<ObjectId> {
         return new Promise<ObjectId>((resolve, reject) => {
             try {
+                if (buffer === null || buffer === undefined) {
+                    reject(new Error('GridFS saveFileWithId: buffer is null/undefined'));
+                    return;
+                }
                 const stream = DataBaseHelper.gridFS.openUploadStreamWithId(id, filename);
-                stream.end(buffer, (err?: any) => err ? reject(err) : resolve(id));
+                let settled = false;
+                const done = (err?: any) => {
+                    if (settled) { return; }
+                    settled = true;
+                    if (err) { reject(err); } else { resolve(id); }
+                };
+                stream.on('error', done);
+                stream.end(buffer, (err?: any) => done(err));
             } catch (e) {
                 reject(e);
             }

--- a/common/src/import-export/policy.ts
+++ b/common/src/import-export/policy.ts
@@ -405,10 +405,22 @@ export class PolicyImportExport {
     private static _createFile(json: string | Buffer, fileName: string): Promise<ObjectId> {
         return new Promise<ObjectId>((resolve, reject) => {
             try {
+                if (json === null || json === undefined) {
+                    reject(new Error(`GridFS write (${fileName}): content is null/undefined`));
+                    return;
+                }
                 const fileStream = DataBaseHelper.gridFS.openUploadStream(fileName);
                 const fileId = fileStream.id;
+                let settled = false;
+                // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
+                const done = (err?: any) => {
+                    if (settled) { return; }
+                    settled = true;
+                    if (err) { reject(err); } else { resolve(fileId); }
+                };
+                fileStream.on('error', done);
                 fileStream.write(json);
-                fileStream.end(() => resolve(fileId));
+                fileStream.end(() => done());
             } catch (error) {
                 reject(error)
             }

--- a/common/src/import-export/policy.ts
+++ b/common/src/import-export/policy.ts
@@ -403,28 +403,7 @@ export class PolicyImportExport {
     }
 
     private static _createFile(json: string | Buffer, fileName: string): Promise<ObjectId> {
-        return new Promise<ObjectId>((resolve, reject) => {
-            try {
-                if (json === null || json === undefined) {
-                    reject(new Error(`GridFS write (${fileName}): content is null/undefined`));
-                    return;
-                }
-                const fileStream = DataBaseHelper.gridFS.openUploadStream(fileName);
-                const fileId = fileStream.id;
-                let settled = false;
-                // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
-                const done = (err?: any) => {
-                    if (settled) { return; }
-                    settled = true;
-                    if (err) { reject(err); } else { resolve(fileId); }
-                };
-                fileStream.on('error', done);
-                fileStream.write(json);
-                fileStream.end(() => done());
-            } catch (error) {
-                reject(error)
-            }
-        });
+        return DataBaseHelper.writeToGridFS(json, fileName, () => DataBaseHelper.gridFS.openUploadStream(fileName));
     }
 
     /**

--- a/common/src/models/base-entity.ts
+++ b/common/src/models/base-entity.ts
@@ -66,29 +66,8 @@ export abstract class BaseEntity {
      * Create File
      */
     protected _createFile(json: string | Buffer, name: string): Promise<ObjectId> {
-        return new Promise<ObjectId>((resolve, reject) => {
-            try {
-                if (json === null || json === undefined) {
-                    reject(new Error(`GridFS write (${name}): content is null/undefined`));
-                    return;
-                }
-                const fileName = `${name}_${this._id?.toString()}_${GenerateUUIDv4()}`;
-                const fileStream = DataBaseHelper.gridFS.openUploadStream(fileName);
-                const fileId = fileStream.id;
-                let settled = false;
-                // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
-                const done = (err?: any) => {
-                    if (settled) { return; }
-                    settled = true;
-                    if (err) { reject(err); } else { resolve(fileId); }
-                };
-                fileStream.on('error', done);
-                fileStream.write(json);
-                fileStream.end(() => done());
-            } catch (error) {
-                reject(error)
-            }
-        });
+        const fileName = `${name}_${this._id?.toString()}_${GenerateUUIDv4()}`;
+        return DataBaseHelper.writeToGridFS(json, name, () => DataBaseHelper.gridFS.openUploadStream(fileName));
     }
 
     /**

--- a/common/src/models/base-entity.ts
+++ b/common/src/models/base-entity.ts
@@ -68,11 +68,23 @@ export abstract class BaseEntity {
     protected _createFile(json: string | Buffer, name: string): Promise<ObjectId> {
         return new Promise<ObjectId>((resolve, reject) => {
             try {
+                if (json === null || json === undefined) {
+                    reject(new Error(`GridFS write (${name}): content is null/undefined`));
+                    return;
+                }
                 const fileName = `${name}_${this._id?.toString()}_${GenerateUUIDv4()}`;
                 const fileStream = DataBaseHelper.gridFS.openUploadStream(fileName);
                 const fileId = fileStream.id;
+                let settled = false;
+                // resolve only after a successful finish; surface async write errors instead of leaving a phantom id
+                const done = (err?: any) => {
+                    if (settled) { return; }
+                    settled = true;
+                    if (err) { reject(err); } else { resolve(fileId); }
+                };
+                fileStream.on('error', done);
                 fileStream.write(json);
-                fileStream.end(() => resolve(fileId));
+                fileStream.end(() => done());
             } catch (error) {
                 reject(error)
             }

--- a/common/tests/unit-tests/gridfs-save-error-handling.test.mjs
+++ b/common/tests/unit-tests/gridfs-save-error-handling.test.mjs
@@ -104,4 +104,53 @@ describe('DataBaseHelper GridFS write error handling', () => {
             );
         });
     });
+
+    // Both BaseEntity._createFile and PolicyImportExport._createFile delegate here,
+    // so asserting the helper directly covers them too.
+    describe('writeToGridFS', () => {
+        it('resolves with the id of the stream it was given', async () => {
+            const id = new ObjectId();
+            const out = await DataBaseHelper.writeToGridFS(
+                'payload', 'label', () => new FakeUploadStream(id, 'ok')
+            );
+            assert.equal(out.toString(), id.toString());
+        });
+
+        it('writes the content to the stream', async () => {
+            const stream = new FakeUploadStream(new ObjectId(), 'ok');
+            await DataBaseHelper.writeToGridFS('payload', 'label', () => stream);
+            assert.deepEqual(stream.written, ['payload']);
+        });
+
+        it('REJECTS when the upload stream emits an error', async () => {
+            await assert.rejects(
+                DataBaseHelper.writeToGridFS('payload', 'label', () => new FakeUploadStream(new ObjectId(), 'error')),
+                /gridfs write failed/
+            );
+        });
+
+        it('rejects on null/undefined content and names the label', async () => {
+            const open = () => new FakeUploadStream(new ObjectId(), 'ok');
+            await assert.rejects(
+                DataBaseHelper.writeToGridFS(null, 'policy.zip', open),
+                /GridFS write \(policy\.zip\): content is null\/undefined/
+            );
+            await assert.rejects(DataBaseHelper.writeToGridFS(undefined, 'label', open), /null\/undefined/);
+        });
+
+        it('allows empty content (valid 0-length file, not null)', async () => {
+            const open = () => new FakeUploadStream(new ObjectId(), 'ok');
+            assert.ok(await DataBaseHelper.writeToGridFS('', 'label', open) instanceof ObjectId);
+            assert.ok(await DataBaseHelper.writeToGridFS(Buffer.alloc(0), 'label', open) instanceof ObjectId);
+        });
+
+        it('rejects instead of throwing when the stream cannot be opened', async () => {
+            await assert.rejects(
+                DataBaseHelper.writeToGridFS('payload', 'label', () => {
+                    throw new Error('gridFS is undefined');
+                }),
+                /gridFS is undefined/
+            );
+        });
+    });
 });

--- a/common/tests/unit-tests/gridfs-save-error-handling.test.mjs
+++ b/common/tests/unit-tests/gridfs-save-error-handling.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { ObjectId } from 'mongodb';
+// Load the package entry first so the module graph initializes in the right order.
+import '../../dist/index.js';
+import { DataBaseHelper } from '../../dist/helpers/db-helper.js';
+
+/**
+ * Regression tests for silent GridFS write loss.
+ *
+ * saveFile / saveFileWithId mint the file _id up front and used to resolve on
+ * `end()` regardless of the write outcome, with NO `on('error')` handler - so an
+ * async GridFS write error would hang the promise (end callback never fires) or
+ * leave a phantom id -> later FileNotFound. The fix must:
+ *   - REJECT (not hang) when the upload stream emits 'error'
+ *   - REJECT on null/undefined content
+ *   - resolve with the id only after a successful finish
+ */
+
+// A fake GridFS upload stream. In 'ok' mode the end callback fires (finish);
+// in 'error' mode it emits 'error' and never calls the callback (mirrors the
+// real failure that used to hang the un-fixed code).
+class FakeUploadStream extends EventEmitter {
+    constructor(id, mode) {
+        super();
+        this.id = id;
+        this._mode = mode;
+        this.written = [];
+    }
+    write(chunk) { this.written.push(chunk); return true; }
+    end(...args) {
+        const cb = typeof args[args.length - 1] === 'function' ? args[args.length - 1] : undefined;
+        setImmediate(() => {
+            if (this._mode === 'error') {
+                this.emit('error', new Error('gridfs write failed'));
+            } else if (cb) {
+                cb();
+            }
+        });
+    }
+}
+
+function fakeBucket(mode) {
+    return {
+        openUploadStream: (_name) => new FakeUploadStream(new ObjectId(), mode),
+        openUploadStreamWithId: (id, _name) => new FakeUploadStream(id, mode),
+    };
+}
+
+describe('DataBaseHelper GridFS write error handling', () => {
+    let saved;
+    beforeEach(() => { saved = DataBaseHelper.gridFS; });
+    afterEach(() => { DataBaseHelper.gridFS = saved; });
+
+    describe('saveFile', () => {
+        it('resolves with the minted file id on a successful finish', async () => {
+            DataBaseHelper.gridFS = fakeBucket('ok');
+            const id = await DataBaseHelper.saveFile('uuid-1', Buffer.from('hello'));
+            assert.ok(id instanceof ObjectId, 'resolves with an ObjectId');
+        });
+
+        it('REJECTS (does not hang) when the upload stream emits an error', async () => {
+            DataBaseHelper.gridFS = fakeBucket('error');
+            await assert.rejects(
+                DataBaseHelper.saveFile('uuid-2', Buffer.from('hello')),
+                /gridfs write failed/
+            );
+        });
+
+        it('rejects on null/undefined content instead of writing a phantom file', async () => {
+            DataBaseHelper.gridFS = fakeBucket('ok');
+            await assert.rejects(DataBaseHelper.saveFile('uuid-3', null), /null\/undefined/);
+            await assert.rejects(DataBaseHelper.saveFile('uuid-4', undefined), /null\/undefined/);
+        });
+
+        it('allows an empty buffer (valid 0-length file, not null)', async () => {
+            DataBaseHelper.gridFS = fakeBucket('ok');
+            const id = await DataBaseHelper.saveFile('uuid-5', Buffer.alloc(0));
+            assert.ok(id instanceof ObjectId);
+        });
+    });
+
+    describe('saveFileWithId', () => {
+        it('resolves with the given id on success', async () => {
+            DataBaseHelper.gridFS = fakeBucket('ok');
+            const id = new ObjectId();
+            const out = await DataBaseHelper.saveFileWithId(id, 'file', Buffer.from('x'));
+            assert.equal(out.toString(), id.toString());
+        });
+
+        it('REJECTS when the upload stream emits an error', async () => {
+            DataBaseHelper.gridFS = fakeBucket('error');
+            await assert.rejects(
+                DataBaseHelper.saveFileWithId(new ObjectId(), 'file', Buffer.from('x')),
+                /gridfs write failed/
+            );
+        });
+
+        it('rejects on null/undefined content', async () => {
+            DataBaseHelper.gridFS = fakeBucket('ok');
+            await assert.rejects(
+                DataBaseHelper.saveFileWithId(new ObjectId(), 'file', null),
+                /null\/undefined/
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes silent GridFS write loss. `DataBaseHelper.saveFile` / `saveFileWithId`, `BaseEntity._createFile`, and `PolicyImportExport._createFile` mint the file `_id` up front and resolve on `end()` regardless of the write outcome, with **no stream `'error'` handler**. An async GridFS write failure is therefore swallowed:

- the returned promise **hangs** (the `end` callback never fires when the stream errors), or
- an unhandled `'error'` event crashes the process, or
- a **phantom `fileId`** is recorded with no bytes written, surfacing later as `FileNotFound` and lost document content (schema / VC / policy-action documents).

Because `BaseEntity._createFile` is used by every file-backed entity's `@BeforeCreate`/`@BeforeUpdate` hook, this affects ~20 entities (`vc-document`, `vp-document`, `schema`, `policy`, `tool`, `policy-action`, etc.).

## Changes

All four write sites now:
- register `fileStream.on('error', reject)` so async write failures **reject** instead of hanging / crashing / leaving a phantom id;
- resolve with the id **only after a successful finish** (single-settle guard so `'error'` and `end` can't double-settle);
- **reject on `null`/`undefined`** content (empty buffers remain valid — 0-length file).

Files:
- `common/src/models/base-entity.ts` — `_createFile`
- `common/src/helpers/db-helper.ts` — `saveFile`, `saveFileWithId`
- `common/src/import-export/policy.ts` — `_createFile`

## Tests

`common/tests/unit-tests/gridfs-save-error-handling.test.mjs` (mocks `DataBaseHelper.gridFS`):
- resolves with id on successful finish
- **rejects (does not hang)** on stream `'error'` — the core regression
- rejects on `null`/`undefined`
- allows an empty buffer

`common` builds clean; 7/7 tests pass.

## Related issue(s)

Silent GridFS write failures leading to `FileNotFound` / lost document content under load.
