### PR TITLE
feat: make Mock Data opt-in for Dry-Run and harden MockHelper

### DIFF
--- a/common/src/helpers/mock-service.ts
+++ b/common/src/helpers/mock-service.ts
@@ -157,7 +157,7 @@ export class MockHelper {
         if (event.type === MockType.API) {
             return await MockHelper.api(event.mockId, event.data);
         }
-        throw new Error('Invalid method');
+        throw new Error('Invalid Mock method');
     }
 
     public static getBuffer(content: Buffer<ArrayBufferLike>): string {
@@ -183,7 +183,7 @@ export class MockHelper {
         if (row && row.document) {
             return row.document;
         } else {
-            throw new Error('Invalid cid');
+            throw new Error('Invalid CID');
         }
     }
 
@@ -256,7 +256,7 @@ export class MockHelper {
         sequence_number: string;
         topicId: string;
         message: string;
-    }> {
+    } | null> {
         if (params.timeStamp) {
             const row = await DatabaseServer.getMock(mockId, MockEntityType.MESSAGE, {
                 'transaction.consensus_timestamp': params.timeStamp
@@ -279,6 +279,7 @@ export class MockHelper {
                 return null;
             }
         }
+        return null;
     }
 
     private static async getHederaMessages(
@@ -291,7 +292,7 @@ export class MockHelper {
         sequence_number: string;
         topicId: string;
         message: string;
-    }[]> {
+    }[] | null> {
         let result: any[];
         if (params.startTimestamp) {
             let rows = await DatabaseServer.getMocks(mockId, MockEntityType.MESSAGE, {
@@ -327,7 +328,7 @@ export class MockHelper {
         });
 
         if (!row) {
-            throw new Error('Response not found');
+            throw new Error('Mocked response was not found');
         }
 
         if (row.request.responseType === 'JSON') {
@@ -359,7 +360,7 @@ export class MockHelper {
         accountId: string,
         transaction: Transaction
     ): {
-        type: MockEntityType,
+        type: MockEntityType | null,
         transaction: any
     } {
         if (type === 'TokenCreateTransaction') {
@@ -370,7 +371,7 @@ export class MockHelper {
             const name = t.tokenName;
             const symbol = t.tokenSymbol;
             const tokenType = t.tokenType === TokenType.FungibleCommon ? 'FUNGIBLE_COMMON' : 'NON_FUNGIBLE_UNIQUE';
-            const decimals = t.decimals.toInt();
+            const decimals = t.decimals?.toInt();
             const adminKey = !!t.adminKey;
             const supplyKey = !!t.supplyKey;
             const freezeKey = !!t.freezeKey;
@@ -500,8 +501,9 @@ export class MockHelper {
             const t = transaction as TopicMessageSubmitTransaction;
             const timestamp = MockHelper.getTimestamp();
             const consensusTimestamp = MockHelper.timestampToString(timestamp);
-            const topicId = t.topicId.toString();
-            const message = t.getMessage().toString();
+            const topicId = t.topicId?.toString();
+            const messageBytes = t.getMessage();
+            const message = messageBytes ? Buffer.from(messageBytes).toString('utf8') : '';
             const base64 = Buffer.from(message, 'utf8').toString('base64');
 
             return {
@@ -581,7 +583,9 @@ export class MockHelper {
 
         for (const row of rows) {
             if (row.type === MockEntityType.FILE) {
-                ipfsMap.set(row.cid, row.document);
+                if (row.cid) {
+                    ipfsMap.set(row.cid, row.document);
+                }
             } else if (row.type === MockEntityType.TOPIC) {
                 const transaction = row.transaction;
                 const topic = topicMap.get(transaction.topic_id);
@@ -603,7 +607,7 @@ export class MockHelper {
                 const transaction = row.transaction;
                 tokenMap.set(transaction.token_id, row.transaction);
             } else if (row.type === MockEntityType.ACCOUNT) {
-                return null;
+                continue;
             } else if (row.type === MockEntityType.API) {
                 const request = row.request;
                 const response = row.response;
@@ -638,7 +642,7 @@ export class MockHelper {
             api.push(config);
         }
 
-        const userRows = await DatabaseServer.getVirtualUsers(mockId, null, true, true);
+        const userRows = await DatabaseServer.getVirtualUsers(mockId, undefined, true, true);
         const users: any[] = [];
         for (const user of userRows) {
             if (user.username !== 'Administrator') {

--- a/common/src/helpers/mock-service.ts
+++ b/common/src/helpers/mock-service.ts
@@ -557,14 +557,14 @@ export class MockHelper {
         return new TopicId(i);
     }
 
-    private static stringToTokenId(id: string): AccountId {
-        const i = Number(id.split('.')[2]);
-        return new AccountId(i);
-    }
-
-    private static stringToAccountId(id: string): TokenId {
+    private static stringToTokenId(id: string): TokenId {
         const i = Number(id.split('.')[2]);
         return new TokenId(i);
+    }
+
+    private static stringToAccountId(id: string): AccountId {
+        const i = Number(id.split('.')[2]);
+        return new AccountId(i);
     }
 
     public static async getMockData(mockId: string): Promise<{

--- a/common/src/helpers/mock-service.ts
+++ b/common/src/helpers/mock-service.ts
@@ -796,6 +796,10 @@ export class MockHelper {
                 row.transaction.message = encodedJson;
 
                 const file = await DatabaseServer.getMock(mockId, MockEntityType.FILE, { cid: contextCid });
+                if (!file) {
+                    console.error(`replaceSchema: context file not found for CID "${contextCid}"`);
+                    return;
+                }
                 file.cid = dryRunCid;
                 await DatabaseServer.updateMock(file);
 

--- a/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.html
@@ -1,0 +1,58 @@
+<div class="dialog-header">
+  <div class="header-container">
+    <div class="header-text">Move to Dry-Run</div>
+  </div>
+  <div class="header-icon" (click)="onCancel()">
+    <svg-icon src="/assets/images/icons/close.svg" svgClass="icon-color-close"></svg-icon>
+  </div>
+</div>
+
+<div class="dialog-body">
+  <div class="intro-text">
+    Dry-Run lets you test the policy in an isolated environment. Turn on Mock Data to
+    intercept all external calls (IPFS, Topics, Tokens, API) and return pre-recorded
+    responses instead of hitting the real network.
+  </div>
+
+  <label class="mock-option">
+    <p-checkbox
+      class="guardian-checkbox checkbox-24"
+      [(ngModel)]="enableMock"
+      [binary]="true"></p-checkbox>
+    <div class="mock-option-text">
+      <div class="mock-option-title">Enable Mock Data</div>
+      <div class="mock-option-sub">
+        Pre-records a response for every schema – moving to Dry-Run may take several minutes.
+      </div>
+    </div>
+  </label>
+
+  <div class="mock-hint">
+    <svg-icon src="/assets/images/icons/info.svg" svgClass="icon-color-info"></svg-icon>
+    <span>
+      You can enable or configure Mock Data anytime later from the 'Mock Config' panel in the policy viewer.
+    </span>
+  </div>
+</div>
+
+<div class="dialog-footer">
+  <label class="mute-option">
+    <p-checkbox
+      class="guardian-checkbox checkbox-24"
+      [(ngModel)]="dontAskAgain"
+      [binary]="true"></p-checkbox>
+    <span>Don't ask again for this policy</span>
+  </label>
+  <div class="action-buttons">
+    <div class="dialog-button">
+      <button
+        (click)="onCancel()"
+      class="guardian-button guardian-button-secondary">Cancel</button>
+    </div>
+    <div class="dialog-button dialog-button-wide">
+      <button
+        (click)="onStart()"
+      class="guardian-button guardian-button-primary">Start Dry-Run</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.scss
@@ -1,0 +1,104 @@
+.dialog-body {
+    position: relative;
+    padding: 14px 0 8px 0;
+    font-family: Inter, sans-serif;
+    font-style: normal;
+}
+
+.intro-text {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    color: var(--guardian-font-color, #23252E);
+}
+
+.mock-option {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 12px;
+    margin-top: 20px;
+    padding: 12px 14px;
+    border: 1px solid var(--guardian-border-color, #E1E7EF);
+    border-radius: 8px;
+    cursor: pointer;
+
+    .mock-option-text {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .mock-option-title {
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 18px;
+        color: var(--guardian-font-color, #23252E);
+    }
+
+    .mock-option-sub {
+        font-size: 13px;
+        font-weight: 400;
+        line-height: 16px;
+        color: var(--color-grey-5, #848FA9);
+        padding-top: 4px;
+    }
+}
+
+.mock-hint {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 12px;
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 16px;
+    color: var(--color-grey-5, #848FA9);
+
+    svg-icon {
+        flex-shrink: 0;
+        line-height: 0;
+    }
+}
+
+.dialog-footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 24px;
+}
+
+.mute-option {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--guardian-font-color, #23252E);
+
+    ::ng-deep .p-checkbox {
+        display: flex;
+        align-items: center;
+    }
+
+    span {
+        line-height: 24px;
+    }
+}
+
+.action-buttons {
+    user-select: none;
+
+    .dialog-button-wide button {
+        min-width: 150px;
+    }
+}
+
+.icon-color-info {
+    fill: var(--color-grey-5, #848FA9);
+    color: var(--color-grey-5, #848FA9);
+}

--- a/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.ts
@@ -1,0 +1,71 @@
+import { Component } from '@angular/core';
+import { DialogService, DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { DryRunSettings } from '../../structures/storage/dry-run-settings';
+
+export interface DryRunDialogResult {
+    enableMock: boolean;
+    dontAskAgain: boolean;
+}
+
+@Component({
+    selector: 'dry-run-dialog',
+    templateUrl: './dry-run-dialog.component.html',
+    styleUrls: ['./dry-run-dialog.component.scss'],
+    standalone: false
+})
+export class DryRunDialog {
+    public enableMock = false;
+    public dontAskAgain = false;
+
+    constructor(
+        public ref: DynamicDialogRef,
+        public config: DynamicDialogConfig
+    ) {
+    }
+
+    public onCancel(): void {
+        this.ref.close(null);
+    }
+
+    public onStart(): void {
+        this.ref.close({
+            enableMock: this.enableMock,
+            dontAskAgain: this.dontAskAgain
+        });
+    }
+}
+
+/**
+ * Ask whether to move a policy to Dry-Run with Mock Data enabled.
+ * Emits the chosen setting when the user proceeds, or null when they cancel.
+ * When the policy has muted the prompt, resolves immediately without mock.
+ */
+export function confirmDryRun(
+    dialogService: DialogService,
+    policyId: string
+): Observable<{ enableMock: boolean } | null> {
+    if (DryRunSettings.skipMockPrompt(policyId)) {
+        return of({ enableMock: false });
+    }
+    const dialogRef = dialogService.open(DryRunDialog, {
+        showHeader: false,
+        width: '640px',
+        styleClass: 'guardian-dialog',
+    });
+    if (!dialogRef) {
+        return of(null);
+    }
+    return dialogRef.onClose.pipe(
+        map((result: DryRunDialogResult | null) => {
+            if (!result) {
+                return null;
+            }
+            if (result.dontAskAgain) {
+                DryRunSettings.muteMockPrompt(policyId);
+            }
+            return { enableMock: result.enableMock };
+        })
+    );
+}

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -54,6 +54,7 @@ import { IndexedDbRegistryService } from 'src/app/services/indexed-db-registry.s
 import { DB_NAME, STORES_NAME } from 'src/app/constants';
 import { UserPolicyDialog } from '../dialogs/user-policy-dialog/user-policy-dialog.component';
 import { CustomConfirmDialogComponent } from '../../common/custom-confirm-dialog/custom-confirm-dialog.component';
+import { confirmDryRun } from '../dialogs/dry-run-dialog/dry-run-dialog.component';
 import { ExternalPoliciesService } from 'src/app/services/external-policy.service';
 
 class MenuButton {
@@ -944,35 +945,21 @@ export class PoliciesComponent implements OnInit {
     }
 
     private dryRun(element: any) {
-        const dialogRef = this.dialogService.open(CustomConfirmDialogComponent, {
-            showHeader: false,
-            width: '640px',
-            styleClass: 'guardian-dialog',
-            data: {
-                header: 'Enable Mock',
-                texts: [
-                    `Mock Data intercepts all external service calls (IPFS, Topics, Tokens, and API requests) and returns pre-configured test responses instead of making real network calls. This lets you run and test your policy in a fully self-contained offline environment.`,
-                    `You can change this setting and configure individual blocks at any time from the 'Mock Config' panel.`,
-                    `Note: enabling Mock pre-records responses for every schema in the policy, so moving to Dry-Run may take several minutes.`
-                ],
-                buttons: [{
-                    name: 'Disable',
-                    class: 'secondary'
-                }, {
-                    name: 'Enable',
-                    class: 'primary'
-                }]
-            },
-        });
+        confirmDryRun(this.dialogService, element.id)
+            .pipe(takeUntil(this._destroy$))
+            .subscribe((choice) => {
+                if (choice) {
+                    this.executeDryRun(element, choice.enableMock);
+                }
+            });
+    }
 
-        dialogRef?.onClose.pipe(takeUntil(this._destroy$)).subscribe((result: string) => {
-            this.loading = true;
-            this.policyEngineService
-                .dryRun(element.id, {
-                    enableMock: result === 'Enable'
-                })
-                .pipe(takeUntil(this._destroy$))
-                .subscribe(
+    private executeDryRun(element: any, enableMock: boolean) {
+        this.loading = true;
+        this.policyEngineService
+            .dryRun(element.id, { enableMock })
+            .pipe(takeUntil(this._destroy$))
+            .subscribe(
                     (data: any) => {
                         const { policies, isValid, errors } = data;
                         if (!isValid) {
@@ -1012,7 +999,6 @@ export class PoliciesComponent implements OnInit {
                         this.loading = false;
                     }
                 );
-        });
     }
 
     private draft(element: any) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -34,6 +34,7 @@ import { PolicyTreeComponent } from '../policy-tree/policy-tree.component';
 import { catchError, takeUntil, tap } from 'rxjs/operators';
 import { TestCodeDialog } from '../../dialogs/test-code-dialog/test-code-dialog.component';
 import { CustomConfirmDialogComponent } from 'src/app/modules/common/custom-confirm-dialog/custom-confirm-dialog.component';
+import { confirmDryRun } from '../../dialogs/dry-run-dialog/dry-run-dialog.component';
 import { IndexedDbRegistryService } from 'src/app/services/indexed-db-registry.service';
 import { DB_NAME, STORES_NAME } from 'src/app/constants';
 import { IgnoreRule } from '@guardian/interfaces';
@@ -1293,51 +1294,37 @@ export class PolicyConfigurationComponent implements OnInit {
     }
 
     private dryRunPolicy() {
-        const dialogRef = this.dialogService.open(CustomConfirmDialogComponent, {
-            showHeader: false,
-            width: '640px',
-            styleClass: 'guardian-dialog',
-            data: {
-                header: 'Enable Mock',
-                texts: [
-                    `Mock Data intercepts all external service calls (IPFS, Topics, Tokens, and API requests) and returns pre-configured test responses instead of making real network calls. This lets you run and test your policy in a fully self-contained offline environment.`,
-                    `You can change this setting and configure individual blocks at any time from the 'Mock Config' panel.`,
-                    `Note: enabling Mock pre-records responses for every schema in the policy, so moving to Dry-Run may take several minutes.`
-                ],
-                buttons: [{
-                    name: 'Disable',
-                    class: 'secondary'
-                }, {
-                    name: 'Enable',
-                    class: 'primary'
-                }]
-            },
-        })!;
-        dialogRef.onClose.pipe(takeUntil(this._destroy$)).subscribe((result: string) => {
-            this.loading = true;
-            this.policyEngineService
-                .dryRun(this.policyId, {
-                    enableMock: result === 'Enable'
-                })
-                .pipe(takeUntil(this._destroy$))
-                .subscribe((data: any) => {
-                    const { policies, isValid, errors } = data;
-                    if (isValid) {
-                        this.clearState();
-                        this.loadData();
-                    } else {
-                        this.setErrors(errors, 'policy');
+        confirmDryRun(this.dialogService, this.policyId)
+            .pipe(takeUntil(this._destroy$))
+            .subscribe((choice) => {
+                if (choice) {
+                    this.executeDryRun(choice.enableMock);
+                }
+            });
+    }
 
-                        this.emptyWarningsStates()
-                        this.emptyInfosStates()
+    private executeDryRun(enableMock: boolean) {
+        this.loading = true;
+        this.policyEngineService
+            .dryRun(this.policyId, { enableMock })
+            .pipe(takeUntil(this._destroy$))
+            .subscribe((data: any) => {
+                const { policies, isValid, errors } = data;
+                if (isValid) {
+                    this.clearState();
+                    this.loadData();
+                } else {
+                    this.setErrors(errors, 'policy');
 
-                        this.loading = false;
-                    }
-                }, (e) => {
-                    console.error(e.error);
+                    this.emptyWarningsStates()
+                    this.emptyInfosStates()
+
                     this.loading = false;
-                });
-        });
+                }
+            }, (e) => {
+                console.error(e.error);
+                this.loading = false;
+            });
     }
 
     private updatePolicyTemplate(policy: any) {

--- a/frontend/src/app/modules/policy-engine/policy-engine.module.ts
+++ b/frontend/src/app/modules/policy-engine/policy-engine.module.ts
@@ -189,6 +189,7 @@ import { PolicyParameterPropertyComponent } from 'src/app/components/policy-para
 import { PolicyParametersConfigDialog } from './dialogs/policy-parameters-config-dialog/policy-parameters-config-dialog.component';
 import { ParameterDocumentPathComponent } from './helpers/parameter-document-path/parameter-document-path.component';
 import { MockDialog } from './dialogs/mock-dialog/mock-dialog.component';
+import { DryRunDialog } from './dialogs/dry-run-dialog/dry-run-dialog.component';
 import { PolicyTestAutomationPopupComponent } from './policy-viewer/policy-test-automation/policy-test-automation-popup.component';
 
 @NgModule({
@@ -334,6 +335,7 @@ import { PolicyTestAutomationPopupComponent } from './policy-viewer/policy-test-
         PolicyParameterPropertyComponent,
         ParameterDocumentPathComponent,
         MockDialog,
+        DryRunDialog,
         PolicyTestAutomationPopupComponent
     ],
     imports: [

--- a/frontend/src/app/modules/policy-engine/structures/storage/dry-run-settings.ts
+++ b/frontend/src/app/modules/policy-engine/structures/storage/dry-run-settings.ts
@@ -1,0 +1,19 @@
+import { BooleanProperty } from './boolean-prop';
+
+const SKIP_MOCK_PROMPT_PREFIX = 'DRY_RUN_SKIP_MOCK_PROMPT:';
+
+export class DryRunSettings {
+    public static skipMockPrompt(policyId: string): boolean {
+        if (!policyId) {
+            return false;
+        }
+        return new BooleanProperty(SKIP_MOCK_PROMPT_PREFIX + policyId, false).load();
+    }
+
+    public static muteMockPrompt(policyId: string): void {
+        if (!policyId) {
+            return;
+        }
+        new BooleanProperty(SKIP_MOCK_PROMPT_PREFIX + policyId, true).save();
+    }
+}


### PR DESCRIPTION
### Description

Make Mock Data opt-in when moving a policy to Dry-Run, and harden the mock service that backs it.

- Replace the forced "Enable Mock" dialog with a "Move to Dry-Run" dialog where Mock Data is an opt-in checkbox, and closing the dialog cancels instead of starting Dry-Run.
- Add a per-policy "don't ask again" option (persisted in localStorage) that skips the prompt and starts Dry-Run without mock; Mock Data can still be enabled later from the Mock Config panel.
- Tighten null/undefined handling and clarify error messages in MockHelper to reduce runtime exceptions when fields are missing.
- Correct swapped TokenId/AccountId conversion in transaction deserialization.
- Guard against a missing context file in replaceSchema.
- Pass undefined instead of null to DatabaseServer.getVirtualUsers.


Closes #6528
