### PR TITLE
perf(policy): run dry-run mock file uploads in-process

### DIFF
--- a/common/src/hedera-modules/message/message-server.ts
+++ b/common/src/hedera-modules/message/message-server.ts
@@ -1,6 +1,6 @@
 import { AccountId, PrivateKey, TopicId, } from '@hiero-ledger/sdk';
 import { GenerateUUIDv4, ISignOptions, SignType, WorkerTaskType } from '@guardian/interfaces';
-import { IPFS, IPFSOptions, PinoLogger, Workers } from '../../helpers/index.js';
+import { IPFS, IPFSOptions, MockEntityType, MockHelper, MockType, PinoLogger, Workers } from '../../helpers/index.js';
 import { TransactionLogger } from '../transaction-logger.js';
 import { Environment } from '../environment.js';
 import { MessageMemo } from '../memo-mappings/message-memo.js';
@@ -313,6 +313,19 @@ export class MessageServer {
             }
             await new TransactionLogger().virtualFileLog(this.dryRun, file, result);
             return result
+        } else if (this.dryRun && options.mockId) {
+            // Dry-run mock ADD_FILE: run it in-process instead of a worker round-trip.
+            // The worker's mock path only forwards the file to MockHelper.execute (generate a
+            // cid + saveMock the content so a later dry-run GET_FILE reads it back) via a
+            // MOCK_EVENT_EXECUTE message - nothing there needs the worker. Calling MockHelper
+            // directly removes two broker round-trips per file, which dominate the dry-run
+            // switch for schema-heavy policies.
+            const cid = await MockHelper.execute({
+                mockId: options.mockId,
+                type: MockType.ADD_FILE,
+                data: { type: MockEntityType.FILE, content: MockHelper.getBuffer(file) }
+            });
+            return { cid, url: IPFS.IPFS_PROTOCOL + cid };
         } else {
             // <-- Steps
             const STEP_SEND_FILE = 'Send file';


### PR DESCRIPTION
## Problem

In dry-run with mock enabled, `MessageServer.addFile` dispatches every file "upload" to `worker-service` as an `ADD_FILE` task. But the worker's mock path does nothing that needs the worker - it just forwards the file to `MockHelper.execute`, which generates a cid and `saveMock`s the content so a later dry-run `GET_FILE` can read it back. That forwarding is itself a `MOCK_EVENT_EXECUTE` message handled back in `guardian-service`.

A dry-run switch runs this **once per schema**, so for a schema-heavy methodology policy it happens hundreds to thousands of times - each being **two broker round-trips** (worker submission + `MOCK_EVENT_EXECUTE`). This serial chain dominates the dry-run switch time.

## Change

For the `dryRun && mockId` case, call `MockHelper.execute` **in-process** instead of round-tripping through the worker:

```ts
} else if (this.dryRun && options.mockId) {
    const cid = await MockHelper.execute({
        mockId: options.mockId,
        type: MockType.ADD_FILE,
        data: { type: MockEntityType.FILE, content: MockHelper.getBuffer(file) }
    });
    return { cid, url: IPFS.IPFS_PROTOCOL + cid };
}
```

This is exactly what the worker's mock path and the `MOCK_EVENT_EXECUTE` handler already do (`const result = await MockHelper.execute(event)`), so the resulting mock DB state is identical - it just removes the two broker round-trips per file.

## Scope / safety

- Only the `dryRun && mockId` path changes. Real (non-dry-run) uploads still go through the worker/IPFS unchanged, and the existing `dryRun && !mockId` virtual-file path is untouched.
- `MockHelper` is DB-backed (`saveMock`/`getFile`) with no in-memory state, so executing it in the caller's process (which has DB access) yields the same result as the centralized `MOCK_EVENT_EXECUTE` handler.

## Effect

Removes the per-file worker round-trips during dry-run switches, which for large policies also eliminates the associated queue pressure and payload traffic to `worker-service`.