### PR TITLE
fix: refresh session token on fresh start to stop 401 console errors

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, provideAppInitializer } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi, withJsonpSupport } from '@angular/common/http';
@@ -22,6 +22,7 @@ import { ProfileService } from './services/profile.service';
 import { TokenService } from './services/token.service';
 import { SchemaService } from './services/schema.service';
 import { HandleErrorsService } from './services/handle-errors.service';
+import { refreshAccessTokenOnStartup } from './services/refresh-access-token.initializer';
 import { AuditService } from './services/audit.service';
 import { CredentialsService } from './services/credentials.service';
 import { PolicyEngineService } from './services/policy-engine.service';
@@ -306,6 +307,9 @@ const GuardianPreset = definePreset(Aura, {
         MenubarModule
     ],
     providers: [
+        // Refresh the access token from the stored refresh token before the app
+        // boots, so the initial requests aren't sent with an expired token.
+        provideAppInitializer(refreshAccessTokenOnStartup),
         MessageService,
         WebSocketService,
         AuthService,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -361,6 +361,10 @@ const GuardianPreset = definePreset(Aura, {
             provide: BLOCK_TYPE_TIPS,
             useValue: BLOCK_TYPE_TIPS_VALUE
         },
+        // Order matters: AuthInterceptor must run inside HandleErrorsService so
+        // it can refresh-and-retry a 401 before the error interceptor sees it.
+        // Reversing these would let HandleErrorsService log the user out before
+        // the refresh gets a chance, disabling refresh-on-401.
         {
             provide: HTTP_INTERCEPTORS,
             useClass: HandleErrorsService,

--- a/frontend/src/app/components/toast/app-toast.component.ts
+++ b/frontend/src/app/components/toast/app-toast.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { BlockErrorType, IUser, UserPermissions } from '@guardian/interfaces';
 import { Subscription } from 'rxjs';
 import { ProfileService } from 'src/app/services/profile.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
     selector: 'app-toast',
@@ -15,9 +16,16 @@ export class AppToastComponent implements OnInit, OnDestroy {
 
     private subscription = new Subscription();
 
-    constructor(private profileService: ProfileService) {}
+    constructor(
+        private profileService: ProfileService,
+        private auth: AuthService,
+    ) {}
 
     public ngOnInit(): void {
+        // No session (e.g. login page): skip getProfile() to avoid a /profiles/null 401.
+        if (!this.auth.getAccessToken()) {
+            return;
+        }
         this.subscription.add(
             this.profileService.getProfile().subscribe({
                 next: (profile: IUser) => {

--- a/frontend/src/app/constants/http-context-tokens.ts
+++ b/frontend/src/app/constants/http-context-tokens.ts
@@ -1,3 +1,7 @@
 import { HttpContextToken } from '@angular/common/http';
 
 export const SILENT_HTTP_ERRORS = new HttpContextToken<boolean>(() => false);
+
+// Marks a request that must not trigger the auth interceptor's refresh-on-401
+// retry — set on the token-refresh call itself so a failed refresh doesn't loop.
+export const SKIP_AUTH_REFRESH = new HttpContextToken<boolean>(() => false);

--- a/frontend/src/app/services/auth-state.service.ts
+++ b/frontend/src/app/services/auth-state.service.ts
@@ -51,6 +51,17 @@ export class AuthStateService {
         this._value.next(state);
     }
 
+    /**
+     * Tear down the current session: drop the stored tokens and username, and
+     * flip the login state (which also stops the refresh timer). The single
+     * place that clears a session, so callers don't re-compose the steps.
+     */
+    public clearSession(): void {
+        this.authService.removeAccessToken();
+        this.authService.removeUsername();
+        this.updateState(false);
+    }
+
     public doLogin(login: string, password: string): void {
         this._loginRequests.next({ login, password });
     }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,10 +1,10 @@
 import { HttpClient, HttpContext, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { ISession, IStandardRegistryResponse, IUser, UserCategory, UserRole } from '@guardian/interfaces';
-import { Observable, of, Subject, Subscription } from 'rxjs';
+import { Observable, of, Subject, Subscription, throwError } from 'rxjs';
 import { API_BASE_URL } from './api';
-import { SILENT_HTTP_ERRORS } from '../constants';
-import { map } from 'rxjs/operators';
+import { SILENT_HTTP_ERRORS, SKIP_AUTH_REFRESH } from '../constants';
+import { catchError, finalize, map, shareReplay, switchMap } from 'rxjs/operators';
 
 /**
  * Services for working from accounts.
@@ -50,7 +50,11 @@ export class AuthService {
         return this.http.post<any>(
             `${this.url}/access-token`,
             { refreshToken: this.getRefreshToken() },
-            { context: new HttpContext().set(SILENT_HTTP_ERRORS, true) }
+            {
+                context: new HttpContext()
+                    .set(SILENT_HTTP_ERRORS, true)
+                    .set(SKIP_AUTH_REFRESH, true)
+            }
         ).pipe(
             map(result => {
                 const { accessToken } = result;
@@ -147,17 +151,73 @@ export class AuthService {
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        if (req.headers.has('Authorization')) {
-            return next.handle(req);
-        }
+    // Shared in-flight refresh, so several requests failing with 401 at once
+    // (e.g. after the access token lapses while the tab was asleep) trigger a
+    // single token refresh instead of one per request.
+    private refresh$: Observable<string> | null = null;
 
+    // AuthService depends on HttpClient, so injecting it directly would create
+    // a cyclic dependency with this interceptor; it is resolved lazily.
+    constructor(private injector: Injector) {
+    }
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        return next.handle(this.addToken(req)).pipe(
+            catchError((error: any) => {
+                if (this.shouldAttemptRefresh(error, req)) {
+                    return this.refreshAndRetry(req, next);
+                }
+                return throwError(() => error);
+            })
+        );
+    }
+
+    private addToken(req: HttpRequest<any>): HttpRequest<any> {
+        if (req.headers.has('Authorization')) {
+            return req;
+        }
         const token = localStorage.getItem('accessToken');
         if (!token) {
-            return next.handle(req);
+            return req;
         }
-        return next.handle(req.clone({
+        return this.withBearer(req, token);
+    }
+
+    private withBearer(req: HttpRequest<any>, token: string): HttpRequest<any> {
+        return req.clone({
             headers: req.headers.set('Authorization', `Bearer ${token}`),
-        }));
+        });
+    }
+
+    /**
+     * Recover a 401 by refreshing the access token — but only when there are
+     * credentials to refresh with, and never for the refresh call itself (that
+     * would loop). Requests without a stored session fall through to the error
+     * interceptor unchanged.
+     */
+    private shouldAttemptRefresh(error: any, req: HttpRequest<any>): boolean {
+        return (
+            error?.status === 401 &&
+            !req.context.get(SKIP_AUTH_REFRESH) &&
+            !!localStorage.getItem('accessToken') &&
+            !!localStorage.getItem('refreshToken')
+        );
+    }
+
+    private refreshAndRetry(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        return this.refreshToken().pipe(
+            switchMap((accessToken: string) => next.handle(this.withBearer(req, accessToken)))
+        );
+    }
+
+    private refreshToken(): Observable<string> {
+        if (!this.refresh$) {
+            const auth = this.injector.get(AuthService);
+            this.refresh$ = auth.updateAccessToken().pipe(
+                shareReplay(1),
+                finalize(() => { this.refresh$ = null; })
+            );
+        }
+        return this.refresh$;
     }
 }

--- a/frontend/src/app/services/branding.service.ts
+++ b/frontend/src/app/services/branding.service.ts
@@ -84,8 +84,7 @@ export class BrandingService {
                 this.brandingData = data || { ...DEFAULT_BRANDING };
                 return this.brandingData as BrandingPayload;
             })
-            .catch((error: any) => {
-                console.log(error)
+            .catch(() => {
                 this.brandingData = { ...DEFAULT_BRANDING };
                 return this.brandingData;
             })
@@ -105,8 +104,7 @@ export class BrandingService {
                 this.applyBranding(this.brandingData);
                 return data
             })
-            .catch((error: any) => {
-                console.log(error)
+            .catch(() => {
                 return this.brandingData;
             });
     }

--- a/frontend/src/app/services/handle-errors.service.ts
+++ b/frontend/src/app/services/handle-errors.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, throwError } from 'rxjs';
@@ -6,8 +6,8 @@ import { catchError } from 'rxjs/operators';
 import { ToastService } from './toast.service';
 import { MessageTranslationService } from './message-translation-service/message-translation-service';
 import { SILENT_HTTP_ERRORS } from '../constants';
-// import { AuthService } from './auth.service';
-// import { AuthStateService } from './auth-state.service';
+import { AuthService } from './auth.service';
+import { AuthStateService } from './auth-state.service';
 
 /**
  * Error interceptor.
@@ -18,8 +18,10 @@ export class HandleErrorsService implements HttpInterceptor {
         public router: Router,
         private toastService: ToastService,
         private messageTranslator: MessageTranslationService,
-        // private auth: AuthService,
-        // private authState: AuthStateService,
+        // AuthService/AuthStateService depend on HttpClient, so injecting them
+        // directly would create a cyclic dependency with this interceptor.
+        // They are resolved lazily through the injector inside intercept().
+        private injector: Injector,
     ) {
     }
 
@@ -109,24 +111,35 @@ export class HandleErrorsService implements HttpInterceptor {
         }
     }
 
-    private ifTokenExpired(error:any){
-        if( error?.status === 401 && error?.error?.message === 'Token expired') {
-            return true;
+    /**
+     * A 401 returned while an access token is attached means that token is no
+     * longer accepted (the session has expired). Clear the stale credentials
+     * and send the user to the login page. Requests made without a token (the
+     * user is already logged out) are left untouched, so this never loops on
+     * the login page. The first handled error clears the token, so concurrent
+     * 401s from the bootstrap requests skip straight past this.
+     */
+    private handleExpiredSession(error: any): boolean {
+        if (error?.status !== 401) {
+            return false;
         }
-        return false;
+        const auth = this.injector.get(AuthService);
+        if (!auth.getAccessToken()) {
+            return false;
+        }
+        const authState = this.injector.get(AuthStateService);
+        authState.clearSession();
+        this.router.navigate(['/login']);
+        return true;
     }
 
     public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(req).pipe(
             catchError((error: any) => {
                 console.error(error);
-                // if(this.ifTokenExpired(error)) {
-                //     this.auth.removeAccessToken();
-                //     this.auth.removeUsername();
-                //     this.authState.updateState(false);
-                //     this.router.navigate(['/login']);
-                //     return throwError(error);
-                // }
+                if (this.handleExpiredSession(error)) {
+                    return throwError(error);
+                }
                 if (req.context.get(SILENT_HTTP_ERRORS)) {
                     return throwError(error);
                 }

--- a/frontend/src/app/services/refresh-access-token.initializer.ts
+++ b/frontend/src/app/services/refresh-access-token.initializer.ts
@@ -1,0 +1,37 @@
+import { inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AuthService } from './auth.service';
+import { AuthStateService } from './auth-state.service';
+
+/**
+ * App initializer that refreshes the access token before the app boots.
+ *
+ * The access token lives only ~60s, and the periodic refresh timer
+ * (AuthStateService) is in-memory, so it never survives a page reload. That
+ * leaves the access token in localStorage almost always expired on a fresh
+ * start, and the bootstrap requests (session, branding, profile, settings)
+ * would be sent with it and rejected with 401 — cluttering the console.
+ *
+ * Exchanging the long-lived (30-day) refresh token for a fresh access token
+ * here, before those requests fire, keeps the session alive and the console
+ * clean. If no refresh token is stored, there is nothing to restore. If the
+ * refresh fails (refresh token expired/invalid), the stale credentials are
+ * dropped so the app starts on the login page instead of firing doomed
+ * requests; the error interceptor performs the redirect.
+ */
+export async function refreshAccessTokenOnStartup(): Promise<void> {
+    const auth = inject(AuthService);
+
+    if (!auth.getRefreshToken()) {
+        return;
+    }
+
+    // Resolve before the first await, while the injection context is active.
+    const authState = inject(AuthStateService);
+
+    try {
+        await firstValueFrom(auth.updateAccessToken());
+    } catch {
+        authState.clearSession();
+    }
+}

--- a/frontend/src/app/services/settings.service.ts
+++ b/frontend/src/app/services/settings.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { AboutInterface, CommonSettings } from '@guardian/interfaces';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { filter, shareReplay } from 'rxjs/operators';
 import { API_BASE_URL } from './api';
 
@@ -12,15 +12,10 @@ import { API_BASE_URL } from './api';
 export class SettingsService {
     private readonly url: string = `${API_BASE_URL}/settings`;
 
-    private hederaNetSubject = new BehaviorSubject<string>('');
-    private hederaNet = this.hederaNetSubject
-        .asObservable()
-        .pipe(filter((res) => !!res));
+    // Fetched lazily on first use so it never fires before login (endpoint requires auth).
+    private hederaNet?: Observable<string>;
 
     constructor(private http: HttpClient) {
-        this.getRemoteHederaNet().subscribe((res) => {
-            this.hederaNetSubject.next(res);
-        });
     }
 
     public updateSettings(settings: CommonSettings): Observable<void> {
@@ -32,6 +27,12 @@ export class SettingsService {
     }
 
     public getHederaNet(): Observable<string> {
+        if (!this.hederaNet) {
+            this.hederaNet = this.getRemoteHederaNet().pipe(
+                filter((res) => !!res),
+                shareReplay(1)
+            );
+        }
         return this.hederaNet;
     }
 


### PR DESCRIPTION
### Description

On a fresh start (page reload), the short-lived access token in localStorage is almost always expired, so the app's bootstrap requests were sent with it and rejected with 401 — cluttering the console and leaving the app in a half-authenticated state. The 30-day refresh token was never used to recover the session outside an already-open tab.

- Refresh the access token from the stored refresh token in an app initializer, before the first request fires, so a fresh start keeps the session alive and the console clean.
- Add a refresh-on-401 retry to the auth interceptor as a mid-session safety net, with a shared in-flight refresh so concurrent 401s trigger a single call, and exclude the refresh call itself to avoid a loop.
- Clear the stale credentials and redirect to login when the refresh token is expired or invalid.
- Remove leftover debug logs from the branding fetch error paths.