### PR TITLE
fix: 6507 layer next gen banner under nav menus

### DIFF
--- a/frontend/src/app/views/next-gen-banner/next-gen-banner.component.scss
+++ b/frontend/src/app/views/next-gen-banner/next-gen-banner.component.scss
@@ -2,8 +2,11 @@
     position: fixed;
     top: var(--header-height);
     right: 0;
-    left: 0;
-    z-index: 10000;
+    /* Inset by the vertical rail, like the page content. */
+    left: var(--header-width, var(--header-width-expand));
+    transition: left 0.125s ease-in-out;
+    /* Below the header layer (100) so menus open over the banner. */
+    z-index: 90;
     min-height: 40px;
     display: flex;
     align-items: center;
@@ -12,6 +15,11 @@
     background: var(--color-primary);
     color: var(--guardian-on-primary-color);
     box-sizing: border-box;
+}
+
+/* No rail here, and --header-width can be stale after a layout switch. */
+:host-context(.layout-horizontal) .next-gen-banner {
+    left: 0;
 }
 
 .next-gen-banner-line {


### PR DESCRIPTION
### Description

The experimental UI banner used `z-index: 10000`, while the header rail and top bar are fixed at `z-index: 100` and therefore form their own stacking contexts. Their dropdowns and flyouts could never paint above the banner, so open menus were covered by it. The banner also spanned the full width, overlapping the vertical rail in the layout where the header height is zero.

- Lower the banner to `z-index: 90` so it sits above page content but below the header layer.
- Inset the banner by the vertical rail width, tracking collapse and expand with the same transition as the page content.
- Pin the banner to the left edge in the horizontal layout, where there is no rail.

Resolves: #6507