### PR TITLE
fix: align policy configurator toolbar

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -28,7 +28,10 @@
                 svgClass="icon-style-article action-color"></svg-icon>
             </div>
             <div class="policy-identity-text">
-              <span class="policy-identity-name">{{ policyTemplate.name || 'Untitled policy' }}</span>
+              <span #policyNameEl class="policy-identity-name"
+                [pTooltip]="policyTemplate.name || 'Untitled policy'"
+                [tooltipDisabled]="policyNameEl.scrollWidth <= policyNameEl.clientWidth"
+                tooltipPosition="bottom">{{ policyTemplate.name || 'Untitled policy' }}</span>
               <span class="policy-identity-meta">Policy details</span>
             </div>
             <i class="pi pi-chevron-down policy-identity-caret"></i>
@@ -84,7 +87,10 @@
                 svgClass="icon-style-policy-module action-color"></svg-icon>
             </div>
             <div class="policy-identity-text">
-              <span class="policy-identity-name">{{ moduleTemplate.name || 'Untitled module' }}</span>
+              <span #moduleNameEl class="policy-identity-name"
+                [pTooltip]="moduleTemplate.name || 'Untitled module'"
+                [tooltipDisabled]="moduleNameEl.scrollWidth <= moduleNameEl.clientWidth"
+                tooltipPosition="bottom">{{ moduleTemplate.name || 'Untitled module' }}</span>
               <span class="policy-identity-meta">Module details</span>
             </div>
             <i class="pi pi-chevron-down policy-identity-caret"></i>
@@ -115,7 +121,10 @@
                 svgClass="icon-style-handyman action-color tool-icon"></svg-icon>
             </div>
             <div class="policy-identity-text">
-              <span class="policy-identity-name">{{ toolTemplate.name || 'Untitled tool' }}</span>
+              <span #toolNameEl class="policy-identity-name"
+                [pTooltip]="toolTemplate.name || 'Untitled tool'"
+                [tooltipDisabled]="toolNameEl.scrollWidth <= toolNameEl.clientWidth"
+                tooltipPosition="bottom">{{ toolTemplate.name || 'Untitled tool' }}</span>
               <span class="policy-identity-meta">Tool details</span>
             </div>
             <i class="pi pi-chevron-down policy-identity-caret"></i>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -15,9 +15,13 @@
       <div class="top-toolbar">
         <!-- ============ LEFT ZONE: identity + status ============ -->
         @if (rootType === 'Policy') {
-          <div (click)="backToPolicies()" class="top-toolbar-btn icon-only all-status" title="Back">
-            <i class="pi pi-arrow-left"></i>
-          </div>
+          <nav class="pc-breadcrumb all-status">
+            <div (click)="backToPolicies()" class="pc-back-crumb" title="Back to policies">
+              <i class="pi pi-arrow-left"></i>
+            </div>
+            <a (click)="backToPolicies()" class="pc-crumb-link">Policies</a>
+            <i class="pi pi-chevron-right pc-breadcrumb-sep"></i>
+          </nav>
           <div (click)="identityMenu.toggle($event)" class="policy-identity all-status">
             <div class="policy-identity-icon">
               <svg-icon src="/assets/images/icons/article.svg"
@@ -59,16 +63,21 @@
             </div>
           }
           @if (policyTemplate.isRun) {
-            <div [routerLink]="['/policy-viewer', policyId]" class="top-toolbar-btn all-status">
-              <i class="pi pi-angle-double-right"></i>
-              <span>Go</span>
+            <div [routerLink]="['/policy-viewer', policyId]"
+              class="top-toolbar-btn top-toolbar-btn--primary all-status" title="Run">
+              <i class="pi pi-play"></i>
+              <span>Run</span>
             </div>
           }
         }
         @if (rootType === 'Module') {
-          <div (click)="backToModules()" class="top-toolbar-btn icon-only all-status" title="Back">
-            <i class="pi pi-arrow-left"></i>
-          </div>
+          <nav class="pc-breadcrumb all-status">
+            <div (click)="backToModules()" class="pc-back-crumb" title="Back to modules">
+              <i class="pi pi-arrow-left"></i>
+            </div>
+            <a (click)="backToModules()" class="pc-crumb-link">Modules</a>
+            <i class="pi pi-chevron-right pc-breadcrumb-sep"></i>
+          </nav>
           <div (click)="moduleIdentityMenu.toggle($event)" class="policy-identity all-status">
             <div class="policy-identity-icon">
               <svg-icon src="/assets/images/icons/policy-module.svg"
@@ -93,9 +102,13 @@
           }
         }
         @if (rootType === 'Tool') {
-          <div (click)="backToTools()" class="top-toolbar-btn icon-only all-status" title="Back">
-            <i class="pi pi-arrow-left"></i>
-          </div>
+          <nav class="pc-breadcrumb all-status">
+            <div (click)="backToTools()" class="pc-back-crumb" title="Back to tools">
+              <i class="pi pi-arrow-left"></i>
+            </div>
+            <a (click)="backToTools()" class="pc-crumb-link">Tools</a>
+            <i class="pi pi-chevron-right pc-breadcrumb-sep"></i>
+          </nav>
           <div (click)="toolIdentityMenu.toggle($event)" class="policy-identity all-status">
             <div class="policy-identity-icon">
               <svg-icon src="/assets/images/icons/handyman.svg"
@@ -129,7 +142,7 @@
 
         <div class="toolbar-spacer"></div>
 
-        <!-- ============ CENTER ZONE: view segment ============ -->
+        <!-- ============ RIGHT ZONE: view segment + actions ============ -->
         <div class="view-segment">
           <div class="view-segment-item" [class.active]="currentView == 'blocks'"
             (click)="onView('blocks')">Design</div>
@@ -139,9 +152,6 @@
             (click)="onView('yaml')">YAML</div>
         </div>
 
-        <div class="toolbar-spacer"></div>
-
-        <!-- ============ RIGHT ZONE: actions ============ -->
         @if (rootType === 'Policy') {
           <div (click)="toggleCommandPalette()" class="top-toolbar-btn icon-only all-status command-palette-btn"
             title="Command palette (⌘K)">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -594,14 +594,11 @@
     }
 
     .view-segment {
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
         display: flex;
         flex-direction: row;
         align-items: center;
         gap: 2px;
+        margin: 0 8px 0 2px;
         height: 36px;
         padding: 3px;
         border-radius: 10px;
@@ -626,10 +623,10 @@
             }
 
             &.active {
-                color: var(--color-primary, #4169e2);
+                color: var(--guardian-font-color, #23252e);
                 background: var(--guardian-background, #fff);
                 box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-                font-weight: 600;
+                font-weight: 500;
             }
         }
     }
@@ -694,6 +691,29 @@
 
         &[active="true"] {
             color: var(--pc-selected-btn-color);
+        }
+    }
+
+    .top-toolbar-btn.top-toolbar-btn--primary {
+        height: 32px;
+        padding: 0 14px;
+        color: #fff;
+        background: var(--color-primary, #4169e2);
+        border-color: var(--color-primary, #4169e2);
+
+        i {
+            font-size: 14px;
+            color: #fff;
+        }
+
+        span {
+            color: #fff;
+            font-weight: 600;
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--color-primary, #4169e2) 88%, #000);
+            border-color: color-mix(in srgb, var(--color-primary, #4169e2) 88%, #000);
         }
     }
 
@@ -2385,6 +2405,56 @@
     i,
     span {
         color: var(--pc-error-color);
+    }
+}
+
+.pc-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 2px;
+
+    .pc-back-crumb {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border: 1px solid var(--pc-border-color);
+        border-radius: 8px;
+        background: transparent;
+        color: var(--pc-no-active-color);
+        cursor: pointer;
+        flex-shrink: 0;
+        transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+        i {
+            font-size: 16px;
+        }
+
+        &:hover {
+            background: var(--guardian-hover, #f9f9fd);
+            color: var(--pc-text-color);
+        }
+    }
+
+    .pc-crumb-link {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--pc-no-active-color);
+        text-decoration: none;
+        cursor: pointer;
+        transition: color 0.15s ease;
+
+        &:hover {
+            color: var(--pc-text-color);
+        }
+    }
+
+    .pc-breadcrumb-sep {
+        flex: 0 0 auto;
+        font-size: 11px;
+        color: var(--pc-no-active-color);
     }
 }
 

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -2465,7 +2465,7 @@
     height: 44px;
     margin: 0 2px;
     padding: 0 10px;
-    max-width: 240px;
+    max-width: 360px;
     border: 1px solid transparent;
     border-radius: 8px;
     cursor: pointer;

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -703,11 +703,9 @@
 
         i {
             font-size: 14px;
-            color: #fff;
         }
 
         span {
-            color: #fff;
             font-weight: 600;
         }
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -49,8 +49,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 26px;
-    height: 26px;
+    width: 32px;
+    height: 32px;
     border-radius: var(--sc-radius-sm);
     border: 1px solid var(--guardian-border-color, #E1E7EF);
     background: var(--guardian-background, #fff);
@@ -59,7 +59,7 @@
     flex-shrink: 0;
     transition: all 0.15s;
 
-    i { font-size: 14px; }
+    i { font-size: 16px; }
 
     &:hover {
         background: var(--guardian-grey-background, #F9FAFC);


### PR DESCRIPTION
### Description
Align the policy configurator top toolbar with the schema editor and refine the policy identity block.

- Replace the back button with a schema-style breadcrumb while keeping the policy, module, and tool dropdown.
- Move the Design/JSON/YAML view switcher into the right-hand action group and unify its styling with the schema panel.
- Restyle the dry-run action as a primary Run button.
- Match the back button sizing across the policy and schema panels.
- Widen the policy details block to 360px and show a tooltip with the full name only when it is truncated.