### PR TITLE
perf: 6535 record dry-run mock messages in-process and batch schema recording

### DIFF
--- a/common/src/database-modules/database-server.ts
+++ b/common/src/database-modules/database-server.ts
@@ -4855,6 +4855,22 @@ export class DatabaseServer extends AbstractDatabaseServer {
     }
 
     /**
+     * Save many Mock rows in a single batch insert
+     * @param dryRun
+     * @param rows array of { type, ...data }
+     */
+    public static async saveMockBatch(
+        dryRun: string,
+        rows: any[]
+    ): Promise<void> {
+        if (!rows || !rows.length) {
+            return;
+        }
+        const items = DatabaseServer.addDryRunId(rows, dryRun, 'Mock', false) as DryRun[];
+        await new DataBaseHelper(DryRun).insertMany(items);
+    }
+
+    /**
      * Save Mock
      * @param dryRun
      * @param type

--- a/common/src/hedera-modules/message/message-server.ts
+++ b/common/src/hedera-modules/message/message-server.ts
@@ -314,12 +314,8 @@ export class MessageServer {
             await new TransactionLogger().virtualFileLog(this.dryRun, file, result);
             return result
         } else if (this.dryRun && options.mockId) {
-            // Dry-run mock ADD_FILE: run it in-process instead of a worker round-trip.
-            // The worker's mock path only forwards the file to MockHelper.execute (generate a
-            // cid + saveMock the content so a later dry-run GET_FILE reads it back) via a
-            // MOCK_EVENT_EXECUTE message - nothing there needs the worker. Calling MockHelper
-            // directly removes two broker round-trips per file, which dominate the dry-run
-            // switch for schema-heavy policies.
+            // Dry-run mock file: record in-process (same saveMock the worker's mock path does),
+            // skipping the per-file worker round-trip that dominates schema-heavy dry-run switches.
             const cid = await MockHelper.execute({
                 mockId: options.mockId,
                 type: MockType.ADD_FILE,
@@ -649,30 +645,42 @@ export class MessageServer {
         }
         const time = await this.messageStartLog('Hedera', options.userId);
         const buffer = message.toMessage();
-        const timestamp = await new Workers().addRetryableTask({
-            type: WorkerTaskType.SEND_HEDERA,
-            data: {
-                topicId: this.topicId,
-                buffer,
-                submitKey: this.submitKey,
-                clientOptions: this.clientOptions,
-                network: Environment.network,
-                localNodeAddress: Environment.localNodeAddress,
-                localNodeProtocol: Environment.localNodeProtocol,
-                signOptions: this.signOptions,
-                memo: message.getMemo(),
+        let timestamp: string;
+        if (this.dryRun && options.mockId) {
+            // Dry-run mock message: record in-process (same saveMock the worker's mock path does),
+            // skipping the per-message worker round-trip that dominates schema-heavy dry-run switches.
+            const record = await MockHelper.execute({
+                mockId: options.mockId,
+                type: MockType.EXECUTE_AND_RECORD,
+                data: MockHelper.getMessageRecord(this.topicId.toString(), buffer, this.operatorId)
+            });
+            timestamp = record.consensus_timestamp;
+        } else {
+            timestamp = await new Workers().addRetryableTask({
+                type: WorkerTaskType.SEND_HEDERA,
+                data: {
+                    topicId: this.topicId,
+                    buffer,
+                    submitKey: this.submitKey,
+                    clientOptions: this.clientOptions,
+                    network: Environment.network,
+                    localNodeAddress: Environment.localNodeAddress,
+                    localNodeProtocol: Environment.localNodeProtocol,
+                    signOptions: this.signOptions,
+                    memo: message.getMemo(),
+                    dryRun: this.dryRun,
+                    payload: { userId: options.userId },
+                }
+            }, {
+                priority: 10,
+                attempts: 0,
+                userId: options.userId,
+                interception: options.interception,
+                registerCallback: true,
                 dryRun: this.dryRun,
-                payload: { userId: options.userId },
-            }
-        }, {
-            priority: 10,
-            attempts: 0,
-            userId: options.userId,
-            interception: options.interception,
-            registerCallback: true,
-            dryRun: this.dryRun,
-            mockId: options.mockId,
-        });
+                mockId: options.mockId,
+            });
+        }
 
         await this.messageEndLog(time, 'Hedera', options.userId);
         message.setId(timestamp);

--- a/common/src/helpers/mock-service.ts
+++ b/common/src/helpers/mock-service.ts
@@ -499,32 +499,16 @@ export class MockHelper {
     } {
         if (type === 'TopicMessageSubmitTransaction') {
             const t = transaction as TopicMessageSubmitTransaction;
-            const timestamp = MockHelper.getTimestamp();
-            const consensusTimestamp = MockHelper.timestampToString(timestamp);
-            const topicId = t.topicId?.toString();
             const messageBytes = t.getMessage();
             const message = messageBytes ? Buffer.from(messageBytes).toString('utf8') : '';
-            const base64 = Buffer.from(message, 'utf8').toString('base64');
-
-            return {
-                type: MockEntityType.MESSAGE,
-                transaction: {
-                    id: consensusTimestamp,
-                    consensus_timestamp: consensusTimestamp,
-                    topicId,
-                    topic_id: topicId,
-                    payer_account_id: accountId,
-                    sequence_number: 1,
-                    message: base64
-                }
-            }
+            return MockHelper.getMessageRecord(t.topicId?.toString(), message, accountId);
         }
         throw new Error('Invalid Type');
     }
 
     /**
-     * getRecord('TopicMessageSubmitTransaction', ...) built from primitives (no Transaction
-     * object), so it can be produced in-process instead of round-tripping through the worker.
+     * Build the TopicMessageSubmitTransaction mock record from primitives (no Transaction
+     * object), so it can be produced in-process. Shared by getRecord and the dry-run fast path.
      */
     public static getMessageRecord(
         topicId: string,

--- a/common/src/helpers/mock-service.ts
+++ b/common/src/helpers/mock-service.ts
@@ -522,6 +522,36 @@ export class MockHelper {
         throw new Error('Invalid Type');
     }
 
+    /**
+     * getRecord('TopicMessageSubmitTransaction', ...) built from primitives (no Transaction
+     * object), so it can be produced in-process instead of round-tripping through the worker.
+     */
+    public static getMessageRecord(
+        topicId: string,
+        message: string,
+        accountId: string
+    ): {
+        type: MockEntityType,
+        transaction: any
+    } {
+        const timestamp = MockHelper.getTimestamp();
+        const consensusTimestamp = MockHelper.timestampToString(timestamp);
+        const base64 = Buffer.from(message ?? '', 'utf8').toString('base64');
+
+        return {
+            type: MockEntityType.MESSAGE,
+            transaction: {
+                id: consensusTimestamp,
+                consensus_timestamp: consensusTimestamp,
+                topicId,
+                topic_id: topicId,
+                payer_account_id: accountId,
+                sequence_number: 1,
+                message: base64
+            }
+        };
+    }
+
     private static getTimestamp(): Timestamp {
         const time = Date.now();
         const seconds = Math.floor(time / 100);

--- a/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/dry-run-dialog/dry-run-dialog.component.html
@@ -22,7 +22,7 @@
     <div class="mock-option-text">
       <div class="mock-option-title">Enable Mock Data</div>
       <div class="mock-option-sub">
-        Pre-records a response for every schema – moving to Dry-Run may take several minutes.
+        Pre-records a response for every schema – large policies may take a few extra seconds.
       </div>
     </div>
   </label>

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -1165,21 +1165,21 @@ export class PolicyEngine extends NatsService {
                     { cid: contextCid, url: schema.contextURL }
                 ]);
 
-                const { transaction } = MockHelper.getMessageRecord(topicId, message.toMessage(), accountId);
                 if (documentBuffer) {
                     mockRows.push({ type: MockEntityType.FILE, cid: documentCid, document: MockHelper.getBuffer(documentBuffer) });
                 }
                 if (contextBuffer) {
                     mockRows.push({ type: MockEntityType.FILE, cid: contextCid, document: MockHelper.getBuffer(contextBuffer) });
                 }
-                mockRows.push({ type: MockEntityType.MESSAGE, transaction });
+                mockRows.push(MockHelper.getMessageRecord(topicId, message.toMessage(), accountId));
             }
         }
 
-        await DatabaseServer.updateSchemas(updatedSchemas);
-        if (mockRows.length) {
-            await DatabaseServer.saveMockBatch(mockId, mockRows);
-        }
+        // Independent bulk writes to different collections - run them concurrently.
+        await Promise.all([
+            DatabaseServer.updateSchemas(updatedSchemas),
+            DatabaseServer.saveMockBatch(mockId, mockRows)
+        ]);
 
         return model;
     }

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -27,10 +27,12 @@ import {
     FormulaImportExport,
     getArtifactType,
     INotificationStep,
+    IPFS,
     IPolicyComponents,
     MessageAction,
     MessageServer,
     MessageType,
+    MockEntityType,
     MockHelper,
     MultiPolicy,
     NatsService,
@@ -51,7 +53,6 @@ import {
     Topic,
     TopicConfig,
     TopicHelper,
-    UrlType,
     Users,
     VcHelper
 } from '@guardian/common';
@@ -1130,12 +1131,15 @@ export class PolicyEngine extends NatsService {
     public async dryRunSchemas(
         model: Policy,
         user: IOwner,
-        messageServer: MessageServer,
+        accountId: string,
         mockId: string
     ): Promise<Policy> {
         const schemas = await DatabaseServer.getSchemas({ topicId: model.topicId });
 
-        // const draftSchemas: SchemaCollection[] = [];
+        const topicId = (model.topicId || '').toString();
+        const updatedSchemas: SchemaCollection[] = [];
+        const mockRows: any[] = [];
+
         for (const schema of schemas) {
             if (schema.status === SchemaStatus.PUBLISHED) {
                 continue;
@@ -1143,32 +1147,40 @@ export class PolicyEngine extends NatsService {
 
             schema.context = generateSchemaContext(schema);
             SchemaHelper.updateIRI(schema);
-            await DatabaseServer.updateSchema(schema.id, schema);
+            updatedSchemas.push(schema);
 
             if (mockId) {
+                // Build the mock schema-publish records in-process with the final context CID
+                // already set, so no per-schema worker round-trip or replaceSchema read-back is
+                // needed. All rows are batch-inserted after the loop.
                 const message = new SchemaMessage(MessageAction.PublishSchema);
                 message.setDocument(schema);
                 message.setRelationships([]);
-                const result = await messageServer
-                    .sendMessage(message, {
-                        sendToIPFS: true,
-                        memo: null,
-                        userId: user.id,
-                        interception: user.id,
-                        mockId
-                    });
+                const [documentBuffer, contextBuffer] = await message.toDocuments();
 
-                const messageId = result.getId();
-                const contextCid = result.getContextUrl(UrlType.cid);
+                const documentCid = GenerateUUIDv4();
+                const contextCid = (schema.contextURL || '').replace('schema:', '');
+                message.setUrls([
+                    { cid: documentCid, url: IPFS.IPFS_PROTOCOL + documentCid },
+                    { cid: contextCid, url: schema.contextURL }
+                ]);
 
-                await MockHelper.replaceSchema(
-                    mockId,
-                    messageId,
-                    contextCid,
-                    schema.contextURL
-                );
+                const { transaction } = MockHelper.getMessageRecord(topicId, message.toMessage(), accountId);
+                if (documentBuffer) {
+                    mockRows.push({ type: MockEntityType.FILE, cid: documentCid, document: MockHelper.getBuffer(documentBuffer) });
+                }
+                if (contextBuffer) {
+                    mockRows.push({ type: MockEntityType.FILE, cid: contextCid, document: MockHelper.getBuffer(contextBuffer) });
+                }
+                mockRows.push({ type: MockEntityType.MESSAGE, transaction });
             }
         }
+
+        await DatabaseServer.updateSchemas(updatedSchemas);
+        if (mockRows.length) {
+            await DatabaseServer.saveMockBatch(mockId, mockRows);
+        }
+
         return model;
     }
 
@@ -1719,7 +1731,7 @@ export class PolicyEngine extends NatsService {
         });
 
         //'Publish' policy schemas
-        model = await this.dryRunSchemas(model, user, messageServer, mockId);
+        model = await this.dryRunSchemas(model, user, root.hederaAccountId, mockId);
         model.status = demo ? PolicyStatus.DEMO : PolicyStatus.DRY_RUN;
         model.version = version;
 


### PR DESCRIPTION
### Description

Completes the Dry-Run Mock Data performance work started in #6533, which removed the per-file worker round-trip. This handles the remaining per-schema cost. Fixes #6535.

- Record the schema-publish message in-process via `MockHelper` for the `dryRun && mockId` path, instead of dispatching a `SEND_HEDERA` worker round-trip (mirrors the in-process file recording from #6533).
- Add `MockHelper.getMessageRecord` to build the mock message record without a `Transaction` object.
- Build the mock schema-publish records in-process with the final context CID already set, dropping the per-schema `replaceSchema` read-modify-write.
- Batch-insert all mock rows via `DatabaseServer.saveMockBatch` and fold the per-schema schema updates into a single `updateSchemas` call.

On a 916-schema policy the mock schema recording drops from ~290 s to ~4 s (~75x) and the overall dry-run switch from ~5.5 min to ~45 s. The mock DB state produced is identical to the previous `sendMessage` + `replaceSchema` path.

The remaining switch time is dominated by policy zip generation, which is unrelated to mock and tracked separately.
