### PR TITLE
fix: 6554 Schema field $ref not cleared when changing field type away from Enum

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-field-configuration/schema-field-configuration.component.ts
@@ -432,6 +432,11 @@ export class SchemaFieldConfigurationComponent implements OnInit, OnDestroy {
         this.geoAncestorTypes = this.geoLocation
             ? relationAncestors('geo', geoType)
             : [];
+        if (!this.enum) {
+            this.field.controlEnum.clear();
+            this.field.controlEnumName.patchValue('');
+            this.field.controlRemoteLink.patchValue('');
+        }
         if (!item) {
             this.field.isUpdatable.setValue(false);
             this.field.isUpdatable.disable()


### PR DESCRIPTION
**Description**:
- Fixed: schema field $ref and enum values not cleared when changing field type away from Enum

**Related issue(s)**:

Fixes [#6554](https://github.com/hashgraph/guardian/issues/6554)
