### PR TITLE
chore: fix tslint errors

### DIFF
--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -766,7 +766,7 @@ function getSnapshotSchemaConfig(
     return config?.schemas?.[templateSchemaId] || {};
 }
 
-function fieldsByTemplateId(fields: Array<ISchemaTemplateSnapshotField | any>): Map<string, any> {
+function fieldsByTemplateId(fields: (ISchemaTemplateSnapshotField | any)[]): Map<string, any> {
     const result = new Map<string, any>();
     for (const field of fields || []) {
         if (field?.templateFieldId) {
@@ -776,7 +776,7 @@ function fieldsByTemplateId(fields: Array<ISchemaTemplateSnapshotField | any>): 
     return result;
 }
 
-function customFields(fields: Array<ISchemaTemplateSnapshotField | any>): any[] {
+function customFields(fields: (ISchemaTemplateSnapshotField | any)[]): any[] {
     return (fields || []).filter((field) => !field?.templateFieldId);
 }
 
@@ -897,7 +897,7 @@ function getFieldDisplayName(field: any): string {
 function buildDetails(
     previous: any,
     next: any,
-    properties: Array<{ key: string, label: string }>
+    properties: { key: string, label: string }[]
 ): ISchemaTemplateUpdateChange['details'] {
     return properties
         .map(({ key, label }) => ({
@@ -1012,9 +1012,9 @@ function findSchemaProperty(document: any, path: string[]): any {
 function ensureSchemaPropertyParent(document: any, path: string[]): any {
     let current = document;
     for (const key of path.slice(0, -1)) {
-        const target = current?.type === 'array' ? current.items : current;
-        target.properties = target.properties || {};
-        current = target.properties[key];
+        const parent = current?.type === 'array' ? current.items : current;
+        parent.properties = parent.properties || {};
+        current = parent.properties[key];
         if (!current) {
             return null;
         }
@@ -1384,7 +1384,7 @@ async function updateAppliedSchemaTemplate(
     for (const [templateSchemaId, source] of templateSchemaById.entries()) {
         const target = context.policySchemaByTemplateId.get(templateSchemaId);
         if (target) {
-            const sourceIri = source.iri;
+            const targetSourceIri = source.iri;
             preparePolicySchemaUpdate(
                 target,
                 source,
@@ -1393,8 +1393,8 @@ async function updateAppliedSchemaTemplate(
             );
             await DatabaseServer.updateSchema(target.id, target);
             schemaMap[templateSchemaId] = target.id;
-            if (sourceIri && target.iri) {
-                iriMap.set(sourceIri, target.iri);
+            if (targetSourceIri && target.iri) {
+                iriMap.set(targetSourceIri, target.iri);
             }
             changedSchemas.push(target);
             continue;

--- a/guardian-service/src/api/schema.service.ts
+++ b/guardian-service/src/api/schema.service.ts
@@ -62,7 +62,6 @@ import { FilterObject } from '@mikro-orm/core';
 @Controller()
 export class SchemaService { }
 
-
 interface TemplateSchemaValidationContext {
     schemaConfig: ISchemaTemplateSchemaConfig;
 }

--- a/interfaces/src/interface/schema-template.interface.ts
+++ b/interfaces/src/interface/schema-template.interface.ts
@@ -87,11 +87,11 @@ export interface ISchemaTemplateUpdateChange {
     fieldName?: string;
     before?: string;
     after?: string;
-    details?: Array<{
+    details?: {
         label: string;
         before?: string;
         after?: string;
-    }>;
+    }[];
     message: string;
 }
 

--- a/policy-service/src/policy-engine/external/grid-action-resolver.ts
+++ b/policy-service/src/policy-engine/external/grid-action-resolver.ts
@@ -75,15 +75,15 @@ function setNestedField(obj: any, fieldPath: string, value: any): any {
 
 export class GridActionResolver {
 
-
     static computeGridId(block: IPolicyBlock): string {
         return stableId(block);
     }
 
-
     static resolveGridBlock(policyId: string, gridId: string): IPolicyBlock | null {
         const tagMap = PolicyComponentsUtils.GetTagBlockMap(policyId);
-        if (!tagMap) return null;
+        if (!tagMap) {
+            return null;
+        }
 
         // Fast path: gridId matches a tag directly
         if (tagMap.has(gridId)) {
@@ -112,22 +112,30 @@ export class GridActionResolver {
         buttonTag?: string;
     } | null {
         const gridBlock = GridActionResolver.resolveGridBlock(policyId, gridId);
-        if (!gridBlock) return null;
+        if (!gridBlock) {
+            return null;
+        }
 
         const tagMap = PolicyComponentsUtils.GetTagBlockMap(policyId);
-        if (!tagMap) return null;
+        if (!tagMap) {
+            return null;
+        }
 
         const fields: any[] = gridBlock.options?.uiMetaData?.fields || [];
         const visited = new Set<string>();
 
         for (const field of fields) {
             for (const bindTag of collectBindTags(field)) {
-                if (visited.has(bindTag) || !tagMap.has(bindTag)) continue;
+                if (visited.has(bindTag) || !tagMap.has(bindTag)) {
+                    continue;
+                }
                 visited.add(bindTag);
 
                 const uuid = tagMap.get(bindTag)!;
                 const actionBlock = PolicyComponentsUtils.GetBlockByUUID<IPolicyBlock>(uuid);
-                if (!actionBlock) continue;
+                if (!actionBlock) {
+                    continue;
+                }
 
                 const blockType = actionBlock.blockType;
                 const opts = actionBlock.options || {};
@@ -177,20 +185,28 @@ export class GridActionResolver {
 
     static async getGrids(policyId: string, user: PolicyUser): Promise<IExternalGrid[]> {
         const tagMap = PolicyComponentsUtils.GetTagBlockMap(policyId);
-        if (!tagMap) return [];
+        if (!tagMap) {
+            return [];
+        }
 
         const grids: IExternalGrid[] = [];
         const seenUuids = new Set<string>();
 
         for (const [, uuid] of tagMap) {
-            if (seenUuids.has(uuid)) continue;
+            if (seenUuids.has(uuid)) {
+                continue;
+            }
             seenUuids.add(uuid);
 
             const block = PolicyComponentsUtils.GetBlockByUUID<IPolicyBlock>(uuid);
-            if (!block || block.blockType !== 'interfaceDocumentsSourceBlock') continue;
+            if (!block || block.blockType !== 'interfaceDocumentsSourceBlock') {
+                continue;
+            }
 
             const available = await block.isAvailable(user);
-            if (!available) continue;
+            if (!available) {
+                continue;
+            }
 
             grids.push(GridActionResolver.buildGridDescriptor(block));
         }
@@ -205,7 +221,9 @@ export class GridActionResolver {
 
         const filterSchema: IExternalFilterAddon[] = [];
         for (const child of children) {
-            if (child.blockType !== 'filtersAddon') continue;
+            if (child.blockType !== 'filtersAddon') {
+                continue;
+            }
             const co = child.options || {};
             filterSchema.push({
                 filterId: stableId(child),
@@ -246,7 +264,9 @@ export class GridActionResolver {
         }
 
         const tagMap = PolicyComponentsUtils.GetTagBlockMap(policyId);
-        if (!tagMap) return [];
+        if (!tagMap) {
+            return [];
+        }
 
         const fields: any[] = gridBlock.options?.uiMetaData?.fields || [];
         const visited = new Set<string>();
@@ -254,15 +274,21 @@ export class GridActionResolver {
 
         for (const field of fields) {
             for (const bindTag of collectBindTags(field)) {
-                if (visited.has(bindTag) || !tagMap.has(bindTag)) continue;
+                if (visited.has(bindTag) || !tagMap.has(bindTag)) {
+                    continue;
+                }
                 visited.add(bindTag);
 
                 const uuid = tagMap.get(bindTag)!;
                 const actionBlock = PolicyComponentsUtils.GetBlockByUUID<IPolicyBlock>(uuid);
-                if (!actionBlock) continue;
+                if (!actionBlock) {
+                    continue;
+                }
 
                 const blockAvailable = await actionBlock.isAvailable(user);
-                if (!blockAvailable) continue;
+                if (!blockAvailable) {
+                    continue;
+                }
 
                 const blockType = actionBlock.blockType;
                 const opts = actionBlock.options || {};
@@ -280,7 +306,7 @@ export class GridActionResolver {
                             });
                         }
                     } else if (opts.type === 'dropdown') {
-                        let options: Array<{ name: any; value: any }> = [];
+                        let options: { name: any; value: any }[] = [];
                         try {
                             const dataResult = await PolicyComponentsUtils.blockGetData(
                                 actionBlock as IPolicyInterfaceBlock, user, {}


### PR DESCRIPTION
### Description

Resolve tslint errors in the schema template and grid action resolver code so the lint job passes.

- Replace `Array<T>` type annotations with `T[]` in the schema template interface, schema template service and grid action resolver
- Brace single-line `if` guards in the grid action resolver
- Remove consecutive blank lines in the grid action resolver and schema service
- Rename shadowed `target` and `sourceIri` locals in the schema template service