### PR TITLE
fix: remove duplicate getSchemaById declaration

### DIFF
--- a/frontend/src/app/services/schema.service.ts
+++ b/frontend/src/app/services/schema.service.ts
@@ -136,10 +136,6 @@ export class SchemaService {
         return this.http.get<any>(`${this.url}`, { observe: 'response', headers: headersV2, params });
     }
 
-    public getSchemaById(id: string): Observable<ISchema> {
-        return this.http.get<ISchema>(`${this.singleSchemaUrl}/${id}`);
-    }
-
     public getSchemasByType(type: string): Observable<ISchema> {
         return this.http.get<ISchema>(`${this.url}/type/${type}`);
     }


### PR DESCRIPTION
### Description

The schema service declared `getSchemaById` twice with identical bodies, which broke the production build with TS2393 "Duplicate function implementation".

- Remove the redundant second `getSchemaById` declaration.
- Keep the declaration grouped with the id-cache resolver.
- Confirm `ng build` produces the bundle with exit 0.