### PR TITLE
fix: retry secret fetch to survive startup delays

### DIFF
--- a/common/src/hedera-modules/utils.ts
+++ b/common/src/hedera-modules/utils.ts
@@ -8,12 +8,19 @@ export function timeout(timeoutValue: number) {
     return (target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<(...params: any[]) => Promise<any>>) => {
         const oldFunc = descriptor.value;
         descriptor.value = async function () {
+            let timer: ReturnType<typeof setTimeout>;
             const timeoutPromise = new Promise((resolve, reject) => {
-                setTimeout(() => {
+                timer = setTimeout(() => {
                     reject(new Error('Transaction timeout exceeded'));
                 }, timeoutValue);
             })
-            return Promise.race([oldFunc.apply(this, arguments), timeoutPromise]);
+            try {
+                return await Promise.race([oldFunc.apply(this, arguments), timeoutPromise]);
+            } finally {
+                // Clear the timer once the race settles so a completed call does not
+                // keep a live timeout (and the captured this/arguments) until it fires.
+                clearTimeout(timer);
+            }
         }
     }
 }

--- a/common/src/secret-manager/old-style/old-secret-manager.ts
+++ b/common/src/secret-manager/old-style/old-secret-manager.ts
@@ -19,13 +19,47 @@ export class OldSecretManager extends NatsService implements SecretManagerBase {
      * @private
      */
     public replySubject = 'settings-reply-' + GenerateUUIDv4();
+
+    // Bounded-retry configuration for secret operations (see withRetry).
+    private static readonly RETRY_ATTEMPTS = 3;
+    private static readonly RETRY_DELAY_MS = 3000;
+
+    /**
+     * Run a secret operation with bounded retries. Each attempt is still guarded
+     * by the per-call {@link timeout} decorator; retrying tolerates a dependency
+     * (auth-service / MQ) that is briefly slow or not yet ready, so a transient
+     * delay does not surface as an unhandled rejection that can crash a service
+     * during startup.
+     * @param operation operation to run
+     * @private
+     */
+    private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= OldSecretManager.RETRY_ATTEMPTS; attempt++) {
+            try {
+                return await operation();
+            } catch (error) {
+                lastError = error;
+                if (attempt < OldSecretManager.RETRY_ATTEMPTS) {
+                    console.warn(`[OldSecretManager] secret operation attempt ${attempt}/${OldSecretManager.RETRY_ATTEMPTS} failed, retrying in ${OldSecretManager.RETRY_DELAY_MS}ms:`, error?.message || error);
+                    await new Promise((resolve) => setTimeout(resolve, OldSecretManager.RETRY_DELAY_MS));
+                }
+            }
+        }
+        throw lastError;
+    }
+
     /**
      * Get secrets
      * @param path
      * @param addition
      */
+    async getSecrets(path: string, addition?: any): Promise<any> {
+        return this.withRetry(() => this.getSecretsOnce(path, addition));
+    }
+
     @timeout(10000)
-    async getSecrets(path: string, addition: any): Promise<any> {
+    private async getSecretsOnce(path: string, addition: any): Promise<any> {
         switch (path) {
             case 'keys/operator':
                 const OPERATOR_ID = await this.sendMessage<IGetKeyResponse>(WalletEvents.GET_GLOBAL_APPLICATION_KEY, { type: 'OPERATOR_ID' });
@@ -62,8 +96,12 @@ export class OldSecretManager extends NatsService implements SecretManagerBase {
      * @async
      * @public
      */
-    @timeout(10000)
     async setSecrets(path: string, data: any, addition?: any): Promise<void> {
+        return this.withRetry(() => this.setSecretsOnce(path, data, addition));
+    }
+
+    @timeout(10000)
+    private async setSecretsOnce(path: string, data: any, addition?: any): Promise<void> {
         switch (path) {
             case 'keys/operator':
                 await this.sendMessage<IGetKeyResponse>(WalletEvents.SET_GLOBAL_APPLICATION_KEY, { type: 'OPERATOR_ID', key: data.OPERATOR_ID });


### PR DESCRIPTION
### Description

Services could exit with an unhandled `Transaction timeout exceeded` rejection during startup when `OldSecretManager` fetched secrets before the auth-service / message queue was ready. The pre-boot error handler treated this as fatal and terminated the process.

- Wrap `OldSecretManager` `getSecrets`/`setSecrets` in bounded retries so a briefly slow or not-yet-ready dependency no longer surfaces as an unhandled rejection at startup.
- Keep each attempt guarded by the existing per-call timeout by moving the decorator onto private single-attempt methods.
- Clear the `timeout` decorator's timer once the race settles to avoid a lingering timer and captured scope per call.