### PR TITLE
fix: align grid status dropdown and tags column

### DIFF
--- a/frontend/src/app/modules/policy-engine/policies/policies.component.scss
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.scss
@@ -764,6 +764,10 @@
             font-style: normal;
             font-weight: 500;
         }
+
+        .p-select-label {
+            font-size: 14px;
+        }
     }
 
     &[published="true"] {

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.scss
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.scss
@@ -767,6 +767,8 @@
 
         .p-select-label {
             font-size: 14px;
+            padding-top: 4px;
+            padding-bottom: 4px;
         }
     }
 

--- a/frontend/src/app/modules/tag-engine/tags-explorer/tags-explorer.component.scss
+++ b/frontend/src/app/modules/tag-engine/tags-explorer/tags-explorer.component.scss
@@ -165,6 +165,7 @@
     display: flex;
     align-items: center;
     column-gap: 8px;
+    white-space: nowrap;
     background: var(--guardian-background, #FFF);
     cursor: pointer;
 }

--- a/frontend/src/app/themes/guardian/dropdown.scss
+++ b/frontend/src/app/themes/guardian/dropdown.scss
@@ -296,6 +296,8 @@
 .policy-status-select.guardian-status-select.p-select {
     width: 150px !important;
     min-width: 150px;
+    height: 32px !important;
+    min-height: 32px !important;
 }
 
 .guardian-dropdown-status.guardian-status-select.p-select {

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -161,7 +161,7 @@
               <tr class="guardian-grid-header">
                 @if (type === 'policy') {
                   @if (canDisplayColumn('select')) {
-                    <th class="header-cell-text" style="min-width: 140px; max-width: 150px;">
+                    <th class="header-cell-text" style="min-width: 64px; width: 64px; max-width: 64px;">
                       <p-checkbox
                         (onChange)="onSelectAllItems($event)"
                         [disabled]="isAnyDeleteDisabled()"
@@ -263,7 +263,7 @@
                   @if (!rowData.isParent) {
                     @if (type === 'policy') {
                       @if (canDisplayColumn('select')) {
-                        <td class="first-schema-grid-cell" style="min-width: 140px; max-width: 150px;">
+                        <td class="first-schema-grid-cell" style="min-width: 64px; width: 64px; max-width: 64px;">
                           <p-checkbox
                             (onChange)="onSelectItem(rowData)"
                             [disabled]="isDeleteDisabled(rowData)"

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -157,11 +157,41 @@
             class="guardian-grid-table"
             [scrollable]="true"
             >
+            <ng-template pTemplate="colgroup">
+              <colgroup>
+                @if (type === 'policy') {
+                  @if (canDisplayColumn('select')) {
+                    <col style="width: 54px;" />
+                  }
+                  <col />
+                  <col style="width: 112px;" />
+                  <col style="width: 85px;" />
+                  <col style="width: 100px;" />
+                  <col style="width: 185px;" />
+                  <col style="width: 100px;" />
+                  <col style="width: 140px;" />
+                  <col style="width: 110px;" />
+                }
+                @if (type === 'module') {
+                  <col style="width: 150px;" />
+                  <col style="width: 100px;" />
+                  <col style="width: 140px;" />
+                  <col style="width: 110px;" />
+                }
+                @if (type === 'tool') {
+                  <col style="width: 150px;" />
+                  <col style="width: 150px;" />
+                  <col style="width: 100px;" />
+                  <col style="width: 140px;" />
+                  <col style="width: 110px;" />
+                }
+              </colgroup>
+            </ng-template>
             <ng-template pTemplate="header">
               <tr class="guardian-grid-header">
                 @if (type === 'policy') {
                   @if (canDisplayColumn('select')) {
-                    <th class="header-cell-text" style="min-width: 64px; width: 64px; max-width: 64px;">
+                    <th class="header-cell-text">
                       <p-checkbox
                         (onChange)="onSelectAllItems($event)"
                         [disabled]="isAnyDeleteDisabled()"
@@ -263,7 +293,7 @@
                   @if (!rowData.isParent) {
                     @if (type === 'policy') {
                       @if (canDisplayColumn('select')) {
-                        <td class="first-schema-grid-cell" style="min-width: 64px; width: 64px; max-width: 64px;">
+                        <td class="first-schema-grid-cell">
                           <p-checkbox
                             (onChange)="onSelectItem(rowData)"
                             [disabled]="isDeleteDisabled(rowData)"

--- a/frontend/src/app/views/schemas/schemas.component.scss
+++ b/frontend/src/app/views/schemas/schemas.component.scss
@@ -818,6 +818,15 @@ a {
     }
 
     ::ng-deep .guardian-grid-table {
+        // Reserve the vertical scrollbar gutter on both the header and the
+        // body so their tables keep identical content widths and the columns
+        // stay aligned (the CSS max-height below scrolls the body without
+        // triggering PrimeNG's own scrollbar compensation).
+        .p-treetable-scrollable-header,
+        .p-treetable-scrollable-body {
+            scrollbar-gutter: stable;
+        }
+
         .p-treetable-scrollable-body {
             max-height: calc(100vh - var(--header-height) - 435px);
         }


### PR DESCRIPTION
### Description

Adjust styling on the Manage Policies and Schemas grids so their elements line up with the rest of the grid.

- Shrink the policy status dropdown text and reduce its height so it matches the grid font instead of PrimeNG's larger default.
- Add a colgroup to the schemas treetable so the header and body share fixed column widths, narrow the select (checkbox) column, and let the Name column take the freed space.
- Reduce the Topic and Version column widths.
- Reserve the scrollbar gutter on the schemas header and body so their columns stay aligned.
- Keep the Create a Tag button label on a single line in the tags column.