### PR TITLE
fix: analytics UI layout and status dropdown

### DIFF
--- a/frontend/src/app/modules/analytics/search-policy-dialog/search-policy-dialog.component.scss
+++ b/frontend/src/app/modules/analytics/search-policy-dialog/search-policy-dialog.component.scss
@@ -23,9 +23,7 @@
     height: 100%;
 
     .icon-btn {
-        position: relative;
-        left: 18px;
-        top: 1px;    
+        margin-right: 8px;
         overflow: visible;
     }
 

--- a/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.html
+++ b/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.html
@@ -256,7 +256,7 @@
                 @if (showStatus(tool)) {
                   <p-select
                     class="status-actions-dropdown {{tool.status}}-dropdown"
-                    styleClass="guardian-status-select"
+                    styleClass="guardian-status-select tool-status-select"
                     appendTo="body"
                     tooltipPosition="bottom"
                     [attr.published]="tool.status == 'PUBLISH'"

--- a/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.scss
+++ b/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.scss
@@ -809,6 +809,12 @@
             font-style: normal;
             font-weight: 500;
         }
+
+        .p-select-label {
+            font-size: 14px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+        }
     }
 
     &[published="true"] {

--- a/frontend/src/app/themes/guardian/dropdown.scss
+++ b/frontend/src/app/themes/guardian/dropdown.scss
@@ -300,6 +300,11 @@
     min-height: 32px !important;
 }
 
+.tool-status-select.guardian-status-select.p-select {
+    height: 32px !important;
+    min-height: 32px !important;
+}
+
 .guardian-dropdown-status.guardian-status-select.p-select {
     width: 140px;
 }

--- a/frontend/src/app/views/suggestions-configuration/suggestions-configuration.component.html
+++ b/frontend/src/app/views/suggestions-configuration/suggestions-configuration.component.html
@@ -31,7 +31,7 @@
             <span cdkDragHandle class="re-order-handler">
               <i class="pi pi-equals"></i>
             </span>
-            <span>{{ item.name }}</span>
+            <span class="item-name" [title]="item.name">{{ item.name }}</span>
             <span (click)="move(item)" class="move-right-btn">
               <i class="pi  pi-arrow-right"></i>
             </span>
@@ -49,7 +49,7 @@
             <span cdkDragHandle class="re-order-handler">
               <i class="pi pi-equals"></i>
             </span>
-            <span>{{ item.name }}</span>
+            <span class="item-name" [title]="item.name">{{ item.name }}</span>
             <span (click)="remove(item)" class="delete-btn">
               <i class="pi pi-trash"></i>
             </span>

--- a/frontend/src/app/views/suggestions-configuration/suggestions-configuration.component.scss
+++ b/frontend/src/app/views/suggestions-configuration/suggestions-configuration.component.scss
@@ -45,7 +45,7 @@
     }
 
     .color-blue {
-      background: #EAEEF8;
+      background: #E8EFFF;
     }
 
     .color-green {
@@ -98,20 +98,46 @@
       .item {
         display: flex;
         align-items: center;
-        justify-content: center;
+        justify-content: flex-start;
         width: 100%;
         height: 48px;
+        padding: 0 12px;
+        column-gap: 8px;
+        box-sizing: border-box;
         border-radius: 8px;
         border: 1px solid var(--color-grey-5, #C4D0E1);
         box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.04);
-      }
 
-      .module {
-        background: #F2FDF5;
-      }
+        &[type="Module"] {
+          background: #F2FDF5;
+        }
 
-      .policy {
-        background: #E8EFFF;
+        &[type="Policy"] {
+          background: #E8EFFF;
+        }
+
+        .re-order-handler {
+          flex: 0 0 auto;
+          display: flex;
+          align-items: center;
+          cursor: move;
+        }
+
+        .item-name {
+          flex: 1 1 auto;
+          min-width: 0;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+
+        .move-right-btn,
+        .delete-btn {
+          flex: 0 0 auto;
+          display: flex;
+          align-items: center;
+          cursor: pointer;
+        }
       }
         }
     }


### PR DESCRIPTION
### Description

Fix several analytics and policy-engine UI layout issues.

- Space the search dialog Filters button icon away from its label so they no longer overlap.
- Match the Tools grid status dropdown font size and row height to the Policies grid.
- Align each suggestion item so the drag handle is on the left, the name truncates in the middle, and the action button is on the right.
- Restore the suggestion item background colors by targeting the `type` attribute instead of unused class selectors, and align the legend swatch to the item color.