### PR TITLE
fix: 6503 Prevent double serialization of schema documents

### DIFF
--- a/api-gateway/src/api/service/module.ts
+++ b/api-gateway/src/api/service/module.ts
@@ -284,11 +284,12 @@ export class ModulesApi {
                 s.readonly = s.readonly || s.owner !== owner.owner
             });
 
-            req.locals = SchemaUtils.toOld(items)
+            const result = SchemaUtils.toOld(items)
+            req.locals = result
 
             return res
                 .header('X-Total-Count', count)
-                .send(SchemaUtils.toOld(items));
+                .send(result);
         } catch (error) {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -503,8 +503,9 @@ export class SchemaApi {
             }
             const { items, count } = await guardians.getSchemasByOwner(options, owner);
             SchemaHelper.updatePermission(items, owner);
-            req.locals = SchemaUtils.toOld(items);
-            return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
+            const result = SchemaUtils.toOld(items);
+            req.locals = result;
+            return res.header('X-Total-Count', count).send(result);
         } catch (error) {
             await InternalException(error, this.logger, user.id);
         }
@@ -780,8 +781,9 @@ export class SchemaApi {
             }
             const { items, count } = await guardians.getSchemasByOwner(options, owner);
             SchemaHelper.updatePermission(items, owner);
-            req.locals = SchemaUtils.toOld(items);
-            return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
+            const result = SchemaUtils.toOld(items);
+            req.locals = result;
+            return res.header('X-Total-Count', count).send(result);
         } catch (error) {
             await InternalException(error, this.logger, user.id);
         }
@@ -2738,8 +2740,9 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const { items, count } = await guardians.getSystemSchemas(user, pageIndex, pageSize);
             items.forEach((s) => { s.readonly = s.readonly || s.owner !== owner.owner });
-            req.locals = SchemaUtils.toOld(items);
-            return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
+            const result = SchemaUtils.toOld(items);
+            req.locals = result;
+            return res.header('X-Total-Count', count).send(result);
         } catch (error) {
             await InternalException(error, this.logger, user.id);
         }

--- a/api-gateway/src/api/service/tags.ts
+++ b/api-gateway/src/api/service/tags.ts
@@ -437,11 +437,12 @@ export class TagsApi {
                 s.readonly = s.readonly || s.owner !== owner.creator;
             });
 
-            req.locals = SchemaUtils.toOld(items)
+            const result = SchemaUtils.toOld(items)
+            req.locals = result
 
             return res
                 .header('X-Total-Count', count)
-                .send(SchemaUtils.toOld(items));
+                .send(result);
         } catch (error) {
             await InternalException(error, this.logger, user.id);
         }
@@ -526,11 +527,12 @@ export class TagsApi {
             const { items, count } = await guardians.getTagSchemasV2(owner, fields, pageIndex, pageSize);
             items.forEach((s) => { s.readonly = s.readonly || s.owner !== owner.creator });
 
-            req.locals = SchemaUtils.toOld(items)
+            const result = SchemaUtils.toOld(items)
+            req.locals = result
 
             return res
                 .header('X-Total-Count', count)
-                .send(SchemaUtils.toOld(items));
+                .send(result);
         } catch (error) {
             await InternalException(error, this.logger, user.id);
         }


### PR DESCRIPTION
**Description**:
* Fixed by calling toOld once and reusing the result for both req.locals and the response.

**Related issue**

Fixes [#6503](https://github.com/hashgraph/guardian/issues/6503)