### PR TITLE
fix: never approve a partially imported external policy

### DIFF
--- a/guardian-service/src/api/external-policies.service.ts
+++ b/guardian-service/src/api/external-policies.service.ts
@@ -98,6 +98,36 @@ async function preparePolicyPreviewMessage(
     return policyToImport;
 }
 
+/**
+ * Remove a VIEW policy left behind by a failed import.
+ * Best-effort: a rollback failure must not mask the original import error.
+ */
+async function rollbackPartialViewPolicy(
+    policy: any,
+    owner: IOwner,
+    logger: PinoLogger,
+    userId: string | null
+): Promise<void> {
+    if (!policy?.id) {
+        return;
+    }
+    try {
+        const policyEngine = new PolicyEngine(logger);
+        await policyEngine.deleteViewPolicy(policy, owner, NewNotifier.empty(), logger);
+        await logger.info(
+            `Rolled back partially imported view policy ${policy.id}`,
+            ['GUARDIAN_SERVICE'],
+            userId
+        );
+    } catch (error) {
+        await logger.error(
+            `Failed to roll back partially imported view policy ${policy.id}: ${error?.message || error}`,
+            ['GUARDIAN_SERVICE'],
+            userId
+        );
+    }
+}
+
 async function addPolicy(
     messageId: string,
     owner: IOwner,
@@ -148,6 +178,12 @@ async function addPolicy(
         const message = PolicyImportExportHelper.errorsMessage(result.errors);
         notifier.fail(message);
         await logger.warn(message, ['GUARDIAN_SERVICE'], userId);
+
+        // importPolicy persists the policy before it evaluates errors, so a
+        // failed tool/schema closure leaves a VIEW policy that can never
+        // generate ('Can not find schema with IRI'), with no retry path.
+        // Drop the partial row so a re-approve can import cleanly.
+        await rollbackPartialViewPolicy(result.policy, owner, logger, userId);
 
         return result;
     }
@@ -275,6 +311,14 @@ export async function externalPoliciesAPI(logger: PinoLogger): Promise<void> {
                 if (!policy) {
                     const result = await addPolicy(messageId, owner, logger, notifier, owner?.id);
                     errors = result.errors;
+                    // Do not approve a policy that did not fully import. Marking
+                    // it APPROVED anyway records a broken policy as a success and
+                    // hides the failure from the user entirely.
+                    if (errors?.length) {
+                        const message = PolicyImportExportHelper.errorsMessage(errors);
+                        notifier.result({ id: messageId, errors });
+                        return new MessageError(`Failed to import policy: ${message}`);
+                    }
                     policy = await DatabaseServer.getPolicy({ messageId });
                 }
 
@@ -326,6 +370,13 @@ export async function externalPoliciesAPI(logger: PinoLogger): Promise<void> {
                     if (!policy) {
                         const result = await addPolicy(messageId, owner, logger, notifier, owner?.id);
                         errors = result.errors;
+                        // See the sync handler - a partial import must not be
+                        // recorded as an approval.
+                        if (errors?.length) {
+                            const message = PolicyImportExportHelper.errorsMessage(errors);
+                            notifier.result({ id: messageId, errors });
+                            throw new Error(`Failed to import policy: ${message}`);
+                        }
                         policy = await DatabaseServer.getPolicy({ messageId });
                     }
 

--- a/guardian-service/src/helpers/import-helpers/policy/policy-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import-helper.ts
@@ -155,13 +155,19 @@ export class PolicyImportExportHelper {
         const schemas: string[] = [];
         const tools: string[] = [];
         const others: string[] = []
+        // Carry the cause into the message, not just the component name. This
+        // string is what an operator sees (it becomes the MessageError returned
+        // to the API); name-only turned every failure into an indistinguishable
+        // 'tools: ["X"]' regardless of whether the package 404'd, timed out or
+        // was rejected.
+        const label = (e: ImportPolicyError): string => (e?.error ? `${e.name}: ${e.error}` : e?.name);
         for (const e of errors) {
             if (e.type === 'schema') {
-                schemas.push(e.name);
+                schemas.push(label(e));
             } else if (e.type === 'tool') {
-                tools.push(e.name);
+                tools.push(label(e));
             } else {
-                others.push(e.name);
+                others.push(label(e));
             }
         }
         let message: string = 'Failed to import components:';

--- a/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
@@ -52,11 +52,14 @@ export async function importSubTools(
             }
             index++;
         } catch (error) {
+            // Keep the underlying cause. Flattening every failure to 'Invalid
+            // tool' makes a transient IPFS/Hedera error undiagnosable - the real
+            // status only survives as an unattributed worker log line.
             errors.push({
                 type: 'tool',
                 name: message.name,
                 messageId: message.messageId,
-                error: 'Invalid tool'
+                error: error?.message || String(error) || 'Invalid tool'
             });
         }
     }

--- a/guardian-service/tests/external-policies-import-closure.test.mjs
+++ b/guardian-service/tests/external-policies-import-closure.test.mjs
@@ -1,0 +1,251 @@
+import { assert } from 'chai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadAPI, Interfaces, MessageResponse, MessageError } from './_handler-harness.mjs';
+
+// Regression tests: an external (VIEW) policy whose tool closure fails to import
+// must not be approved.
+//
+// A policy zip carries its tools as messageId REFERENCES only - their schemas are
+// re-fetched from Hedera+IPFS per tool at import time. When those fetches fail,
+// importToolByMessage throws, importSubTools collects the failures into a
+// non-fatal error list, importPolicy persists the policy row anyway (it saves
+// before it evaluates errors), and APPROVE_EXTERNAL_POLICY marks the request
+// APPROVED regardless and returns MessageResponse(true).
+//
+// The importer is left with a VIEW policy holding 0 tools and 0 TOOL schemas,
+// which can never generate ('Can not find schema with IRI: ...'), with no retry
+// path and no user-visible failure - recoverable only by manual DB surgery.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const p = (rel) => path.resolve(__dirname, rel).split(path.sep).join('/');
+const importHelpersPath = p('../dist/helpers/import-helpers/index.js');
+const policyEnginePath = p('../dist/policy-engine/policy-engine.js');
+
+const M = Interfaces.MessageAPI;
+const ExternalPolicyStatus = Interfaces.ExternalPolicyStatus;
+
+const flushAsync = () => Promise.all(store.asyncPromises);
+
+const OWNER = { creator: 'did:creator', owner: 'did:owner', username: 'alice', id: 'u-1' };
+const MESSAGE_ID = '1700000000.000000000';
+
+// Two failing tools, carrying the error importToolByMessage now surfaces
+// (previously flattened to the literal 'Invalid tool').
+const TOOL_ERRORS = [
+    { type: 'tool', name: 'Tool A', messageId: '1600000000.000000000', error: 'Request failed with status code 404' },
+    { type: 'tool', name: 'Tool B', messageId: '1650000000.000000000', error: 'Request failed with status code 404' },
+];
+
+let handlers;
+let store;
+
+const fakeNotifier = {
+    addStep() { return fakeNotifier; }, start() {}, startStep() {}, completeStep() {},
+    complete() {}, fail(msg) { store.notifierFailures.push(msg); },
+    result(r) { store.notifierResults.push(r); }, getStep() { return fakeNotifier; },
+};
+
+function makeDatabaseServer() {
+    class DatabaseServer {
+        static async getPolicy(filter) {
+            return typeof store.policy === 'function' ? store.policy(filter) : store.policy;
+        }
+        static async getExternalPolicies(filter) { return store.externalPolicies; }
+        static async updateExternalPolicy(item) {
+            store.updated.push({ status: item.status });
+            return item;
+        }
+        static async assignEntity(type, policyId, flag, user, owner) {
+            store.assigned.push({ policyId, user });
+        }
+        static async getAssignedEntity() { return null; }
+    }
+    return DatabaseServer;
+}
+
+before(async function () {
+    this.timeout(120000);
+
+    const loaded = await loadAPI('../dist/api/external-policies.service.js', 'externalPoliciesAPI', {
+        '@guardian/common': {
+            DatabaseServer: makeDatabaseServer(),
+            NewNotifier: { empty: () => fakeNotifier, create: async () => fakeNotifier },
+            // Default harness RunFunctionAsync swallows throws; record them so the
+            // async handler's failure path is assertable.
+            // The production handler fires RunFunctionAsync without awaiting it,
+            // so the test must be able to join the background work rather than
+            // race it. Keep the promise for flushAsync().
+            RunFunctionAsync: (fn, onError) => {
+                const promise = (async () => {
+                    try { await fn(() => {}); } catch (error) {
+                        store.asyncErrors.push(error?.message || String(error));
+                        if (onError) { await onError(error); }
+                    }
+                })();
+                store.asyncPromises.push(promise);
+                return promise;
+            },
+        },
+        [importHelpersPath]: {
+            ImportMode: { VIEW: 'VIEW', DEMO: 'DEMO', COMMON: 'COMMON' },
+            ImportPolicyOptions: class {
+                constructor() {}
+                setComponents() { return this; }
+                setUser() { return this; }
+                setAdditionalPolicy() { return this; }
+            },
+            PolicyImportExportHelper: {
+                async loadPolicyMessage() { return { policy: {}, tools: [], schemas: [] }; },
+                async importPolicy() {
+                    store.importCalls++;
+                    return { policy: store.importedPolicy, errors: store.importErrors };
+                },
+                errorsMessage(errors) {
+                    return errors.map((e) => `${e.type}:${e.name}:${e.error}`).join('; ');
+                },
+            },
+        },
+        [policyEnginePath]: {
+            PolicyEngine: class {
+                async startView(policy) { store.startViewCalls.push(policy?.id); }
+                async deleteViewPolicy(policy) {
+                    store.deleteViewCalls.push(policy?.id);
+                    if (store.deleteViewThrows) { throw new Error('cleanup exploded'); }
+                    return true;
+                }
+            },
+        },
+    });
+    handlers = loaded.handlers;
+});
+
+beforeEach(() => {
+    store = {
+        policy: null,
+        externalPolicies: [{ id: 'ext-1', messageId: MESSAGE_ID, creator: 'did:requester' }],
+        updated: [],
+        assigned: [],
+        importCalls: 0,
+        importErrors: [],
+        importedPolicy: { id: 'policy-1', status: 'VIEW' },
+        startViewCalls: [],
+        deleteViewCalls: [],
+        deleteViewThrows: false,
+        notifierFailures: [],
+        notifierResults: [],
+        asyncErrors: [],
+        asyncPromises: [],
+    };
+});
+
+describe('@unit APPROVE_EXTERNAL_POLICY does not approve a partial import ', () => {
+    it('returns an error instead of approving when the tool closure fails', async () => {
+        store.importErrors = TOOL_ERRORS;
+        const r = await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.instanceOf(r, MessageError, 'a failed import must not report success');
+        assert.include(r.error, 'Failed to import policy');
+    });
+
+    it('leaves the external policy request un-approved when the import fails', async () => {
+        store.importErrors = TOOL_ERRORS;
+        await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.deepEqual(
+            store.updated.filter((u) => u.status === ExternalPolicyStatus.APPROVED),
+            [],
+            'the request must not be flipped to APPROVED'
+        );
+        assert.deepEqual(store.assigned, [], 'a broken policy must not be assigned to users');
+    });
+
+    it('surfaces the underlying tool error, not a generic message', async () => {
+        store.importErrors = TOOL_ERRORS;
+        const r = await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.include(r.error, 'Tool A');
+        assert.include(r.error, 'Request failed with status code 404');
+        assert.notInclude(r.error, 'Invalid tool');
+    });
+
+    it('rolls back the partially imported view policy so a retry can re-import', async () => {
+        store.importErrors = TOOL_ERRORS;
+        await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.deepEqual(store.deleteViewCalls, ['policy-1'], 'the orphan VIEW policy must be removed');
+        assert.deepEqual(store.startViewCalls, [], 'a failed import must not start the policy');
+    });
+
+    it('does not mask the import error when the rollback itself fails', async () => {
+        store.importErrors = TOOL_ERRORS;
+        store.deleteViewThrows = true;
+        const r = await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.instanceOf(r, MessageError);
+        assert.include(r.error, 'Failed to import policy');
+        assert.notInclude(r.error, 'cleanup exploded');
+    });
+
+    it('still approves and assigns on a clean import', async () => {
+        store.importErrors = [];
+        store.policy = (filter) => ({ id: 'policy-1', messageId: filter.messageId, status: 'VIEW' });
+        const r = await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.instanceOf(r, MessageResponse);
+        assert.isTrue(r.body);
+        assert.isAbove(
+            store.updated.filter((u) => u.status === ExternalPolicyStatus.APPROVED).length,
+            0,
+            'a clean import must still be approved'
+        );
+        assert.isAbove(store.assigned.length, 0);
+        assert.deepEqual(store.deleteViewCalls, [], 'nothing to roll back on success');
+    });
+
+    it('skips import entirely when the policy already exists', async () => {
+        store.policy = { id: 'policy-1', status: 'VIEW' };
+        await handlers[M.APPROVE_EXTERNAL_POLICY]({ messageId: MESSAGE_ID, owner: OWNER });
+
+        assert.equal(store.importCalls, 0);
+        assert.deepEqual(store.deleteViewCalls, []);
+    });
+});
+
+describe('@unit APPROVE_EXTERNAL_POLICY_ASYNC does not approve a partial import ', () => {
+    it('fails the task and does not approve when the tool closure fails', async () => {
+        store.importErrors = TOOL_ERRORS;
+        const r = await handlers[M.APPROVE_EXTERNAL_POLICY_ASYNC]({
+            messageId: MESSAGE_ID, owner: OWNER, task: { taskId: 't-1' },
+        });
+        await flushAsync();
+
+        // The handler itself returns the task; the failure surfaces through the
+        // async runner's error callback.
+        assert.instanceOf(r, MessageResponse);
+        assert.equal(store.asyncErrors.length, 1);
+        assert.include(store.asyncErrors[0], 'Failed to import policy');
+        assert.deepEqual(
+            store.updated.filter((u) => u.status === ExternalPolicyStatus.APPROVED),
+            []
+        );
+        assert.deepEqual(store.assigned, []);
+        assert.deepEqual(store.deleteViewCalls, ['policy-1']);
+    });
+
+    it('approves normally on a clean import', async () => {
+        store.importErrors = [];
+        store.policy = (filter) => ({ id: 'policy-1', messageId: filter.messageId, status: 'VIEW' });
+        await handlers[M.APPROVE_EXTERNAL_POLICY_ASYNC]({
+            messageId: MESSAGE_ID, owner: OWNER, task: { taskId: 't-1' },
+        });
+        await flushAsync();
+
+        assert.deepEqual(store.asyncErrors, []);
+        assert.isAbove(
+            store.updated.filter((u) => u.status === ExternalPolicyStatus.APPROVED).length,
+            0
+        );
+        assert.deepEqual(store.deleteViewCalls, []);
+    });
+});

--- a/guardian-service/tests/external-policies-import-closure.test.mjs
+++ b/guardian-service/tests/external-policies-import-closure.test.mjs
@@ -2,9 +2,14 @@ import { assert } from 'chai';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { loadAPI, Interfaces, MessageResponse, MessageError } from './_handler-harness.mjs';
+import { PolicyImportExportHelper } from '../dist/helpers/import-helpers/index.js';
+
+// The production errorsMessage(), used verbatim by the handler stubs below so the
+// suite can never assert diagnosability the shipped code does not provide.
+const realErrorsMessage = (errors) => PolicyImportExportHelper.errorsMessage(errors);
 
 // Regression tests: an external (VIEW) policy whose tool closure fails to import
-// must not be approved.
+// must not be approved, and the reason must reach the operator.
 //
 // A policy zip carries its tools as messageId REFERENCES only - their schemas are
 // re-fetched from Hedera+IPFS per tool at import time. When those fetches fail,
@@ -101,9 +106,11 @@ before(async function () {
                     store.importCalls++;
                     return { policy: store.importedPolicy, errors: store.importErrors };
                 },
-                errorsMessage(errors) {
-                    return errors.map((e) => `${e.type}:${e.name}:${e.error}`).join('; ');
-                },
+                // Delegate to the REAL implementation. A hand-written stub here
+                // was richer than production (it interpolated e.error, which
+                // errorsMessage did not), so the "surfaces the underlying error"
+                // assertion passed against a message the operator never saw.
+                errorsMessage: realErrorsMessage,
             },
         },
         [policyEnginePath]: {
@@ -137,6 +144,45 @@ beforeEach(() => {
         asyncErrors: [],
         asyncPromises: [],
     };
+});
+
+describe('@unit PolicyImportExportHelper.errorsMessage carries the cause ', () => {
+    // errorsMessage builds the string an operator actually sees - it becomes the
+    // MessageError returned to the API. It used to emit component NAMES only, so
+    // preserving the real error inside the structured errors array was invisible
+    // at the boundary: every failure read as 'tools: ["Tool A","Tool B"];'
+    // whether the package 404'd, timed out, or was rejected.
+
+    it('includes the underlying error for tools, not just the name', () => {
+        const message = PolicyImportExportHelper.errorsMessage(TOOL_ERRORS);
+        assert.include(message, 'Tool A');
+        assert.include(message, 'Request failed with status code 404');
+    });
+
+    it('includes the underlying error for schemas too', () => {
+        const message = PolicyImportExportHelper.errorsMessage([
+            { type: 'schema', name: 'Schema A', error: 'Invalid schema IRI' },
+        ]);
+        assert.include(message, 'Schema A');
+        assert.include(message, 'Invalid schema IRI');
+    });
+
+    it('still groups by component type', () => {
+        const message = PolicyImportExportHelper.errorsMessage([
+            ...TOOL_ERRORS,
+            { type: 'schema', name: 'S1', error: 'boom' },
+            { type: 'other', name: 'O1', error: 'bang' },
+        ]);
+        assert.include(message, 'schemas:');
+        assert.include(message, 'tools:');
+        assert.include(message, 'others:');
+    });
+
+    it('degrades to the bare name when no cause was captured', () => {
+        const message = PolicyImportExportHelper.errorsMessage([{ type: 'tool', name: 'Tool A' }]);
+        assert.include(message, 'Tool A');
+        assert.notInclude(message, 'undefined');
+    });
 });
 
 describe('@unit APPROVE_EXTERNAL_POLICY does not approve a partial import ', () => {


### PR DESCRIPTION
## Problem

A policy zip carries its tools as **messageId references only** — their schemas are not in the zip, and are re-fetched from Hedera+IPFS per tool at import time (`importToolByMessage` → `saveSchemas`). When one of those fetches fails, the failure is currently silent and permanent:

1. `importToolByMessage` throws.
2. `importSubTools` catches it and records a **non-fatal** error entry, replacing the real cause with the literal string `'Invalid tool'` (`tool-import-helper.ts`).
3. `PolicyImport.import()` **persists the policy row anyway** — `savePolicy()` runs before `getErrors()` is evaluated (`policy-import.ts`).
4. `APPROVE_EXTERNAL_POLICY` marks the request `APPROVED` **regardless** of the returned errors, assigns the policy to users, and returns `MessageResponse(true)` (`external-policies.service.ts`, both the sync and async handlers).

The importing user is left with a VIEW policy holding **zero tools and zero TOOL schemas**. It can never generate — `Can not find schema with IRI: ...` — there is no retry path because the policy row already exists, and nothing ever surfaced a failure. Recovery requires manual database repair.

## How it was found

Observed in production. Both tools of a published policy returned **HTTP 404** from IPFS during import:

```
12:27:02 [INFO]  Import policy by message
12:32:51 [ERROR] Task error: …, Request failed with status code 404
12:32:51 [ERROR] Task error: …, Request failed with status code 404
12:33:19         policy row PERSISTED
12:33:24 [WARN]  Failed to import components: tools: ["Tool A","Tool B"];
```

The policy was saved **five seconds before the errors were evaluated**, and was then reported to the user as an approved policy. I confirmed against the published artifact that the zip *did* carry both tools as `tools/<hash>.json` references, that those records contain no `schemas` key, and that the failing schema IRI was not among the policy's own schemas — so the closure genuinely depends on those per-tool round-trips succeeding.

## Changes

1. **`importSubTools` keeps the underlying error** instead of flattening every failure to `'Invalid tool'`. That single line is what makes a transient fetch error undiagnosable — the real status otherwise survives only as an unattributed worker log line, and correlating it to the import meant matching timestamps by eye.
2. **`addPolicy` rolls back the persisted VIEW policy** via the existing `deleteViewPolicy` path, so a re-approve can import cleanly instead of wedging on an orphan row. Best-effort and try/caught — a rollback failure must not mask the original import error.
3. **Both approve handlers refuse to mark `APPROVED`** when the import returned errors: `MessageError` in the sync handler, `throw` into `RunFunctionAsync`'s error callback in the async one so the task fails properly.

## Deliberately not addressed

The **save-before-validate ordering** in `PolicyImport.import()` itself. Fixing that properly — validating the component closure before persisting, or wrapping the import in a transaction — touches every import mode, not just VIEW, and is a much larger change. This PR contains the damage at the external-policy boundary without restructuring `PolicyImport`. Happy to follow up with that separately if maintainers would like it.

## Tests

New `guardian-service/tests/external-policies-import-closure.test.mjs`, 9 cases built on the existing `_handler-harness.mjs`. **6 of the 9 fail without this change.**

- sync: returns an error rather than approving; the request stays un-approved and nothing is assigned; the underlying tool error is surfaced and `'Invalid tool'` is explicitly asserted absent; the orphan VIEW policy is rolled back and `startView` is not called; a throwing rollback does not mask the import error; a clean import still approves and assigns; an already-existing policy skips import entirely
- async: the failure reaches the error callback with nothing approved and the rollback done; a clean import approves normally

One note on the async cases: the handler fires `RunFunctionAsync` without awaiting it, so the stub retains the promise and each async test joins it explicitly. Without that the assertions race the background work and pass only by microtask ordering.

```
guardian-service/tests/external-policies-import-closure.test.mjs
  9 passing        (3 passing / 6 failing without the fix)
```
