### PR TITLE
perf: lazy-load policy schemas on demand

### DIFF
--- a/policy-service/src/policy-engine/helpers/components-service.ts
+++ b/policy-service/src/policy-engine/helpers/components-service.ts
@@ -10,7 +10,7 @@ import {
     Users,
     VcHelper
 } from '@guardian/common';
-import { GenerateUUIDv4, PolicyHelper, PolicyStatus, SchemaEntity } from '@guardian/interfaces';
+import { GenerateUUIDv4, PolicyHelper, PolicyStatus, SchemaEntity, SchemaStatus } from '@guardian/interfaces';
 import { PrivateKey } from '@hiero-ledger/sdk';
 import { IPolicyBlock } from '../policy-engine.interface.js';
 import { PolicyUser } from '../policy-user.js';
@@ -68,6 +68,19 @@ export class ComponentsService {
      * Schemas
      */
     private readonly schemasByType: Map<string, SchemaCollection>;
+    /**
+     * Topics whose schemas this policy may reference (policy topic + tool topics).
+     * Schemas are resolved lazily by IRI/type from these topics on first use
+     * instead of bulk-loading the whole topic set — a large methodology can have
+     * thousands of schemas on a topic while a policy references only a handful.
+     */
+    private readonly schemaTopicIds: string[] = [];
+    /**
+     * True when the policy this service serves is a VIEW/imported policy. VIEW
+     * schemas are duplicate copies (same IRIs) of the PUBLISHED set created by
+     * view-imports; only a VIEW policy resolves them.
+     */
+    private isViewPolicy: boolean = false;
     /**
      * Automatic recording flag
      */
@@ -165,7 +178,17 @@ export class ComponentsService {
      * @param type
      */
     public async loadSchemaByType(type: SchemaEntity): Promise<SchemaCollection> {
-        return this.schemasByType.get(type);
+        if (this.schemasByType.has(type)) {
+            return this.schemasByType.get(type) || undefined;
+        }
+        // Resolve the readonly schema for this entity from the policy/tool topics
+        // on first use, then cache (incl. a null miss to avoid re-querying).
+        const schema = await this.resolveSchema({ entity: type, readonly: true });
+        this.schemasByType.set(type, schema || null);
+        if (schema) {
+            this.schemasByID.set(schema.iri, schema);
+        }
+        return schema || undefined;
     }
 
     /**
@@ -173,7 +196,17 @@ export class ComponentsService {
      * @param id
      */
     public async loadSchemaByID(id: string): Promise<SchemaCollection> {
-        return this.schemasByID.get(id);
+        if (this.schemasByID.has(id)) {
+            return this.schemasByID.get(id) || undefined;
+        }
+        // Resolve this IRI from the policy/tool topics on first use, then cache
+        // (incl. a null miss so a genuinely-absent schema isn't re-queried).
+        const schema = await this.resolveSchema({ iri: id });
+        this.schemasByID.set(id, schema || null);
+        if (schema && schema.readonly) {
+            this.schemasByType.set(schema.entity, schema);
+        }
+        return schema || undefined;
     }
 
     /**
@@ -228,15 +261,11 @@ export class ComponentsService {
         this.policyTokens = (policy as PolicyCollection).policyTokens || [];
         this.policyGroups = (policy as PolicyCollection).policyGroups || [];
         this.policyRoles = (policy as PolicyCollection).policyRoles || [];
-        if (policy.topicId) {
-            const schemas = await DatabaseServer.getSchemas({ topicId: policy.topicId });
-            for (const schema of schemas) {
-                if (schema.readonly) {
-                    this.schemasByType.set(schema.entity, schema);
-                }
-                this.schemasByID.set(schema.iri, schema);
-            }
-        }
+        // Only a VIEW policy resolves VIEW-status (duplicate) schemas.
+        this.isViewPolicy = (policy as PolicyCollection).status === PolicyStatus.VIEW;
+        // Track the topic; schemas are resolved lazily on first use
+        // (loadSchemaByID/Type) instead of bulk-loading the whole topic set.
+        this.trackSchemaTopic(policy.topicId);
     }
 
     /**
@@ -244,15 +273,37 @@ export class ComponentsService {
      * @param name
      */
     public async registerTool(tool: PolicyToolCollection): Promise<void> {
-        if (tool.topicId) {
-            const schemas = await DatabaseServer.getSchemas({ topicId: tool.topicId });
-            for (const schema of schemas) {
-                if (schema.readonly) {
-                    this.schemasByType.set(schema.entity, schema);
-                }
-                this.schemasByID.set(schema.iri, schema);
-            }
+        // Track the tool topic; schemas resolved lazily on first use.
+        this.trackSchemaTopic(tool.topicId);
+    }
+
+    /**
+     * Record a topic whose schemas this policy may reference, for lazy
+     * resolution. De-duplicated.
+     * @param topicId
+     */
+    private trackSchemaTopic(topicId: string): void {
+        if (topicId && !this.schemaTopicIds.includes(topicId)) {
+            this.schemaTopicIds.push(topicId);
         }
+    }
+
+    /**
+     * Resolve a single schema matching `match` (e.g. { iri } or
+     * { entity, readonly }) from the tracked policy/tool topics, excluding
+     * duplicate VIEW schemas unless this is a VIEW policy. Returns null if none.
+     * @param match
+     */
+    private async resolveSchema(match: any): Promise<SchemaCollection> {
+        if (!this.schemaTopicIds.length) {
+            return null;
+        }
+        const filter: any = { ...match, topicId: { $in: this.schemaTopicIds } };
+        if (!this.isViewPolicy) {
+            filter.status = { $ne: SchemaStatus.VIEW };
+        }
+        const schemas = await DatabaseServer.getSchemas(filter);
+        return (schemas && schemas.length) ? schemas[0] : null;
     }
 
     /**

--- a/policy-service/tests/unit-tests/helpers/components-service-lazy-schema.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/components-service-lazy-schema.test.mjs
@@ -1,0 +1,133 @@
+import { assert } from 'chai';
+import esmock from 'esmock';
+
+/**
+ * Lazy schema loading in ComponentsService: registerPolicy/registerTool only
+ * record topic ids; loadSchemaByID/loadSchemaByType resolve a single schema on
+ * first use, cache it (incl. a null miss), and exclude duplicate VIEW schemas
+ * unless the policy itself is a VIEW policy.
+ */
+
+let getSchemasCalls = [];
+let schemaStore = [];
+
+// Emulate DatabaseServer.getSchemas(filter) against schemaStore, honouring the
+// filter shape produced by resolveSchema: { iri|entity, readonly?, topicId:{$in}, status?:{$ne} }.
+function getSchemasImpl(filter = {}) {
+    getSchemasCalls.push(filter);
+    return schemaStore.filter((s) => {
+        if (filter.iri !== undefined && s.iri !== filter.iri) { return false; }
+        if (filter.entity !== undefined && s.entity !== filter.entity) { return false; }
+        if (filter.readonly !== undefined && Boolean(s.readonly) !== filter.readonly) { return false; }
+        if (filter.topicId && filter.topicId.$in && !filter.topicId.$in.includes(s.topicId)) { return false; }
+        if (filter.status && filter.status.$ne !== undefined && s.status === filter.status.$ne) { return false; }
+        return true;
+    });
+}
+
+const { ComponentsService } = await esmock.strict(
+    '../../../dist/policy-engine/helpers/components-service.js',
+    {
+        '@guardian/common': {
+            DatabaseServer: class {
+                constructor() { }
+                static async getSchemas(filter) { return getSchemasImpl(filter); }
+            },
+            PinoLogger: class { info() { } warn() { } error() { } },
+            TopicConfig: class { },
+            Users: class { },
+            VcHelper: class { },
+        },
+        '@guardian/interfaces': {
+            GenerateUUIDv4: () => 'uuid',
+            PolicyHelper: { isDryRunMode: () => false },
+            PolicyStatus: { PUBLISH: 'PUBLISH', VIEW: 'VIEW', DRAFT: 'DRAFT' },
+            SchemaStatus: { VIEW: 'VIEW', PUBLISHED: 'PUBLISHED' },
+        },
+    },
+);
+
+const POLICY_TOPIC = '0.0.POLICY';
+const TOOL_TOPIC = '0.0.TOOL';
+
+function makeService(status = 'DRAFT') {
+    return new ComponentsService(
+        { owner: 'o', ownerId: 'oid', topicId: POLICY_TOPIC, status },
+        'policy-id'
+    );
+}
+
+async function registered(status = 'DRAFT') {
+    const svc = makeService(status);
+    await svc.registerPolicy({ topicId: POLICY_TOPIC, status });
+    await svc.registerTool({ topicId: TOOL_TOPIC });
+    return svc;
+}
+
+describe('@unit ComponentsService lazy schema loading', () => {
+    beforeEach(() => {
+        getSchemasCalls = [];
+        schemaStore = [
+            { iri: '#A', entity: null, readonly: false, topicId: POLICY_TOPIC, status: 'PUBLISHED' },
+            { iri: '#A', entity: null, readonly: false, topicId: POLICY_TOPIC, status: 'VIEW' }, // duplicate view copy
+            { iri: '#B', entity: null, readonly: false, topicId: TOOL_TOPIC, status: 'PUBLISHED' },
+            { iri: '#R', entity: 'MINT_TOKEN', readonly: true, topicId: POLICY_TOPIC, status: 'PUBLISHED' },
+        ];
+    });
+
+    it('registerPolicy/registerTool do NOT bulk-load schemas', async () => {
+        await registered();
+        assert.equal(getSchemasCalls.length, 0, 'no schema query should run at registration');
+    });
+
+    it('loadSchemaByID resolves on first use, from policy + tool topics, excluding VIEW', async () => {
+        const svc = await registered('DRAFT');
+
+        const a = await svc.loadSchemaByID('#A');
+        assert.equal(a.iri, '#A');
+        assert.equal(a.status, 'PUBLISHED', 'VIEW duplicate must be excluded for a non-VIEW policy');
+        assert.equal(getSchemasCalls.length, 1);
+
+        const filter = getSchemasCalls[0];
+        assert.deepEqual(filter.topicId, { $in: [POLICY_TOPIC, TOOL_TOPIC] }, 'searches policy + tool topics');
+        assert.deepEqual(filter.status, { $ne: 'VIEW' }, 'excludes VIEW schemas');
+        assert.equal(filter.iri, '#A');
+
+        // tool-topic schema also resolves (proves the tool topic was tracked)
+        const b = await svc.loadSchemaByID('#B');
+        assert.equal(b.iri, '#B');
+    });
+
+    it('caches a resolved schema (no re-query on second call)', async () => {
+        const svc = await registered();
+        await svc.loadSchemaByID('#A');
+        await svc.loadSchemaByID('#A');
+        assert.equal(getSchemasCalls.length, 1, 'second lookup served from cache');
+    });
+
+    it('caches a null miss (no re-query for an absent schema)', async () => {
+        const svc = await registered();
+        const miss1 = await svc.loadSchemaByID('#DOES_NOT_EXIST');
+        const miss2 = await svc.loadSchemaByID('#DOES_NOT_EXIST');
+        assert.isUndefined(miss1);
+        assert.isUndefined(miss2);
+        assert.equal(getSchemasCalls.length, 1, 'absent schema queried once, then cached');
+    });
+
+    it('loadSchemaByType resolves the readonly schema for an entity', async () => {
+        const svc = await registered();
+        const r = await svc.loadSchemaByType('MINT_TOKEN');
+        assert.equal(r.iri, '#R');
+        const filter = getSchemasCalls[0];
+        assert.equal(filter.entity, 'MINT_TOKEN');
+        assert.equal(filter.readonly, true);
+        assert.deepEqual(filter.status, { $ne: 'VIEW' });
+    });
+
+    it('a VIEW policy resolves VIEW schemas (no status exclusion)', async () => {
+        const svc = await registered('VIEW');
+        await svc.loadSchemaByID('#A');
+        const filter = getSchemasCalls[0];
+        assert.isUndefined(filter.status, 'VIEW policy must not exclude VIEW schemas');
+    });
+});


### PR DESCRIPTION
## Problem

`ComponentsService` eagerly loads **every schema on a policy's topic** into memory (`DatabaseServer.getSchemas({ topicId })`) when a policy is registered, even though the policy's blocks reference only a handful of schemas. For a large methodology a topic can carry **thousands** of schemas — and that set is effectively **doubled** when `VIEW`-status copies (created by view-imports) share the topic.

The result is that building the block tree / serving `get-root-block-data` performs a large amount of needless loading and JSON-LD work, which for big policies can peg the policy-service event loop and stall the policy-viewer (block requests time out).

Observed on a large VM0033-style policy: **~1,800 schemas loaded into the resident maps, but only ~5 referenced by the blocks**.

## Change

- `registerPolicy` / `registerTool` no longer bulk-load the topic's schemas — they only **record the topic ids**.
- `loadSchemaByID` / `loadSchemaByType` **resolve a single schema on first use** (`resolveSchema`) and cache it, including a **null miss** so a genuinely-absent schema isn't re-queried.
- `VIEW`-status schemas (duplicate copies of the `PUBLISHED` set) are **excluded** unless the policy itself is a `VIEW` policy.

## Why it's safe

- The schema maps (`schemasByID` / `schemasByType`) are only ever accessed via `.get()`/`.set()` — **no code iterates them in bulk**. Every consumer goes through `loadSchemaByID` / `loadSchemaByType`, so switching those to on-demand resolution is behavior-preserving.
- `tsc --noEmit` passes for `policy-service`.

## Effect

The resident schema set drops from **the entire topic** to **only the schemas the blocks actually reference**, removing the loading/JSON-LD work that made `get-root-block-data` slow (or time out) for large policies.

## Notes

- Concurrent first-time lookups of the same IRI may issue a couple of duplicate queries before the cache fills (correct, mildly redundant); an in-flight-promise dedup could be added if desired.
- `loadSchemaByType` returns the first match for an entity rather than the last-loaded; this only differs if two `readonly` schemas share an entity type on the same topics (not observed in practice, where each entity has exactly one readonly schema).
