### PR TITLE
feat: move draft file actions to top of document dialog

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.html
@@ -16,6 +16,15 @@
     </div>
   }
   <div class="dialog-body-container">
+    <div class="draft-file-actions">
+      <request-draft-file-actions
+        [schema]="schema"
+        [policyId]="policyId"
+        [blockId]="id"
+        [dataForm]="dataForm"
+        (draftImported)="onDraftImported($event)">
+      </request-draft-file-actions>
+    </div>
     @if (restoreData) {
       <div class="restore-data">
         <svg-icon class="svg-icon"
@@ -268,13 +277,6 @@
       </button>
     </div>
   }
-    <request-draft-file-actions
-      [schema]="schema"
-      [policyId]="policyId"
-      [blockId]="id"
-      [dataForm]="dataForm"
-      (draftImported)="onDraftImported($event)">
-    </request-draft-file-actions>
   @if (lastSavedAt) {
     <div class="last-autosave">
       {{ minutesAgo$ | async }}

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/request-document-block/dialog/request-document-block-dialog.component.scss
@@ -70,6 +70,15 @@ form {
     margin-bottom: 16px;
 }
 
+.draft-file-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 2px;
+    margin-bottom: 12px;
+    margin-right: 32px;
+}
+
 .dialog-footer {
     padding: 20px 32px 32px 32px !important;
 }
@@ -81,10 +90,6 @@ form {
 
     &>div {
         margin-left: 0px;
-        margin-right: 16px;
-    }
-
-    request-draft-file-actions {
         margin-right: 16px;
     }
 


### PR DESCRIPTION
**Description**:

This PR moves the `request-draft-file-actions` (import/export draft) controls in the request document dialog from the bottom of the form to the top of `dialog-body-container`, so the action is visible without scrolling through the full form first. Split out of #6447 per review feedback, since it was unrelated to that PR's step-block transition fix.

* Move `request-draft-file-actions` from the bottom of the dialog form to the top of `dialog-body-container`, wrapped in a new `.draft-file-actions` container
* Add `.draft-file-actions` styling (flex row, right-aligned, spacing) in place of the old bottom-anchored `request-draft-file-actions` margin rule

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

No functional/behavioral changes to draft save/restore logic — this is a placement and styling change only. Originally included in #6447; excluded from that PR after review and reintroduced here as its own change.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
