### PR TITLE
perf: normalize policy hash refs in one pass

### DIFF
--- a/common/src/import-export/policy.ts
+++ b/common/src/import-export/policy.ts
@@ -546,64 +546,8 @@ export class PolicyImportExport {
             delete token._propHash;
         });
 
-        const schemaIds = new Map();
-        const tokenIds = new Map();
-
-        let tokenCounter = 0;
-        let schemaCounter = 0;
-
-        components.schemas.forEach(schema => {
-            schemaIds.set(`schema:${schema.uuid}#${schema.uuid}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`schema:${schema.uuid}&${schema.version}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`schema:${schema.uuid}#`, `#`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`schema:${schema.uuid}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`#${schema.uuid}&${schema.version}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`#${schema.uuid}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(`${schema.uuid}&${schema.version}`, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.schemas.forEach(schema => {
-            schemaIds.set(schema.uuid, `@${schemaCounter}`);
-            schemaCounter++;
-        });
-
-        schemaCounter = 0;
-        components.tokens.forEach(token => {
-            tokenIds.set(token.tokenId, `@token${tokenCounter}`)
-            tokenCounter++;
-        });
+        // Build ref maps before deleting version (some forms embed it).
+        const { groups, tokenIds } = PolicyImportExport.buildRefGroups(components.schemas, components.tokens);
 
         components.schemas.forEach(schema => {
             delete schema.version;
@@ -612,19 +556,84 @@ export class PolicyImportExport {
 
         let componentsJson = JSON.stringify(components);
         componentsJson = PolicyImportExport.removeIpfsFromJson(componentsJson);
-        schemaIds.forEach((value, key)  => {
-            componentsJson = componentsJson.replaceAll(key, value);
-        });
 
-        tokenIds.forEach((value, key)  => {
-            componentsJson = componentsJson.replaceAll(key, value);
-        });
+        const normalized = PolicyImportExport.applyRefGroups(componentsJson, groups, tokenIds);
 
-        return JSON.parse(componentsJson);
+        return JSON.parse(normalized);
     }
 
     private static removeIpfsFromJson(json: string): string {
         return json.replace(/ipfs:\/\/[^\s"#&]+/g, '');
+    }
+
+    /**
+     * Build one ref map per textual reference form, mapping each schema to a positional tag
+     * (`@<index>`) so equivalent policies hash equally. Ordered most-specific-first, since a
+     * later form can match an earlier form's output (`schema:${uuid}#` -> `#`, then `#${uuid}`).
+     */
+    private static buildRefGroups(
+        schemas: Schema[],
+        tokens: Token[]
+    ): { groups: Map<string, string>[]; tokenIds: Map<string, string> } {
+        const g1 = new Map<string, string>(); // schema:${uuid}#${uuid}
+        const g2 = new Map<string, string>(); // schema:${uuid}&${version}
+        const g3 = new Map<string, string>(); // schema:${uuid}#
+        const g4 = new Map<string, string>(); // schema:${uuid}
+        const g5 = new Map<string, string>(); // #${uuid}&${version}
+        const g6 = new Map<string, string>(); // #${uuid}
+        const g7 = new Map<string, string>(); // ${uuid}&${version}
+        const g8 = new Map<string, string>(); // ${uuid}
+        const tokenIds = new Map<string, string>();
+
+        schemas.forEach((schema, index) => {
+            const tag = `@${index}`;
+            g1.set(`schema:${schema.uuid}#${schema.uuid}`, tag);
+            g2.set(`schema:${schema.uuid}&${schema.version}`, tag);
+            g3.set(`schema:${schema.uuid}#`, `#`);
+            g4.set(`schema:${schema.uuid}`, tag);
+            g5.set(`#${schema.uuid}&${schema.version}`, tag);
+            g6.set(`#${schema.uuid}`, tag);
+            g7.set(`${schema.uuid}&${schema.version}`, tag);
+            g8.set(`${schema.uuid}`, tag);
+        });
+
+        tokens.forEach((token, index) => {
+            tokenIds.set(token.tokenId, `@token${index}`);
+        });
+
+        return { groups: [g1, g2, g3, g4, g5, g6, g7, g8], tokenIds };
+    }
+
+    /**
+     * Apply each ref map in a single pass via one alternation regex of its exact keys, in
+     * insertion order. Reproduces the original per-key `replaceAll` sequence byte-for-byte
+     * (same substrings and prefix precedence) but avoids the O(schemas^2) full-string rescans.
+     */
+    private static applyRefGroups(
+        json: string,
+        groups: Map<string, string>[],
+        tokenIds: Map<string, string>
+    ): string {
+        let result = json;
+        for (const map of groups) {
+            if (map.size === 0) {
+                continue;
+            }
+            const pattern = Array.from(map.keys(), PolicyImportExport.escapeRegExp).join('|');
+            const regex = new RegExp(pattern, 'g');
+            // Every match is verbatim one of this map's keys, so the lookup is always defined.
+            result = result.replace(regex, (match) => map.get(match));
+        }
+
+        tokenIds.forEach((value, key) => {
+            result = result.replaceAll(key, value);
+        });
+
+        return result;
+    }
+
+    private static escapeRegExp(value: string): string {
+        return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 
     private static preparePolicyComponents(components: IPolicyComponents): IPolicyComponents {

--- a/common/tests/unit-tests/policy-hash-normalization.test.mjs
+++ b/common/tests/unit-tests/policy-hash-normalization.test.mjs
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { PolicyImportExport } from '../../dist/import-export/policy.js';
+
+// Lock applyRefGroups (fast path) to the original replaceAll-per-key algorithm (oracle below).
+// getPolicyHash needs byte-identical output; any divergence would silently change
+// already-published policy hashes.
+
+const buildRefGroups = (schemas, tokens) =>
+    PolicyImportExport.buildRefGroups(schemas, tokens);
+const applyFast = (json, groups, tokenIds) =>
+    PolicyImportExport.applyRefGroups(json, groups, tokenIds);
+// Original implementation kept here as the correctness oracle.
+const applyLegacy = (json, groups, tokenIds) => {
+    let result = json;
+    for (const map of groups) {
+        map.forEach((value, key) => { result = result.replaceAll(key, value); });
+    }
+    tokenIds.forEach((value, key) => { result = result.replaceAll(key, value); });
+    return result;
+};
+
+const assertParity = (json, schemas, tokens) => {
+    const { groups, tokenIds } = buildRefGroups(schemas, tokens);
+    const fast = applyFast(json, groups, tokenIds);
+    // buildRefGroups is pure, but rebuild for the oracle so the two calls do not share map state.
+    const { groups: g2, tokenIds: t2 } = buildRefGroups(schemas, tokens);
+    const legacy = applyLegacy(json, g2, t2);
+    assert.equal(fast, legacy);
+    return fast;
+};
+
+describe('PolicyImportExport reference normalization (fast vs legacy parity)', () => {
+    it('normalizes every reference form for a single schema', () => {
+        const uuid = crypto.randomUUID();
+        const schemas = [{ uuid, version: '1.0.0', name: 'A' }];
+        const json = JSON.stringify({
+            a: `schema:${uuid}#${uuid}`,
+            b: `schema:${uuid}&1.0.0`,
+            c: `schema:${uuid}#`,
+            d: `schema:${uuid}`,
+            e: `#${uuid}&1.0.0`,
+            f: `#${uuid}`,
+            g: `${uuid}&1.0.0`,
+            h: `${uuid}`,
+        });
+        const out = assertParity(json, schemas, []);
+        // Sanity: the bare uuid must have been replaced by its positional tag.
+        assert.ok(!out.includes(uuid));
+    });
+
+    it('handles cross-schema adjacency (schema:A#B with A !== B)', () => {
+        const a = crypto.randomUUID();
+        const b = crypto.randomUUID();
+        const schemas = [
+            { uuid: a, version: '1.0.0', name: 'A' },
+            { uuid: b, version: '2.0.0', name: 'B' },
+        ];
+        const json = JSON.stringify({
+            ref: `schema:${a}#${b}`,
+            self: `schema:${a}#${a}`,
+            frag: `#${b}`,
+        });
+        assertParity(json, schemas, []);
+    });
+
+    it('replaces token ids', () => {
+        const uuid = crypto.randomUUID();
+        const schemas = [{ uuid, version: '1.0.0', name: 'A' }];
+        const tokens = [{ tokenId: '0.0.4321' }, { tokenId: '0.0.9999' }];
+        const json = JSON.stringify({
+            s: `#${uuid}`,
+            t1: '0.0.4321',
+            t2: '0.0.9999',
+        });
+        const out = assertParity(json, schemas, tokens);
+        assert.ok(out.includes('@token0'));
+        assert.ok(out.includes('@token1'));
+    });
+
+    it('keeps the later index for duplicate uuids', () => {
+        const uuid = crypto.randomUUID();
+        const schemas = [
+            { uuid, version: '1.0.0', name: 'Z' },
+            { uuid, version: '1.0.0', name: 'A' },
+        ];
+        const json = JSON.stringify({ ref: `#${uuid}` });
+        assertParity(json, schemas, []);
+    });
+
+    it('replaces references embedded inside free text (substring semantics)', () => {
+        const a = crypto.randomUUID();
+        const b = crypto.randomUUID();
+        const schemas = [
+            { uuid: a, version: '1.0.0', name: 'A' },
+            { uuid: b, version: '2.0.0', name: 'B' },
+        ];
+        const json = JSON.stringify({
+            comment: `see schema:${a}&1.0.0 and also #${b} within this sentence`,
+            nested: `prefix ${a} suffix`,
+        });
+        assertParity(json, schemas, []);
+    });
+
+    it('respects key precedence for prefix versions (1.0 vs 1.0.0)', () => {
+        const uuid = crypto.randomUUID();
+        const schemas = [
+            { uuid, version: '1.0', name: 'Z' },
+            { uuid, version: '1.0.0', name: 'A' },
+        ];
+        // Both orderings of appearance in the serialized string.
+        assertParity(JSON.stringify({
+            a: `schema:${uuid}&1.0.0`,
+            b: `schema:${uuid}&1.0`,
+            c: `#${uuid}&1.0`,
+            d: `${uuid}&1.0.0`,
+        }), schemas, []);
+        assertParity(JSON.stringify({
+            a: `schema:${uuid}&1.0`,
+            b: `schema:${uuid}&1.0.0`,
+        }), schemas, []);
+    });
+
+    it('leaves unrelated content untouched', () => {
+        const uuid = crypto.randomUUID();
+        const schemas = [{ uuid, version: '1.0.0', name: 'A' }];
+        const json = JSON.stringify({
+            title: 'Tom & Jerry',
+            note: 'no refs here',
+            hash: 'deadbeef1234',
+        });
+        assertParity(json, schemas, []);
+    });
+
+    it('matches on a large randomized policy body', () => {
+        const count = 400;
+        const schemas = [];
+        for (let i = 0; i < count; i++) {
+            schemas.push({
+                uuid: crypto.randomUUID(),
+                version: `1.${i}.0`,
+                name: `Schema_${i}`,
+            });
+        }
+        const tokens = [{ tokenId: '0.0.1000' }, { tokenId: '0.0.2000' }];
+
+        const forms = [
+            (s) => `schema:${s.uuid}#${s.uuid}`,
+            (s) => `schema:${s.uuid}&${s.version}`,
+            (s) => `schema:${s.uuid}#`,
+            (s) => `schema:${s.uuid}`,
+            (s) => `#${s.uuid}&${s.version}`,
+            (s) => `#${s.uuid}`,
+            (s) => `${s.uuid}&${s.version}`,
+            (s) => `${s.uuid}`,
+        ];
+
+        const doc = {};
+        for (let i = 0; i < schemas.length; i++) {
+            const s = schemas[i];
+            const form = forms[i % forms.length];
+            doc[`field_${i}`] = form(s);
+            // Cross reference (different uuids around a '#').
+            if (i % 5 === 0) {
+                const other = schemas[(i + 7) % schemas.length];
+                doc[`ref_${i}`] = `schema:${s.uuid}#${other.uuid}`;
+            }
+            // Reference embedded inside free text (must still be substring-replaced).
+            if (i % 7 === 0) {
+                const other = schemas[(i + 1) % schemas.length];
+                doc[`note_${i}`] = `some text ${forms[(i + 3) % forms.length](s)} and #${other.uuid} end`;
+            }
+            if (i % 50 === 0) {
+                doc[`tok_${i}`] = '0.0.1000 and 0.0.2000';
+            }
+        }
+        const json = JSON.stringify(doc);
+        assertParity(json, schemas, tokens);
+    });
+});


### PR DESCRIPTION
### Description
Moving a policy from Draft to Dry-Run took ~40–50s for large policies because `PolicyImportExport.cleanBeforeHash` normalized schema and token references with a full-string `replaceAll` per schema per reference form (O(schemas²)), which accounted for the majority of the transition time on a ~900-schema policy.

- Apply each reference form in a single pass using one alternation regex of its exact keys in insertion order, reproducing the original `replaceAll` substring semantics and prefix precedence byte-for-byte so policy hashes stay stable for already-published policies.
- Add a parity unit test asserting the single-pass output matches the original algorithm across every reference form, references embedded in free text, prefix versions, token ids, and a large randomized policy body.

Fixes #6540.