### PR TITLE
fix: align the new schema editor with the design system

### DIFF
--- a/frontend/src/app/modules/schema-engine/field-type-ui.ts
+++ b/frontend/src/app/modules/schema-engine/field-type-ui.ts
@@ -30,8 +30,8 @@ const FIELD_TYPE_ADDONS: Record<string, UIAddon> = {
     'Country':       { key: 'country',       icon: 'pi-flag',                group: 'Geographic' },
     'Continent':     { key: 'continent',     icon: 'pi-globe',               group: 'Geographic' },
     'State/Province': { key: 'state',         icon: 'pi-map-marker',          group: 'Geographic' },
-    'Postfix':       { key: 'postfix',       icon: 'pi-hashtag',             group: 'Units of Measure' },
-    'Prefix':        { key: 'prefix',        icon: 'pi-hashtag',             group: 'Units of Measure' },
+    'postfix':       { key: 'postfix',       icon: 'pi-hashtag',             group: 'Units of Measure', label: 'Postfix' },
+    'prefix':        { key: 'prefix',        icon: 'pi-hashtag',             group: 'Units of Measure', label: 'Prefix' },
     'hederaAccount': { key: 'hederaAccount', icon: 'pi-id-card',             group: 'Hedera',           label: 'Account' },
 };
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -710,21 +710,29 @@
                             </div>
                             <div class="sc-rp-group">
                                 <label class="sc-rp-label">Color</label>
-                                <input
-                                    class="sc-rp-input"
-                                    type="text"
-                                    placeholder="#000000"
-                                    [(ngModel)]="$any(selectedField).textColor"
-                                    (ngModelChange)="markDirty()" />
+                                <div class="sc-rp-color">
+                                    <p-colorPicker
+                                        class="sc-rp-color-picker"
+                                        [format]="'hex'"
+                                        [(ngModel)]="$any(selectedField).textColor"
+                                        (ngModelChange)="markDirty()"></p-colorPicker>
+                                    <input
+                                        class="sc-rp-input sc-rp-color-hex"
+                                        type="text"
+                                        placeholder="#000000"
+                                        [(ngModel)]="$any(selectedField).textColor"
+                                        (ngModelChange)="markDirty()" />
+                                </div>
                             </div>
                             <div class="sc-rp-group">
                                 <label class="sc-rp-label">Font size (px)</label>
                                 <input
                                     class="sc-rp-input"
-                                    type="text"
+                                    type="number"
+                                    min="1"
                                     placeholder="18"
-                                    [(ngModel)]="$any(selectedField).textSize"
-                                    (ngModelChange)="markDirty()" />
+                                    [ngModel]="getHelpTextSize()"
+                                    (ngModelChange)="setHelpTextSize($event)" />
                             </div>
                             <button class="sc-btn" (click)="resetHelpText()">
                                 <i class="pi pi-refresh"></i>

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -739,7 +739,7 @@
                             <div class="sc-rp-divider"></div>
                             <div class="sc-rp-group">
                                 <label class="sc-rp-label">
-                                    <i class="pi pi-sitemap" style="font-size:11px;color:#534ab7;margin-right:4px"></i>
+                                    <i class="pi pi-sitemap" style="font-size:11px;color:var(--color-primary, #4169E2);margin-right:4px"></i>
                                     Referenced schema
                                 </label>
                                 <p-select
@@ -757,14 +757,14 @@
                                     (onChange)="onSubSchemaRefChange($event.value)">
                                     <ng-template pTemplate="selectedItem" let-s>
                                         <div class="sc-ref-sel-item">
-                                            <i class="pi pi-file" style="color:#534ab7;font-size:12px"></i>
+                                            <i class="pi pi-file" style="color:var(--color-primary, #4169E2);font-size:12px"></i>
                                             <span>{{ s.name }}</span>
                                             @if (s.version) { <span class="sc-ref-sel-ver">v{{ s.version }}</span> }
                                         </div>
                                     </ng-template>
                                     <ng-template pTemplate="item" let-s>
                                         <div class="sc-ref-sel-item">
-                                            <i class="pi pi-file" style="color:#534ab7;font-size:12px"></i>
+                                            <i class="pi pi-file" style="color:var(--color-primary, #4169E2);font-size:12px"></i>
                                             <span>{{ s.name }}</span>
                                             @if (s.version) { <span class="sc-ref-sel-ver">v{{ s.version }}</span> }
                                         </div>

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -762,7 +762,7 @@
                                 </label>
                                 <p-select
                                     class="guardian-dropdown sc-rp-select"
-                                    panelStyleClass="guardian-dropdown-panel"
+                                    panelStyleClass="guardian-dropdown-panel sc-ref-schema-panel"
                                     [options]="availableRefSchemas"
                                     [filter]="true"
                                     filterBy="name"
@@ -776,14 +776,14 @@
                                     <ng-template pTemplate="selectedItem" let-s>
                                         <div class="sc-ref-sel-item">
                                             <i class="pi pi-file" style="color:var(--color-primary, #4169E2);font-size:12px"></i>
-                                            <span>{{ s.name }}</span>
+                                            <span [title]="s.name">{{ s.name }}</span>
                                             @if (s.version) { <span class="sc-ref-sel-ver">v{{ s.version }}</span> }
                                         </div>
                                     </ng-template>
                                     <ng-template pTemplate="item" let-s>
                                         <div class="sc-ref-sel-item">
                                             <i class="pi pi-file" style="color:var(--color-primary, #4169E2);font-size:12px"></i>
-                                            <span>{{ s.name }}</span>
+                                            <span [title]="s.name">{{ s.name }}</span>
                                             @if (s.version) { <span class="sc-ref-sel-ver">v{{ s.version }}</span> }
                                         </div>
                                     </ng-template>

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -556,7 +556,7 @@
                         <div class="sc-rp-group">
                             <label class="sc-rp-label">Key</label>
                             <input
-                                class="sc-rp-input sc-rp-input--mono"
+                                class="sc-rp-input"
                                 type="text"
                                 placeholder="Field name"
                                 [ngModel]="selectedField.name"
@@ -577,7 +577,7 @@
                             <div class="sc-rp-group">
                                 <label class="sc-rp-label">Pattern</label>
                                 <input
-                                    class="sc-rp-input sc-rp-input--mono"
+                                    class="sc-rp-input"
                                     type="text"
                                     placeholder="e.g. [0-9]+"
                                     [(ngModel)]="selectedField.pattern"

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -245,6 +245,11 @@
                                     <i class="pi pi-file-edit"></i>Schema properties
                                     @if (selectedSchema.iri) {
                                         <span class="sc-schema-props-iri">({{ selectedSchema.iri }})</span>
+                                        <i class="pi sc-schema-props-iri-copy"
+                                           [class.pi-check]="copiedIri"
+                                           [class.pi-copy]="!copiedIri"
+                                           [title]="copiedIri ? 'Copied' : 'Copy schema IRI'"
+                                           (click)="copyIri(selectedSchema.iri, $event)"></i>
                                     }
                                 </div>
                                 <button class="sc-schema-props-toggle" (click)="schemaPropsCollapsed = !schemaPropsCollapsed">
@@ -253,11 +258,14 @@
                                 </button>
                             </div>
                             @if (!schemaPropsCollapsed) {
-                                <input class="sc-schema-props-name"
-                                       [(ngModel)]="selectedSchema.name"
-                                       (ngModelChange)="markDirty()"
-                                       placeholder="Schema name" />
-                                <div class="sc-schema-props-row">
+                                <div class="sc-schema-props-row sc-schema-props-row--main">
+                                    <div class="sc-schema-props-field">
+                                        <label class="sc-schema-props-label">Schema name</label>
+                                        <input class="sc-schema-props-name"
+                                               [(ngModel)]="selectedSchema.name"
+                                               (ngModelChange)="markDirty()"
+                                               placeholder="Schema name" />
+                                    </div>
                                     <div class="sc-schema-props-field">
                                         <label class="sc-schema-props-label">Entity type</label>
                                         <p-select class="guardian-dropdown sc-schema-props-select"
@@ -269,11 +277,6 @@
                                                   [(ngModel)]="selectedSchema.entity"
                                                   (ngModelChange)="markDirty()">
                                         </p-select>
-                                    </div>
-                                    <div class="sc-schema-props-field">
-                                        <label class="sc-schema-props-label">Status</label>
-                                        <input class="sc-schema-props-input sc-schema-props-input--readonly"
-                                               [value]="selectedSchema.status" readonly />
                                     </div>
                                 </div>
                                 <div class="sc-schema-props-field sc-schema-props-field--full">
@@ -421,6 +424,11 @@
                                         <i class="pi pi-sitemap"></i>Sub-schema properties
                                         @if (ds.iri) {
                                             <span class="sc-schema-props-iri">({{ ds.iri }})</span>
+                                            <i class="pi sc-schema-props-iri-copy"
+                                               [class.pi-check]="copiedIri"
+                                               [class.pi-copy]="!copiedIri"
+                                               [title]="copiedIri ? 'Copied' : 'Copy schema IRI'"
+                                               (click)="copyIri(ds.iri, $event)"></i>
                                         }
                                     </div>
                                     <button class="sc-schema-props-toggle" (click)="drillPropsCollapsed = !drillPropsCollapsed">
@@ -429,11 +437,14 @@
                                     </button>
                                 </div>
                                 @if (!drillPropsCollapsed) {
-                                    <input class="sc-schema-props-name"
-                                           [(ngModel)]="ds.name"
-                                           (ngModelChange)="markDirty()"
-                                           placeholder="Sub-schema name" />
-                                    <div class="sc-schema-props-row">
+                                    <div class="sc-schema-props-row sc-schema-props-row--main">
+                                        <div class="sc-schema-props-field">
+                                            <label class="sc-schema-props-label">Sub-schema name</label>
+                                            <input class="sc-schema-props-name"
+                                                   [(ngModel)]="ds.name"
+                                                   (ngModelChange)="markDirty()"
+                                                   placeholder="Sub-schema name" />
+                                        </div>
                                         <div class="sc-schema-props-field">
                                             <label class="sc-schema-props-label">Entity type</label>
                                             <p-select class="guardian-dropdown sc-schema-props-select"
@@ -445,11 +456,6 @@
                                                       [(ngModel)]="ds.entity"
                                                       (ngModelChange)="markDirty()">
                                             </p-select>
-                                        </div>
-                                        <div class="sc-schema-props-field">
-                                            <label class="sc-schema-props-label">Status</label>
-                                            <input class="sc-schema-props-input sc-schema-props-input--readonly"
-                                                   [value]="ds.status" readonly />
                                         </div>
                                     </div>
                                     <div class="sc-schema-props-field sc-schema-props-field--full">

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -913,8 +913,8 @@
                                                       panelStyleClass="guardian-dropdown-panel"
                                                       [options]="selectedField!.enum || []"
                                                       appendTo="body"
-                                                      [showClear]="true"
-                                                      placeholder="— none —"
+                                                      [showClear]="false"
+                                                      placeholder="None"
                                                       [ngModel]="$any(selectedField).default"
                                                       (ngModelChange)="setFieldPresetValue('default', $event)">
                                             </p-select>
@@ -941,8 +941,8 @@
                                                       panelStyleClass="guardian-dropdown-panel"
                                                       [options]="selectedField!.enum || []"
                                                       appendTo="body"
-                                                      [showClear]="true"
-                                                      placeholder="— none —"
+                                                      [showClear]="false"
+                                                      placeholder="None"
                                                       [ngModel]="$any(selectedField).suggest"
                                                       (ngModelChange)="setFieldPresetValue('suggest', $event)">
                                             </p-select>
@@ -969,8 +969,8 @@
                                                       panelStyleClass="guardian-dropdown-panel"
                                                       [options]="selectedField!.enum || []"
                                                       appendTo="body"
-                                                      [showClear]="true"
-                                                      placeholder="— none —"
+                                                      [showClear]="false"
+                                                      placeholder="None"
                                                       [ngModel]="getFieldTestValue()"
                                                       (ngModelChange)="setFieldTestValue($event)">
                                             </p-select>

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -260,13 +260,15 @@
                                 <div class="sc-schema-props-row">
                                     <div class="sc-schema-props-field">
                                         <label class="sc-schema-props-label">Entity type</label>
-                                        <select class="sc-schema-props-select"
-                                                [(ngModel)]="selectedSchema.entity"
-                                                (ngModelChange)="markDirty()">
-                                            @for (opt of entityOptions; track opt.value) {
-                                                <option [value]="opt.value">{{ opt.label }}</option>
-                                            }
-                                        </select>
+                                        <p-select class="guardian-dropdown sc-schema-props-select"
+                                                  panelStyleClass="guardian-dropdown-panel"
+                                                  [options]="entityOptions"
+                                                  optionLabel="label"
+                                                  optionValue="value"
+                                                  appendTo="body"
+                                                  [(ngModel)]="selectedSchema.entity"
+                                                  (ngModelChange)="markDirty()">
+                                        </p-select>
                                     </div>
                                     <div class="sc-schema-props-field">
                                         <label class="sc-schema-props-label">Status</label>
@@ -434,13 +436,15 @@
                                     <div class="sc-schema-props-row">
                                         <div class="sc-schema-props-field">
                                             <label class="sc-schema-props-label">Entity type</label>
-                                            <select class="sc-schema-props-select"
-                                                    [(ngModel)]="ds.entity"
-                                                    (ngModelChange)="markDirty()">
-                                                @for (opt of entityOptions; track opt.value) {
-                                                    <option [value]="opt.value">{{ opt.label }}</option>
-                                                }
-                                            </select>
+                                            <p-select class="guardian-dropdown sc-schema-props-select"
+                                                      panelStyleClass="guardian-dropdown-panel"
+                                                      [options]="entityOptions"
+                                                      optionLabel="label"
+                                                      optionValue="value"
+                                                      appendTo="body"
+                                                      [(ngModel)]="ds.entity"
+                                                      (ngModelChange)="markDirty()">
+                                            </p-select>
                                         </div>
                                         <div class="sc-schema-props-field">
                                             <label class="sc-schema-props-label">Status</label>
@@ -660,9 +664,9 @@
                             <div class="sc-check-list">
                                 @for (opt of geoJsonOptions; track opt) {
                                     <div class="sc-check-item" (click)="toggleGeoJsonType(opt)">
-                                        <div class="sc-check-box" [class.active]="isGeoJsonTypeSelected(opt)">
-                                            <i class="pi pi-check"></i>
-                                        </div>
+                                        <p-checkbox class="guardian-checkbox checkbox-24" [binary]="true"
+                                                    style="pointer-events:none"
+                                                    [ngModel]="isGeoJsonTypeSelected(opt)"></p-checkbox>
                                         <div class="sc-check-desc">
                                             <strong>{{ opt }}</strong>
                                         </div>
@@ -676,9 +680,9 @@
                             <div class="sc-rp-label">Text style</div>
                             <div class="sc-check-list">
                                 <div class="sc-check-item" (click)="$any(selectedField).textBold = !$any(selectedField).textBold; markDirty()">
-                                    <div class="sc-check-box" [class.active]="$any(selectedField).textBold">
-                                        <i class="pi pi-check"></i>
-                                    </div>
+                                    <p-checkbox class="guardian-checkbox checkbox-24" [binary]="true"
+                                                style="pointer-events:none"
+                                                [ngModel]="$any(selectedField).textBold"></p-checkbox>
                                     <div class="sc-check-desc">
                                         <strong>Bold</strong>
                                     </div>
@@ -799,7 +803,10 @@
                         <div class="sc-radio-list">
                             @for (opt of requiredModeOptions; track opt.value) {
                                 <div class="sc-radio-item" (click)="setFieldRequiredMode(opt.value)">
-                                    <div class="sc-radio-dot" [class.active]="getFieldRequiredMode(selectedField) === opt.value"></div>
+                                    <p-radioButton class="guardian-radio-button radio-button-24" name="sc-required-mode"
+                                                   style="pointer-events:none"
+                                                   [value]="opt.value"
+                                                   [ngModel]="getFieldRequiredMode(selectedField)"></p-radioButton>
                                     <span>{{ opt.label }}</span>
                                 </div>
                             }
@@ -834,9 +841,9 @@
                             <div class="sc-check-list">
                                 @if (selectedFieldCanBeArray) {
                                     <div class="sc-check-item" (click)="toggleBehaviour('isArray')">
-                                        <div class="sc-check-box" [class.active]="selectedField.isArray">
-                                            <i class="pi pi-check"></i>
-                                        </div>
+                                        <p-checkbox class="guardian-checkbox checkbox-24" [binary]="true"
+                                                    style="pointer-events:none"
+                                                    [ngModel]="selectedField.isArray"></p-checkbox>
                                         <div class="sc-check-desc">
                                             <strong>Allow multiple answers</strong>
                                             <span>Renders as a list</span>
@@ -845,9 +852,9 @@
                                 }
                                 @if (selectedFieldCanBeUpdatable) {
                                     <div class="sc-check-item" (click)="toggleBehaviour('isUpdatable')">
-                                        <div class="sc-check-box" [class.active]="selectedField.isUpdatable">
-                                            <i class="pi pi-check"></i>
-                                        </div>
+                                        <p-checkbox class="guardian-checkbox checkbox-24" [binary]="true"
+                                                    style="pointer-events:none"
+                                                    [ngModel]="selectedField.isUpdatable"></p-checkbox>
                                         <div class="sc-check-desc">
                                             <strong>Updatable field</strong>
                                             <span>Value can be updated after submission</span>
@@ -888,12 +895,15 @@
                                                 <button class="sc-fv-yesno-btn" [class.active]="$any(selectedField).default === false" (click)="setFieldBooleanValue('default', $any(selectedField).default === false ? null : false)">No</button>
                                             </div>
                                         } @else if (getFieldValueInputType(selectedField!) === 'enum') {
-                                            <select class="sc-fv-select" [ngModel]="$any(selectedField).default" (ngModelChange)="setFieldPresetValue('default', $event)">
-                                                <option value="">— none —</option>
-                                                @for (opt of (selectedField!.enum || []); track opt) {
-                                                    <option [value]="opt">{{ opt }}</option>
-                                                }
-                                            </select>
+                                            <p-select class="guardian-dropdown sc-fv-select"
+                                                      panelStyleClass="guardian-dropdown-panel"
+                                                      [options]="selectedField!.enum || []"
+                                                      appendTo="body"
+                                                      [showClear]="true"
+                                                      placeholder="— none —"
+                                                      [ngModel]="$any(selectedField).default"
+                                                      (ngModelChange)="setFieldPresetValue('default', $event)">
+                                            </p-select>
                                         } @else {
                                             <input class="sc-fv-input" [type]="getFieldValueInputType(selectedField!)"
                                                 [ngModel]="$any(selectedField).default"
@@ -913,12 +923,15 @@
                                                 <button class="sc-fv-yesno-btn" [class.active]="$any(selectedField).suggest === false" (click)="setFieldBooleanValue('suggest', $any(selectedField).suggest === false ? null : false)">No</button>
                                             </div>
                                         } @else if (getFieldValueInputType(selectedField!) === 'enum') {
-                                            <select class="sc-fv-select" [ngModel]="$any(selectedField).suggest" (ngModelChange)="setFieldPresetValue('suggest', $event)">
-                                                <option value="">— none —</option>
-                                                @for (opt of (selectedField!.enum || []); track opt) {
-                                                    <option [value]="opt">{{ opt }}</option>
-                                                }
-                                            </select>
+                                            <p-select class="guardian-dropdown sc-fv-select"
+                                                      panelStyleClass="guardian-dropdown-panel"
+                                                      [options]="selectedField!.enum || []"
+                                                      appendTo="body"
+                                                      [showClear]="true"
+                                                      placeholder="— none —"
+                                                      [ngModel]="$any(selectedField).suggest"
+                                                      (ngModelChange)="setFieldPresetValue('suggest', $event)">
+                                            </p-select>
                                         } @else {
                                             <input class="sc-fv-input" [type]="getFieldValueInputType(selectedField!)"
                                                 [ngModel]="$any(selectedField).suggest"
@@ -938,12 +951,15 @@
                                                 <button class="sc-fv-yesno-btn" [class.active]="getFieldTestValue() === false" (click)="setFieldTestBooleanValue(getFieldTestValue() === false ? null : false)">No</button>
                                             </div>
                                         } @else if (getFieldValueInputType(selectedField!) === 'enum') {
-                                            <select class="sc-fv-select" [ngModel]="getFieldTestValue()" (ngModelChange)="setFieldTestValue($event)">
-                                                <option value="">— none —</option>
-                                                @for (opt of (selectedField!.enum || []); track opt) {
-                                                    <option [value]="opt">{{ opt }}</option>
-                                                }
-                                            </select>
+                                            <p-select class="guardian-dropdown sc-fv-select"
+                                                      panelStyleClass="guardian-dropdown-panel"
+                                                      [options]="selectedField!.enum || []"
+                                                      appendTo="body"
+                                                      [showClear]="true"
+                                                      placeholder="— none —"
+                                                      [ngModel]="getFieldTestValue()"
+                                                      (ngModelChange)="setFieldTestValue($event)">
+                                            </p-select>
                                         } @else {
                                             <input class="sc-fv-input" [type]="getFieldValueInputType(selectedField!)"
                                                 [ngModel]="getFieldTestValue()"

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -117,7 +117,7 @@
     &.active {
         background: var(--guardian-background, #fff);
         color: var(--guardian-font-color, #23252E);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+        box-shadow: 0 1px 3px var(--guardian-shadow), 0 1px 2px var(--guardian-shadow);
     }
 }
 
@@ -168,7 +168,7 @@
     }
     &.saving {
         background: var(--guardian-grey-background, #F9FAFC);
-        border-color: rgba(0, 0, 0, 0.12);
+        border-color: var(--guardian-border-color, #E1E7EF);
         color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
@@ -411,7 +411,7 @@
     &.sc-schema-row--no-drop {
         cursor: default;
         opacity: 0.55;
-        &:hover { border-color: rgba(0, 0, 0, 0.1); }
+        &:hover { border-color: var(--guardian-border-color, #E1E7EF); }
     }
 
     &.active {
@@ -666,7 +666,7 @@
 /* ── Schema properties panel (root = green, sub = purple) ── */
 .sc-schema-props {
     background: var(--guardian-success-background, #EEFBF0);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     padding: 10px 16px 10px;
     flex-shrink: 0;
 
@@ -742,7 +742,7 @@
     padding: 5px 8px;
     border-radius: 5px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
-    background: white;
+    background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
@@ -793,7 +793,7 @@
     padding: 4px 7px;
     border-radius: 5px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
-    background: white;
+    background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
@@ -817,7 +817,7 @@
     padding: 4px 7px;
     border-radius: 5px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
-    background: white;
+    background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
@@ -835,7 +835,7 @@
 }
 
 .sc-section-usage {
-    background: white;
+    background: var(--guardian-background, #fff);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 5px;
     padding: 10px 12px;
@@ -913,8 +913,8 @@
     position: relative;
 
     &:hover {
-        border-color: rgba(0, 0, 0, 0.2);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+        border-color: var(--guardian-border-color, #E1E7EF);
+        box-shadow: 0 1px 3px var(--guardian-shadow);
 
         .sc-field-card-actions { opacity: 1; }
     }
@@ -1064,7 +1064,7 @@
 /* ── Drill field cards ── */
 .sc-drill-card {
     background: var(--guardian-grey-background, #F9FAFC);
-    border: 1px solid rgba(0, 0, 0, 0.08);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 8px;
     padding: 7px 10px;
     display: flex;
@@ -1076,8 +1076,8 @@
 
     &:hover {
         background: var(--guardian-background, #fff);
-        border-color: rgba(0, 0, 0, 0.15);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+        border-color: var(--guardian-border-color, #E1E7EF);
+        box-shadow: 0 1px 3px var(--guardian-shadow);
 
         .sc-drill-card-actions { opacity: 1; }
     }
@@ -1283,7 +1283,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    &--hidden { background: var(--guardian-grey-background, #F9FAFC); border-color: rgba(0,0,0,0.1); color: var(--guardian-font-color-secondary, #848FA9); }
+    &--hidden { background: var(--guardian-grey-background, #F9FAFC); border-color: var(--guardian-border-color, #E1E7EF); color: var(--guardian-font-color-secondary, #848FA9); }
     &--auto { background: var(--guardian-warning-background, #FFF6E3); border-color: color-mix(in srgb, var(--color-primary, #4169E2) 10%, transparent); color: var(--color-primary, #4169E2); }
     &--upd    { background: var(--guardian-success-background, #EEFBF0); border-color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 20%, transparent); color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
 }
@@ -1293,7 +1293,7 @@
     align-items: center;
     gap: 12px;
     padding: 10px 14px;
-    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    border-top: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
     background: var(--guardian-background, #fff);
 }
@@ -1609,7 +1609,7 @@
 // ── Tab bar ──────────────────────────────────────────────────────────────────
 .sc-rp-tabs {
     display: flex;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
     background: var(--guardian-grey-background, #F9FAFC);
 }
@@ -1782,7 +1782,7 @@
     width: 16px;
     height: 16px;
     border-radius: 4px;
-    border: 1.5px solid rgba(0, 0, 0, 0.2);
+    border: 1.5px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     display: flex;
     align-items: center;
@@ -2152,7 +2152,7 @@
     justify-content: space-between;
     padding: 8px 10px;
     background: rgba(0, 0, 0, 0.03);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
 }
 
 .sc-cond-card-title {
@@ -2185,7 +2185,7 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
 
     &:last-child { border-bottom: none; }
     &--else { background: rgba(0, 0, 0, 0.015); }
@@ -2284,7 +2284,7 @@
     padding: 3px 6px;
     border-radius: 6px;
     background: rgba(255, 255, 255, 0.7);
-    border: 1px solid rgba(0, 0, 0, 0.07);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
 
     &--cross {
         background: var(--guardian-primary-background, #E1E7FA);
@@ -2441,7 +2441,7 @@
     &.active {
         background: var(--guardian-background);
         color: var(--guardian-font-color);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 1px 3px var(--guardian-shadow);
     }
 }
 
@@ -2831,7 +2831,7 @@
     border: 1.5px solid var(--color-primary);
     border-radius: 12px;
     padding: 10px 12px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 8px 24px var(--guardian-shadow), 0 2px 6px var(--guardian-shadow);
     pointer-events: none;
     display: flex;
     align-items: center;
@@ -2883,7 +2883,7 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    border: 1.5px solid rgba(0, 0, 0, 0.25);
+    border: 1.5px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     flex-shrink: 0;
     position: relative;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -684,7 +684,6 @@
         .sc-schema-props-toggle { color: var(--color-primary, #4169E2); }
         .sc-schema-props-label { color: var(--color-primary, #4169E2); }
         .sc-schema-props-name,
-        .sc-schema-props-input,
         .sc-schema-props-desc {
             border-color: color-mix(in srgb, var(--color-primary, #4169E2) 25%, transparent);
             &:focus { border-color: var(--color-primary, #4169E2); box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent); }
@@ -696,7 +695,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 8px;
+    // No bottom margin: keeps the header centered when the panel is collapsed;
+    // the gap to the first field row is set on .sc-schema-props-row--main.
 }
 
 .sc-schema-props-title {
@@ -723,6 +723,18 @@
     word-break: break-all;
 }
 
+.sc-schema-props-iri-copy {
+    font-size: 10px;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.6;
+    margin-left: 2px;
+    transition: opacity 0.12s, color 0.12s;
+
+    &:hover { opacity: 1; }
+    &.pi-check { color: var(--color-accent-green-1, #19BE47); opacity: 1; }
+}
+
 .sc-schema-props-toggle {
     font-size: 10px;
     background: none;
@@ -742,16 +754,16 @@
 
 .sc-schema-props-name {
     width: 100%;
-    font-size: 13px;
+    height: 40px;
+    font-size: 14px;
     font-weight: 500;
-    padding: 5px 8px;
-    border-radius: 6px;
+    padding: 0 12px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
-    margin-bottom: 6px;
 
     &:focus {
         border-color: var(--color-primary, #4169E2);
@@ -764,6 +776,13 @@
     grid-template-columns: 1fr 1fr;
     gap: 6px;
     margin-bottom: 6px;
+}
+
+// Schema name (flex) + entity-type dropdown (wide enough for the longest label)
+.sc-schema-props-row--main {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 300px);
+    align-items: end;
+    margin-top: 14px;
 }
 
 .sc-schema-props-field {
@@ -792,35 +811,30 @@
     font-weight: 400;
 }
 
-.sc-schema-props-input {
-    font-size: 11px;
-    padding: 4px 7px;
-    border-radius: 6px;
-    border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
-    background: var(--guardian-background, #fff);
-    color: var(--guardian-font-color, #23252E);
-    font-family: inherit;
-    outline: none;
-    width: 100%;
-
-    &:focus {
-        border-color: var(--color-primary, #4169E2);
-    }
-
-    &--readonly {
-        background: var(--guardian-grey-background, #F9FAFC);
-        color: var(--guardian-font-color-secondary, #848FA9);
-        cursor: default;
-    }
-}
-
 // Entity-type dropdown is a p-select (guardian-dropdown); host only needs sizing
 .sc-schema-props-select { width: 100%; }
 
+// Compact block: dropdown text matches the schema-name/description scale
+::ng-deep .sc-schema-props .sc-schema-props-select {
+    .p-select-label,
+    .p-inputtext {
+        font-size: 14px;
+    }
+    // Vertically center the value within the 40px control
+    .p-select-label {
+        display: flex;
+        align-items: center;
+        align-self: stretch;
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: normal;
+    }
+}
+
 .sc-schema-props-desc {
-    font-size: 11px;
-    padding: 4px 7px;
-    border-radius: 6px;
+    font-size: 13px;
+    padding: 6px 10px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -3045,7 +3045,7 @@
 .sc-fv-list {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
     margin-top: 2px;
 }
 
@@ -3092,11 +3092,11 @@
 
 .sc-fv-input {
     width: 100%;
-    padding: 5px 9px;
+    padding: 7px 10px;
     border-radius: 6px;
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-grey-background, #F9FAFC);
-    font-size: 12px;
+    font-size: 13px;
     color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
@@ -3125,7 +3125,7 @@
     // (&.p-select) and any descendant (.p-select), mirroring the theme.
     &.p-select,
     .p-select {
-        height: 30px;
+        height: 34px;
         border-radius: 6px;
         background: var(--guardian-grey-background, #F9FAFC);
 
@@ -3133,8 +3133,8 @@
             display: flex;
             align-items: center;
             align-self: stretch;
-            padding: 0 9px;
-            font-size: 12px;
+            padding: 0 10px;
+            font-size: 13px;
             line-height: normal;
         }
 
@@ -3159,11 +3159,11 @@
 
 .sc-fv-yesno-btn {
     flex: 1;
-    padding: 5px 8px;
+    padding: 7px 8px;
     border-radius: 6px;
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-grey-background, #F9FAFC);
-    font-size: 12px;
+    font-size: 13px;
     color: var(--guardian-font-color-secondary, #848FA9);
     font-family: inherit;
     cursor: pointer;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -862,8 +862,8 @@
 
 .sc-schema-tag {
     font-size: 12px;
-    background: var(--guardian-failure-background, #FFEAEA);
-    color: var(--guardian-font-color, #23252E);
+    background: var(--guardian-primary-background, #E1E7FA);
+    color: var(--color-primary, #4169E2);
     border-radius: 3px;
     padding: 1px 6px;
     font-weight: 500;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -3114,8 +3114,43 @@
     }
 }
 
-// Field-value enum picker is a p-select (guardian-dropdown); host only needs sizing
+// Field-value enum picker is a p-select (guardian-dropdown); shrink it to match
+// the compact scalar value inputs (.sc-fv-input) instead of the full 40px control.
 .sc-fv-select { width: 100%; }
+
+::ng-deep .sc-fv-select.guardian-dropdown {
+    height: auto;
+
+    // PrimeNG puts .p-select on the host element itself, so match both the host
+    // (&.p-select) and any descendant (.p-select), mirroring the theme.
+    &.p-select,
+    .p-select {
+        height: 30px;
+        border-radius: 6px;
+        background: var(--guardian-grey-background, #F9FAFC);
+
+        .p-select-label {
+            display: flex;
+            align-items: center;
+            align-self: stretch;
+            padding: 0 9px;
+            font-size: 12px;
+            line-height: normal;
+        }
+
+        .p-placeholder {
+            color: var(--guardian-font-color-secondary, #848FA9);
+        }
+
+        .p-select-dropdown {
+            width: 28px;
+
+            .p-select-dropdown-icon {
+                font-size: 11px;
+            }
+        }
+    }
+}
 
 .sc-fv-yesno {
     display: flex;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -3051,6 +3051,28 @@
     margin-left: auto;
 }
 
+// Constrain the expanded ref-schema panel so long schema names don't stretch it
+// across the screen; the name ellipsises within a sensible width instead.
+// The panel is appended to <body>, so this rule must be global (leading ::ng-deep).
+::ng-deep .guardian-dropdown-panel.sc-ref-schema-panel {
+    max-width: 480px;
+
+    .sc-ref-sel-item {
+        min-width: 0;
+
+        > span:not(.sc-ref-sel-ver) {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .sc-ref-sel-ver {
+            flex-shrink: 0;
+        }
+    }
+}
+
 // ── Values section (Default / Suggested / Test value) ────────────────────────
 .sc-fv-list {
     display: flex;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -940,10 +940,10 @@
 
     &.active {
         border: 1.5px solid var(--color-primary, #4169E2);
-        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-green-1, #19BE47) 10%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary, #4169E2) 10%, transparent);
 
         .sc-field-type-icon {
-            background: var(--guardian-success-background, #EEFBF0);
+            background: var(--guardian-primary-background, #E1E7FA);
             i { color: var(--color-primary, #4169E2); }
         }
 
@@ -2057,16 +2057,16 @@
 
     &:hover {
         border-color: var(--color-primary, #4169E2);
-        background: var(--guardian-success-background, #EEFBF0);
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        i, span { color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
+        i, span { color: var(--color-primary, #4169E2); }
     }
 
     &.active {
         border: 1.5px solid var(--color-primary, #4169E2);
-        background: var(--guardian-success-background, #EEFBF0);
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        i, span { color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
+        i, span { color: var(--color-primary, #4169E2); }
     }
 
     &--accent {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -1591,8 +1591,21 @@
     overflow: hidden;
 }
 
-::ng-deep .sc-page .sc-right-panel .guardian-dropdown .p-select-label {
-    padding: 4px 0px;
+// Match the Schema properties dropdown: 14px value, vertically centered in the
+// 40px control, with the theme's horizontal padding (chevron sits flush right).
+::ng-deep .sc-page .sc-right-panel .sc-rp-select {
+    .p-select-label,
+    .p-inputtext {
+        font-size: 14px;
+    }
+    .p-select-label {
+        display: flex;
+        align-items: center;
+        align-self: stretch;
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: normal;
+    }
 }
 
 .sc-rp-header {
@@ -2125,10 +2138,7 @@
 
 // ── Select input (mirrors sc-rp-input) ──────────────────────────────────────
 .sc-rp-select {
-    @extend .sc-rp-input;
     cursor: pointer;
-    appearance: auto;
-    padding-right: 28px;
 }
 
 // ── Conditions panel ─────────────────────────────────────────────────────────

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -890,7 +890,7 @@
 .sc-section-line {
     flex: 1;
     height: 1px;
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--guardian-border-color, #E1E7EF);
 }
 
 .sc-fields-list {
@@ -1304,7 +1304,7 @@
 }
 
 .sc-drag-handle {
-    color: rgba(0, 0, 0, 0.2);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 13px;
     cursor: grab;
     flex-shrink: 0;
@@ -1439,7 +1439,7 @@
 
     i {
         font-size: 32px;
-        color: rgba(0, 0, 0, 0.12);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
@@ -1557,7 +1557,7 @@
 
     i {
         font-size: 48px;
-        color: rgba(0, 0, 0, 0.08);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
@@ -1642,7 +1642,7 @@
 
     &:not(.active):hover {
         color: var(--guardian-font-color, #23252E);
-        background: rgba(0, 0, 0, 0.03);
+        background: var(--guardian-hover, #F0F3FC);
     }
 }
 
@@ -1756,7 +1756,7 @@
 
 .sc-rp-divider {
     height: 1px;
-    background: rgba(0, 0, 0, 0.08);
+    background: var(--guardian-border-color, #E1E7EF);
 }
 
 .sc-check-list {
@@ -1912,7 +1912,7 @@
     font-size: 11px;
     color: var(--guardian-font-color-secondary, #848FA9);
 
-    i { font-size: 18px; color: rgba(0, 0, 0, 0.12); }
+    i { font-size: 18px; color: var(--guardian-font-color-secondary, #848FA9); }
 }
 
 /* ── Enum options editor ── */
@@ -2151,7 +2151,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 8px 10px;
-    background: rgba(0, 0, 0, 0.03);
+    background: var(--guardian-hover, #F0F3FC);
     border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
 }
 
@@ -2188,7 +2188,7 @@
     border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
 
     &:last-child { border-bottom: none; }
-    &--else { background: rgba(0, 0, 0, 0.015); }
+    &--else { background: var(--guardian-hover, #F0F3FC); }
 }
 
 .sc-cond-section-hd {
@@ -2412,7 +2412,7 @@
 
 .sc-canvas-tab-pill {
     display: flex;
-    background: rgba(0, 0, 0, 0.06);
+    background: var(--guardian-hover, #F0F3FC);
     border-radius: 6px;
     padding: 2px;
     gap: 1px;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -1759,6 +1759,25 @@
     white-space: pre;
 }
 
+.sc-rp-color {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .sc-rp-color-hex {
+        flex: 1;
+        min-width: 0;
+    }
+}
+
+::ng-deep .sc-rp-color .sc-rp-color-picker .p-colorpicker-preview {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--sc-radius-sm);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    cursor: pointer;
+}
+
 .sc-rp-hint {
     font-size: 10px;
     font-weight: 400;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -2426,11 +2426,6 @@
     background: var(--guardian-grey-background);
     flex-shrink: 0;
     gap: 8px;
-
-    &--drill {
-        background: var(--guardian-primary-background);
-        border-bottom-color: var(--color-secondary);
-    }
 }
 
 .sc-canvas-tab-pill {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -3,6 +3,12 @@
     flex-direction: column;
     height: 100%;
     overflow: hidden;
+
+    /* Radius & elevation vocabulary (mirrors policy-configurator --pc-*) */
+    --sc-radius: 10px;
+    --sc-radius-sm: 8px;
+    --sc-elevation: 0 1px 2px var(--guardian-shadow, #00000014), 0 1px 1px var(--guardian-shadow, #00000014);
+    --sc-elevation-overlay: 0 8px 24px var(--guardian-shadow, #00000014), 0 2px 6px var(--guardian-shadow, #00000014);
 }
 
 .sc-page {
@@ -45,7 +51,7 @@
     justify-content: center;
     width: 26px;
     height: 26px;
-    border-radius: 7px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     cursor: pointer;
@@ -94,7 +100,7 @@
     display: flex;
     gap: 2px;
     background: var(--guardian-grey-background, #F9FAFC);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 3px;
 }
 
@@ -117,7 +123,7 @@
     &.active {
         background: var(--guardian-background, #fff);
         color: var(--guardian-font-color, #23252E);
-        box-shadow: 0 1px 3px var(--guardian-shadow), 0 1px 2px var(--guardian-shadow);
+        box-shadow: var(--sc-elevation);
     }
 }
 
@@ -149,7 +155,7 @@
     font-size: 11px;
     font-weight: 500;
     padding: 5px 11px;
-    border-radius: 7px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid transparent;
     transition: all 0.2s;
     white-space: nowrap;
@@ -181,7 +187,7 @@
     font-weight: 500;
     font-family: inherit;
     padding: 6px 14px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: none;
     cursor: pointer;
     transition: all 0.15s;
@@ -212,7 +218,7 @@
     gap: 5px;
     font-size: 14px;
     padding: 6px 14px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     cursor: pointer;
@@ -352,7 +358,7 @@
     width: 100%;
     font-size: 14px;
     padding: 5px 9px 5px 28px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-grey-background, #F9FAFC);
     color: var(--guardian-font-color, #23252E);
@@ -399,7 +405,7 @@
     align-items: center;
     gap: 8px;
     padding: 8px 10px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     margin-bottom: 5px;
@@ -502,7 +508,7 @@
     align-items: center;
     gap: 8px;
     padding: 7px 10px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-grey-background, #F9FAFC);
     margin-bottom: 4px;
@@ -553,7 +559,7 @@
     font-size: 9px;
     font-weight: 500;
     padding: 1px 6px;
-    border-radius: 10px;
+    border-radius: var(--sc-radius);
     background: var(--guardian-success-background, #EEFBF0);
     color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     text-transform: uppercase;
@@ -659,7 +665,7 @@
         background: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 4%, transparent);
         outline: 2px dashed var(--color-primary, #4169E2);
         outline-offset: -6px;
-        border-radius: 8px;
+        border-radius: var(--sc-radius-sm);
     }
 }
 
@@ -740,7 +746,7 @@
     font-size: 13px;
     font-weight: 500;
     padding: 5px 8px;
-    border-radius: 5px;
+    border-radius: 6px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
@@ -791,7 +797,7 @@
 .sc-schema-props-input {
     font-size: 11px;
     padding: 4px 7px;
-    border-radius: 5px;
+    border-radius: 6px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
@@ -815,7 +821,7 @@
 .sc-schema-props-desc {
     font-size: 11px;
     padding: 4px 7px;
-    border-radius: 5px;
+    border-radius: 6px;
     border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: var(--guardian-background, #fff);
     color: var(--guardian-font-color, #23252E);
@@ -837,7 +843,7 @@
 .sc-section-usage {
     background: var(--guardian-background, #fff);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 5px;
+    border-radius: 6px;
     padding: 10px 12px;
     margin-bottom: 8px;
     font-size: 14px;
@@ -903,7 +909,7 @@
 .sc-field-card {
     background: var(--guardian-background, #fff);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 12px;
+    border-radius: var(--sc-radius);
     padding: 10px 12px;
     display: flex;
     align-items: center;
@@ -914,7 +920,7 @@
 
     &:hover {
         border-color: var(--guardian-border-color, #E1E7EF);
-        box-shadow: 0 1px 3px var(--guardian-shadow);
+        box-shadow: var(--sc-elevation);
 
         .sc-field-card-actions { opacity: 1; }
     }
@@ -1036,7 +1042,7 @@
     border: none;
     cursor: pointer;
     padding: 3px 6px;
-    border-radius: 5px;
+    border-radius: 6px;
     font-family: inherit;
     transition: background 0.12s;
 
@@ -1065,7 +1071,7 @@
 .sc-drill-card {
     background: var(--guardian-grey-background, #F9FAFC);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 7px 10px;
     display: flex;
     align-items: center;
@@ -1077,7 +1083,7 @@
     &:hover {
         background: var(--guardian-background, #fff);
         border-color: var(--guardian-border-color, #E1E7EF);
-        box-shadow: 0 1px 3px var(--guardian-shadow);
+        box-shadow: var(--sc-elevation);
 
         .sc-drill-card-actions { opacity: 1; }
     }
@@ -1212,7 +1218,7 @@
     justify-content: center;
     width: 24px;
     height: 24px;
-    border-radius: 5px;
+    border-radius: 6px;
     background: var(--color-primary, #4169E2);
     color: #fff;
     border: none;
@@ -1229,7 +1235,7 @@
 .sc-drill-badge {
     font-size: 9px;
     padding: 1px 6px;
-    border-radius: 10px;
+    border-radius: var(--sc-radius);
     font-weight: 500;
     white-space: nowrap;
     line-height: 1.7;
@@ -1313,7 +1319,7 @@
 .sc-field-type-icon {
     width: 28px;
     height: 28px;
-    border-radius: 7px;
+    border-radius: var(--sc-radius-sm);
     background: var(--guardian-grey-background, #F9FAFC);
     display: flex;
     align-items: center;
@@ -1446,7 +1452,7 @@
 /* ── Drop zone & add section ── */
 .sc-drop-zone {
     border: 1.5px dashed var(--guardian-border-color, #E1E7EF);
-    border-radius: 12px;
+    border-radius: var(--sc-radius);
     padding: 14px;
     text-align: center;
     color: var(--guardian-font-color-secondary, #848FA9);
@@ -1654,7 +1660,7 @@
     min-width: 14px;
     height: 14px;
     padding: 0 4px;
-    border-radius: 7px;
+    border-radius: var(--sc-radius-sm);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1680,7 +1686,7 @@
     padding: 8px 10px;
     background: var(--guardian-failure-background, #FFEAEA);
     border: 1px solid color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
 }
 
 .sc-rp-error {
@@ -1709,7 +1715,7 @@
 .sc-rp-input {
     font-size: 14px;
     padding: 6px 10px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-grey-background, #F9FAFC);
     color: var(--guardian-font-color, #23252E);
@@ -1770,7 +1776,7 @@
     align-items: flex-start;
     gap: 10px;
     cursor: pointer;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 4px;
     margin: -4px;
     transition: background 0.12s;
@@ -1829,7 +1835,7 @@
     max-height: 200px;
     overflow-y: auto;
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 4px;
     background: var(--guardian-grey-background, #F9FAFC);
 }
@@ -1952,7 +1958,7 @@
     font-family: inherit;
     font-weight: 500;
     padding: 5px 10px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1.5px dashed var(--guardian-border-color, #E1E7EF);
     background: transparent;
     color: var(--guardian-font-color-secondary, #848FA9);
@@ -1975,7 +1981,7 @@
     justify-content: center;
     width: 28px;
     height: 28px;
-    border-radius: 7px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
     cursor: pointer;
@@ -2007,7 +2013,7 @@
 
 .sc-type-tile {
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 8px 4px 6px;
     cursor: pointer;
     text-align: center;
@@ -2076,7 +2082,7 @@
         color: var(--guardian-font-color-secondary, #848FA9);
         background: var(--guardian-grey-background, #F9FAFC);
         border: 1px solid var(--guardian-border-color, #E1E7EF);
-        border-radius: 10px;
+        border-radius: var(--sc-radius);
         padding: 1px 7px;
         flex-shrink: 0;
     }
@@ -2131,7 +2137,7 @@
     align-items: center;
     gap: 7px;
     padding: 10px 12px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px dashed var(--guardian-border-color, #E1E7EF);
     color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
@@ -2141,7 +2147,7 @@
 
 .sc-cond-card {
     border: 1px solid var(--guardian-border-color, #E1E7EF);
-    border-radius: 10px;
+    border-radius: var(--sc-radius);
     background: var(--guardian-grey-background, #F9FAFC);
     overflow: hidden;
 }
@@ -2172,7 +2178,7 @@
     padding: 3px 6px;
     cursor: pointer;
     color: var(--guardian-font-color-secondary, #848FA9);
-    border-radius: 5px;
+    border-radius: 6px;
     line-height: 1;
     transition: color 0.12s, background 0.12s;
 
@@ -2258,7 +2264,7 @@
     align-self: flex-start;
     background: none;
     border: 1px dashed var(--guardian-border-color, #E1E7EF);
-    border-radius: 5px;
+    border-radius: 6px;
     padding: 3px 8px;
     font-size: 11px;
     color: var(--guardian-font-color-secondary, #848FA9);
@@ -2334,7 +2340,7 @@
     align-self: flex-start;
     background: none;
     border: 1px dashed var(--guardian-border-color, #E1E7EF);
-    border-radius: 5px;
+    border-radius: 6px;
     padding: 3px 10px;
     font-size: 11px;
     color: var(--guardian-font-color-secondary, #848FA9);
@@ -2359,7 +2365,7 @@
     color: var(--color-primary, #4169E2) !important;
     border-color: color-mix(in srgb, var(--color-primary, #4169E2) 30%, transparent) !important;
     border-style: dashed !important;
-    border-radius: 5px !important;
+    border-radius: 6px !important;
     background: var(--guardian-primary-background, #E1E7FA) !important;
 }
 
@@ -2368,7 +2374,7 @@
     padding: 12px;
     background: transparent;
     border: 1px dashed var(--guardian-border-color, #E1E7EF);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     font-size: 14px;
     color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
@@ -2441,7 +2447,7 @@
     &.active {
         background: var(--guardian-background);
         color: var(--guardian-font-color);
-        box-shadow: 0 1px 3px var(--guardian-shadow);
+        box-shadow: var(--sc-elevation);
     }
 }
 
@@ -2450,7 +2456,7 @@
     font-weight: 700;
     background: var(--color-primary);
     color: var(--guardian-on-primary-color);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     min-width: 14px;
     height: 14px;
     padding: 0 4px;
@@ -2480,7 +2486,7 @@
     color: var(--color-grey-5);
     background: var(--guardian-grey-background);
     border: 1px solid var(--guardian-border-color);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     padding: 10px 14px;
     line-height: 1.5;
 
@@ -2491,7 +2497,7 @@
 .sc-cond-block {
     background: var(--guardian-background);
     border: 1px solid var(--guardian-border-color);
-    border-radius: 10px;
+    border-radius: var(--sc-radius);
     overflow: hidden;
 }
 
@@ -2575,7 +2581,7 @@
     padding: 8px 12px;
     background: var(--guardian-grey-background);
     border: 1px solid var(--guardian-border-color);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
 }
 
 .sc-cond-rule-num {
@@ -2601,7 +2607,7 @@
 .sc-cond-val-inp {
     height: 40px;
     padding: 0 12px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color);
     background: var(--guardian-background);
     font-size: 14px;
@@ -2670,7 +2676,7 @@
 
 .sc-cond-te-block {
     border: 1px solid var(--guardian-border-color);
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     overflow: hidden;
 }
 
@@ -2810,7 +2816,7 @@
 }
 
 .sc-cond-field-card {
-    border-radius: 8px !important;
+    border-radius: var(--sc-radius-sm) !important;
     padding: 8px 10px !important;
 
     .sc-field-card-actions {
@@ -2829,9 +2835,9 @@
     z-index: 9999;
     background: var(--guardian-background);
     border: 1.5px solid var(--color-primary);
-    border-radius: 12px;
+    border-radius: var(--sc-radius);
     padding: 10px 12px;
-    box-shadow: 0 8px 24px var(--guardian-shadow), 0 2px 6px var(--guardian-shadow);
+    box-shadow: var(--sc-elevation-overlay);
     pointer-events: none;
     display: flex;
     align-items: center;
@@ -2869,7 +2875,7 @@
     gap: 8px;
     padding: 4px;
     margin: -4px;
-    border-radius: 8px;
+    border-radius: var(--sc-radius-sm);
     cursor: pointer;
     font-size: 14px;
     font-weight: 500;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -684,7 +684,6 @@
         .sc-schema-props-toggle { color: var(--color-primary, #4169E2); }
         .sc-schema-props-label { color: var(--color-primary, #4169E2); }
         .sc-schema-props-name,
-        .sc-schema-props-select,
         .sc-schema-props-input,
         .sc-schema-props-desc {
             border-color: color-mix(in srgb, var(--color-primary, #4169E2) 25%, transparent);
@@ -793,7 +792,6 @@
     font-weight: 400;
 }
 
-.sc-schema-props-select,
 .sc-schema-props-input {
     font-size: 11px;
     padding: 4px 7px;
@@ -816,7 +814,8 @@
     }
 }
 
-.sc-schema-props-select { cursor: pointer; }
+// Entity-type dropdown is a p-select (guardian-dropdown); host only needs sizing
+.sc-schema-props-select { width: 100%; }
 
 .sc-schema-props-desc {
     font-size: 11px;
@@ -1782,31 +1781,6 @@
     transition: background 0.12s;
 
     &:hover { background: var(--guardian-grey-background, #F9FAFC); }
-}
-
-.sc-check-box {
-    width: 16px;
-    height: 16px;
-    border-radius: 4px;
-    border: 1.5px solid var(--guardian-border-color, #E1E7EF);
-    background: var(--guardian-background, #fff);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    margin-top: 1px;
-
-    i {
-        font-size: 9px;
-        color: transparent;
-    }
-
-    &.active {
-        background: var(--color-primary, #4169E2);
-        border-color: var(--color-primary, #4169E2);
-
-        i { color: #fff; }
-    }
 }
 
 .sc-check-desc {
@@ -2885,33 +2859,6 @@
     &:hover { background: var(--guardian-grey-background, #F9FAFC); }
 }
 
-.sc-radio-dot {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    border: 1.5px solid var(--guardian-border-color, #E1E7EF);
-    background: var(--guardian-background, #fff);
-    flex-shrink: 0;
-    position: relative;
-    transition: border-color 0.12s, background 0.12s;
-
-    &::after {
-        content: '';
-        position: absolute;
-        inset: 2px;
-        border-radius: 50%;
-        background: transparent;
-        transition: background 0.12s;
-    }
-
-    &.active {
-        border-color: var(--color-primary, #4169E2);
-        background: var(--color-primary, #4169E2);
-
-        &::after { background: var(--guardian-background, #fff); }
-    }
-}
-
 // ── Expression editor row ────────────────────────────────────────────────────
 .sc-rp-group--expr {
     margin-top: 8px;
@@ -3134,22 +3081,8 @@
     }
 }
 
-.sc-fv-select {
-    width: 100%;
-    padding: 5px 9px;
-    border-radius: 6px;
-    border: 1px solid var(--guardian-border-color, #E1E7EF);
-    background: var(--guardian-grey-background, #F9FAFC);
-    font-size: 12px;
-    color: var(--guardian-font-color, #23252E);
-    font-family: inherit;
-    outline: none;
-    cursor: pointer;
-
-    &:focus {
-        border-color: var(--color-primary, #4169E2);
-    }
-}
+// Field-value enum picker is a p-select (guardian-dropdown); host only needs sizing
+.sc-fv-select { width: 100%; }
 
 .sc-fv-yesno {
     display: flex;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -2035,7 +2035,7 @@
     }
 
     span {
-        font-size: 9px;
+        font-size: 10px;
         color: var(--guardian-font-color-secondary, #848FA9);
         display: block;
         line-height: 1.25;
@@ -3061,7 +3061,7 @@
     justify-content: space-between;
     font-size: 11px;
     font-weight: 500;
-    color: var(--guardian-font-color, #23252E);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 .sc-fv-label-text {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -10,13 +10,15 @@
     flex-direction: column;
     height: 100%;
     overflow: hidden;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
+    color: var(--guardian-font-color, #23252E);
 }
 
 /* ── Top nav ── */
 .sc-topnav {
-    height: 48px;
-    background: #fff;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    height: 64px;
+    background: var(--guardian-background, #fff);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     display: flex;
     align-items: center;
     padding: 0 16px;
@@ -30,7 +32,7 @@
     align-items: center;
     gap: 6px;
     font-size: 13px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 .sc-breadcrumb-icon {
@@ -44,30 +46,30 @@
     width: 26px;
     height: 26px;
     border-radius: 7px;
-    border: 1px solid rgba(0, 0, 0, 0.12);
-    background: #fff;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #fff);
     cursor: pointer;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
     transition: all 0.15s;
 
     i { font-size: 14px; }
 
     &:hover {
-        background: var(--surface-ground, #f8f8f7);
-        color: var(--text-color, #2c2c2a);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color, #23252E);
     }
 }
 
 .sc-crumb-link {
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.15s;
     cursor: pointer;
 
     &:hover {
-        color: var(--text-color, #2c2c2a);
+        color: var(--guardian-font-color, #23252E);
     }
 }
 
@@ -76,7 +78,7 @@
 }
 
 .sc-crumb-current {
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-weight: 500;
     max-width: 320px;
     overflow: hidden;
@@ -91,7 +93,7 @@
 .sc-nav-tabs {
     display: flex;
     gap: 2px;
-    background: var(--surface-ground, #f1efe8);
+    background: var(--guardian-grey-background, #F9FAFC);
     border-radius: 8px;
     padding: 3px;
 }
@@ -103,18 +105,18 @@
     border: none;
     cursor: pointer;
     background: transparent;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-family: inherit;
     font-weight: 500;
     transition: all 0.15s;
 
     &:hover {
-        color: var(--text-color, #2c2c2a);
+        color: var(--guardian-font-color, #23252E);
     }
 
     &.active {
-        background: #fff;
-        color: var(--text-color, #2c2c2a);
+        background: var(--guardian-background, #fff);
+        color: var(--guardian-font-color, #23252E);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
     }
 }
@@ -131,9 +133,9 @@
     gap: 5px;
     font-size: 14px;
     font-weight: 500;
-    color: #dc2626;
-    background: #fee2e2;
-    border: 1px solid #fca5a5;
+    color: var(--color-accent-red-1, #FF432A);
+    background: var(--guardian-failure-background, #FFEAEA);
+    border: 1px solid color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
     border-radius: 6px;
     padding: 4px 10px;
 
@@ -155,19 +157,19 @@
     i { font-size: 14px; }
 
     &.saved {
-        background: #eaf3de;
-        border-color: #7ab648;
-        color: #27500a;
+        background: var(--guardian-success-background, #EEFBF0);
+        border-color: var(--color-accent-green-1, #19BE47);
+        color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     }
     &.dirty {
-        background: #faeeda;
-        border-color: #ef9f27;
-        color: #412402;
+        background: var(--guardian-warning-background, #FFF6E3);
+        border-color: var(--color-accent-yellow-1, #DA9B22);
+        color: color-mix(in srgb, var(--color-accent-yellow-1, #DA9B22) 70%, #000);
     }
     &.saving {
-        background: var(--surface-ground, #f8f8f7);
+        background: var(--guardian-grey-background, #F9FAFC);
         border-color: rgba(0, 0, 0, 0.12);
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
@@ -187,19 +189,19 @@
     i { font-size: 13px; }
 
     &.dirty {
-        background: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
         color: #fff;
         &:hover { filter: brightness(0.92); }
     }
     &.invalid {
-        background: #fee2e2;
-        color: #dc2626;
-        border: 1px solid #fca5a5;
+        background: var(--guardian-failure-background, #FFEAEA);
+        color: var(--color-accent-red-1, #FF432A);
+        border: 1px solid color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
         cursor: not-allowed;
     }
     &.clean {
-        background: var(--surface-ground, #f1efe8);
-        color: var(--text-color-secondary, #888780);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color-secondary, #848FA9);
         cursor: default;
     }
 }
@@ -211,10 +213,10 @@
     font-size: 14px;
     padding: 6px 14px;
     border-radius: 8px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: #fff;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #fff);
     cursor: pointer;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     font-weight: 500;
     transition: all 0.15s;
@@ -222,18 +224,18 @@
     i { font-size: 13px; }
 
     &:hover {
-        background: var(--surface-ground, #f8f8f7);
+        background: var(--guardian-grey-background, #F9FAFC);
     }
 }
 
 .sc-btn-primary {
-    background: var(--primary-color, #1d9e75);
+    background: var(--color-primary, #4169E2);
     color: #fff;
-    border-color: var(--primary-color, #1d9e75);
+    border-color: var(--color-primary, #4169E2);
 
     &:hover {
         filter: brightness(0.92);
-        background: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
     }
 }
 
@@ -247,8 +249,8 @@
 /* ── Sidebar ── */
 .sc-sidebar {
     width: 230px;
-    background: #fff;
-    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--guardian-background, #fff);
+    border-right: 1px solid var(--guardian-border-color, #E1E7EF);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
@@ -257,7 +259,7 @@
 
 .sc-sidebar-tabs {
     display: flex;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
 }
 
@@ -269,8 +271,8 @@
     font-weight: 500;
     text-align: center;
     cursor: pointer;
-    color: var(--text-color-secondary, #888780);
-    background: var(--surface-ground, #f8f8f7);
+    color: var(--guardian-font-color-secondary, #848FA9);
+    background: var(--guardian-grey-background, #F9FAFC);
     border: none;
     font-family: inherit;
     text-transform: uppercase;
@@ -278,12 +280,12 @@
     border-bottom: 2px solid transparent;
     transition: all 0.15s;
 
-    &:hover { color: var(--text-color, #2c2c2a); }
+    &:hover { color: var(--guardian-font-color, #23252E); }
 
     &.active {
-        background: #fff;
-        color: var(--primary-color, #1d9e75);
-        border-bottom-color: var(--primary-color, #1d9e75);
+        background: var(--guardian-background, #fff);
+        color: var(--color-primary, #4169E2);
+        border-bottom-color: var(--color-primary, #4169E2);
     }
 }
 
@@ -293,7 +295,7 @@
     right: 4px;
     width: 6px;
     height: 6px;
-    background: #534ab7;
+    background: var(--color-primary, #4169E2);
     border-radius: 50%;
 }
 
@@ -307,7 +309,7 @@
 .sc-sidebar-label {
     font-size: 10px;
     font-weight: 500;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     text-transform: uppercase;
     letter-spacing: 0.07em;
     margin-bottom: 8px;
@@ -327,7 +329,7 @@
     align-items: center;
     gap: 6px;
     padding: 10px 12px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
 }
 
@@ -342,7 +344,7 @@
     position: absolute;
     left: 8px;
     font-size: 14px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     pointer-events: none;
 }
 
@@ -351,16 +353,16 @@
     font-size: 14px;
     padding: 5px 9px 5px 28px;
     border-radius: 8px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: var(--surface-ground, #f8f8f7);
-    color: var(--text-color, #2c2c2a);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     transition: border-color 0.15s;
 
     &:focus {
-        border-color: #534ab7;
-        background: #fff;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-background, #fff);
     }
 }
 
@@ -377,12 +379,12 @@
     justify-content: center;
     gap: 8px;
     padding: 32px 12px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
 
     i {
         font-size: 28px;
-        color: var(--surface-300, #c8c6be);
+        color: var(--guardian-border-color, #E1E7EF);
     }
 }
 
@@ -398,13 +400,13 @@
     gap: 8px;
     padding: 8px 10px;
     border-radius: 8px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    background: #fff;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #fff);
     margin-bottom: 5px;
     cursor: pointer;
     transition: border-color 0.15s;
 
-    &:hover { border-color: #c8c6f0; }
+    &:hover { border-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF)); }
 
     &.sc-schema-row--no-drop {
         cursor: default;
@@ -413,13 +415,13 @@
     }
 
     &.active {
-        border-color: #c8c6f0;
-        background: #eeedfe;
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        .sc-schema-name { color: #534ab7; }
+        .sc-schema-name { color: var(--color-primary, #4169E2); }
 
         .sc-schema-icon {
-            background: #534ab7;
+            background: var(--color-primary, #4169E2);
             i { color: #fff; }
         }
     }
@@ -432,11 +434,11 @@
     cursor: pointer;
     padding: 4px;
     border-radius: 4px;
-    color: #aaa;
+    color: var(--guardian-disabled-color, #848FA9);
     display: flex;
     align-items: center;
     justify-content: center;
-    &:hover { color: #e53935; background: #fdecea; }
+    &:hover { color: var(--color-accent-red-1, #FF432A); background: var(--guardian-failure-background, #FFEAEA); }
     i { font-size: 13px; }
 }
 
@@ -444,13 +446,13 @@
     width: 26px;
     height: 26px;
     border-radius: 6px;
-    background: #eeedfe;
+    background: var(--guardian-primary-background, #E1E7FA);
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
 
-    i { font-size: 13px; color: #534ab7; }
+    i { font-size: 13px; color: var(--color-primary, #4169E2); }
 }
 
 .sc-schema-info {
@@ -464,7 +466,7 @@
 .sc-schema-name {
     font-size: 14px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -479,7 +481,7 @@
 
 .sc-schema-version {
     font-size: 10px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 
@@ -489,7 +491,7 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: #94a3b8;
+    color: var(--guardian-font-color-secondary, #848FA9);
     user-select: none;
 
     &:first-child { padding-top: 0; }
@@ -501,41 +503,41 @@
     gap: 8px;
     padding: 7px 10px;
     border-radius: 8px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    background: var(--surface-ground, #f8f8f7);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
     margin-bottom: 4px;
     cursor: grab;
     font-size: 14px;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     transition: all 0.15s;
     user-select: none;
 
     i {
         font-size: 15px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
         flex-shrink: 0;
     }
 
     &:hover {
-        background: #e6f1fb;
-        color: #185fa5;
-        border-color: #b5d4f4;
+        background: var(--guardian-primary-background, #E1E7FA);
+        color: var(--color-primary, #4169E2);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 40%, var(--guardian-border-color, #E1E7EF));
 
-        i { color: #185fa5; }
+        i { color: var(--color-primary, #4169E2); }
     }
 
     &--accent {
-        border-color: #c8c6f0;
-        color: #534ab7;
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
+        color: var(--color-primary, #4169E2);
 
-        i { color: #534ab7; }
+        i { color: var(--color-primary, #4169E2); }
 
         &:hover {
-            background: #eeedfe;
-            color: #534ab7;
-            border-color: #b5b2e8;
+            background: var(--guardian-primary-background, #E1E7FA);
+            color: var(--color-primary, #4169E2);
+            border-color: color-mix(in srgb, var(--color-primary, #4169E2) 40%, var(--guardian-border-color, #E1E7EF));
 
-            i { color: #534ab7; }
+            i { color: var(--color-primary, #4169E2); }
         }
     }
 
@@ -552,14 +554,14 @@
     font-weight: 500;
     padding: 1px 6px;
     border-radius: 10px;
-    background: #e1f5ee;
-    color: #0f6e56;
+    background: var(--guardian-success-background, #EEFBF0);
+    color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     text-transform: uppercase;
     letter-spacing: 0.04em;
 
     &--draft {
-        background: var(--surface-ground, #f1efe8);
-        color: var(--text-color-secondary, #888780);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
@@ -573,7 +575,7 @@
 .sc-canvas-body {
     flex: 1;
     overflow-y: auto;
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
     position: relative;
 
     &--drilling { overflow-y: hidden; }
@@ -595,12 +597,12 @@
     justify-content: center;
     gap: 12px;
     padding: 80px 24px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
 
     i {
         font-size: 48px;
-        color: var(--surface-300, #c8c6be);
+        color: var(--guardian-border-color, #E1E7EF);
     }
 }
 
@@ -617,8 +619,8 @@
     align-items: center;
     gap: 10px;
     padding: 10px 16px;
-    background: #fff;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--guardian-background, #fff);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
     position: sticky;
     top: 0;
@@ -635,7 +637,7 @@
 .sc-editor-title {
     font-size: 14px;
     font-weight: 600;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -644,7 +646,7 @@
 
 .sc-editor-version {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
 }
 
@@ -654,8 +656,8 @@
     transition: background 0.15s, outline 0.15s;
 
     &.sc-drop-active {
-        background: rgba(29, 158, 117, 0.04);
-        outline: 2px dashed var(--primary-color, #1d9e75);
+        background: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 4%, transparent);
+        outline: 2px dashed var(--color-primary, #4169E2);
         outline-offset: -6px;
         border-radius: 8px;
     }
@@ -663,24 +665,24 @@
 
 /* ── Schema properties panel (root = green, sub = purple) ── */
 .sc-schema-props {
-    background: #E1F5EE;
+    background: var(--guardian-success-background, #EEFBF0);
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
     padding: 10px 16px 10px;
     flex-shrink: 0;
 
     &--sub {
-        background: #EEEDFE;
-        border-bottom-color: #c8c6f0;
+        background: var(--guardian-primary-background, #E1E7FA);
+        border-bottom-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
 
-        .sc-schema-props-title { color: #3C3489; }
-        .sc-schema-props-toggle { color: #534AB7; }
-        .sc-schema-props-label { color: #534AB7; }
+        .sc-schema-props-title { color: color-mix(in srgb, var(--color-primary, #4169E2) 82%, #000); }
+        .sc-schema-props-toggle { color: var(--color-primary, #4169E2); }
+        .sc-schema-props-label { color: var(--color-primary, #4169E2); }
         .sc-schema-props-name,
         .sc-schema-props-select,
         .sc-schema-props-input,
         .sc-schema-props-desc {
-            border-color: rgba(83, 74, 183, 0.25);
-            &:focus { border-color: #534AB7; box-shadow: 0 0 0 2px rgba(83, 74, 183, 0.12); }
+            border-color: color-mix(in srgb, var(--color-primary, #4169E2) 25%, transparent);
+            &:focus { border-color: var(--color-primary, #4169E2); box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent); }
         }
     }
 }
@@ -698,7 +700,7 @@
     gap: 5px;
     font-size: 10px;
     font-weight: 600;
-    color: #0F6E56;
+    color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 
@@ -722,7 +724,7 @@
     border: none;
     cursor: pointer;
     font-family: inherit;
-    color: #0F6E56;
+    color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     opacity: 0.65;
     display: flex;
     align-items: center;
@@ -739,16 +741,16 @@
     font-weight: 500;
     padding: 5px 8px;
     border-radius: 5px;
-    border: 1px solid rgba(29, 158, 117, 0.3);
+    border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: white;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     margin-bottom: 6px;
 
     &:focus {
-        border-color: var(--primary-color, #1d9e75);
-        box-shadow: 0 0 0 2px rgba(29, 158, 117, 0.12);
+        border-color: var(--color-primary, #4169E2);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent-green-1, #19BE47) 12%, transparent);
     }
 }
 
@@ -772,7 +774,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: #0F6E56;
+    color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     opacity: 0.75;
 }
 
@@ -790,20 +792,20 @@
     font-size: 11px;
     padding: 4px 7px;
     border-radius: 5px;
-    border: 1px solid rgba(29, 158, 117, 0.3);
+    border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: white;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     width: 100%;
 
     &:focus {
-        border-color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
     }
 
     &--readonly {
-        background: var(--surface-ground, #f8f8f7);
-        color: var(--text-color-secondary, #888780);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color-secondary, #848FA9);
         cursor: default;
     }
 }
@@ -814,16 +816,16 @@
     font-size: 11px;
     padding: 4px 7px;
     border-radius: 5px;
-    border: 1px solid rgba(29, 158, 117, 0.3);
+    border: 1px solid color-mix(in srgb, var(--color-accent-green-1, #19BE47) 30%, transparent);
     background: white;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     width: 100%;
     resize: none;
 
     &:focus {
-        border-color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
     }
 }
 
@@ -834,18 +836,18 @@
 
 .sc-section-usage {
     background: white;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 5px;
     padding: 10px 12px;
     margin-bottom: 8px;
     font-size: 14px;
-    color: var(--text-color, #000);
+    color: var(--guardian-font-color, #23252E);
     line-height: 1.5;
     font-weight: 500;
 
     span {
         font-size: 12px;
-        color: var(--color-grey-6, #495057);
+        color: var(--color-grey-6, #23252E);
         line-height: 1.5;
         font-weight: 500;
     }
@@ -861,7 +863,7 @@
 .sc-schema-tag {
     font-size: 12px;
     background: var(--guardian-failure-background, #FFEAEA);
-    color: var(--text-color, #000);
+    color: var(--guardian-font-color, #23252E);
     border-radius: 3px;
     padding: 1px 6px;
     font-weight: 500;
@@ -879,7 +881,7 @@
 .sc-section-name {
     font-size: 11px;
     font-weight: 500;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     white-space: nowrap;
@@ -899,8 +901,8 @@
 
 /* ── Field cards ── */
 .sc-field-card {
-    background: #fff;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--guardian-background, #fff);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 12px;
     padding: 10px 12px;
     display: flex;
@@ -918,39 +920,39 @@
     }
 
     &.active {
-        border: 1.5px solid var(--primary-color, #1d9e75);
-        box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.1);
+        border: 1.5px solid var(--color-primary, #4169E2);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-green-1, #19BE47) 10%, transparent);
 
         .sc-field-type-icon {
-            background: #e1f5ee;
-            i { color: var(--primary-color, #1d9e75); }
+            background: var(--guardian-success-background, #EEFBF0);
+            i { color: var(--color-primary, #4169E2); }
         }
 
         .sc-field-card-actions { opacity: 1; }
     }
 
     &.sc-field-card--ref {
-        border-color: #c8c6f0;
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
         border-width: 1.5px;
-        background: #f5f4fd;
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        &:hover { border-color: #9d99e0; }
+        &:hover { border-color: color-mix(in srgb, var(--color-primary, #4169E2) 45%, var(--guardian-border-color, #E1E7EF)); }
 
         &.active {
-            border-color: #534ab7;
-            box-shadow: 0 0 0 3px rgba(83, 74, 183, 0.12);
+            border-color: var(--color-primary, #4169E2);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
         }
     }
 
     &.sc-field-card--invalid {
-        border-color: #fca5a5;
-        background: #fff8f8;
+        border-color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
+        background: var(--guardian-failure-background, #FFEAEA);
 
-        &:hover { border-color: #f87171; }
+        &:hover { border-color: var(--color-accent-red-1, #FF432A); }
 
         &.active {
-            border-color: #ef4444;
-            box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+            border-color: var(--color-accent-red-1, #FF432A);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-red-1, #FF432A) 12%, transparent);
         }
     }
 
@@ -960,18 +962,18 @@
 
     // Reorder: whole-card highlight (hover = this is where source lands)
     &.sc-field-card--drag-target {
-        outline: 2px dashed var(--primary-color, #1d9e75);
+        outline: 2px dashed var(--color-primary, #4169E2);
         outline-offset: -1px;
-        background: #f0faf6;
+        background: var(--guardian-success-background, #EEFBF0);
     }
 
     // Sidebar insert: line between cards
     &.sc-field-card--drag-top {
-        border-top: 2px solid var(--primary-color, #1d9e75);
+        border-top: 2px solid var(--color-primary, #4169E2);
     }
 
     &.sc-field-card--drag-bot {
-        border-bottom: 2px solid var(--primary-color, #1d9e75);
+        border-bottom: 2px solid var(--color-primary, #4169E2);
     }
 }
 
@@ -981,7 +983,7 @@
     gap: 4px;
     padding: 4px 10px;
     border-radius: 6px;
-    background: #534ab7;
+    background: var(--color-primary, #4169E2);
     color: #fff;
     border: none;
     font-size: 11px;
@@ -1000,7 +1002,7 @@
 .sc-drill-panel {
     position: absolute;
     inset: 0;
-    background: #fff;
+    background: var(--guardian-background, #fff);
     z-index: 20;
     display: flex;
     flex-direction: column;
@@ -1017,8 +1019,8 @@
     align-items: center;
     gap: 2px;
     padding: 8px 14px;
-    background: #eeedf8;
-    border-bottom: 1px solid #c8c6f0;
+    background: var(--guardian-primary-background, #E1E7FA);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
     flex-shrink: 0;
     flex-wrap: wrap;
 }
@@ -1029,7 +1031,7 @@
     gap: 4px;
     font-size: 14px;
     font-weight: 500;
-    color: #534ab7;
+    color: var(--color-primary, #4169E2);
     background: none;
     border: none;
     cursor: pointer;
@@ -1039,15 +1041,15 @@
     transition: background 0.12s;
 
     i { font-size: 14px; }
-    &:hover { background: rgba(83, 74, 183, 0.1); }
+    &:hover { background: color-mix(in srgb, var(--color-primary, #4169E2) 10%, transparent); }
 
-    &--root { color: var(--text-color-secondary, #888780); }
-    &--current { color: #534ab7; font-weight: 600; cursor: default; &:hover { background: none; } }
+    &--root { color: var(--guardian-font-color-secondary, #848FA9); }
+    &--current { color: var(--color-primary, #4169E2); font-weight: 600; cursor: default; &:hover { background: none; } }
 }
 
 .sc-drill-sep {
     font-size: 10px;
-    color: #b0aee8;
+    color: color-mix(in srgb, var(--color-primary, #4169E2) 40%, var(--guardian-border-color, #E1E7EF));
 }
 
 .sc-drill-content {
@@ -1061,7 +1063,7 @@
 
 /* ── Drill field cards ── */
 .sc-drill-card {
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 8px;
     padding: 7px 10px;
@@ -1073,7 +1075,7 @@
     position: relative;
 
     &:hover {
-        background: #fff;
+        background: var(--guardian-background, #fff);
         border-color: rgba(0, 0, 0, 0.15);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
 
@@ -1081,13 +1083,13 @@
     }
 
     &.active {
-        background: #fff;
-        border: 1.5px solid var(--primary-color, #1d9e75);
-        box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.1);
+        background: var(--guardian-background, #fff);
+        border: 1.5px solid var(--color-primary, #4169E2);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-green-1, #19BE47) 10%, transparent);
 
         .sc-drill-card-icon {
-            background: #e1f5ee;
-            i { color: var(--primary-color, #1d9e75); }
+            background: var(--guardian-success-background, #EEFBF0);
+            i { color: var(--color-primary, #4169E2); }
         }
 
         .sc-drill-card-actions { opacity: 1; }
@@ -1095,32 +1097,32 @@
 
     /* Sub-schema ref field: left accent stripe instead of full border */
     &--ref {
-        border-left: 3px solid #534ab7;
-        background: #f9f8fe;
+        border-left: 3px solid var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        &:hover { background: #fff; border-left-color: #3c3489; }
+        &:hover { background: var(--guardian-background, #fff); border-left-color: color-mix(in srgb, var(--color-primary, #4169E2) 82%, #000); }
 
         &.active {
-            border-color: #534ab7;
+            border-color: var(--color-primary, #4169E2);
             border-left-width: 3px;
-            box-shadow: 0 0 0 3px rgba(83, 74, 183, 0.1);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary, #4169E2) 10%, transparent);
 
             .sc-drill-card-icon {
-                background: #eeedfe;
-                i { color: #534ab7; }
+                background: var(--guardian-primary-background, #E1E7FA);
+                i { color: var(--color-primary, #4169E2); }
             }
         }
     }
 
     &--invalid {
-        border-color: #fca5a5;
-        background: #fff8f8;
+        border-color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
+        background: var(--guardian-failure-background, #FFEAEA);
 
-        &:hover { border-color: #f87171; }
+        &:hover { border-color: var(--color-accent-red-1, #FF432A); }
 
         &.active {
-            border-color: #ef4444;
-            box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+            border-color: var(--color-accent-red-1, #FF432A);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-red-1, #FF432A) 10%, transparent);
         }
     }
 
@@ -1129,17 +1131,17 @@
     }
 
     &--drag-target {
-        outline: 2px dashed #534ab7;
+        outline: 2px dashed var(--color-primary, #4169E2);
         outline-offset: -1px;
-        background: #f5f4fd;
+        background: var(--guardian-primary-background, #E1E7FA);
     }
 
     &--drag-top {
-        border-top: 2px solid #534ab7;
+        border-top: 2px solid var(--color-primary, #4169E2);
     }
 
     &--drag-bot {
-        border-bottom: 2px solid #534ab7;
+        border-bottom: 2px solid var(--color-primary, #4169E2);
     }
 }
 
@@ -1147,17 +1149,17 @@
     width: 24px;
     height: 24px;
     border-radius: 6px;
-    background: var(--surface-200, #e8e8e6);
+    background: var(--guardian-grey-background, #F1F3F9);
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
 
-    i { font-size: 14px; color: var(--text-color-secondary, #888780); }
+    i { font-size: 14px; color: var(--guardian-font-color-secondary, #848FA9); }
 
     &--ref {
-        background: #eeedfe;
-        i { color: #534ab7; }
+        background: var(--guardian-primary-background, #E1E7FA);
+        i { color: var(--color-primary, #4169E2); }
     }
 }
 
@@ -1169,7 +1171,7 @@
 .sc-drill-card-name {
     font-size: 14px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1178,13 +1180,13 @@
 
 .sc-drill-card-key {
     font-size: 10px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;
     margin-top: 1px;
-    font-family: 'Courier New', Courier, monospace;
+    font-family: var(--font-mono, 'Courier New', Courier, monospace);
 }
 
 .sc-drill-card-meta {
@@ -1211,7 +1213,7 @@
     width: 24px;
     height: 24px;
     border-radius: 5px;
-    background: #534ab7;
+    background: var(--color-primary, #4169E2);
     color: #fff;
     border: none;
     font-size: 11px;
@@ -1235,30 +1237,30 @@
 
     /* Required keeps coral — universal semantic meaning */
     &--req {
-        background: #FAECE7;
-        border-color: rgba(152, 60, 29, 0.2);
-        color: #993C1D;
+        background: var(--guardian-failure-background, #FFEAEA);
+        border-color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 20%, transparent);
+        color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 82%, #000);
     }
 
     /* Optional: light purple tint */
     &--opt {
-        background: rgba(83, 74, 183, 0.07);
-        border-color: rgba(83, 74, 183, 0.18);
-        color: #534ab7;
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 7%, transparent);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 18%, transparent);
+        color: var(--color-primary, #4169E2);
     }
 
     /* Array: purple tint */
     &--arr {
-        background: rgba(83, 74, 183, 0.07);
-        border-color: rgba(83, 74, 183, 0.18);
-        color: #534ab7;
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 7%, transparent);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 18%, transparent);
+        color: var(--color-primary, #4169E2);
     }
 
     /* Condition: slightly stronger purple */
     &--cond {
-        background: rgba(83, 74, 183, 0.12);
-        border-color: rgba(83, 74, 183, 0.25);
-        color: #534ab7;
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 12%, transparent);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 25%, transparent);
+        color: var(--color-primary, #4169E2);
         display: inline-flex;
         align-items: center;
         gap: 3px;
@@ -1267,23 +1269,23 @@
 
     /* Data type: muted purple-tinted */
     &--type {
-        background: rgba(83, 74, 183, 0.06);
-        border-color: rgba(83, 74, 183, 0.14);
-        color: #534ab7;
+        background: color-mix(in srgb, var(--color-primary, #4169E2) 6%, transparent);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 14%, transparent);
+        color: var(--color-primary, #4169E2);
     }
 
     /* Referenced schema name — solid purple */
     &--ref-name {
-        background: #534ab7;
-        border-color: #3c3489;
+        background: var(--color-primary, #4169E2);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 82%, #000);
         color: #fff;
         max-width: 120px;
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    &--hidden { background: #f1efe8; border-color: rgba(0,0,0,0.1); color: #6b6b6b; }
-    &--auto { background: #ecdca2; border-color: rgba(35,35,125,0.1); color: #47a5ca; }
-    &--upd    { background: #e6f6ee; border-color: rgba(26,122,69,0.2); color: #1a7a45; }
+    &--hidden { background: var(--guardian-grey-background, #F9FAFC); border-color: rgba(0,0,0,0.1); color: var(--guardian-font-color-secondary, #848FA9); }
+    &--auto { background: var(--guardian-warning-background, #FFF6E3); border-color: color-mix(in srgb, var(--color-primary, #4169E2) 10%, transparent); color: var(--color-primary, #4169E2); }
+    &--upd    { background: var(--guardian-success-background, #EEFBF0); border-color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 20%, transparent); color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
 }
 
 .sc-drill-back-bar {
@@ -1293,12 +1295,12 @@
     padding: 10px 14px;
     border-top: 1px solid rgba(0, 0, 0, 0.08);
     flex-shrink: 0;
-    background: #fff;
+    background: var(--guardian-background, #fff);
 }
 
 .sc-drill-info {
     font-size: 14px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 .sc-drag-handle {
@@ -1312,7 +1314,7 @@
     width: 28px;
     height: 28px;
     border-radius: 7px;
-    background: var(--surface-ground, #f1efe8);
+    background: var(--guardian-grey-background, #F9FAFC);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1320,12 +1322,12 @@
 
     i {
         font-size: 13px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 
     &--ref {
-        background: #eeedfe;
-        i { color: #534ab7; }
+        background: var(--guardian-primary-background, #E1E7FA);
+        i { color: var(--color-primary, #4169E2); }
     }
 }
 
@@ -1337,7 +1339,7 @@
 .sc-field-key {
     font-size: 13px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1347,12 +1349,12 @@
 .sc-field-desc {
     display: block;
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     margin-top: 1px;
-    font-family: 'Courier New', Courier, monospace;
+    font-family: var(--font-mono, 'Courier New', Courier, monospace);
 }
 
 .sc-field-meta-row {
@@ -1371,13 +1373,13 @@
     font-weight: 500;
     white-space: nowrap;
 
-    &--req  { background: #faece7; color: #993c1d; }
-    &--opt  { background: var(--surface-ground, #f1efe8); color: var(--text-color-secondary, #888780); }
-    &--arr  { background: #e6f1fb; color: #185fa5; }
-    &--type { background: var(--surface-ground, #f1efe8); color: #5f5e5a; }
+    &--req  { background: var(--guardian-failure-background, #FFEAEA); color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 82%, #000); }
+    &--opt  { background: var(--guardian-grey-background, #F9FAFC); color: var(--guardian-font-color-secondary, #848FA9); }
+    &--arr  { background: var(--guardian-primary-background, #E1E7FA); color: var(--color-primary, #4169E2); }
+    &--type { background: var(--guardian-grey-background, #F9FAFC); color: var(--guardian-font-color-secondary, #848FA9); }
     &--cond {
-        background: #eeedfe;
-        color: #534ab7;
+        background: var(--guardian-primary-background, #E1E7FA);
+        color: var(--color-primary, #4169E2);
         display: inline-flex;
         align-items: center;
         gap: 3px;
@@ -1385,15 +1387,15 @@
     }
     /* Referenced schema name — solid purple, same style as v5 subschema-ref-badge */
     &--ref-name {
-        background: #534ab7;
+        background: var(--color-primary, #4169E2);
         color: #fff;
         max-width: 160px;
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    &--hidden { background: #f1efe8; color: #6b6b6b; }
-    &--auto { background: #cae0f8; color: #005e88; }
-    &--upd { background: #e6f6ee; color: #1a7a45; }
+    &--hidden { background: var(--guardian-grey-background, #F9FAFC); color: var(--guardian-font-color-secondary, #848FA9); }
+    &--auto { background: var(--guardian-primary-background, #E1E7FA); color: color-mix(in srgb, var(--color-primary, #4169E2) 82%, #000); }
+    &--upd { background: var(--guardian-success-background, #EEFBF0); color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
 }
 
 .sc-field-card-actions {
@@ -1410,19 +1412,19 @@
     cursor: pointer;
     padding: 5px 7px;
     border-radius: 6px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 13px;
     flex-shrink: 0;
     transition: all 0.15s;
 
     &:hover {
-        background: var(--surface-ground, #f1efe8);
-        color: var(--text-color, #2c2c2a);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color, #23252E);
     }
 
     &--danger:hover {
-        background: #faece7;
-        color: #993c1d;
+        background: var(--guardian-failure-background, #FFEAEA);
+        color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 82%, #000);
     }
 }
 
@@ -1432,7 +1434,7 @@
     align-items: center;
     gap: 8px;
     padding: 48px 0;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 13px;
 
     i {
@@ -1443,11 +1445,11 @@
 
 /* ── Drop zone & add section ── */
 .sc-drop-zone {
-    border: 1.5px dashed rgba(0, 0, 0, 0.15);
+    border: 1.5px dashed var(--guardian-border-color, #E1E7EF);
     border-radius: 12px;
     padding: 14px;
     text-align: center;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
     margin-top: 8px;
     cursor: pointer;
@@ -1460,15 +1462,15 @@
     i { font-size: 14px; }
 
     &:hover {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
-        background: #e1f5ee;
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-success-background, #EEFBF0);
     }
 
     &--reorder {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
-        background: #e1f5ee;
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-success-background, #EEFBF0);
     }
 }
 
@@ -1485,10 +1487,10 @@
     align-items: center;
     gap: 8px;
     padding: 8px 16px;
-    background: #fff;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--guardian-background, #fff);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     font-size: 14px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
     position: sticky;
     top: 0;
@@ -1499,17 +1501,17 @@
     font-size: 14px;
     padding: 4px 12px;
     border-radius: 20px;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: transparent;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     font-family: inherit;
     transition: all 0.15s;
 
     &.active,
     &:hover {
-        background: var(--primary-color, #1d9e75);
-        border-color: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
+        border-color: var(--color-primary, #4169E2);
         color: #fff;
     }
 }
@@ -1550,7 +1552,7 @@
     align-items: center;
     gap: 12px;
     padding: 80px 24px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
 
     i {
@@ -1562,8 +1564,8 @@
 /* ── Right panel (field properties) ── */
 .sc-right-panel {
     width: 340px;
-    background: #fff;
-    border-left: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--guardian-background, #fff);
+    border-left: 1px solid var(--guardian-border-color, #E1E7EF);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
@@ -1579,7 +1581,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 12px 14px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--guardian-border-color, #E1E7EF);
     flex-shrink: 0;
 }
 
@@ -1589,9 +1591,9 @@
     gap: 7px;
     font-size: 13px;
     font-weight: 600;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
 
-    i { font-size: 14px; color: var(--text-color-secondary, #888780); }
+    i { font-size: 14px; color: var(--guardian-font-color-secondary, #848FA9); }
 }
 
 .sc-rp-badge {
@@ -1599,8 +1601,8 @@
     font-weight: 500;
     padding: 2px 8px;
     border-radius: 20px;
-    background: #e1f5ee;
-    color: #0f6e56;
+    background: var(--guardian-success-background, #EEFBF0);
+    color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000);
     text-transform: capitalize;
 }
 
@@ -1609,7 +1611,7 @@
     display: flex;
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
     flex-shrink: 0;
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
 }
 
 .sc-rp-tab {
@@ -1619,7 +1621,7 @@
     font-weight: 500;
     text-align: center;
     cursor: pointer;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     background: transparent;
     border: none;
     font-family: inherit;
@@ -1633,19 +1635,19 @@
     i { font-size: 14px; }
 
     &.active {
-        background: #fff;
-        color: var(--primary-color, #1d9e75);
-        border-bottom-color: var(--primary-color, #1d9e75);
+        background: var(--guardian-background, #fff);
+        color: var(--color-primary, #4169E2);
+        border-bottom-color: var(--color-primary, #4169E2);
     }
 
     &:not(.active):hover {
-        color: var(--text-color, #2c2c2a);
+        color: var(--guardian-font-color, #23252E);
         background: rgba(0, 0, 0, 0.03);
     }
 }
 
 .sc-rp-tab-count {
-    background: var(--primary-color, #1d9e75);
+    background: var(--color-primary, #4169E2);
     color: #fff;
     font-size: 9px;
     font-weight: 700;
@@ -1676,8 +1678,8 @@
     flex-direction: column;
     gap: 5px;
     padding: 8px 10px;
-    background: #fff8f8;
-    border: 1px solid #fca5a5;
+    background: var(--guardian-failure-background, #FFEAEA);
+    border: 1px solid color-mix(in srgb, var(--color-accent-red-1, #FF432A) 40%, var(--guardian-border-color, #E1E7EF));
     border-radius: 8px;
 }
 
@@ -1686,7 +1688,7 @@
     align-items: flex-start;
     gap: 6px;
     font-size: 11px;
-    color: #dc2626;
+    color: var(--color-accent-red-1, #FF432A);
     line-height: 1.4;
 
     i { font-size: 14px; flex-shrink: 0; margin-top: 1px; }
@@ -1701,33 +1703,33 @@
 .sc-rp-label {
     font-size: 11px;
     font-weight: 500;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 .sc-rp-input {
     font-size: 14px;
     padding: 6px 10px;
     border-radius: 8px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: var(--surface-ground, #f8f8f7);
-    color: var(--text-color, #2c2c2a);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     width: 100%;
     transition: border-color 0.15s, background 0.15s;
 
     &:not([readonly]):focus {
-        border-color: var(--primary-color, #1d9e75);
-        background: #fff;
-        box-shadow: 0 0 0 3px rgba(29, 158, 117, 0.1);
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-background, #fff);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent-green-1, #19BE47) 10%, transparent);
     }
 
     &[readonly] {
         cursor: default;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 
-    &--mono { font-family: monospace; font-size: 11px; }
+    &--mono { font-family: var(--font-mono, monospace); font-size: 11px; }
 }
 
 .sc-rp-textarea {
@@ -1741,7 +1743,7 @@
 .sc-rp-hint {
     font-size: 10px;
     font-weight: 400;
-    color: #94a3b8;
+    color: var(--guardian-font-color-secondary, #848FA9);
     margin-left: 6px;
     text-transform: none;
     letter-spacing: 0;
@@ -1773,7 +1775,7 @@
     margin: -4px;
     transition: background 0.12s;
 
-    &:hover { background: var(--surface-ground, #f1efe8); }
+    &:hover { background: var(--guardian-grey-background, #F9FAFC); }
 }
 
 .sc-check-box {
@@ -1781,7 +1783,7 @@
     height: 16px;
     border-radius: 4px;
     border: 1.5px solid rgba(0, 0, 0, 0.2);
-    background: #fff;
+    background: var(--guardian-background, #fff);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1794,8 +1796,8 @@
     }
 
     &.active {
-        background: var(--primary-color, #1d9e75);
-        border-color: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
+        border-color: var(--color-primary, #4169E2);
 
         i { color: #fff; }
     }
@@ -1810,12 +1812,12 @@
         font-size: 14px;
         font-weight: 500;
         line-height: 18px;
-        color: var(--text-color, #2c2c2a);
+        color: var(--guardian-font-color, #23252E);
     }
 
     span {
         font-size: 11px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
@@ -1826,10 +1828,10 @@
     gap: 4px;
     max-height: 200px;
     overflow-y: auto;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 8px;
     padding: 4px;
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
 }
 
 .sc-rp-ref-option {
@@ -1841,17 +1843,17 @@
     border: 1px solid transparent;
     cursor: pointer;
     transition: all 0.12s;
-    background: #fff;
+    background: var(--guardian-background, #fff);
     flex-shrink: 0;
 
     &:hover {
-        border-color: #c8c6f0;
-        background: #eeedfe;
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
+        background: var(--guardian-primary-background, #E1E7FA);
     }
 
     &.active {
-        border-color: #534ab7;
-        background: #eeedfe;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #E1E7FA);
     }
 }
 
@@ -1859,7 +1861,7 @@
     width: 24px;
     height: 24px;
     border-radius: 6px;
-    background: #eeedfe;
+    background: var(--guardian-primary-background, #E1E7FA);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1867,7 +1869,7 @@
 
     i {
         font-size: 14px;
-        color: #534ab7;
+        color: var(--color-primary, #4169E2);
     }
 }
 
@@ -1882,7 +1884,7 @@
 .sc-rp-ref-name {
     font-size: 14px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1890,13 +1892,13 @@
 
 .sc-rp-ref-ver {
     font-size: 10px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
 }
 
 .sc-rp-ref-check {
     font-size: 11px;
-    color: #534ab7;
+    color: var(--color-primary, #4169E2);
     flex-shrink: 0;
 }
 
@@ -1908,7 +1910,7 @@
     gap: 5px;
     padding: 14px;
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 
     i { font-size: 18px; color: rgba(0, 0, 0, 0.12); }
 }
@@ -1934,7 +1936,7 @@
 
 .sc-enum-empty {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-style: italic;
     text-align: center;
     padding: 4px 0;
@@ -1951,18 +1953,18 @@
     font-weight: 500;
     padding: 5px 10px;
     border-radius: 8px;
-    border: 1.5px dashed rgba(0, 0, 0, 0.15);
+    border: 1.5px dashed var(--guardian-border-color, #E1E7EF);
     background: transparent;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     transition: all 0.15s;
 
     i { font-size: 11px; }
 
     &:hover {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
-        background: #e1f5ee;
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-success-background, #EEFBF0);
     }
 }
 
@@ -1974,19 +1976,19 @@
     width: 28px;
     height: 28px;
     border-radius: 7px;
-    border: 1px solid rgba(0, 0, 0, 0.12);
-    background: #fff;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #fff);
     cursor: pointer;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
     transition: all 0.15s;
 
     i { font-size: 14px; }
 
     &:hover {
-        background: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
         color: #fff;
-        border-color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
     }
 }
 
@@ -2004,51 +2006,51 @@
 }
 
 .sc-type-tile {
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 8px;
     padding: 8px 4px 6px;
     cursor: pointer;
     text-align: center;
     transition: all 0.15s;
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
 
     i {
         font-size: 15px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
         display: block;
         margin-bottom: 3px;
     }
 
     span {
         font-size: 9px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
         display: block;
         line-height: 1.25;
         word-break: break-word;
     }
 
     &:hover {
-        border-color: var(--primary-color, #1d9e75);
-        background: #e1f5ee;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-success-background, #EEFBF0);
 
-        i, span { color: #0f6e56; }
+        i, span { color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
     }
 
     &.active {
-        border: 1.5px solid var(--primary-color, #1d9e75);
-        background: #e1f5ee;
+        border: 1.5px solid var(--color-primary, #4169E2);
+        background: var(--guardian-success-background, #EEFBF0);
 
-        i, span { color: #0f6e56; }
+        i, span { color: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 82%, #000); }
     }
 
     &--accent {
-        border-color: #534ab7;
-        background: #eeedfe;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #E1E7FA);
 
-        i, span { color: #534ab7; }
+        i, span { color: var(--color-primary, #4169E2); }
 
         &:hover {
-            background: #dddcfa;
+            background: var(--guardian-primary-background, #E1E7FA);
         }
     }
 }
@@ -2064,16 +2066,16 @@
 
     .sc-system-chevron {
         font-size: 14px;
-        color: #6b7280;
+        color: var(--guardian-font-color-secondary, #848FA9);
         flex-shrink: 0;
     }
 
     .sc-system-count {
         font-size: 11px;
         font-weight: 600;
-        color: #6b7280;
-        background: #f1f5f9;
-        border: 1px solid #e2e8f0;
+        color: var(--guardian-font-color-secondary, #848FA9);
+        background: var(--guardian-grey-background, #F9FAFC);
+        border: 1px solid var(--guardian-border-color, #E1E7EF);
         border-radius: 10px;
         padding: 1px 7px;
         flex-shrink: 0;
@@ -2081,31 +2083,31 @@
 }
 
 .sc-field-card--system {
-    background: #f8fafc;
-    border-color: #e2e8f0;
+    background: var(--guardian-grey-background, #F9FAFC);
+    border-color: var(--guardian-border-color, #E1E7EF);
     cursor: default;
     opacity: 0.85;
 
     &:hover {
-        border-color: #cbd5e1;
-        background: #f1f5f9;
+        border-color: var(--guardian-border-color, #E1E7EF);
+        background: var(--guardian-grey-background, #F9FAFC);
         transform: none;
         box-shadow: none;
     }
 
     .sc-field-type-icon {
-        background: #e2e8f0;
-        color: #64748b;
+        background: var(--guardian-border-color, #E1E7EF);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 
-    .sc-field-key { color: #475569; }
-    .sc-field-desc { color: #94a3b8; }
+    .sc-field-key { color: var(--guardian-font-color, #23252E); }
+    .sc-field-desc { color: var(--guardian-font-color-secondary, #848FA9); }
 }
 
 .sc-badge--sys {
-    background: #e2e8f0;
-    color: #64748b;
-    border: 1px solid #cbd5e1;
+    background: var(--guardian-border-color, #E1E7EF);
+    color: var(--guardian-font-color-secondary, #848FA9);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
 }
 
 // ── Select input (mirrors sc-rp-input) ──────────────────────────────────────
@@ -2119,7 +2121,7 @@
 // ── Conditions panel ─────────────────────────────────────────────────────────
 .sc-cond-intro {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     line-height: 1.5;
     margin: 0;
 }
@@ -2130,17 +2132,17 @@
     gap: 7px;
     padding: 10px 12px;
     border-radius: 8px;
-    border: 1px dashed rgba(0, 0, 0, 0.12);
-    color: var(--text-color-secondary, #888780);
+    border: 1px dashed var(--guardian-border-color, #E1E7EF);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-size: 14px;
 
     i { font-size: 16px; opacity: 0.5; }
 }
 
 .sc-cond-card {
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 10px;
-    background: var(--surface-ground, #f8f8f7);
+    background: var(--guardian-grey-background, #F9FAFC);
     overflow: hidden;
 }
 
@@ -2156,12 +2158,12 @@
 .sc-cond-card-title {
     font-size: 11px;
     font-weight: 600;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     display: flex;
     align-items: center;
     gap: 5px;
 
-    i { font-size: 14px; color: var(--text-color-secondary, #888780); }
+    i { font-size: 14px; color: var(--guardian-font-color-secondary, #848FA9); }
 }
 
 .sc-cond-remove {
@@ -2169,12 +2171,12 @@
     border: none;
     padding: 3px 6px;
     cursor: pointer;
-    color: #94a3b8;
+    color: var(--guardian-font-color-secondary, #848FA9);
     border-radius: 5px;
     line-height: 1;
     transition: color 0.12s, background 0.12s;
 
-    &:hover { color: #ef4444; background: #fee2e2; }
+    &:hover { color: var(--color-accent-red-1, #FF432A); background: var(--guardian-failure-background, #FFEAEA); }
     i { font-size: 14px; }
 }
 
@@ -2204,9 +2206,9 @@
     border-radius: 4px;
     flex-shrink: 0;
 
-    &--if   { background: var(--surface-200, #e8e8e6); color: var(--text-color, #2c2c2a); }
-    &--then { background: var(--surface-ground, #f8f8f7); color: var(--primary-color, #1d9e75); }
-    &--else { background: var(--surface-200, #e8e8e6); color: var(--text-color-secondary, #888780); }
+    &--if   { background: var(--guardian-grey-background, #F1F3F9); color: var(--guardian-font-color, #23252E); }
+    &--then { background: var(--guardian-grey-background, #F9FAFC); color: var(--color-primary, #4169E2); }
+    &--else { background: var(--guardian-grey-background, #F1F3F9); color: var(--guardian-font-color-secondary, #848FA9); }
 }
 
 .sc-cond-op-sel {
@@ -2217,7 +2219,7 @@
 
 .sc-cond-section-sub {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
 }
 
 .sc-cond-if-row {
@@ -2231,7 +2233,7 @@
 
 .sc-cond-eq {
     font-size: 14px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
     font-weight: 500;
 }
@@ -2241,13 +2243,13 @@
     border: none;
     padding: 3px 5px;
     cursor: pointer;
-    color: #94a3b8;
+    color: var(--guardian-font-color-secondary, #848FA9);
     border-radius: 4px;
     line-height: 1;
     flex-shrink: 0;
     transition: color 0.12s, background 0.12s;
 
-    &:hover:not(:disabled) { color: #ef4444; background: #fee2e2; }
+    &:hover:not(:disabled) { color: var(--color-accent-red-1, #FF432A); background: var(--guardian-failure-background, #FFEAEA); }
     &:disabled { opacity: 0.3; cursor: default; }
     i { font-size: 11px; }
 }
@@ -2255,11 +2257,11 @@
 .sc-cond-add-row {
     align-self: flex-start;
     background: none;
-    border: 1px dashed rgba(0, 0, 0, 0.15);
+    border: 1px dashed var(--guardian-border-color, #E1E7EF);
     border-radius: 5px;
     padding: 3px 8px;
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     font-family: inherit;
     display: flex;
@@ -2268,8 +2270,8 @@
     transition: border-color 0.12s, color 0.12s;
 
     &:hover {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
     }
 
     i { font-size: 10px; }
@@ -2285,8 +2287,8 @@
     border: 1px solid rgba(0, 0, 0, 0.07);
 
     &--cross {
-        background: #f5f3ff;
-        border-color: rgba(83, 74, 183, 0.2);
+        background: var(--guardian-primary-background, #E1E7FA);
+        border-color: color-mix(in srgb, var(--color-primary, #4169E2) 20%, transparent);
     }
 
 }
@@ -2294,16 +2296,16 @@
 
 .sc-cond-target-ic {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     flex-shrink: 0;
 
-    .sc-cond-target-row--cross & { color: #534ab7; }
+    .sc-cond-target-row--cross & { color: var(--color-primary, #4169E2); }
 }
 
 .sc-cond-target-lbl {
     flex: 1;
     font-size: 11px;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -2311,13 +2313,13 @@
     &--path {
         font-family: var(--font-mono, monospace);
         font-size: 10px;
-        color: #534ab7;
+        color: var(--color-primary, #4169E2);
     }
 }
 
 .sc-cond-empty-branch {
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-style: italic;
 }
 
@@ -2331,11 +2333,11 @@
 .sc-cond-add-field-btn {
     align-self: flex-start;
     background: none;
-    border: 1px dashed rgba(0, 0, 0, 0.15);
+    border: 1px dashed var(--guardian-border-color, #E1E7EF);
     border-radius: 5px;
     padding: 3px 10px;
     font-size: 11px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     font-family: inherit;
     display: flex;
@@ -2344,8 +2346,8 @@
     transition: border-color 0.12s, color 0.12s;
 
     &:hover {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
     }
 
     i { font-size: 10px; }
@@ -2354,21 +2356,21 @@
 .sc-cond-cross-sel {
     font-size: 11px !important;
     padding: 3px 7px !important;
-    color: #534ab7 !important;
-    border-color: rgba(83, 74, 183, 0.3) !important;
+    color: var(--color-primary, #4169E2) !important;
+    border-color: color-mix(in srgb, var(--color-primary, #4169E2) 30%, transparent) !important;
     border-style: dashed !important;
     border-radius: 5px !important;
-    background: #f5f3ff !important;
+    background: var(--guardian-primary-background, #E1E7FA) !important;
 }
 
 .sc-add-cond-btn {
     width: 100%;
     padding: 12px;
     background: transparent;
-    border: 1px dashed rgba(0, 0, 0, 0.15);
+    border: 1px dashed var(--guardian-border-color, #E1E7EF);
     border-radius: 8px;
     font-size: 14px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     font-family: inherit;
     display: flex;
@@ -2378,9 +2380,9 @@
     transition: border-color 0.15s, color 0.15s, background 0.15s;
 
     &:hover:not(:disabled) {
-        border-color: var(--primary-color, #1d9e75);
-        color: var(--primary-color, #1d9e75);
-        background: rgba(29, 158, 117, 0.05);
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
+        background: color-mix(in srgb, var(--color-accent-green-1, #19BE47) 5%, transparent);
     }
 
     &:disabled {
@@ -2603,7 +2605,7 @@
     border: 1px solid var(--guardian-border-color);
     background: var(--guardian-background);
     font-size: 14px;
-    font-family: Inter, sans-serif;
+    font-family: var(--font-family-inter, 'Inter', sans-serif);
     color: var(--guardian-font-color);
     min-width: 80px;
     max-width: 200px;
@@ -2871,10 +2873,10 @@
     cursor: pointer;
     font-size: 14px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     transition: background 0.12s;
 
-    &:hover { background: var(--surface-ground, #f1efe8); }
+    &:hover { background: var(--guardian-grey-background, #F9FAFC); }
 }
 
 .sc-radio-dot {
@@ -2882,7 +2884,7 @@
     height: 14px;
     border-radius: 50%;
     border: 1.5px solid rgba(0, 0, 0, 0.25);
-    background: #fff;
+    background: var(--guardian-background, #fff);
     flex-shrink: 0;
     position: relative;
     transition: border-color 0.12s, background 0.12s;
@@ -2897,10 +2899,10 @@
     }
 
     &.active {
-        border-color: var(--primary-color, #1d9e75);
-        background: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
+        background: var(--color-primary, #4169E2);
 
-        &::after { background: #fff; }
+        &::after { background: var(--guardian-background, #fff); }
     }
 }
 
@@ -2918,7 +2920,7 @@
 .sc-expr-preview {
     flex: 1;
     cursor: default;
-    color: var(--text-color-secondary, #888780) !important;
+    color: var(--guardian-font-color-secondary, #848FA9) !important;
     font-size: 11px !important;
 }
 
@@ -2927,27 +2929,27 @@
     align-items: center;
     gap: 4px;
     padding: 5px 10px;
-    border: 1.5px solid var(--surface-border, #ccc);
+    border: 1.5px solid var(--guardian-border-color, #E1E7EF);
     border-radius: 6px;
-    background: #fff;
+    background: var(--guardian-background, #fff);
     font-size: 14px;
     cursor: pointer;
     white-space: nowrap;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     transition: background 0.12s, border-color 0.12s;
 
-    &:hover { background: var(--surface-ground, #f1efe8); }
+    &:hover { background: var(--guardian-grey-background, #F9FAFC); }
 
     &--warn {
-        border-color: #e57373;
-        color: #c62828;
+        border-color: var(--color-accent-red-1, #FF432A);
+        color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 82%, #000);
 
-        &:hover { background: #fef2f2; }
+        &:hover { background: var(--guardian-failure-background, #FFEAEA); }
     }
 }
 
 .sc-rp-hint--warn {
-    color: #e57373;
+    color: var(--color-accent-red-1, #FF432A);
     font-weight: 500;
 }
 
@@ -2989,18 +2991,18 @@
     border-radius: 20px;
     font-size: 11px;
     font-weight: 500;
-    background: #eeedfe;
-    color: #534ab7;
-    border: 1px solid #c8c6f0;
+    background: var(--guardian-primary-background, #E1E7FA);
+    color: var(--color-primary, #4169E2);
+    border: 1px solid color-mix(in srgb, var(--color-primary, #4169E2) 35%, var(--guardian-border-color, #E1E7EF));
     max-width: 120px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 
     &--more {
-        background: var(--surface-ground, #f1efe8);
-        color: var(--text-color-secondary, #888780);
-        border-color: var(--surface-border, #ccc);
+        background: var(--guardian-grey-background, #F9FAFC);
+        color: var(--guardian-font-color-secondary, #848FA9);
+        border-color: var(--guardian-border-color, #E1E7EF);
     }
 }
 
@@ -3017,9 +3019,9 @@
     width: 32px;
     height: 32px;
     border-radius: 6px;
-    border: 1px solid var(--surface-border, #ccc);
-    background: var(--surface-card, #fff);
-    color: var(--text-color-secondary, #888780);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-background, #FFFFFF);
+    color: var(--guardian-font-color-secondary, #848FA9);
     cursor: pointer;
     transition: all 0.12s;
     flex-shrink: 0;
@@ -3027,14 +3029,14 @@
     i { font-size: 13px; }
 
     &:hover {
-        border-color: #534ab7;
-        color: #534ab7;
-        background: #eeedfe;
+        border-color: var(--color-primary, #4169E2);
+        color: var(--color-primary, #4169E2);
+        background: var(--guardian-primary-background, #E1E7FA);
     }
 
     &.active {
-        border-color: #534ab7;
-        background: #534ab7;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--color-primary, #4169E2);
         color: #fff;
     }
 }
@@ -3049,7 +3051,7 @@
 
 .sc-ref-sel-ver {
     font-size: 10px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     margin-left: auto;
 }
 
@@ -3073,7 +3075,7 @@
     justify-content: space-between;
     font-size: 11px;
     font-weight: 500;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
 }
 
 .sc-fv-label-text {
@@ -3083,13 +3085,13 @@
 
     i {
         font-size: 12px;
-        color: var(--text-color-secondary, #888780);
+        color: var(--guardian-font-color-secondary, #848FA9);
     }
 }
 
 .sc-fv-clear {
     font-size: 10px;
-    color: var(--text-color-secondary, #888780);
+    color: var(--guardian-font-color-secondary, #848FA9);
     background: none;
     border: none;
     cursor: pointer;
@@ -3098,7 +3100,7 @@
     line-height: 1;
 
     &:hover {
-        color: #c0392b;
+        color: color-mix(in srgb, var(--color-accent-red-1, #FF432A) 82%, #000);
     }
 }
 
@@ -3106,17 +3108,17 @@
     width: 100%;
     padding: 5px 9px;
     border-radius: 6px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: var(--surface-ground, #f8f8f7);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
     font-size: 12px;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     transition: border-color 0.15s;
 
     &:focus {
-        border-color: var(--primary-color, #1d9e75);
-        background: #fff;
+        border-color: var(--color-primary, #4169E2);
+        background: var(--guardian-background, #fff);
     }
 
     &[type='date'],
@@ -3130,16 +3132,16 @@
     width: 100%;
     padding: 5px 9px;
     border-radius: 6px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: var(--surface-ground, #f8f8f7);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
     font-size: 12px;
-    color: var(--text-color, #2c2c2a);
+    color: var(--guardian-font-color, #23252E);
     font-family: inherit;
     outline: none;
     cursor: pointer;
 
     &:focus {
-        border-color: var(--primary-color, #1d9e75);
+        border-color: var(--color-primary, #4169E2);
     }
 }
 
@@ -3152,17 +3154,17 @@
     flex: 1;
     padding: 5px 8px;
     border-radius: 6px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: var(--surface-ground, #f8f8f7);
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    background: var(--guardian-grey-background, #F9FAFC);
     font-size: 12px;
-    color: var(--text-color-secondary, #5f5e5a);
+    color: var(--guardian-font-color-secondary, #848FA9);
     font-family: inherit;
     cursor: pointer;
     transition: all 0.15s;
 
     &.active {
-        background: var(--primary-color, #1d9e75);
-        border-color: var(--primary-color, #1d9e75);
+        background: var(--color-primary, #4169E2);
+        border-color: var(--color-primary, #4169E2);
         color: #fff;
         font-weight: 500;
     }

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -973,8 +973,27 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         if (!this.selectedField) { return; }
         const f = this.selectedField as any;
         f.textColor = '#000000';
-        f.textSize = '18';
+        f.textSize = '18px';
         f.textBold = false;
+        this.markDirty();
+    }
+
+    public getHelpTextSize(): number | null {
+        const raw = (this.selectedField as any)?.textSize;
+        if (raw === null || raw === undefined || raw === '') { return null; }
+        const num = parseFloat(String(raw).replace('px', ''));
+        return isNaN(num) ? null : num;
+    }
+
+    public setHelpTextSize(value: number | string | null): void {
+        if (!this.selectedField) { return; }
+        const f = this.selectedField as any;
+        if (value === null || value === undefined || value === '') {
+            f.textSize = '';
+        } else {
+            const num = parseFloat(String(value).replace('px', ''));
+            f.textSize = isNaN(num) ? '' : num + 'px';
+        }
         this.markDirty();
     }
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -121,8 +121,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     public drillPropsCollapsed: boolean = false;
 
     public get drilledSchema(): Schema | null {
-        const iri = this.currentDrilledSchemaIri;
-        return iri ? (this.schemas.find(s => s.iri === iri) ?? null) : null;
+        return this.resolveRefSchema(this.currentDrilledSchemaIri) ?? null;
     }
 
     public get currentContextSchema(): Schema | null {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -155,6 +155,8 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         { label: 'Encrypted Verifiable Credential', value: SchemaEntity.EVC },
     ];
 
+    public copiedIri: boolean = false;
+
     public get systemFields(): any[] {
         return DefaultFieldDictionary.getDefaultFields(this.selectedSchema?.entity as SchemaEntity);
     }
@@ -677,6 +679,15 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public selectField(field: SchemaField): void {
         this.selectedField = this.selectedField === field ? null : field;
+    }
+
+    public copyIri(value: string | null | undefined, event?: Event): void {
+        event?.stopPropagation();
+        if (!value) { return; }
+        navigator.clipboard.writeText(value).then(() => {
+            this.copiedIri = true;
+            setTimeout(() => { this.copiedIri = false; }, 1500);
+        }).catch(() => { this.copiedIri = false; });
     }
 
     private static readonly HIDE_VALUES_TYPES = new Set(['helptext', 'file', 'table']);

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -1071,9 +1071,28 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public changeFieldType(ft: FieldTypeUI): void {
         if (!this.selectedField) { return; }
-        // Sub-schema fields are added by dragging from the Schemas tab; clicking the
-        // tile on an existing sub-schema field is a no-op to avoid corruption.
-        if (ft.key === 'sub-schema') { return; }
+        if (ft.key === 'sub-schema') {
+            // Already a sub-schema: keep the current reference — the "Referenced schema"
+            // dropdown is how it gets changed, so clicking the tile is a no-op.
+            if (this.getFieldCurrentType(this.selectedField) === 'sub-schema') { return; }
+            // Convert a plain field into a sub-schema: set up a bare reference and let the
+            // "Referenced schema" dropdown pick the actual schema.
+            const sub = this.selectedField as any;
+            sub.isRef = true;
+            sub.type = '';
+            sub.fields = [];
+            sub.format = '';
+            sub.pattern = '';
+            sub.customType = '';
+            sub.unitSystem = '';
+            delete sub.enum;
+            sub.default = null;
+            sub.suggest = null;
+            sub.examples = undefined;
+            this._rebuildRefPreset();
+            this.markDirty();
+            return;
+        }
         const f = this.selectedField as any;
         f.isRef = ft.isRef || false;
         f.type = ft.schemaType || 'string';

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -931,7 +931,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     }
 
     public onSubSchemaRefChange(iri: string): void {
-        const schema = this.schemas.find(s => s.iri === iri);
+        const schema = this.resolveRefSchema(iri);
         if (schema) { this.changeSubSchemaRef(schema); }
     }
 
@@ -1105,8 +1105,23 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         this.markDirty();
     }
 
+    // Referenced sub-schemas may live only in _subSchemasByIri (the API's $defs for the
+    // loaded schema), not in the paginated sidebar list, so resolve from both.
+    private resolveRefSchema(iri: string): Schema | undefined {
+        if (!iri) { return undefined; }
+        return this.schemas.find(s => s.iri === iri) ?? this._subSchemasByIri.get(iri);
+    }
+
     public get availableRefSchemas(): Schema[] {
-        return this.schemas.filter(s => this.canDragSchema(s));
+        const list = this.schemas.filter(s => this.canDragSchema(s));
+        // Keep the currently-referenced schema selectable even when it isn't in the
+        // draggable list, otherwise the dropdown value matches no option and shows blank.
+        const currentIri = this.selectedSubSchemaIri;
+        if (currentIri && !list.some(s => s.iri === currentIri)) {
+            const current = this.resolveRefSchema(currentIri);
+            if (current) { return [current, ...list]; }
+        }
+        return list;
     }
 
     public enterSubSchema(field: SchemaField, event: Event): void {
@@ -1562,7 +1577,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public getRefSchemaName(field: SchemaField): string {
         if (!field.isRef) { return ''; }
-        return this.schemas.find(s => s.iri === field.type)?.name || '';
+        return this.resolveRefSchema((field as any).type)?.name || '';
     }
 
     // ── Conditions ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Description

Align the new schema editor with Guardian's design system and fix several sub-schema issues surfaced during the pass.

- Restyle the editor to match the design system, adopting the reference radius, elevation scale, chip colours and prefix/postfix palette.
- Make the editor dark-theme safe by tokenizing dark-unsafe fills and icon colours.
- Swap bespoke controls to PrimeNG and refine the schema properties panel.
- Refine the field properties panel: use a colour picker and number input for help text style, tidy the enum value dropdowns, enlarge the value inputs, and unify fonts and labels.
- Align the general settings dropdowns with the schema properties styling.
- Use the blue selection tint for the selected type tile and field row so the fill matches the selection border.
- Populate the referenced schema dropdown and field-row badge for sub-schema fields, resolving the schema from the loaded schema's $defs when it is absent from the sidebar list.
- Show the sub-schema properties block when drilling into a sub-schema.
- Convert a plain field into a sub-schema from the type tile.
- Match the drilled fields/conditions tab bar background to the root schema.
