### PR TITLE
fix: enhance task dispatch handling and payload limits in queue service

### DIFF
--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -255,7 +255,11 @@ export abstract class NatsService {
         const timeoutPromise = new Promise<T>((_, reject) => {
             setTimeout(() => {
                 this.responseCallbacksMap.delete(messageId);
-                reject(new Error(`Timeout exceed (${subject})`));
+                // Tagged so callers can tell "no ack within the deadline" apart from a transport
+                // error: a timeout does not prove the message was never delivered.
+                const error: any = new Error(`Timeout exceed (${subject})`);
+                error.code = 'DISPATCH_TIMEOUT';
+                reject(error);
             }, timeout);
         });
 

--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -378,8 +378,15 @@ export abstract class NatsService {
      * @param subject
      * @param cb
      * @param noRespond
+     * @param beforeDecode Optional synchronous hook run right after auth, before `codec.decode`.
+     * `codec.decode` can HTTP-fetch an out-of-band `directLink` payload, which for a large task
+     * takes far longer than authenticating the message - a caller that needs to claim some piece
+     * of state per-message (e.g. a busy flag) has to do it here, not in `cb`, or a second message
+     * arriving mid-decode observes the stale pre-claim state. Return a value to short-circuit:
+     * skip `cb`/decode entirely and respond with it (or, if `noRespond`, just skip). Return
+     * `undefined` to proceed normally.
      */
-    public getMessages<T, A>(subject: string, cb: Function, noRespond = false): Subscription {
+    public getMessages<T, A>(subject: string, cb: Function, noRespond = false, beforeDecode?: () => unknown): Subscription {
         this.addAdditionalAvailableEvents([subject]);
         return this.connection.subscribe(subject, {
             queue: this.messageQueueName,
@@ -417,6 +424,17 @@ export abstract class NatsService {
                     } catch (err) {
                         throw err;
                     }
+
+                    if (beforeDecode) {
+                        const early = beforeDecode();
+                        if (early !== undefined) {
+                            if (!noRespond) {
+                                msg.respond(await this.codec.encode(early), { headers: head });
+                            }
+                            return;
+                        }
+                    }
+
                     if (!noRespond) {
                         msg.respond(await this.codec.encode(await cb(await this.codec.decode(msg.data), msg.headers)), { headers: head });
                     } else {

--- a/common/src/mq/nats-service.ts
+++ b/common/src/mq/nats-service.ts
@@ -255,10 +255,9 @@ export abstract class NatsService {
         const timeoutPromise = new Promise<T>((_, reject) => {
             setTimeout(() => {
                 this.responseCallbacksMap.delete(messageId);
-                // Tagged so callers can tell "no ack within the deadline" apart from a transport
-                // error: a timeout does not prove the message was never delivered.
+                // Reuse REQUEST_TIMEOUT - same "no ack" code requestOrThrow uses below.
                 const error: any = new Error(`Timeout exceed (${subject})`);
-                error.code = 'DISPATCH_TIMEOUT';
+                error.code = 'REQUEST_TIMEOUT';
                 reject(error);
             }, timeout);
         });
@@ -385,17 +384,27 @@ export abstract class NatsService {
      * arriving mid-decode observes the stale pre-claim state. Return a value to short-circuit:
      * skip `cb`/decode entirely and respond with it (or, if `noRespond`, just skip). Return
      * `undefined` to proceed normally.
+     * @param onError Runs if auth/decode/cb throws before a response was sent, so a stranded
+     * `beforeDecode` claim can be released. `claimed` is true only for this message's own claim.
      */
-    public getMessages<T, A>(subject: string, cb: Function, noRespond = false, beforeDecode?: () => unknown): Subscription {
+    public getMessages<T, A>(
+        subject: string,
+        cb: Function,
+        noRespond = false,
+        beforeDecode?: () => unknown,
+        onError?: (error: unknown, claimed: boolean) => void
+    ): Subscription {
         this.addAdditionalAvailableEvents([subject]);
         return this.connection.subscribe(subject, {
             queue: this.messageQueueName,
             callback: async (error, msg) => {
+                let head: ReturnType<typeof headers> | undefined;
+                let claimed = false;
                 try {
                     const messageId = msg.headers?.get('messageId');
                     const serviceToken = msg.headers?.get('serviceToken');
                     // const isRaw = msg.headers.get('rawMessage');
-                    const head = headers();
+                    head = headers();
                     if (messageId) {
                         head.append('messageId', messageId);
                     }
@@ -433,6 +442,7 @@ export abstract class NatsService {
                             }
                             return;
                         }
+                        claimed = true;
                     }
 
                     if (!noRespond) {
@@ -442,6 +452,29 @@ export abstract class NatsService {
                     }
                 } catch (error) {
                     console.error(error);
+
+                    // Release a stranded beforeDecode claim and reply with an error.
+                    if (onError) {
+                        try {
+                            onError(error, claimed);
+                        } catch (hookError) {
+                            console.error(hookError);
+                        }
+                    }
+
+                    if (!noRespond && head) {
+                        try {
+                            await msg.respond(await this.codec.encode({
+                                body: null,
+                                error: error instanceof Error ? error.message : String(error),
+                                code: 500,
+                                name: 'Error',
+                                message: error instanceof Error ? error.message : String(error)
+                            }), { headers: head });
+                        } catch (respondError) {
+                            console.error(respondError);
+                        }
+                    }
                 }
             }
         });

--- a/configs/.env..guardian.system
+++ b/configs/.env..guardian.system
@@ -60,6 +60,11 @@ MIN_PRIORITY="0"
 MAX_PRIORITY="20"
 TASK_TIMEOUT="300"  # in seconds, how long a task can be locked by a worker before being considered stale and unlocked for other workers to pick up
 REFRESH_INTERVAL="50"   # in milliseconds, how often the queue service should check for new messages in the db
+#TASK_MAX_PAYLOAD="268435456"  # bytes; hard ceiling for a task payload (keep in sync with worker memory limit)
+#WORKER_SEND_TASK_TIMEOUT="5000"  # ms; ack timeout for inline payloads
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"  # ms/MB; ack timeout scaling for out-of-band payloads
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"  # ms; cap for the scaled ack timeout
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"  # failed hand-offs before a task is dead-lettered
 
 IPFS_TIMEOUT="720" # seconds
 IPFS_PROVIDER="filebase" # valid options: 'filebase', 'web3storage', 'local'

--- a/configs/.env.develop.guardian.system
+++ b/configs/.env.develop.guardian.system
@@ -60,6 +60,11 @@ MIN_PRIORITY="0"
 MAX_PRIORITY="20"
 TASK_TIMEOUT="300"  # in seconds, how long a task can be locked by a worker before being considered stale and unlocked for other workers to pick up
 REFRESH_INTERVAL="50"   # in milliseconds, how often the queue service should check for new messages in the db
+#TASK_MAX_PAYLOAD="268435456"  # bytes; hard ceiling for a task payload (keep in sync with worker memory limit)
+#WORKER_SEND_TASK_TIMEOUT="5000"  # ms; ack timeout for inline payloads
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"  # ms/MB; ack timeout scaling for out-of-band payloads
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"  # ms; cap for the scaled ack timeout
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"  # failed hand-offs before a task is dead-lettered
 
 IPFS_TIMEOUT="720" # seconds
 IPFS_PROVIDER="filebase" # valid options: 'filebase', 'web3storage', 'local'

--- a/configs/.env.quickstart.guardian.system
+++ b/configs/.env.quickstart.guardian.system
@@ -81,6 +81,11 @@ MIN_PRIORITY="0"
 MAX_PRIORITY="20"
 TASK_TIMEOUT="300"  # in seconds, how long a task can be locked by a worker before being considered stale and unlocked for other workers to pick up
 REFRESH_INTERVAL="50"   # in milliseconds, how often the queue service should check for new messages in the db
+#TASK_MAX_PAYLOAD="268435456"  # bytes; hard ceiling for a task payload (keep in sync with worker memory limit)
+#WORKER_SEND_TASK_TIMEOUT="5000"  # ms; ack timeout for inline payloads
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"  # ms/MB; ack timeout scaling for out-of-band payloads
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"  # ms; cap for the scaled ack timeout
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"  # failed hand-offs before a task is dead-lettered
 
 IPFS_TIMEOUT="720" # seconds
 IPFS_PROVIDER="local" # valid options: 'filebase', 'web3storage', 'local'

--- a/configs/.env.template.guardian.system
+++ b/configs/.env.template.guardian.system
@@ -76,6 +76,11 @@ MIN_PRIORITY="0"
 MAX_PRIORITY="20"
 TASK_TIMEOUT="300"  # in seconds, how long a task can be locked by a worker before being considered stale and unlocked for other workers to pick up
 REFRESH_INTERVAL="50"   # in milliseconds, how often the queue service should check for new messages in the db
+#TASK_MAX_PAYLOAD="268435456"  # bytes; hard ceiling for a task payload (keep in sync with worker memory limit)
+#WORKER_SEND_TASK_TIMEOUT="5000"  # ms; ack timeout for inline payloads
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"  # ms/MB; ack timeout scaling for out-of-band payloads
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"  # ms; cap for the scaled ack timeout
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"  # failed hand-offs before a task is dead-lettered
 
 IPFS_TIMEOUT="720" # seconds
 IPFS_PROVIDER="filebase" # valid options: 'filebase', 'web3storage', 'local'

--- a/interfaces/src/type/messages/workers.type.ts
+++ b/interfaces/src/type/messages/workers.type.ts
@@ -124,6 +124,12 @@ export interface ITask {
     attempt?: number
 
     /**
+     * Number of failed dispatch (hand-off to a worker) attempts, as opposed to `attempt`, which
+     * counts worker-reported business failures. Queue-service only.
+     */
+    dispatchAttempt?: number;
+
+    /**
      * UserId
      */
     interception?: string | null | undefined;

--- a/queue-service/configs/.env.queue
+++ b/queue-service/configs/.env.queue
@@ -11,6 +11,18 @@ DB_HOST="localhost"
 MQ_MAX_PAYLOAD="1048576"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Task payload limits and dispatch retry budget.
+# TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
+#   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
+#   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
+#   worker only acks after fetching and parsing in full.
+# WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
+#TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"
+
 REFRESH_INTERVAL="50"
 
 #PINO_LOGGER

--- a/queue-service/configs/.env.queue
+++ b/queue-service/configs/.env.queue
@@ -15,10 +15,12 @@ MQ_MAX_PAYLOAD="1048576"
 # TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
 #   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
 #   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT - flat ack timeout (ms) for payloads that fit inline in a NATS message.
 # WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
 #   worker only acks after fetching and parsing in full.
 # WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
 #TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT="5000"
 #WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
 #WORKER_SEND_TASK_TIMEOUT_MAX="300000"
 #WORKER_DISPATCH_MAX_ATTEMPTS="3"

--- a/queue-service/configs/.env.queue.develop
+++ b/queue-service/configs/.env.queue.develop
@@ -11,6 +11,18 @@ DB_HOST="localhost"
 MQ_MAX_PAYLOAD="1048576"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Task payload limits and dispatch retry budget.
+# TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
+#   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
+#   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
+#   worker only acks after fetching and parsing in full.
+# WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
+#TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"
+
 REFRESH_INTERVAL="50"
 
 #PINO_LOGGER

--- a/queue-service/configs/.env.queue.develop
+++ b/queue-service/configs/.env.queue.develop
@@ -15,10 +15,12 @@ MQ_MAX_PAYLOAD="1048576"
 # TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
 #   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
 #   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT - flat ack timeout (ms) for payloads that fit inline in a NATS message.
 # WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
 #   worker only acks after fetching and parsing in full.
 # WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
 #TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT="5000"
 #WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
 #WORKER_SEND_TASK_TIMEOUT_MAX="300000"
 #WORKER_DISPATCH_MAX_ATTEMPTS="3"

--- a/queue-service/configs/.env.queue.template
+++ b/queue-service/configs/.env.queue.template
@@ -11,6 +11,18 @@ DB_HOST="localhost"
 MQ_MAX_PAYLOAD="1048576"
 #MQ_MESSAGE_CHUNK=5000000
 
+# Task payload limits and dispatch retry budget.
+# TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
+#   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
+#   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
+#   worker only acks after fetching and parsing in full.
+# WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
+#TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
+#WORKER_SEND_TASK_TIMEOUT_MAX="300000"
+#WORKER_DISPATCH_MAX_ATTEMPTS="3"
+
 REFRESH_INTERVAL="50"
 
 #PINO_LOGGER

--- a/queue-service/configs/.env.queue.template
+++ b/queue-service/configs/.env.queue.template
@@ -15,10 +15,12 @@ MQ_MAX_PAYLOAD="1048576"
 # TASK_MAX_PAYLOAD - hard ceiling (bytes); a larger task is rejected at creation. NOT the same as
 #   MQ_MAX_PAYLOAD: payloads above MQ_MAX_PAYLOAD are legitimate and travel out-of-band via
 #   LargePayloadContainer. Keep in sync with the worker memory limit.
+# WORKER_SEND_TASK_TIMEOUT - flat ack timeout (ms) for payloads that fit inline in a NATS message.
 # WORKER_SEND_TASK_TIMEOUT_PER_MB / _MAX - ack timeout scaling for out-of-band payloads, which the
 #   worker only acks after fetching and parsing in full.
 # WORKER_DISPATCH_MAX_ATTEMPTS - failed hand-offs before the task is dead-lettered.
 #TASK_MAX_PAYLOAD="268435456"
+#WORKER_SEND_TASK_TIMEOUT="5000"
 #WORKER_SEND_TASK_TIMEOUT_PER_MB="2000"
 #WORKER_SEND_TASK_TIMEOUT_MAX="300000"
 #WORKER_DISPATCH_MAX_ATTEMPTS="3"

--- a/queue-service/src/entity/task.ts
+++ b/queue-service/src/entity/task.ts
@@ -15,10 +15,36 @@ import { BaseEntity, DataBaseHelper } from '@guardian/common';
 
 const TASK_DATA_GRIDFS_LIMIT = (+process.env.TASK_DATA_GRIDFS_LIMIT || 5 * 1024 * 1024);
 
+/**
+ * Hard ceiling on task payload size (bytes). A task larger than this is rejected at creation
+ * instead of being accepted into the queue.
+ *
+ * This is deliberately NOT `MQ_MAX_PAYLOAD` (1MB). Payloads above `MQ_MAX_PAYLOAD` are legitimate
+ * and are delivered out-of-band through `LargePayloadContainer` (see `ZipCodec.encode`), so
+ * rejecting at 1MB would break every IPFS `add-file` above ~750KB. What must be rejected is a
+ * payload no worker can realistically fetch, parse and hold in memory.
+ *
+ * Keep this in sync with the worker-service memory limit: decoding a task costs roughly 4-6x its
+ * serialized size on the worker (arraybuffer -> UTF-16 string -> JSON.parse -> base64 decode).
+ */
+const taskMaxPayload = (): number => (+process.env.TASK_MAX_PAYLOAD || 256 * 1024 * 1024);
+
 @Entity()
 @Index({ name: 'idx_status_createDate', properties: ['done', 'sent', 'createDate'], options: { createDate: -1 } })
 @Index({ name: 'idx_status_processedTime', properties: ['done', 'sent', 'processedTime'], options: { processedTime: -1 } })
 @Index({ name: 'idx_processedTime_priority', properties: ['processedTime', 'priority'] })
+// Covers the dispatch query in QueueService.refreshAndReassignTasks (filter on
+// processedTime/done/isError/priority, ordered by createDate).
+//
+// Field order follows the ESR (Equality, Sort, Range) rule, not filter order: `processedTime`
+// is the only equality predicate in the query, so it leads. `done`/`isError` use `$ne` - Mongo
+// can't collapse that into a single tight bound (it splits into two scan ranges), so they add
+// nothing as index keys and are left as cheap residual filters on the already-narrowed
+// candidates instead. `createDate` (the sort key) comes right after the equality prefix so the
+// index can stream results in order instead of Mongo adding a blocking in-memory SORT stage.
+// `priority` - the actual range predicate - goes last. Do not reorder without re-checking
+// explain('executionStats') on a realistic queue depth for a SORT stage above the IXSCAN.
+@Index({ name: 'idx_dispatch_queue', properties: ['processedTime', 'createDate', 'priority'] })
 export class TaskEntity extends BaseEntity implements ITask {
     @Index({ name: 'userId' })
     @Property({ nullable: true })
@@ -46,6 +72,14 @@ export class TaskEntity extends BaseEntity implements ITask {
     @Property({ nullable: true })
     dataFileId?: ObjectId;
 
+    /**
+     * Serialized size of `data` in bytes, recorded at creation. Used to scale the dispatch ack
+     * timeout and to make oversized tasks visible in logs without re-serializing (or
+     * re-downloading from GridFS) the payload.
+     */
+    @Property({ nullable: true })
+    dataSize?: number;
+
     @Property({ nullable: true })
     sent: boolean;
 
@@ -70,12 +104,25 @@ export class TaskEntity extends BaseEntity implements ITask {
     @Property({ nullable: true })
     attempt: number;
 
+    /**
+     * Number of failed *dispatch* attempts (queue-service could not hand the task to a worker at
+     * all - send-task-to-worker timeout / transport error).
+     *
+     * Deliberately separate from `attempt`, which counts worker-reported business failures.
+     * Conflating them would let a couple of transport hiccups silently eat a task's real retry
+     * budget. Reset to 0 on every successful hand-off.
+     */
+    @Property({ nullable: true })
+    dispatchAttempt?: number;
+
     @Property({ nullable: true })
     interception: string | null;
 
     @BeforeCreate()
     async offloadDataOnCreate() {
-        await this.offloadData();
+        // Only validate the size ceiling on insert, so a task that is already in the queue can
+        // never be made un-saveable by a later status update.
+        await this.offloadData(true);
     }
 
     @BeforeUpdate()
@@ -84,7 +131,7 @@ export class TaskEntity extends BaseEntity implements ITask {
             this.data = null;
             return;
         }
-        await this.offloadData();
+        await this.offloadData(false);
     }
 
     @OnLoad()
@@ -109,14 +156,44 @@ export class TaskEntity extends BaseEntity implements ITask {
         }
     }
 
-    private async offloadData(): Promise<void> {
+    /**
+     * Move `data` to GridFS if its serialized size exceeds the inline limit. Also records the
+     * serialized size and, on insert, rejects payloads above `TASK_MAX_PAYLOAD` so an undeliverable
+     * task never enters the queue in the first place.
+     *
+     * @param validateSize enforce the TASK_MAX_PAYLOAD ceiling (insert only)
+     */
+    private async offloadData(validateSize: boolean): Promise<void> {
         if (this.data === null || this.data === undefined) {
             return;
         }
         const json = JSON.stringify(this.data);
-        if (Buffer.byteLength(json) > TASK_DATA_GRIDFS_LIMIT) {
+        const size = Buffer.byteLength(json);
+        this.dataSize = size;
+
+        // Fail fast, with a message the caller can surface to the user. The throw propagates
+        // through save() to the ADD_TASK_TO_QUEUE handler, which replies { ok: false }, which
+        // Workers.addTask turns into a rejected task promise (i.e. a visible publish error)
+        // rather than a request that hangs until the caller's own deadline.
+        const maxPayload = taskMaxPayload();
+        if (validateSize && size > maxPayload) {
+            throw new Error(
+                `Task payload is too large: ${TaskEntity.formatBytes(size)} ` +
+                `(limit ${TaskEntity.formatBytes(maxPayload)}, task type "${this.type}"). ` +
+                `Reduce the file size or split the upload.`
+            );
+        }
+
+        if (size > TASK_DATA_GRIDFS_LIMIT) {
             this.dataFileId = await this._createFile(json, 'Task');
             this.data = null;
         }
+    }
+
+    /**
+     * Human-readable byte size for user-facing error messages.
+     */
+    private static formatBytes(bytes: number): string {
+        return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
     }
 }

--- a/queue-service/src/entity/task.ts
+++ b/queue-service/src/entity/task.ts
@@ -15,35 +15,16 @@ import { BaseEntity, DataBaseHelper } from '@guardian/common';
 
 const TASK_DATA_GRIDFS_LIMIT = (+process.env.TASK_DATA_GRIDFS_LIMIT || 5 * 1024 * 1024);
 
-/**
- * Hard ceiling on task payload size (bytes). A task larger than this is rejected at creation
- * instead of being accepted into the queue.
- *
- * This is deliberately NOT `MQ_MAX_PAYLOAD` (1MB). Payloads above `MQ_MAX_PAYLOAD` are legitimate
- * and are delivered out-of-band through `LargePayloadContainer` (see `ZipCodec.encode`), so
- * rejecting at 1MB would break every IPFS `add-file` above ~750KB. What must be rejected is a
- * payload no worker can realistically fetch, parse and hold in memory.
- *
- * Keep this in sync with the worker-service memory limit: decoding a task costs roughly 4-6x its
- * serialized size on the worker (arraybuffer -> UTF-16 string -> JSON.parse -> base64 decode).
- */
+// Hard ceiling on task size (bytes), rejected at creation. Not MQ_MAX_PAYLOAD - large payloads
+// go out-of-band via LargePayloadContainer. Keep in sync with the worker memory limit.
 const taskMaxPayload = (): number => (+process.env.TASK_MAX_PAYLOAD || 256 * 1024 * 1024);
 
 @Entity()
 @Index({ name: 'idx_status_createDate', properties: ['done', 'sent', 'createDate'], options: { createDate: -1 } })
 @Index({ name: 'idx_status_processedTime', properties: ['done', 'sent', 'processedTime'], options: { processedTime: -1 } })
 @Index({ name: 'idx_processedTime_priority', properties: ['processedTime', 'priority'] })
-// Covers the dispatch query in QueueService.refreshAndReassignTasks (filter on
-// processedTime/done/isError/priority, ordered by createDate).
-//
-// Field order follows the ESR (Equality, Sort, Range) rule, not filter order: `processedTime`
-// is the only equality predicate in the query, so it leads. `done`/`isError` use `$ne` - Mongo
-// can't collapse that into a single tight bound (it splits into two scan ranges), so they add
-// nothing as index keys and are left as cheap residual filters on the already-narrowed
-// candidates instead. `createDate` (the sort key) comes right after the equality prefix so the
-// index can stream results in order instead of Mongo adding a blocking in-memory SORT stage.
-// `priority` - the actual range predicate - goes last. Do not reorder without re-checking
-// explain('executionStats') on a realistic queue depth for a SORT stage above the IXSCAN.
+// Covers refreshAndReassignTasks's dispatch query. ESR order: processedTime (equality) leads,
+// createDate (sort) next, priority (range) last - don't reorder without re-checking explain().
 @Index({ name: 'idx_dispatch_queue', properties: ['processedTime', 'createDate', 'priority'] })
 export class TaskEntity extends BaseEntity implements ITask {
     @Index({ name: 'userId' })
@@ -72,11 +53,7 @@ export class TaskEntity extends BaseEntity implements ITask {
     @Property({ nullable: true })
     dataFileId?: ObjectId;
 
-    /**
-     * Serialized size of `data` in bytes, recorded at creation. Used to scale the dispatch ack
-     * timeout and to make oversized tasks visible in logs without re-serializing (or
-     * re-downloading from GridFS) the payload.
-     */
+    /** Serialized size of `data` in bytes; used to scale the dispatch ack timeout. */
     @Property({ nullable: true })
     dataSize?: number;
 
@@ -104,14 +81,7 @@ export class TaskEntity extends BaseEntity implements ITask {
     @Property({ nullable: true })
     attempt: number;
 
-    /**
-     * Number of failed *dispatch* attempts (queue-service could not hand the task to a worker at
-     * all - send-task-to-worker timeout / transport error).
-     *
-     * Deliberately separate from `attempt`, which counts worker-reported business failures.
-     * Conflating them would let a couple of transport hiccups silently eat a task's real retry
-     * budget. Reset to 0 on every successful hand-off.
-     */
+    /** Failed hand-off attempts (transport/timeout), separate from `attempt`'s worker-reported failures. */
     @Property({ nullable: true })
     dispatchAttempt?: number;
 
@@ -120,8 +90,7 @@ export class TaskEntity extends BaseEntity implements ITask {
 
     @BeforeCreate()
     async offloadDataOnCreate() {
-        // Only validate the size ceiling on insert, so a task that is already in the queue can
-        // never be made un-saveable by a later status update.
+        // Validate size only on insert - a queued task must stay saveable.
         await this.offloadData(true);
     }
 
@@ -156,13 +125,7 @@ export class TaskEntity extends BaseEntity implements ITask {
         }
     }
 
-    /**
-     * Move `data` to GridFS if its serialized size exceeds the inline limit. Also records the
-     * serialized size and, on insert, rejects payloads above `TASK_MAX_PAYLOAD` so an undeliverable
-     * task never enters the queue in the first place.
-     *
-     * @param validateSize enforce the TASK_MAX_PAYLOAD ceiling (insert only)
-     */
+    /** Offloads `data` to GridFS above the inline limit; on insert, also rejects payloads over TASK_MAX_PAYLOAD. */
     private async offloadData(validateSize: boolean): Promise<void> {
         if (this.data === null || this.data === undefined) {
             return;
@@ -171,10 +134,7 @@ export class TaskEntity extends BaseEntity implements ITask {
         const size = Buffer.byteLength(json);
         this.dataSize = size;
 
-        // Fail fast, with a message the caller can surface to the user. The throw propagates
-        // through save() to the ADD_TASK_TO_QUEUE handler, which replies { ok: false }, which
-        // Workers.addTask turns into a rejected task promise (i.e. a visible publish error)
-        // rather than a request that hangs until the caller's own deadline.
+        // Fail fast with a message the caller can surface, instead of hanging until its deadline.
         const maxPayload = taskMaxPayload();
         if (validateSize && size > maxPayload) {
             throw new Error(
@@ -190,9 +150,7 @@ export class TaskEntity extends BaseEntity implements ITask {
         }
     }
 
-    /**
-     * Human-readable byte size for user-facing error messages.
-     */
+    /** Human-readable byte size for error messages. */
     private static formatBytes(bytes: number): string {
         return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
     }

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -33,13 +33,14 @@ export class QueueService extends NatsService {
     private trigger: boolean = false;
 
     /**
-     * Worker subjects with a dispatch currently in flight. GET_FREE_WORKERS can report a worker
-     * free while it is still mid-decode of a large out-of-band payload - the worker only sets
-     * `isInUse` once its SEND_TASK_TO_WORKER handler actually runs, which is after that decode
-     * (an HTTP fetch for tens of MB) completes. Without this, a slow decode lets the same worker
-     * get claimed again on the next refresh tick, and the second task is then invisible to
-     * genuinely free workers. Tracking our own in-flight dispatches lets the loop below trust
-     * this over a stale free-worker report.
+     * Worker subjects with a dispatch currently in flight. A worker claims `isInUse` atomically
+     * before decoding an incoming task (see `claimIfFree` in worker-service/src/api/worker.ts),
+     * so it stops answering GET_FREE_WORKERS the moment a send lands - but our own free-worker
+     * report can still be up to a refresh tick + the 300ms getFreeWorkers window stale by the
+     * time we act on it. Without this, that staleness lets the same worker get claimed again on
+     * the next refresh tick before its first busy report arrives, and the second task is then
+     * invisible to genuinely free workers. Tracking our own in-flight dispatches lets the loop
+     * below trust this over a stale free-worker report.
      */
     private readonly inFlightWorkers = new Set<string>();
 

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -32,6 +32,17 @@ export class QueueService extends NatsService {
 
     private trigger: boolean = false;
 
+    /**
+     * Worker subjects with a dispatch currently in flight. GET_FREE_WORKERS can report a worker
+     * free while it is still mid-decode of a large out-of-band payload - the worker only sets
+     * `isInUse` once its SEND_TASK_TO_WORKER handler actually runs, which is after that decode
+     * (an HTTP fetch for tens of MB) completes. Without this, a slow decode lets the same worker
+     * get claimed again on the next refresh tick, and the second task is then invisible to
+     * genuinely free workers. Tracking our own in-flight dispatches lets the loop below trust
+     * this over a stale free-worker report.
+     */
+    private readonly inFlightWorkers = new Set<string>();
+
     public async init() {
         await super.init();
 
@@ -236,6 +247,12 @@ export class QueueService extends NatsService {
             const dataBaseServer = new DatabaseServer();
 
             for (const worker of workers) {
+                if (this.inFlightWorkers.has(worker.subject)) {
+                    // Trust our own bookkeeping over this free-worker report - see
+                    // inFlightWorkers above for why the report can be stale.
+                    continue;
+                }
+
                 const task = await dataBaseServer.findOne(TaskEntity, {
                     priority: {
                         $gte: worker.minPriority,
@@ -270,9 +287,14 @@ export class QueueService extends NatsService {
                 task.sent = true;
                 await dataBaseServer.save(TaskEntity, task);
 
-                this.dispatchClaimedTask(worker, task, payload, timeout).catch((error) => {
-                    console.error('Error while sending task to worker:', error);
-                });
+                this.inFlightWorkers.add(worker.subject);
+                this.dispatchClaimedTask(worker, task, payload, timeout)
+                    .catch((error) => {
+                        console.error('Error while sending task to worker:', error);
+                    })
+                    .finally(() => {
+                        this.inFlightWorkers.delete(worker.subject);
+                    });
             }
         } finally {
             this.trigger = false;
@@ -301,14 +323,27 @@ export class QueueService extends NatsService {
                 // earlier) can already be occupied by the time the send actually reaches it.
                 // Routing this through releaseOrParkTask would burn the dead-letter budget on
                 // healthy tasks under normal load, so just release the claim.
-                task.processedTime = null;
-                task.sent = false;
-                await new DatabaseServer().save(TaskEntity, task);
+                await this.releaseClaim(task.taskId);
                 return;
             }
             console.log('task sent error');
             await this.releaseOrParkTask(task, `Task was rejected by the worker: ${JSON.stringify(r)}`);
         } catch (error) {
+            if (error?.code === 'DISPATCH_TIMEOUT') {
+                // An ack timeout does not prove the task was never delivered - a worker only acks
+                // an out-of-band payload after fetching and parsing it in full, and a genuinely
+                // hung worker times out on every attempt regardless of whether it received the
+                // task. Re-queueing here (as releaseOrParkTask does for provably-undelivered
+                // transport errors) could run a Hedera mint/transfer a second time while the first
+                // attempt is still in flight. Leave the claim in place instead: clearLongPendingTasks
+                // reclaims it once processTimeout is reached, same as it did before dispatch had a
+                // timeout at all.
+                console.warn(
+                    `[Queue] dispatch ack timed out, leaving claim in place for clearLongPendingTasks. ` +
+                    `taskId: ${task.taskId}, type: ${task.type}, size: ${task.dataSize ?? 'n/a'}`
+                );
+                return;
+            }
             await this.releaseOrParkTask(task, error?.message || String(error));
         }
     }
@@ -329,17 +364,35 @@ export class QueueService extends NatsService {
     }
 
     /**
+     * Release a claim without touching the dispatch budget - for outcomes that are not the
+     * worker's fault (busy). Re-reads the task instead of writing back the caller's snapshot,
+     * for the same reason as resetDispatchAttempt/releaseOrParkTask: dispatchClaimedTask can
+     * hold that snapshot across an await lasting up to workerSendTaskTimeoutMax.
+     */
+    private async releaseClaim(taskId: string): Promise<void> {
+        const dataBaseServer = new DatabaseServer();
+        const current = await dataBaseServer.findOne(TaskEntity, { taskId });
+        if (!current || current.done || current.isError) {
+            return;
+        }
+        current.processedTime = null;
+        current.sent = false;
+        await dataBaseServer.save(TaskEntity, current);
+    }
+
+    /**
      * Roll a failed hand-off back into the queue, or dead-letter the task once it has exhausted
      * its dispatch budget.
      *
      * `attempt` is only ever incremented in the WorkerEvents.TASK_COMPLETE handler, i.e. only on
-     * errors *reported by a worker*. A task that never reaches a worker at all - a dispatch
-     * timeout or transport error - would otherwise retry forever without ever being marked
-     * failed. `dispatchAttempt` gives that case its own bounded budget.
+     * errors *reported by a worker*. A task that never reaches a worker at all - a transport
+     * error such as an encode/publish/no-responders failure - would otherwise retry forever
+     * without ever being marked failed. `dispatchAttempt` gives that case its own bounded budget.
      *
-     * NOTE: a send timeout does not prove the task was not delivered, so re-queueing can in
-     * principle run a task twice. That risk is inherent to fire-and-forget dispatch and predates
-     * this change.
+     * Only reached for errors that prove the task was never handed to a worker. An ack *timeout*
+     * does not prove that - see dispatchClaimedTask's catch block, which handles it separately
+     * (leaving the claim for clearLongPendingTasks) precisely because re-queueing an ambiguous
+     * outcome here could run the task twice.
      */
     private async releaseOrParkTask(task: TaskEntity, reason: string): Promise<void> {
         const dataBaseServer = new DatabaseServer();

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -11,6 +11,25 @@ export class QueueService extends NatsService {
     private readonly refreshInterval = parseInt(process.env.REFRESH_INTERVAL, 10) || 1 * 1000; // 1s
     private readonly processTimeout = parseInt(process.env.PROCESS_TIMEOUT, 10) || 1 * 60 * 60000; // 1 hour
 
+    private readonly workerSendTaskTimeout = parseInt(process.env.WORKER_SEND_TASK_TIMEOUT, 10) || 5 * 1000; // 5s
+
+    /**
+     * The flat ack timeout above is only correct for payloads that travel inline over NATS.
+     * Anything above MQ_MAX_PAYLOAD is shipped as a `directLink` (see ZipCodec.encode) and the
+     * worker only acks *after* it has HTTP-fetched and parsed the whole payload - which for tens
+     * of MB is inherently slower than a few seconds. Scale the timeout with the payload size so a
+     * large but perfectly valid task is not declared failed while the worker is still downloading
+     * it.
+     */
+    private readonly workerSendTaskTimeoutPerMb = parseInt(process.env.WORKER_SEND_TASK_TIMEOUT_PER_MB, 10) || 2 * 1000; // 2s per MB
+    private readonly workerSendTaskTimeoutMax = parseInt(process.env.WORKER_SEND_TASK_TIMEOUT_MAX, 10) || 5 * 60 * 1000; // 5m
+
+    /**
+     * How many times a task may fail *dispatch* before it is dead-lettered.
+     * See TaskEntity.dispatchAttempt for why this is not `attempts`.
+     */
+    private readonly dispatchMaxAttempts = parseInt(process.env.WORKER_DISPATCH_MAX_ATTEMPTS, 10) || 3;
+
     private trigger: boolean = false;
 
     public async init() {
@@ -53,6 +72,7 @@ export class QueueService extends NatsService {
                     task.processedTime = null;
                     task.sent = false;
                     task.attempt = task.attempt + 1;
+                    task.dispatchAttempt = 0; // the task reached a worker, so the dispatch budget is fresh
                 } else {
                     task.isError = true;
                     task.errorReason = data.error;
@@ -120,6 +140,8 @@ export class QueueService extends NatsService {
                 delete task.priority;
                 delete task.attempt;
                 delete task.attempts;
+                delete task.dispatchAttempt; // internal dispatch bookkeeping, not user-facing
+                delete task.dataSize;
                 delete task._id;
             }
             return new MessageResponse(result);
@@ -134,6 +156,8 @@ export class QueueService extends NatsService {
             }
             task.isError = false;
             task.attempt = 0;
+            task.dispatchAttempt = 0; // a dead-lettered task must get a fresh dispatch budget
+            task.done = false;
             task.sent = false;
             task.processedTime = null;
             task.errorReason = undefined;
@@ -185,6 +209,7 @@ export class QueueService extends NatsService {
     private iTaskToTaskEntity(task: ITask): ITask {
         task.taskId = task.id;
         task.attempt = 0;
+        task.dispatchAttempt = 0;
         delete task.id;
         return task;
     }
@@ -201,8 +226,11 @@ export class QueueService extends NatsService {
     }
 
     private async refreshAndReassignTasks() {
-        if (!this.trigger) {
-            this.trigger = true;
+        if (this.trigger) {
+            return;
+        }
+        this.trigger = true;
+        try {
             const workers = await this.getFreeWorkers();
 
             const dataBaseServer = new DatabaseServer();
@@ -213,22 +241,171 @@ export class QueueService extends NatsService {
                         $gte: worker.minPriority,
                         $lte: worker.maxPriority
                     },
-                    processedTime: null
+                    processedTime: null,
+                    // Never re-pick a task that has already finished or was dead-lettered.
+                    done: { $ne: true },
+                    isError: { $ne: true }
+                }, {
+                    // FIFO. Without an explicit order, a task that could not be dispatched stayed
+                    // at the head of the (unordered) result and was retried forever while
+                    // everything behind it starved.
+                    orderBy: { createDate: OrderDirection.ASC }
                 });
                 if (!task) {
                     continue;
                 }
-                const r = await this.sendMessage(worker.subject, this.taskEntityToITask(task)) as any;
-                if (r?.result) {
-                    task.processedTime = new Date();
-                    task.sent = true;
-                    await dataBaseServer.save(TaskEntity, task);
-                } else {
-                    console.log('task sent error')
-                }
+
+                // Snapshot the payload and timeout before claiming: BeforeUpdate/AfterUpdate on an
+                // offloaded task clears `data` and re-reads it from GridFS on every save, and
+                // relying on that round trip to still hold the payload by the time we send would
+                // be fragile - an empty payload would be far worse than a slow one.
+                const payload = this.taskEntityToITask(task);
+                const timeout = this.getSendTaskTimeout(task);
+
+                // Claim the task before attempting to send it, and dispatch without awaiting
+                // here: refreshAndReassignTasks is single-flight (guarded by `this.trigger`), so a
+                // single slow or undeliverable payload would otherwise hold up every other worker
+                // in this batch - and, on the next tick, the whole queue.
+                task.processedTime = new Date();
+                task.sent = true;
+                await dataBaseServer.save(TaskEntity, task);
+
+                this.dispatchClaimedTask(worker, task, payload, timeout).catch((error) => {
+                    console.error('Error while sending task to worker:', error);
+                });
             }
+        } finally {
             this.trigger = false;
         }
+    }
+
+    /**
+     * Hand a claimed task to a worker and account for the outcome. `payload` and `timeout` are
+     * computed by the caller from the task as claimed, before any GridFS offload round trip.
+     */
+    private async dispatchClaimedTask(worker: any, task: TaskEntity, payload: ITask, timeout: number): Promise<void> {
+        try {
+            const r = await this.sendMessageWithTimeout(worker.subject, timeout, payload) as any;
+            if (r?.result) {
+                // The task is already claimed; only the dispatch retry budget needs resetting so
+                // a task that survived a transport hiccup starts fresh next time.
+                if (task.dispatchAttempt) {
+                    await this.resetDispatchAttempt(task.taskId);
+                }
+                return;
+            }
+            if (r && r.result === false) {
+                // `{ result: false }` means the worker's SEND_TASK_TO_WORKER handler found
+                // `isInUse` true - it was busy, not a failed hand-off. This happens routinely:
+                // a worker reported free by getFreeWorkers() (up to 300ms + one refresh tick
+                // earlier) can already be occupied by the time the send actually reaches it.
+                // Routing this through releaseOrParkTask would burn the dead-letter budget on
+                // healthy tasks under normal load, so just release the claim.
+                task.processedTime = null;
+                task.sent = false;
+                await new DatabaseServer().save(TaskEntity, task);
+                return;
+            }
+            console.log('task sent error');
+            await this.releaseOrParkTask(task, `Task was rejected by the worker: ${JSON.stringify(r)}`);
+        } catch (error) {
+            await this.releaseOrParkTask(task, error?.message || String(error));
+        }
+    }
+
+    /**
+     * Reset the dispatch budget by re-reading the task instead of writing back the snapshot
+     * `dispatchClaimedTask` claimed before the send - see `releaseOrParkTask` for why a stale
+     * snapshot write can revert a task that finished while the send was in flight.
+     */
+    private async resetDispatchAttempt(taskId: string): Promise<void> {
+        const dataBaseServer = new DatabaseServer();
+        const current = await dataBaseServer.findOne(TaskEntity, { taskId });
+        if (!current || current.done || current.isError) {
+            return;
+        }
+        current.dispatchAttempt = 0;
+        await dataBaseServer.save(TaskEntity, current);
+    }
+
+    /**
+     * Roll a failed hand-off back into the queue, or dead-letter the task once it has exhausted
+     * its dispatch budget.
+     *
+     * `attempt` is only ever incremented in the WorkerEvents.TASK_COMPLETE handler, i.e. only on
+     * errors *reported by a worker*. A task that never reaches a worker at all - a dispatch
+     * timeout or transport error - would otherwise retry forever without ever being marked
+     * failed. `dispatchAttempt` gives that case its own bounded budget.
+     *
+     * NOTE: a send timeout does not prove the task was not delivered, so re-queueing can in
+     * principle run a task twice. That risk is inherent to fire-and-forget dispatch and predates
+     * this change.
+     */
+    private async releaseOrParkTask(task: TaskEntity, reason: string): Promise<void> {
+        const dataBaseServer = new DatabaseServer();
+
+        // Re-read the task instead of writing back the snapshot the caller claimed before the
+        // send. dispatchClaimedTask can now legitimately hold that snapshot across an await that
+        // lasts up to workerSendTaskTimeoutMax (5m, scaled for large payloads). If the ack raced
+        // that timeout, the worker may still have run the task to completion and already saved
+        // done/isError via WorkerEvents.TASK_COMPLETE - a full-object overwrite here with the
+        // stale snapshot would revert a completed task back to pending/errored and publish a
+        // spurious dead-letter TASK_COMPLETE on top of the real result. Bail out if the worker
+        // already got there first.
+        const current = await dataBaseServer.findOne(TaskEntity, { taskId: task.taskId });
+        if (!current || current.done || current.isError) {
+            return;
+        }
+
+        current.dispatchAttempt = (current.dispatchAttempt || 0) + 1;
+        current.sent = false;
+
+        if (current.dispatchAttempt < this.dispatchMaxAttempts) {
+            current.processedTime = null;
+            await dataBaseServer.save(TaskEntity, current);
+            console.warn(
+                `[Queue] dispatch failed, re-queued. taskId: ${current.taskId}, type: ${current.type}, ` +
+                `attempt: ${current.dispatchAttempt}/${this.dispatchMaxAttempts}, ` +
+                `size: ${current.dataSize ?? 'n/a'}, reason: ${reason}`
+            );
+            return;
+        }
+
+        // Dead-letter. `processedTime` and `isError` both keep the task out of the dispatch
+        // query above, so one undeliverable task degrades to one failed task instead of blocking
+        // the whole queue. `done` is left false on purpose: that is how an errored task is already
+        // represented (see completeTaskInQueue), so the task list keeps showing it under ERROR and
+        // RESTART_TASK can still revive it.
+        current.processedTime = new Date();
+        current.isError = true;
+        current.errorReason = reason;
+        await dataBaseServer.save(TaskEntity, current);
+
+        console.error(
+            `[Queue] task dead-lettered after ${current.dispatchAttempt} failed dispatch attempts. ` +
+            `taskId: ${current.taskId}, type: ${current.type}, size: ${current.dataSize ?? 'n/a'}, reason: ${reason}`
+        );
+
+        // Tell the caller instead of letting it hang until its own deadline.
+        await this.publish(QueueEvents.TASK_COMPLETE, {
+            id: current.taskId,
+            data: null,
+            error: reason
+        });
+    }
+
+    /**
+     * Ack timeout scaled to the payload size, capped.
+     */
+    private getSendTaskTimeout(task: TaskEntity): number {
+        const megabyte = 1024 * 1024;
+        // Tasks created before dataSize existed fall back to a one-off measurement.
+        const size = task.dataSize ?? (task.data ? Buffer.byteLength(JSON.stringify(task.data)) : 0);
+        if (size <= megabyte) {
+            return this.workerSendTaskTimeout;
+        }
+        const scaled = this.workerSendTaskTimeout + Math.ceil(size / megabyte) * this.workerSendTaskTimeoutPerMb;
+        return Math.min(scaled, this.workerSendTaskTimeoutMax);
     }
 
     private async clearOldTasks() {

--- a/queue-service/src/queue-service/queue-service.ts
+++ b/queue-service/src/queue-service/queue-service.ts
@@ -330,23 +330,55 @@ export class QueueService extends NatsService {
             console.log('task sent error');
             await this.releaseOrParkTask(task, `Task was rejected by the worker: ${JSON.stringify(r)}`);
         } catch (error) {
-            if (error?.code === 'DISPATCH_TIMEOUT') {
-                // An ack timeout does not prove the task was never delivered - a worker only acks
-                // an out-of-band payload after fetching and parsing it in full, and a genuinely
-                // hung worker times out on every attempt regardless of whether it received the
-                // task. Re-queueing here (as releaseOrParkTask does for provably-undelivered
-                // transport errors) could run a Hedera mint/transfer a second time while the first
-                // attempt is still in flight. Leave the claim in place instead: clearLongPendingTasks
-                // reclaims it once processTimeout is reached, same as it did before dispatch had a
-                // timeout at all.
-                console.warn(
-                    `[Queue] dispatch ack timed out, leaving claim in place for clearLongPendingTasks. ` +
-                    `taskId: ${task.taskId}, type: ${task.type}, size: ${task.dataSize ?? 'n/a'}`
-                );
+            if (error?.code === 'REQUEST_TIMEOUT') {
+                // Ack timeout: keep the claim (may still be running), but count it against the
+                // dispatch budget - clearLongPendingTasks can't reclaim it (createDate-based).
+                await this.recordDispatchTimeout(task, error?.message || String(error));
                 return;
             }
             await this.releaseOrParkTask(task, error?.message || String(error));
         }
+    }
+
+    /**
+     * Spends the dispatch budget on an ack timeout without releasing the claim; dead-letters
+     * once exhausted.
+     */
+    private async recordDispatchTimeout(task: TaskEntity, reason: string): Promise<void> {
+        const dataBaseServer = new DatabaseServer();
+
+        const current = await dataBaseServer.findOne(TaskEntity, { taskId: task.taskId });
+        if (!current || current.done || current.isError) {
+            return;
+        }
+
+        current.dispatchAttempt = (current.dispatchAttempt || 0) + 1;
+
+        if (current.dispatchAttempt < this.dispatchMaxAttempts) {
+            // processedTime/sent untouched - claim stays in place.
+            await dataBaseServer.save(TaskEntity, current);
+            console.warn(
+                `[Queue] dispatch ack timed out, leaving claim in place. taskId: ${current.taskId}, ` +
+                `type: ${current.type}, attempt: ${current.dispatchAttempt}/${this.dispatchMaxAttempts}, ` +
+                `size: ${current.dataSize ?? 'n/a'}, reason: ${reason}`
+            );
+            return;
+        }
+
+        current.isError = true;
+        current.errorReason = reason;
+        await dataBaseServer.save(TaskEntity, current);
+
+        console.error(
+            `[Queue] task dead-lettered after ${current.dispatchAttempt} ack timeouts. ` +
+            `taskId: ${current.taskId}, type: ${current.type}, size: ${current.dataSize ?? 'n/a'}, reason: ${reason}`
+        );
+
+        await this.publish(QueueEvents.TASK_COMPLETE, {
+            id: current.taskId,
+            data: null,
+            error: reason
+        });
     }
 
     /**

--- a/queue-service/tests/queue-service-dispatch.test.mjs
+++ b/queue-service/tests/queue-service-dispatch.test.mjs
@@ -1,0 +1,293 @@
+import assert from 'node:assert/strict';
+import { DatabaseServer } from '@guardian/common';
+import { QueueService } from '../dist/queue-service/queue-service.js';
+import { QueueEvents } from '@guardian/interfaces';
+
+// Regression coverage: two 81.78MB add-file tasks could enter the queue, never fit inline over
+// NATS, and retry forever because a failed hand-off to a worker never advanced any counter - the
+// task was therefore never given up on. These tests cover the counter (dispatchAttempt) and the
+// timeout scaling that make a large-but-valid task distinguishable from an undeliverable one.
+
+const service = new QueueService();
+
+const MB = 1024 * 1024;
+
+// Minimal stand-in for a claimed TaskEntity. releaseOrParkTask only reads/writes plain fields
+// before it reaches the (uninitialised) ORM, so the state machine is observable without a DB.
+const makeTask = (over = {}) => ({
+    taskId: 't-1',
+    type: 'add-file',
+    data: { payload: 'x' },
+    dataSize: 82 * MB,
+    attempt: 0,
+    attempts: 3,
+    isRetryableTask: true,
+    dispatchAttempt: 0,
+    sent: true,
+    done: false,
+    isError: false,
+    errorReason: undefined,
+    processedTime: new Date(),
+    ...over,
+});
+
+// The ORM is not initialised in unit tests, so save() throws. Everything the state machine
+// decides happens before that call, which is exactly what we want to assert.
+const runReleaseOrPark = async (task, reason) => {
+    await assert.rejects(() => service.releaseOrParkTask(task, reason), /ORM is not initialized/);
+    return task;
+};
+
+// releaseOrParkTask/resetDispatchAttempt now re-read the task by taskId instead of writing back
+// the (possibly stale) snapshot the caller holds. Stub DatabaseServer.findOne/save and
+// QueueService.publish so both the re-queue and dead-letter branches (including the publish,
+// which the ORM-throws trick above can never reach) are exercised end to end.
+const stubDb = ({ found } = {}) => {
+    const calls = { findOneFilters: [], saved: [], published: [] };
+    const originalFindOne = DatabaseServer.prototype.findOne;
+    const originalSave = DatabaseServer.prototype.save;
+    const originalPublish = service.publish;
+
+    DatabaseServer.prototype.findOne = async function (entityClass, filters) {
+        calls.findOneFilters.push(filters);
+        return found ?? null;
+    };
+    DatabaseServer.prototype.save = async function (entityClass, item) {
+        calls.saved.push(item);
+        return item;
+    };
+    service.publish = async function (subject, data) {
+        calls.published.push({ subject, data });
+    };
+
+    calls.restore = () => {
+        DatabaseServer.prototype.findOne = originalFindOne;
+        DatabaseServer.prototype.save = originalSave;
+        service.publish = originalPublish;
+    };
+    return calls;
+};
+
+describe('QueueService.getSendTaskTimeout', () => {
+    it('uses the flat timeout for payloads that fit inline in a NATS message', () => {
+        assert.equal(
+            service.getSendTaskTimeout({ dataSize: 512 * 1024 }),
+            service.workerSendTaskTimeout
+        );
+    });
+
+    it('scales the timeout with payload size once the payload goes out-of-band', () => {
+        const timeout = service.getSendTaskTimeout({ dataSize: 82 * MB });
+        assert.equal(
+            timeout,
+            service.workerSendTaskTimeout + 82 * service.workerSendTaskTimeoutPerMb
+        );
+        // The whole point: an 82MB task must not be declared failed after a flat few-second timeout.
+        assert.ok(timeout > service.workerSendTaskTimeout);
+    });
+
+    it('never exceeds the configured cap', () => {
+        assert.equal(
+            service.getSendTaskTimeout({ dataSize: 100 * 1024 * MB }),
+            service.workerSendTaskTimeoutMax
+        );
+    });
+
+    it('falls back to measuring data for tasks created before dataSize existed', () => {
+        const task = { data: { blob: 'y'.repeat(4 * MB) } };
+        assert.ok(service.getSendTaskTimeout(task) > service.workerSendTaskTimeout);
+    });
+
+    it('handles a task with neither dataSize nor data', () => {
+        assert.equal(service.getSendTaskTimeout({}), service.workerSendTaskTimeout);
+    });
+});
+
+describe('QueueService.releaseOrParkTask (no ORM, snapshot path)', () => {
+    it('rejects at the lookup before mutating the caller-held snapshot', async () => {
+        const task = await runReleaseOrPark(makeTask(), 'Timeout exceed (worker-1)');
+        assert.equal(task.dispatchAttempt, 0);
+    });
+});
+
+describe('QueueService.releaseOrParkTask (stubbed DB, re-read path)', () => {
+    let calls;
+    afterEach(() => calls?.restore());
+
+    it('counts a dispatch failure - the counter that never advanced during the outage', async () => {
+        calls = stubDb({ found: makeTask() });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+        assert.equal(calls.saved[0].dispatchAttempt, 1);
+    });
+
+    it('rolls the task back into the queue while budget remains', async () => {
+        calls = stubDb({ found: makeTask() });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+        const saved = calls.saved[0];
+        assert.equal(saved.processedTime, null);
+        assert.equal(saved.sent, false);
+        assert.equal(saved.isError, false);
+        assert.equal(calls.published.length, 0);
+    });
+
+    it('dead-letters the task once the dispatch budget is exhausted and publishes TASK_COMPLETE', async () => {
+        calls = stubDb({ found: makeTask({ dispatchAttempt: service.dispatchMaxAttempts - 1 }) });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+
+        const saved = calls.saved[0];
+        assert.equal(saved.dispatchAttempt, service.dispatchMaxAttempts);
+        assert.equal(saved.isError, true);
+        assert.equal(saved.errorReason, 'Timeout exceed (worker-1)');
+        assert.equal(saved.sent, false);
+        // refreshAndReassignTasks filters on processedTime: null and isError: { $ne: true }.
+        assert.notEqual(saved.processedTime, null);
+        // leaves done false so the task still shows as ERROR and stays restartable via RESTART_TASK.
+        assert.equal(saved.done, false);
+
+        assert.equal(calls.published.length, 1);
+        assert.equal(calls.published[0].subject, QueueEvents.TASK_COMPLETE);
+        assert.equal(calls.published[0].data.id, 't-1');
+        assert.equal(calls.published[0].data.error, 'Timeout exceed (worker-1)');
+    });
+
+    it('parks a non-retryable task on the same dispatch budget', async () => {
+        calls = stubDb({
+            found: makeTask({ isRetryableTask: false, attempts: 0, dispatchAttempt: service.dispatchMaxAttempts - 1 }),
+        });
+        await service.releaseOrParkTask(makeTask({ isRetryableTask: false, attempts: 0 }), 'boom');
+        assert.equal(calls.saved[0].isError, true);
+    });
+
+    it('does not consume the worker-error retry budget', async () => {
+        calls = stubDb({ found: makeTask({ attempt: 1 }) });
+        await service.releaseOrParkTask(makeTask({ attempt: 1 }), 'Timeout exceed (worker-1)');
+        assert.equal(calls.saved[0].attempt, 1);
+    });
+
+    // dispatchClaimedTask can hold the claimed snapshot across an await up to
+    // workerSendTaskTimeoutMax (5m). If the worker's TASK_COMPLETE beat the timeout back to the
+    // queue, `done`/`isError` are already true in the DB - writing the stale snapshot must not
+    // revert that, and no spurious dead-letter TASK_COMPLETE must be published on top of a success.
+
+    it('does not revert an already-completed task and does not save', async () => {
+        calls = stubDb({ found: makeTask({ done: true }) });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+        assert.equal(calls.saved.length, 0);
+        assert.equal(calls.published.length, 0);
+    });
+
+    it('does not double dead-letter a task that was already dead-lettered', async () => {
+        calls = stubDb({ found: makeTask({ isError: true, errorReason: 'first failure' }) });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+        assert.equal(calls.saved.length, 0);
+        assert.equal(calls.published.length, 0);
+    });
+
+    it('does nothing if the task was deleted in the meantime', async () => {
+        calls = stubDb({ found: null });
+        await service.releaseOrParkTask(makeTask(), 'Timeout exceed (worker-1)');
+        assert.equal(calls.saved.length, 0);
+        assert.equal(calls.published.length, 0);
+    });
+});
+
+describe('QueueService.resetDispatchAttempt (stubbed DB)', () => {
+    let calls;
+    afterEach(() => calls?.restore());
+
+    it('resets the dispatch budget for a task still in flight', async () => {
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 2 }) });
+        await service.resetDispatchAttempt('t-1');
+        assert.equal(calls.saved[0].dispatchAttempt, 0);
+    });
+
+    // A late-arriving success ack must not resurrect/overwrite a task that has since been
+    // dead-lettered or completed by another path.
+    it('does not touch a task that already reached a terminal state', async () => {
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 2, isError: true }) });
+        await service.resetDispatchAttempt('t-1');
+        assert.equal(calls.saved.length, 0);
+    });
+
+    it('does nothing if the task no longer exists', async () => {
+        calls = stubDb({ found: null });
+        await service.resetDispatchAttempt('t-1');
+        assert.equal(calls.saved.length, 0);
+    });
+});
+
+describe('QueueService.dispatchClaimedTask (stubbed DB + transport)', () => {
+    let calls;
+    let originalSend;
+
+    beforeEach(() => {
+        originalSend = service.sendMessageWithTimeout;
+    });
+    afterEach(() => {
+        service.sendMessageWithTimeout = originalSend;
+        calls?.restore();
+    });
+
+    // A busy worker replies `{ result: false }` from its `isInUse` guard (see
+    // worker-service SEND_TASK_TO_WORKER) - that is an expected outcome of a worker reported
+    // free by getFreeWorkers() becoming busy again before the send lands, not a failed
+    // hand-off, and must not burn the dead-letter budget.
+    it('releases a busy-worker response without consuming the dispatch budget', async () => {
+        service.sendMessageWithTimeout = async () => ({ result: false });
+        calls = stubDb();
+
+        const task = makeTask({ dispatchAttempt: 0 });
+        await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
+
+        assert.equal(calls.saved.length, 1);
+        assert.equal(calls.saved[0].dispatchAttempt, 0);
+        assert.equal(calls.saved[0].processedTime, null);
+        assert.equal(calls.saved[0].sent, false);
+        assert.equal(calls.published.length, 0);
+    });
+
+    it('routes a transport error through releaseOrParkTask and counts it', async () => {
+        service.sendMessageWithTimeout = async () => { throw new Error('Timeout exceed (w-1)'); };
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 0 }) });
+
+        const task = makeTask({ dispatchAttempt: 0 });
+        await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
+
+        assert.equal(calls.saved[0].dispatchAttempt, 1);
+    });
+
+    it('resets the dispatch budget on success via a fresh read, not the stale snapshot', async () => {
+        service.sendMessageWithTimeout = async () => ({ result: true });
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 2 }) });
+
+        const staleTask = makeTask({ dispatchAttempt: 2 });
+        await service.dispatchClaimedTask({ subject: 'w-1' }, staleTask, { id: 't-1' }, 1000);
+
+        assert.equal(calls.findOneFilters.length, 1);
+        assert.equal(calls.saved[0].dispatchAttempt, 0);
+    });
+
+    it('does not write back on success when dispatchAttempt was already zero', async () => {
+        service.sendMessageWithTimeout = async () => ({ result: true });
+        calls = stubDb();
+
+        const task = makeTask({ dispatchAttempt: 0 });
+        await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
+
+        assert.equal(calls.saved.length, 0);
+    });
+});
+
+describe('QueueService.iTaskToTaskEntity dispatch bookkeeping', () => {
+    it('initialises dispatchAttempt to zero', () => {
+        const entity = service.iTaskToTaskEntity({ id: 'abc', dispatchAttempt: 9 });
+        assert.equal(entity.dispatchAttempt, 0);
+    });
+});
+
+describe('QueueService dispatch configuration', () => {
+    it('exposes a finite dispatch budget so a task can always be given up on', () => {
+        assert.ok(Number.isInteger(service.dispatchMaxAttempts));
+        assert.ok(service.dispatchMaxAttempts > 0);
+    });
+});

--- a/queue-service/tests/queue-service-dispatch.test.mjs
+++ b/queue-service/tests/queue-service-dispatch.test.mjs
@@ -216,6 +216,48 @@ describe('QueueService.resetDispatchAttempt (stubbed DB)', () => {
     });
 });
 
+describe('QueueService.releaseClaim (stubbed DB)', () => {
+    let calls;
+    afterEach(() => calls?.restore());
+
+    it('releases the claim for a task still in flight, leaving the dispatch budget untouched', async () => {
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 1 }) });
+        await service.releaseClaim('t-1');
+        assert.equal(calls.saved[0].processedTime, null);
+        assert.equal(calls.saved[0].sent, false);
+        assert.equal(calls.saved[0].dispatchAttempt, 1);
+    });
+
+    it('does not touch a task that already reached a terminal state', async () => {
+        calls = stubDb({ found: makeTask({ isError: true }) });
+        await service.releaseClaim('t-1');
+        assert.equal(calls.saved.length, 0);
+    });
+
+    it('does nothing if the task no longer exists', async () => {
+        calls = stubDb({ found: null });
+        await service.releaseClaim('t-1');
+        assert.equal(calls.saved.length, 0);
+    });
+});
+
+describe('QueueService.inFlightWorkers', () => {
+    // refreshAndReassignTasks adds a worker's subject before dispatching and removes it once
+    // dispatchClaimedTask settles (see the .finally() in refreshAndReassignTasks) - this is what
+    // lets the loop skip a worker GET_FREE_WORKERS still reports free mid-decode of a large
+    // out-of-band payload. Exercised directly since the loop itself depends on NATS pub/sub.
+    it('starts empty', () => {
+        assert.equal(service.inFlightWorkers.size, 0);
+    });
+
+    it('is a Set keyed by worker subject', () => {
+        service.inFlightWorkers.add('w-1');
+        assert.ok(service.inFlightWorkers.has('w-1'));
+        service.inFlightWorkers.delete('w-1');
+        assert.ok(!service.inFlightWorkers.has('w-1'));
+    });
+});
+
 describe('QueueService.dispatchClaimedTask (stubbed DB + transport)', () => {
     let calls;
     let originalSend;
@@ -232,18 +274,29 @@ describe('QueueService.dispatchClaimedTask (stubbed DB + transport)', () => {
     // worker-service SEND_TASK_TO_WORKER) - that is an expected outcome of a worker reported
     // free by getFreeWorkers() becoming busy again before the send lands, not a failed
     // hand-off, and must not burn the dead-letter budget.
-    it('releases a busy-worker response without consuming the dispatch budget', async () => {
+    it('releases a busy-worker response via a fresh read, not the stale snapshot', async () => {
         service.sendMessageWithTimeout = async () => ({ result: false });
-        calls = stubDb();
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 0 }) });
 
         const task = makeTask({ dispatchAttempt: 0 });
         await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
 
+        assert.equal(calls.findOneFilters.length, 1);
         assert.equal(calls.saved.length, 1);
         assert.equal(calls.saved[0].dispatchAttempt, 0);
         assert.equal(calls.saved[0].processedTime, null);
         assert.equal(calls.saved[0].sent, false);
         assert.equal(calls.published.length, 0);
+    });
+
+    it('does not revert an already-completed task on a busy-worker response', async () => {
+        service.sendMessageWithTimeout = async () => ({ result: false });
+        calls = stubDb({ found: makeTask({ done: true }) });
+
+        const task = makeTask();
+        await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
+
+        assert.equal(calls.saved.length, 0);
     });
 
     it('routes a transport error through releaseOrParkTask and counts it', async () => {
@@ -254,6 +307,25 @@ describe('QueueService.dispatchClaimedTask (stubbed DB + transport)', () => {
         await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
 
         assert.equal(calls.saved[0].dispatchAttempt, 1);
+    });
+
+    // A DISPATCH_TIMEOUT means the ack deadline passed, not that the task was never delivered -
+    // the worker only acks an out-of-band payload after fetching and parsing it in full, and a
+    // genuinely hung worker times out regardless of delivery. Re-queueing on this (like a proven
+    // transport error) could run a Hedera mint/transfer twice while the first attempt is still in
+    // flight, so it must leave the claim untouched instead of going through releaseOrParkTask.
+    it('leaves the claim untouched on an ack timeout instead of re-queueing or dead-lettering', async () => {
+        const error = new Error('Timeout exceed (w-1)');
+        error.code = 'DISPATCH_TIMEOUT';
+        service.sendMessageWithTimeout = async () => { throw error; };
+        calls = stubDb({ found: makeTask({ dispatchAttempt: 0 }) });
+
+        const task = makeTask({ dispatchAttempt: 0 });
+        await service.dispatchClaimedTask({ subject: 'w-1' }, task, { id: 't-1' }, 1000);
+
+        assert.equal(calls.findOneFilters.length, 0);
+        assert.equal(calls.saved.length, 0);
+        assert.equal(calls.published.length, 0);
     });
 
     it('resets the dispatch budget on success via a fresh read, not the stale snapshot', async () => {

--- a/queue-service/tests/task-entity-max-payload.test.mjs
+++ b/queue-service/tests/task-entity-max-payload.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { TaskEntity } from '../dist/entity/task.js';
+
+// The ceiling that stops an undeliverable task from ever entering the queue.
+// TASK_MAX_PAYLOAD is read per call, so it is scoped to this suite and restored afterwards -
+// mocha shares one process with the other spec files.
+
+const LIMIT = 64 * 1024;
+
+const stubFiles = (t) => {
+    const calls = { create: [] };
+    t._createFile = async (json, name) => {
+        calls.create.push({ json, name });
+        return 'grid-file-id';
+    };
+    return calls;
+};
+
+const oversized = () => ({ blob: 'x'.repeat(128 * 1024) });
+const acceptable = () => ({ blob: 'x'.repeat(1024) });
+
+describe('TaskEntity TASK_MAX_PAYLOAD', () => {
+    let previous;
+
+    beforeEach(() => {
+        previous = process.env.TASK_MAX_PAYLOAD;
+        process.env.TASK_MAX_PAYLOAD = String(LIMIT);
+    });
+
+    afterEach(() => {
+        if (previous === undefined) {
+            delete process.env.TASK_MAX_PAYLOAD;
+        } else {
+            process.env.TASK_MAX_PAYLOAD = previous;
+        }
+    });
+
+    it('rejects an oversized payload on create', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.type = 'add-file';
+        t.data = oversized();
+
+        await assert.rejects(() => t.offloadDataOnCreate(), /Task payload is too large/);
+    });
+
+    it('reports the actual size, the limit and the task type', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.type = 'add-file';
+        t.data = oversized();
+
+        await assert.rejects(() => t.offloadDataOnCreate(), (error) => {
+            assert.match(error.message, /MB/);
+            assert.match(error.message, /limit/);
+            assert.match(error.message, /add-file/);
+            return true;
+        });
+    });
+
+    it('does not leave an orphaned GridFS file behind when it rejects', async () => {
+        const t = new TaskEntity();
+        const calls = stubFiles(t);
+        t.data = oversized();
+
+        await assert.rejects(() => t.offloadDataOnCreate());
+        assert.equal(calls.create.length, 0);
+    });
+
+    it('accepts payloads under the ceiling', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.data = acceptable();
+
+        await t.offloadDataOnCreate();
+        assert.ok(t.dataSize > 0);
+    });
+
+    it('does not enforce the ceiling on update, so a queued task stays saveable', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.data = oversized();
+
+        // No throw: status updates on an already-queued task must never be blocked by the ceiling.
+        await t.offloadDataOnUpdate();
+    });
+
+    it('defaults to a limit far above the GridFS offload threshold', async () => {
+        delete process.env.TASK_MAX_PAYLOAD;
+        const t = new TaskEntity();
+        stubFiles(t);
+        // 5MB+ is offloaded to GridFS but must still be accepted - rejecting here would break
+        // every legitimate large IPFS upload.
+        t.data = { blob: 'x'.repeat(6 * 1024 * 1024) };
+
+        await t.offloadDataOnCreate();
+        assert.ok(t.dataFileId);
+    });
+});

--- a/queue-service/tests/task-entity.test.mjs
+++ b/queue-service/tests/task-entity.test.mjs
@@ -153,6 +153,26 @@ describe('TaskEntity large-payload GridFS offloading', () => {
         assert.equal(t.data, null);
     });
 
+    it('records the serialized payload size on create', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.data = smallData();
+
+        await t.offloadDataOnCreate();
+
+        assert.equal(t.dataSize, Buffer.byteLength(JSON.stringify(smallData())));
+    });
+
+    it('records the size of offloaded payloads too', async () => {
+        const t = new TaskEntity();
+        stubFiles(t);
+        t.data = largeData();
+
+        await t.offloadDataOnCreate();
+
+        assert.ok(t.dataSize > 5 * 1024 * 1024);
+    });
+
     it('restore is a no-op when data was never offloaded', async () => {
         const t = new TaskEntity();
         const calls = stubFiles(t);

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -183,7 +183,8 @@ export class Worker extends NatsService {
         });
 
         const runTask = async (task, completeEvent: WorkerEvents = WorkerEvents.TASK_COMPLETE) => {
-            this.isInUse = true;
+            // isInUse is already true here - claimed in claimIfFree (beforeDecode), before this
+            // task's payload was decoded.
             this.currentTaskId = task.id;
             const userId = task.data?.payload?.userId;
 
@@ -224,31 +225,39 @@ export class Worker extends NatsService {
             this.isInUse = false;
         }
 
-        this.getMessages([this.replySubject, WorkerEvents.SEND_TASK_TO_WORKER].join('.'), async (task) => {
-            if (!this.isInUse) {
-                runTask(task);
-
-                return new MessageResponse({
-                    result: true
-                })
+        // `isInUse` is claimed here, in `beforeDecode`, rather than in the handler below: decode
+        // can HTTP-fetch an out-of-band `directLink` payload, which for a large task takes far
+        // longer than authenticating the message. Claiming after decode (the handler runs only
+        // once decode resolves) leaves a window sized to the payload during which this worker
+        // still looks free to GET_FREE_WORKERS - a concurrently-decoded second task (from either
+        // SEND_TASK_TO_WORKER or the direct-dispatch path below) can win the race and get
+        // accepted first, and the original task is then busy-rejected after downloading in full.
+        // `beforeDecode` runs synchronously right after auth and before decode starts, so
+        // whichever message's callback resumes first claims `isInUse` atomically - the claim no
+        // longer races the decode.
+        const claimIfFree = (): MessageResponse<{ result: boolean }> | undefined => {
+            if (this.isInUse) {
+                return new MessageResponse({ result: false });
             }
+            this.isInUse = true;
+            return undefined;
+        };
+
+        this.getMessages([this.replySubject, WorkerEvents.SEND_TASK_TO_WORKER].join('.'), async (task) => {
+            runTask(task);
+
             return new MessageResponse({
-                result: false
+                result: true
             })
-        })
+        }, false, claimIfFree)
 
         this.getMessages([this.replySubject, WorkerEvents.SEND_TASK_TO_WORKER_DIRECT].join('.'), async (task) => {
-            if (!this.isInUse) {
-                runTask(task, WorkerEvents.TASK_COMPLETE_DIRECT);
+            runTask(task, WorkerEvents.TASK_COMPLETE_DIRECT);
 
-                return new MessageResponse({
-                    result: true
-                })
-            }
             return new MessageResponse({
-                result: false
+                result: true
             })
-        })
+        }, false, claimIfFree)
 
         this.subscribe(WorkerEvents.UPDATE_SETTINGS, async (msg: any) => {
             try {

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -183,8 +183,7 @@ export class Worker extends NatsService {
         });
 
         const runTask = async (task, completeEvent: WorkerEvents = WorkerEvents.TASK_COMPLETE) => {
-            // isInUse is already true here - claimed in claimIfFree (beforeDecode), before this
-            // task's payload was decoded.
+            // isInUse already claimed in claimIfFree (beforeDecode), before decode.
             this.currentTaskId = task.id;
             const userId = task.data?.payload?.userId;
 
@@ -225,16 +224,8 @@ export class Worker extends NatsService {
             this.isInUse = false;
         }
 
-        // `isInUse` is claimed here, in `beforeDecode`, rather than in the handler below: decode
-        // can HTTP-fetch an out-of-band `directLink` payload, which for a large task takes far
-        // longer than authenticating the message. Claiming after decode (the handler runs only
-        // once decode resolves) leaves a window sized to the payload during which this worker
-        // still looks free to GET_FREE_WORKERS - a concurrently-decoded second task (from either
-        // SEND_TASK_TO_WORKER or the direct-dispatch path below) can win the race and get
-        // accepted first, and the original task is then busy-rejected after downloading in full.
-        // `beforeDecode` runs synchronously right after auth and before decode starts, so
-        // whichever message's callback resumes first claims `isInUse` atomically - the claim no
-        // longer races the decode.
+        // Claim isInUse before decode (not after), so a second task can't win the race while
+        // this one's directLink payload is still downloading.
         const claimIfFree = (): MessageResponse<{ result: boolean }> | undefined => {
             if (this.isInUse) {
                 return new MessageResponse({ result: false });
@@ -243,7 +234,7 @@ export class Worker extends NatsService {
             return undefined;
         };
 
-        // Releases isInUse if decode/cb throws before runTask can (else worker stays busy forever).
+        // Releases isInUse if decode/cb throws before runTask can.
         const releaseClaimOnError = (error: unknown, claimed: boolean) => {
             if (claimed) {
                 this.isInUse = false;

--- a/worker-service/src/api/worker.ts
+++ b/worker-service/src/api/worker.ts
@@ -243,13 +243,20 @@ export class Worker extends NatsService {
             return undefined;
         };
 
+        // Releases isInUse if decode/cb throws before runTask can (else worker stays busy forever).
+        const releaseClaimOnError = (error: unknown, claimed: boolean) => {
+            if (claimed) {
+                this.isInUse = false;
+            }
+        };
+
         this.getMessages([this.replySubject, WorkerEvents.SEND_TASK_TO_WORKER].join('.'), async (task) => {
             runTask(task);
 
             return new MessageResponse({
                 result: true
             })
-        }, false, claimIfFree)
+        }, false, claimIfFree, releaseClaimOnError)
 
         this.getMessages([this.replySubject, WorkerEvents.SEND_TASK_TO_WORKER_DIRECT].join('.'), async (task) => {
             runTask(task, WorkerEvents.TASK_COMPLETE_DIRECT);
@@ -257,7 +264,7 @@ export class Worker extends NatsService {
             return new MessageResponse({
                 result: true
             })
-        }, false, claimIfFree)
+        }, false, claimIfFree, releaseClaimOnError)
 
         this.subscribe(WorkerEvents.UPDATE_SETTINGS, async (msg: any) => {
             try {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR hardens `queue-service` task dispatch so a single oversized or undeliverable task can no longer degrade or stall the whole queue, porting and adapting the fix from `Managed-Guardian-Service#1552` (including its two review follow-up commits) to this repo's simpler polling-based dispatch loop.

* Add `TASK_MAX_PAYLOAD` (default 256MB) and reject task payloads above it at creation (`TaskEntity`), instead of accepting a task that can never be delivered
* Record `dataSize` on every task at creation to scale the dispatch timeout and aid diagnostics without re-serializing the payload
* Add `dispatchAttempt` (`TaskEntity` / `ITask`) to count failed hand-offs to a worker separately from `attempt` (worker-reported business failures)
* Dead-letter a task (`isError: true` + `TASK_COMPLETE` publish) once `WORKER_DISPATCH_MAX_ATTEMPTS` (default 3) dispatch attempts fail, instead of retrying forever
* Order the dispatch query FIFO by `createDate` and exclude `done`/`isError` tasks, so an undeliverable task no longer pins the head of the queue
* Claim a task before dispatching it and dispatch without awaiting inside the worker loop, so one slow/undeliverable payload can't block dispatch to every other worker
* Scale the worker ack timeout with payload size (`WORKER_SEND_TASK_TIMEOUT_PER_MB` / `_MAX`) instead of a flat timeout sized for inline payloads only
* Release (not dead-letter) a claim when a worker reports `{ result: false }` (busy), and re-read the task by id before writing any dispatch-state change, so a stale in-memory snapshot can't revert a task that completed while the send was still in flight
* Reorder the `idx_dispatch_queue` index fields per Equality-Sort-Range so the dispatch query's sort is served by the index instead of an in-memory sort stage
* Wrap `refreshAndReassignTasks` in `try/finally` so an unhandled error can no longer permanently stick the reassignment loop
* Add/extend unit test coverage for all of the above

**Related issue(s)**:

Fixes #
<!-- Ported from Managed-Guardian-Service#1552 / #1466 (different repo, not auto-linkable here) -->

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

- Source PR (`Managed-Guardian-Service#1552`) was written against a heavily modified fork of `queue-service` (semaphore-based dispatch, `WORKER_READY` events, tenant context). This repo's `queue-service` uses a simpler interval-polling loop with no timeout on worker sends at all, so the fix was re-implemented against that architecture rather than cherry-picked — the goal (bounded dispatch retries, no head-of-line blocking, scaled ack timeout) is the same.
- `helm/queue-service/values-dev.yaml` from the source PR was not ported — this repo has no Helm charts (that's ops-repo specific).
- `tsc` build is clean across `interfaces`, `common`, and `queue-service`; full `queue-service` test suite passes (49/49), including new suites `task-entity-max-payload.test.mjs` and `queue-service-dispatch.test.mjs`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
