### PR TITLE
feat: skip non-exposable blocks in policy API config

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
@@ -25,8 +25,9 @@ export class PolicyApiConfigDialogComponent {
     public validationErrors: Map<number, string> = new Map();
     public isLargeSize = true;
 
-    // Block types whose APIs should not be exposed externally and are therefore
-    // skipped by "Add all". Extend this list by adding another block type string.
+    // Block types whose APIs should not be exposed externally: excluded from the
+    // target dropdown and "Add all", and flagged invalid if present in imported
+    // entries. Extend this list by adding another block type string.
     private static readonly SKIPPED_BLOCK_TYPES: ReadonlySet<string> = new Set<string>([
         'informationBlock',
         'interfaceStepBlock',
@@ -34,6 +35,8 @@ export class PolicyApiConfigDialogComponent {
         'ipfsTransformationUIAddon',
         'transformationUIAddon',
         'httpRequestUIAddon',
+        'documentsSourceAddon',
+        'paginationAddon',
     ]);
 
     private static readonly POST_PARAMS: { name: string; type: string; description: string }[] = [

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-api-config-dialog/policy-api-config-dialog.component.ts
@@ -25,6 +25,17 @@ export class PolicyApiConfigDialogComponent {
     public validationErrors: Map<number, string> = new Map();
     public isLargeSize = true;
 
+    // Block types whose APIs should not be exposed externally and are therefore
+    // skipped by "Add all". Extend this list by adding another block type string.
+    private static readonly SKIPPED_BLOCK_TYPES: ReadonlySet<string> = new Set<string>([
+        'informationBlock',
+        'interfaceStepBlock',
+        'interfaceContainerBlock',
+        'ipfsTransformationUIAddon',
+        'transformationUIAddon',
+        'httpRequestUIAddon',
+    ]);
+
     private static readonly POST_PARAMS: { name: string; type: string; description: string }[] = [
         { name: 'timeout', type: 'number', description: 'Request timeout in ms (default: 60000)' },
         { name: 'waitRemotePolicy', type: 'boolean', description: 'Wait for remote policy response (default: true)' },
@@ -55,7 +66,9 @@ export class PolicyApiConfigDialogComponent {
         this.policyId = this.config.data?.policyId ?? '';
         this.blocks = this.config.data?.blocks ?? [];
         this.root = this.config.data?.root;
-        this.eligibleBlocks = this.blocks.filter((block: any) => this.isApiCapableBlock(block));
+        this.eligibleBlocks = this.blocks.filter(
+            (block: any) => this.isApiCapableBlock(block) && !this.isSkippedBlock(block)
+        );
         const existing: IPolicyDocumentationEntry[] = this.config.data?.entries ?? [];
         this.entries = existing.map((e) => ({ ...e }));
     }
@@ -165,6 +178,10 @@ export class PolicyApiConfigDialogComponent {
         return !!(about?.get || about?.post);
     }
 
+    private isSkippedBlock(block: any): boolean {
+        return PolicyApiConfigDialogComponent.SKIPPED_BLOCK_TYPES.has(block?.blockType);
+    }
+
     private getBlockAbout(block: any): IBlockAbout | null {
         return this.registeredService.getAbout(block, this.root);
     }
@@ -225,6 +242,9 @@ export class PolicyApiConfigDialogComponent {
         }
         if (!POLICY_ALIAS_REGEX.test(entry.alias)) {
             return "Alias: lowercase letters, digits, hyphens; use '/' to separate path segments";
+        }
+        if (block && this.isSkippedBlock(block)) {
+            return 'Selected block cannot be exposed via API';
         }
         if (!block || !about || (!about.get && !about.post)) {
             return 'Selected block does not support API aliases';


### PR DESCRIPTION
### Description

Add a block-type skip list to the policy API config dialog so blocks whose APIs must not be exposed externally are consistently excluded.

- Introduce a `SKIPPED_BLOCK_TYPES` set as a single, easily extended source of truth.
- Exclude skip-listed blocks from the target dropdown so they cannot be added manually.
- Exclude skip-listed blocks from "Add all".
- Flag imported or existing entries pointing at a skip-listed block as invalid.
- Seed the list with information, step, container, IPFS/transformation/HTTP UI addons, document source addon, and pagination addon.