### PR TITLE
fix: 6562 Cross-schema condition targets incorrectly auto-required in then/else blocks

### DIFF
--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -317,6 +317,7 @@ export class VCJS {
         addFormats.default(ajv);
 
         this.prepareSchema(schema);
+        this.coerceConditionConsts(schema);
 
         const schemaObject = Schema.fromVc(schema);
 
@@ -548,6 +549,56 @@ export class VCJS {
         return '';
     }
 
+    private coerceConditionConsts(schema: any): void {
+        const rootDefs = schema.$defs || {};
+
+        const coerceConst = (value: any, type: string): any => {
+            if (type === 'number' || type === 'integer') {
+                const n = Number(value);
+                return isNaN(n) ? value : n;
+            }
+            if (type === 'boolean') {
+                return value === 'true';
+            }
+            if (type === 'string' && value !== null && value !== undefined) {
+                return String(value);
+            }
+            return value;
+        };
+
+        const walkIfNode = (node: any, context: any): void => {
+            if (!node || typeof node !== 'object') { return; }
+            if (Array.isArray(node.allOf)) {
+                for (const child of node.allOf) { walkIfNode(child, context); }
+                return;
+            }
+            if (!node.properties) { return; }
+            for (const [key, val] of Object.entries(node.properties) as [string, any][]) {
+                if (!val || typeof val !== 'object') { continue; }
+                if ('const' in val) {
+                    const type = context?.properties?.[key]?.type;
+                    if (type) { val.const = coerceConst(val.const, type); }
+                } else if (val.properties || val.allOf) {
+                    const ref = context?.properties?.[key]?.$ref;
+                    const subContext = ref ? (context.$defs?.[ref] ?? rootDefs[ref]) : null;
+                    if (subContext) { walkIfNode(val, subContext); }
+                }
+            }
+        };
+
+        const walkAllOf = (s: any, context: any): void => {
+            if (!Array.isArray(s?.allOf)) { return; }
+            for (const entry of s.allOf) {
+                if (entry?.if) { walkIfNode(entry.if, context); }
+            }
+        };
+
+        walkAllOf(schema, schema);
+        for (const def of Object.values(rootDefs) as any[]) {
+            if (def && typeof def === 'object') { walkAllOf(def, def); }
+        }
+    }
+
     /**
      * Replaces AJV messages with a human-readable description
      */
@@ -612,6 +663,7 @@ export class VCJS {
         addFormats.default(ajv);
 
         this.prepareSchema(schema);
+        this.coerceConditionConsts(schema);
 
         const schemaObject = Schema.fromVc(schema);
 

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -305,11 +305,15 @@ export class VCJS {
             throw new Error('Schema Loader not found');
         }
 
-        const schema = await this.schemaLoader(subject['@context'], subject.type, 'vc');
+        const loadedSchema = await this.schemaLoader(subject['@context'], subject.type, 'vc');
 
-        if (!schema) {
+        if (!loadedSchema) {
             throw new Error('Schema not found');
         }
+
+        // prepareSchema/coerceConditionConsts rewrite the document in place; the loader may
+        // hand back a cached instance shared with other callers, so validate against a copy.
+        const schema = JSON.parse(JSON.stringify(loadedSchema));
 
         const ajv = new Ajv({
             loadSchema: this.loadSchema
@@ -360,6 +364,16 @@ export class VCJS {
     }
 
     /**
+     * $ref sits directly on the property for objects, under `items` for arrays.
+     *
+     * @param prop Schema property
+     * @returns Referenced $defs key, if any
+     */
+    private readRef(prop: any): string | undefined {
+        return prop?.$ref ?? prop?.items?.$ref;
+    }
+
+    /**
      * Delete system fields from schema defs
      *
      * @param schema Schema
@@ -392,11 +406,17 @@ export class VCJS {
         // Multiple conditions targeting the same container accumulate into one Set.
         const stripByPath = new Map<string, Set<string>>();
 
+        const withRef = (prop: any, newRef: string): any => {
+            if (prop?.$ref) { return { ...prop, $ref: newRef }; }
+            if (prop?.items?.$ref) { return { ...prop, items: { ...prop.items, $ref: newRef } }; }
+            return prop;
+        };
+
         const collectPath = (constraint: any, pathSoFar: string[], currentProps: any) => {
             if (!constraint?.properties) { return; }
             for (const [propKey, val] of Object.entries(constraint.properties) as [string, any][]) {
                 if (!val || typeof val !== 'object') { continue; }
-                const ref = currentProps[propKey]?.$ref;
+                const ref = this.readRef(currentProps[propKey]);
                 if (!ref || !defsObj[ref]) { continue; }
                 const containerPath = [...pathSoFar, propKey];
                 const pathKey = containerPath.join('.');
@@ -430,7 +450,7 @@ export class VCJS {
         const computeOriginalIri = (pathArr: string[]): string | undefined => {
             let props = rootProperties;
             for (let i = 0; i < pathArr.length; i++) {
-                const ref = props[pathArr[i]]?.$ref;
+                const ref = this.readRef(props[pathArr[i]]);
                 if (!ref || !defsObj[ref]) { return undefined; }
                 if (i === pathArr.length - 1) { return ref; }
                 props = defsObj[ref]?.properties || {};
@@ -481,17 +501,17 @@ export class VCJS {
             // Rewrite the $ref on this specific container only.
             if (pathArr.length === 1) {
                 if (rootProperties[pathArr[0]]) {
-                    rootProperties[pathArr[0]] = { ...rootProperties[pathArr[0]], $ref: cloneKey };
+                    rootProperties[pathArr[0]] = withRef(rootProperties[pathArr[0]], cloneKey);
                 }
             } else {
                 const parentPathKey = pathArr.slice(0, -1).join('.');
                 const parentCloneKey = cloneKeys.get(parentPathKey);
                 const leafProp = pathArr[pathArr.length - 1];
                 if (parentCloneKey && defsObj[parentCloneKey]?.properties?.[leafProp]) {
-                    defsObj[parentCloneKey].properties[leafProp] = {
-                        ...defsObj[parentCloneKey].properties[leafProp],
-                        $ref: cloneKey,
-                    };
+                    defsObj[parentCloneKey].properties[leafProp] = withRef(
+                        defsObj[parentCloneKey].properties[leafProp],
+                        cloneKey
+                    );
                 }
             }
         }
@@ -558,7 +578,11 @@ export class VCJS {
                 return isNaN(n) ? value : n;
             }
             if (type === 'boolean') {
-                return typeof value === 'boolean' ? value : value === 'true';
+                if (typeof value === 'boolean') { return value; }
+                const s = String(value).trim().toLowerCase();
+                if (s === 'true' || s === '1') { return true; }
+                if (s === 'false' || s === '0') { return false; }
+                return value;
             }
             if (type === 'string' && value !== null && value !== undefined) {
                 return String(value);
@@ -566,27 +590,42 @@ export class VCJS {
             return value;
         };
 
+        // Mirrors describeIfConditionLeaf's shape: const, nested container, or anyOf/allOf of either.
+        const coerceValueNode = (val: any, contextProp: any, context: any): void => {
+            if (!val || typeof val !== 'object') { return; }
+            if ('const' in val) {
+                const type = contextProp?.type === 'array'
+                    ? contextProp?.items?.type
+                    : contextProp?.type;
+                if (type) { val.const = coerceConst(val.const, type); }
+                return;
+            }
+            if (val.properties) {
+                const ref = this.readRef(contextProp);
+                const subContext = ref ? (context.$defs?.[ref] ?? rootDefs[ref]) : null;
+                if (subContext) { walkIfNode(val, subContext); }
+                return;
+            }
+            if (Array.isArray(val.anyOf)) {
+                for (const branch of val.anyOf) { coerceValueNode(branch, contextProp, context); }
+            }
+            if (Array.isArray(val.allOf)) {
+                for (const branch of val.allOf) { coerceValueNode(branch, contextProp, context); }
+            }
+        };
+
         const walkIfNode = (node: any, context: any): void => {
             if (!node || typeof node !== 'object') { return; }
+            // allOf/anyOf may both be present on a node, so neither branch may return early.
             if (Array.isArray(node.allOf)) {
                 for (const child of node.allOf) { walkIfNode(child, context); }
-                return;
             }
             if (Array.isArray(node.anyOf)) {
                 for (const child of node.anyOf) { walkIfNode(child, context); }
-                return;
             }
             if (!node.properties) { return; }
             for (const [key, val] of Object.entries(node.properties) as [string, any][]) {
-                if (!val || typeof val !== 'object') { continue; }
-                if ('const' in val) {
-                    const type = context?.properties?.[key]?.type;
-                    if (type) { val.const = coerceConst(val.const, type); }
-                } else if (val.properties || val.allOf || val.anyOf) {
-                    const ref = context?.properties?.[key]?.$ref;
-                    const subContext = ref ? (context.$defs?.[ref] ?? rootDefs[ref]) : null;
-                    if (subContext) { walkIfNode(val, subContext); }
-                }
+                coerceValueNode(val, context?.properties?.[key], context);
             }
         };
 
@@ -603,37 +642,19 @@ export class VCJS {
         }
     }
 
-    /**
-     * Replaces AJV messages with a human-readable description
-     */
-    private resolveSchemaForError(rootSchema: any, instancePath: string): any {
-        // Root $defs is flat (updateSchemaDefs hoists all nested defs up); fall back to
-        // the current node's own $defs for schemas that were not hoisted.
-        const rootDefs = rootSchema.$defs || {};
-        const segments = instancePath.split('/').filter(Boolean).slice(0, -1);
-        let current = rootSchema;
-        for (const seg of segments) {
-            const prop = current.properties?.[seg];
-            const ref = prop?.$ref ?? prop?.items?.$ref;
-            if (ref) {
-                const next = current.$defs?.[ref] ?? rootDefs[ref];
-                if (next) { current = next; }
-            }
-        }
-        return current;
-    }
-
     private enhanceConditionErrors(errors: any[] | null | undefined, schema: any): any[] | null | undefined {
-        if (!errors?.length || !Array.isArray(schema?.allOf)) {
-            return errors;
-        }
+        if (!errors?.length) { return errors; }
+        // Condition owner/index live in schemaPath ("#.../allOf/N/then|else"), not instancePath.
+        const defs = schema.$defs ?? {};
         return errors.map(error => {
             if (error.keyword !== 'false schema') { return error; }
-            const match = (error.schemaPath as string)?.match(/^#\/allOf\/(\d+)\/(then|else)\//);
+            const match = (error.schemaPath as string)
+                ?.match(/^(#[^/]*)\/allOf\/(\d+)\/(then|else)\//);
             if (!match) { return error; }
-            const schemaForError = this.resolveSchemaForError(schema, error.instancePath);
-            if (!Array.isArray(schemaForError?.allOf)) { return error; }
-            const condEntry = schemaForError.allOf[parseInt(match[1], 10)];
+            const [, base, idx] = match;
+            const owner = base === '#' ? schema : (defs[base] ?? schema);
+            if (!Array.isArray(owner?.allOf)) { return error; }
+            const condEntry = owner.allOf[parseInt(idx, 10)];
             if (!condEntry?.if) { return error; }
             const fieldName = (error.instancePath as string).split('/').filter(Boolean).pop() || 'field';
             const condition = this.describeIfCondition(condEntry.if) || 'condition not met';
@@ -656,11 +677,15 @@ export class VCJS {
             throw new Error('Schema Loader not found');
         }
 
-        const schema = await this.schemaLoader(subject['@context'], subject.type, 'subject');
+        const loadedSchema = await this.schemaLoader(subject['@context'], subject.type, 'subject');
 
-        if (!schema) {
+        if (!loadedSchema) {
             throw new Error('Schema not found');
         }
+
+        // prepareSchema/coerceConditionConsts rewrite the document in place; the loader may
+        // hand back a cached instance shared with other callers, so validate against a copy.
+        const schema = JSON.parse(JSON.stringify(loadedSchema));
 
         const ajv = new Ajv({
             loadSchema: this.loadSchema

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -551,6 +551,22 @@ export class VCJS {
     /**
      * Replaces AJV messages with a human-readable description
      */
+    private resolveSchemaForError(rootSchema: any, instancePath: string): any {
+        // Root $defs is flat (updateSchemaDefs hoists all nested defs up); fall back to
+        // the current node's own $defs for schemas that were not hoisted.
+        const rootDefs = rootSchema.$defs || {};
+        const segments = instancePath.split('/').filter(Boolean).slice(0, -1);
+        let current = rootSchema;
+        for (const seg of segments) {
+            const ref = current.properties?.[seg]?.$ref;
+            if (ref) {
+                const next = current.$defs?.[ref] ?? rootDefs[ref];
+                if (next) { current = next; }
+            }
+        }
+        return current;
+    }
+
     private enhanceConditionErrors(errors: any[] | null | undefined, schema: any): any[] | null | undefined {
         if (!errors?.length || !Array.isArray(schema?.allOf)) {
             return errors;
@@ -559,7 +575,9 @@ export class VCJS {
             if (error.keyword !== 'false schema') { return error; }
             const match = (error.schemaPath as string)?.match(/^#\/allOf\/(\d+)\/(then|else)\//);
             if (!match) { return error; }
-            const condEntry = schema.allOf[parseInt(match[1], 10)];
+            const schemaForError = this.resolveSchemaForError(schema, error.instancePath);
+            if (!Array.isArray(schemaForError?.allOf)) { return error; }
+            const condEntry = schemaForError.allOf[parseInt(match[1], 10)];
             if (!condEntry?.if) { return error; }
             const fieldName = (error.instancePath as string).split('/').filter(Boolean).pop() || 'field';
             const condition = this.describeIfCondition(condEntry.if) || 'condition not met';

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -558,7 +558,7 @@ export class VCJS {
                 return isNaN(n) ? value : n;
             }
             if (type === 'boolean') {
-                return value === 'true';
+                return typeof value === 'boolean' ? value : value === 'true';
             }
             if (type === 'string' && value !== null && value !== undefined) {
                 return String(value);
@@ -572,13 +572,17 @@ export class VCJS {
                 for (const child of node.allOf) { walkIfNode(child, context); }
                 return;
             }
+            if (Array.isArray(node.anyOf)) {
+                for (const child of node.anyOf) { walkIfNode(child, context); }
+                return;
+            }
             if (!node.properties) { return; }
             for (const [key, val] of Object.entries(node.properties) as [string, any][]) {
                 if (!val || typeof val !== 'object') { continue; }
                 if ('const' in val) {
                     const type = context?.properties?.[key]?.type;
                     if (type) { val.const = coerceConst(val.const, type); }
-                } else if (val.properties || val.allOf) {
+                } else if (val.properties || val.allOf || val.anyOf) {
                     const ref = context?.properties?.[key]?.$ref;
                     const subContext = ref ? (context.$defs?.[ref] ?? rootDefs[ref]) : null;
                     if (subContext) { walkIfNode(val, subContext); }
@@ -609,7 +613,8 @@ export class VCJS {
         const segments = instancePath.split('/').filter(Boolean).slice(0, -1);
         let current = rootSchema;
         for (const seg of segments) {
-            const ref = current.properties?.[seg]?.$ref;
+            const prop = current.properties?.[seg];
+            const ref = prop?.$ref ?? prop?.items?.$ref;
             if (ref) {
                 const next = current.$defs?.[ref] ?? rootDefs[ref];
                 if (next) { current = next; }

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -644,7 +644,7 @@ export class VCJS {
 
     private enhanceConditionErrors(errors: any[] | null | undefined, schema: any): any[] | null | undefined {
         if (!errors?.length) { return errors; }
-        // Condition owner/index live in schemaPath ("#.../allOf/N/then|else"), not instancePath.
+        // Condition owner/index live in schemaPath (base "#..." is the $defs entry's own $id, never a literal "/$defs/").
         const defs = schema.$defs ?? {};
         return errors.map(error => {
             if (error.keyword !== 'false schema') { return error; }

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs-condition-errors.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs-condition-errors.test.mjs
@@ -1,0 +1,216 @@
+import { assert } from 'chai';
+
+import { DefaultDocumentLoader } from '../../../../dist/hedera-modules/document-loader/document-loader-default.js';
+import { LocalDidLoader } from '../../../../dist/document-loader/local-did-loader.js';
+import { VCJS } from '../../../../dist/hedera-modules/vcjs/vcjs.js';
+
+void DefaultDocumentLoader;
+void LocalDidLoader;
+
+describe('VCJS — enhanceConditionErrors', function () {
+    function makeVcjs() {
+        return new VCJS();
+    }
+
+    it('enhances a root-level condition violation with a readable message', async function () {
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: {
+                trigger: { type: 'string' },
+                optField: { type: 'string' },
+            },
+            allOf: [
+                {
+                    if: { properties: { trigger: { const: 'go' } }, required: ['trigger'] },
+                    then: { properties: {}, required: [] },
+                    else: { properties: { optField: false } },
+                },
+            ],
+        });
+
+        const result = await vcjs.verifySubject({ trigger: 'stop', optField: 'should not be here' });
+
+        assert.isFalse(result.ok);
+        const enhanced = result.error.details.find(e => e.keyword === 'false schema');
+        assert.exists(enhanced, 'the false-schema error should be present');
+        assert.match(enhanced.message, /not allowed unless/);
+        assert.match(enhanced.message, /trigger = 'go'/);
+    });
+
+    it('resolves the condition owner via schemaPath for a condition inside a $defs entry', async function () {
+        // Regression guard: schemaPath for a condition nested inside a $defs entry never
+        // contains a literal "/$defs/" segment — AJV uses the sub-schema's own $id as the
+        // fragment base (e.g. "#Sub/allOf/0/else/..."), not a path through the parent's $defs.
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: { sub: { $ref: '#Sub' } },
+            required: ['sub'],
+            $defs: {
+                '#Sub': {
+                    $id: '#Sub',
+                    type: 'object',
+                    properties: {
+                        innerTrigger: { type: 'string' },
+                        innerOptField: { type: 'string' },
+                    },
+                    allOf: [
+                        {
+                            if: { properties: { innerTrigger: { const: 'go' } }, required: ['innerTrigger'] },
+                            then: { properties: {}, required: [] },
+                            else: { properties: { innerOptField: false } },
+                        },
+                    ],
+                },
+            },
+        });
+
+        const result = await vcjs.verifySubject({
+            sub: { innerTrigger: 'stop', innerOptField: 'should not be here' },
+        });
+
+        assert.isFalse(result.ok);
+        const enhanced = result.error.details.find(e => e.keyword === 'false schema');
+        assert.exists(enhanced, 'the false-schema error inside the $defs entry should be present');
+        assert.match(enhanced.message, /not allowed unless/);
+        assert.match(enhanced.message, /innerTrigger = 'go'/);
+    });
+
+    it('does not conflate two sibling conditions defined in different $defs entries', async function () {
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: { subA: { $ref: '#SubA' }, subB: { $ref: '#SubB' } },
+            required: ['subA', 'subB'],
+            $defs: {
+                '#SubA': {
+                    $id: '#SubA',
+                    type: 'object',
+                    properties: { triggerA: { type: 'string' }, fieldA: { type: 'string' } },
+                    allOf: [{
+                        if: { properties: { triggerA: { const: 'yesA' } }, required: ['triggerA'] },
+                        then: { properties: {}, required: [] },
+                        else: { properties: { fieldA: false } },
+                    }],
+                },
+                '#SubB': {
+                    $id: '#SubB',
+                    type: 'object',
+                    properties: { triggerB: { type: 'string' }, fieldB: { type: 'string' } },
+                    allOf: [{
+                        if: { properties: { triggerB: { const: 'yesB' } }, required: ['triggerB'] },
+                        then: { properties: {}, required: [] },
+                        else: { properties: { fieldB: false } },
+                    }],
+                },
+            },
+        });
+
+        const result = await vcjs.verifySubject({
+            subA: { triggerA: 'no', fieldA: 'leaked' },
+            subB: { triggerB: 'yesB' },
+        });
+
+        assert.isFalse(result.ok);
+        const enhanced = result.error.details.find(e => e.keyword === 'false schema');
+        assert.exists(enhanced);
+        assert.match(enhanced.message, /triggerA = 'yesA'/, 'must resolve SubA\'s own condition, not SubB\'s');
+    });
+});
+
+describe('VCJS — coerceConditionConsts', function () {
+    function makeVcjs() {
+        return new VCJS();
+    }
+
+    it('coerces a string const to match a numeric field so the condition actually fires', async function () {
+        // A schema authored/imported with the const stored as a string (e.g. "5" instead of 5)
+        // must still match a real numeric document value — otherwise the condition silently
+        // never triggers and its then/else constraints never apply.
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: { score: { type: 'number' }, optField: { type: 'string' } },
+            allOf: [{
+                if: { properties: { score: { const: '5' } }, required: ['score'] },
+                then: { properties: {}, required: [] },
+                else: { properties: { optField: false } },
+            }],
+        });
+
+        const matching = await vcjs.verifySubject({ score: 5, optField: 'allowed because condition is true' });
+        assert.isTrue(matching.ok, 'condition should fire for score=5, allowing optField');
+
+        const nonMatching = await vcjs.verifySubject({ score: 7, optField: 'should be forbidden' });
+        assert.isFalse(nonMatching.ok, 'condition should not fire for score=7, forbidding optField');
+    });
+
+    it('coerces string consts inside a per-field anyOf to match a numeric field', async function () {
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: { score: { type: 'number' }, optField: { type: 'string' } },
+            allOf: [{
+                if: {
+                    properties: { score: { anyOf: [{ const: '1' }, { const: '2' }] } },
+                    required: ['score'],
+                },
+                then: { properties: {}, required: [] },
+                else: { properties: { optField: false } },
+            }],
+        });
+
+        const matching = await vcjs.verifySubject({ score: 2, optField: 'allowed' });
+        assert.isTrue(matching.ok, 'condition should fire for score=2 (matches the second anyOf branch)');
+
+        const nonMatching = await vcjs.verifySubject({ score: 3, optField: 'should be forbidden' });
+        assert.isFalse(nonMatching.ok, 'condition should not fire for score=3');
+    });
+
+    it('coerces a "True"/"1"-style string const to a real boolean', function () {
+        const vcjs = makeVcjs();
+        const schema = {
+            type: 'object',
+            properties: { flag: { type: 'boolean' } },
+            allOf: [{ if: { properties: { flag: { const: 'True' } }, required: ['flag'] }, then: {} }],
+        };
+        vcjs.coerceConditionConsts(schema);
+        assert.strictEqual(schema.allOf[0].if.properties.flag.const, true);
+    });
+
+    it('coerces a const against an array-typed field using the array\'s item type', function () {
+        // contextProp.type === 'array': the coercion target type must come from items.type,
+        // not from the (non-primitive) "array" type itself.
+        const vcjs = makeVcjs();
+        const schema = {
+            type: 'object',
+            properties: { tags: { type: 'array', items: { type: 'number' } } },
+            allOf: [{ if: { properties: { tags: { const: '5' } }, required: ['tags'] }, then: {} }],
+        };
+        vcjs.coerceConditionConsts(schema);
+        assert.strictEqual(schema.allOf[0].if.properties.tags.const, 5);
+    });
+});
+
+describe('VCJS — enhanceConditionErrors passthrough', function () {
+    function makeVcjs() {
+        return new VCJS();
+    }
+
+    it('leaves an unrelated AJV error untouched', async function () {
+        const vcjs = makeVcjs();
+        vcjs.schemaLoader = async () => ({
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+        });
+
+        const result = await vcjs.verifySubject({});
+
+        assert.isFalse(result.ok);
+        const error = result.error.details[0];
+        assert.equal(error.keyword, 'required');
+        assert.notMatch(error.message, /not allowed unless/);
+    });
+});

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
@@ -242,6 +242,60 @@ describe('VCJS coverage (offline paths)', function () {
                     'sibling.b must still be required — the required-strip must not leak from targeted to sibling');
             });
         });
+
+        describe('array-typed sub-schema ref (items.$ref)', function () {
+            // Regression guard: a sub-schema reference under an array property sits at
+            // `items.$ref`, not `$ref` directly on the property. Before readRef/withRef
+            // handled that shape, prepareSchema silently skipped the strip-and-clone pass
+            // for any array-typed ref field entirely.
+            function makeArrayRefSchema() {
+                return {
+                    type: 'object',
+                    properties: {
+                        targetedList: { type: 'array', items: { $ref: '#Sub' } }
+                    },
+                    required: [],
+                    allOf: [{
+                        if: {
+                            properties: { targetedList: { properties: { a: { const: 1 } }, required: ['a'] } },
+                            required: ['targetedList']
+                        },
+                        then: { properties: { targetedList: { required: ['b'] } } },
+                        else: { properties: { targetedList: { properties: { b: false } } } }
+                    }],
+                    $defs: {
+                        '#Sub': {
+                            $id: '#Sub',
+                            type: 'object',
+                            properties: { a: { type: 'number' }, b: { type: 'number' } },
+                            required: ['a', 'b']
+                        }
+                    }
+                };
+            }
+
+            it('rewrites items.$ref to a per-container clone', function () {
+                const vcjs = makeVcjs();
+                const schema = makeArrayRefSchema();
+                vcjs.prepareSchema(schema);
+
+                assert.notEqual(schema.properties.targetedList.items.$ref, '#Sub',
+                    'items.$ref should point to a clone, proving the array-typed ref was recognized');
+            });
+
+            it('strips the conditional field from the clone required, without mutating the original', function () {
+                const vcjs = makeVcjs();
+                const schema = makeArrayRefSchema();
+                vcjs.prepareSchema(schema);
+
+                const cloneKey = schema.properties.targetedList.items.$ref;
+                assert.exists(schema.$defs[cloneKey], 'clone must be present in $defs');
+                assert.notInclude(schema.$defs[cloneKey].required ?? [], 'b',
+                    'b should be stripped from the clone required array');
+                assert.include(schema.$defs['#Sub'].required, 'b',
+                    'original required must not be mutated');
+            });
+        });
     });
 
     describe('verifySubject', function () {

--- a/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
@@ -92,6 +92,7 @@ export class FieldForm {
     private readonly ancestorChildPaths: Map<string, Set<string>>;
     public rootForm: FieldForm;
     private arrayGroupCache: Map<IFieldControl<any>, IArrayGroupEntry[]> | null = null;
+    private fieldOrder: Map<string, number> | null = null;
 
     private readonly destroy$: Subject<boolean>;
 
@@ -184,6 +185,7 @@ export class FieldForm {
         const { fields, conditions } = this.updateData();
         this.arrayGroupCache = null;
         this.crossSchemaItems = [];
+        this.fieldOrder = fields ? new Map(fields.map((f, index) => [f.name, index])) : null;
         this.fieldControls = this.buildFields(fields);
         this.conditionControls = this.buildConditions(conditions);
         if (this.schema?.arrayDependencies?.length) {
@@ -265,7 +267,10 @@ export class FieldForm {
 
     private findControl(name: string): IFieldControl<any> | undefined {
         const base = this.fieldControls?.find(control => control.name === name);
-        if (base || !this.rootForm.schema?.arrayDependencies?.length) { return base; }
+        if (base) { return base; }
+        // A container may itself be condition-controlled, in which case it lives in
+        // conditionControls rather than fieldControls. Cross-schema conditions that target a
+        // path inside such a container must still be able to resolve it.
         return this.conditionControls?.find(control => control.name === name);
     }
 
@@ -414,9 +419,7 @@ export class FieldForm {
             }
         }
 
-        if (this.rootForm.schema?.arrayDependencies?.length) {
-            this.conditionControls = controls;
-        }
+        this.conditionControls = controls;
 
         for (const item of this.crossSchemaItems) {
             for (const entryIndex of this.getEntryIndexes(item)) {
@@ -447,11 +450,29 @@ export class FieldForm {
         if (!this.fieldControls) { this.fieldControls = []; }
         if (this.fieldControls.find(c => c.name === field.name)) { return; }
         const item = this.createFieldControl(field, containerPreset);
-        this.fieldControls.push(item);
+        this.insertFieldControlInOrder(item);
         if (item.control) {
             this.form.addControl(item.name, item.control, { emitEvent: false });
         }
         this.controls = this.rebuildControls();
+    }
+
+    private insertFieldControlInOrder(item: IFieldControl<any>): void {
+        this.fieldControls = this.fieldControls || [];
+        const targetIdx = this.fieldOrder?.get(item.name);
+        if (targetIdx === undefined) {
+            this.fieldControls.push(item);
+            return;
+        }
+        const insertBefore = this.fieldControls.findIndex(c => {
+            const idx = this.fieldOrder!.get(c.name);
+            return idx !== undefined && idx > targetIdx;
+        });
+        if (insertBefore < 0) {
+            this.fieldControls.push(item);
+        } else {
+            this.fieldControls.splice(insertBefore, 0, item);
+        }
     }
 
     public removeParentControlledField(fieldName: string): void {

--- a/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
@@ -446,7 +446,7 @@ export class FieldForm {
     public addParentControlledField(field: SchemaField, containerPreset?: any): void {
         if (!this.fieldControls) { this.fieldControls = []; }
         if (this.fieldControls.find(c => c.name === field.name)) { return; }
-        const item = this.createFieldControl(field, containerPreset?.[field.name]);
+        const item = this.createFieldControl(field, containerPreset);
         this.fieldControls.push(item);
         if (item.control) {
             this.form.addControl(item.name, item.control, { emitEvent: false });

--- a/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
+++ b/frontend/src/app/modules/schema-engine/schema-form-model/field-form.ts
@@ -419,6 +419,7 @@ export class FieldForm {
             }
         }
 
+        // Must be set before this loop: findControl (used by resolveChildModels below) falls back to it.
         this.conditionControls = controls;
 
         for (const item of this.crossSchemaItems) {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.html
@@ -1630,7 +1630,7 @@
                                     } @else {
                                         <input class="sc-cond-val-inp" type="text" placeholder="value"
                                             [value]="getIfRowValue(row)"
-                                            (change)="setIfRowValue(cond, ri, $any($event.target).value)" />
+                                            (input)="setIfRowValue(cond, ri, $any($event.target).value)" />
                                     }
                                 </div>
                                 <button class="sc-cond-row-del"

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -2633,6 +2633,21 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         return all.filter(f => !owned.has(f.name));
     }
 
+    // Rebuilt only when the schema list itself changes; these getters run on every
+    // change-detection pass, so the map must not be reconstructed each time.
+    private _schemaByIriSource: Schema[] | null = null;
+    private _schemaByIriCache = new Map<string, Schema>();
+
+    private get _schemaByIri(): Map<string, Schema> {
+        if (this._schemaByIriSource !== this.schemas) {
+            this._schemaByIriSource = this.schemas;
+            this._schemaByIriCache = new Map(
+                (this.schemas ?? []).filter(s => s.iri).map(s => [s.iri as string, s])
+            );
+        }
+        return this._schemaByIriCache;
+    }
+
     public getConditionFieldGroups(): {
         groupLabel: string;
         isRoot: boolean;
@@ -2640,7 +2655,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     }[] {
         const schema = this.currentContextSchema;
         if (!schema) { return []; }
-        const schemaByIri = new Map(this.schemas.filter(s => s.iri).map(s => [s.iri as string, s]));
+        const schemaByIri = this._schemaByIri;
         const rootGroup = { groupLabel: '', isRoot: true, fields: [] as { pathStr: string; label: string; field: SchemaField }[] };
         const nested: { groupLabel: string; isRoot: false; fields: { pathStr: string; label: string; field: SchemaField }[] }[] = [];
 
@@ -2651,7 +2666,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                 const refFields = ref?.fields ?? (Array.isArray((f as any).fields) && (f as any).fields.length ? (f as any).fields : []);
                 if (refFields.length) {
                     const group = { groupLabel: f.title || f.name, isRoot: false as const, fields: [] as { pathStr: string; label: string; field: SchemaField }[] };
-                    this._collectLeafConditionFields(refFields, [f.name], schemaByIri, group.fields);
+                    this._collectConditionFields(refFields, [f.name], schemaByIri, group.fields);
                     if (group.fields.length) { nested.push(group); }
                 }
             } else {
@@ -2665,22 +2680,28 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         return result;
     }
 
-    private _collectLeafConditionFields(
+    private _collectConditionFields(
         fields: SchemaField[],
         pathParts: string[],
         schemaByIri: Map<string, Schema>,
-        out: { pathStr: string; label: string; field: SchemaField }[]
+        out: { pathStr: string; label: string; field: SchemaField }[],
+        seen: Set<string> = new Set()
     ): void {
         for (const f of fields) {
             if (f.readOnly) { continue; }
+            const pathStr = [...pathParts, f.name].join('.');
             if (f.isRef && f.type) {
+                // Leaves only — whole-container selection is handled separately by getCrossTargetPSelectGroups.
+                if (seen.has(f.type)) { continue; } // guards against cyclic schema refs
                 const ref = schemaByIri.get(f.type);
                 const refFields = ref?.fields ?? (Array.isArray((f as any).fields) && (f as any).fields.length ? (f as any).fields : []);
                 if (refFields.length) {
-                    this._collectLeafConditionFields(refFields, [...pathParts, f.name], schemaByIri, out);
+                    this._collectConditionFields(
+                        refFields, [...pathParts, f.name], schemaByIri, out, new Set(seen).add(f.type)
+                    );
                 }
             } else {
-                out.push({ pathStr: [...pathParts, f.name].join('.'), label: f.title || f.name, field: f });
+                out.push({ pathStr, label: f.title || f.name, field: f });
             }
         }
     }
@@ -2749,8 +2770,12 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     private get _firstConditionEntry(): { field: SchemaField; fieldPath: string[] } | null {
         for (const group of this.getConditionFieldGroups()) {
-            const opt = group.fields[0];
-            if (opt) { return { field: opt.field, fieldPath: opt.pathStr.split('.') }; }
+            for (const opt of group.fields) {
+                // Re-resolve against the current schemas so a field left over from a removed
+                // sub-schema is never embedded into a condition.
+                const field = this._resolveConditionField(opt.pathStr);
+                if (field) { return { field, fieldPath: opt.pathStr.split('.') }; }
+            }
         }
         return null;
     }
@@ -2796,7 +2821,10 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     public setConditionOperator(cond: SchemaCondition, op: 'SINGLE' | 'AND' | 'OR'): void {
         const rows = this.getIfRows(cond);
         const firstEntry = this._firstConditionEntry;
-        const first = rows[0] ?? { field: firstEntry?.field, fieldValue: '', ...(firstEntry && firstEntry.fieldPath.length > 1 ? { fieldPath: firstEntry.fieldPath } : {}) };
+        // getIfRows returns a placeholder row for a null ifCondition, so an existing row is
+        // only usable when it actually carries a field; otherwise fall back to the first entry.
+        const existing = rows[0]?.field ? rows[0] : null;
+        const first = existing ?? { field: firstEntry?.field, fieldValue: '', ...(firstEntry && firstEntry.fieldPath.length > 1 ? { fieldPath: firstEntry.fieldPath } : {}) };
         const predicate = {
             field: first.field,
             fieldValue: first.fieldValue,

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -2636,13 +2636,13 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     public getConditionFieldGroups(): {
         groupLabel: string;
         isRoot: boolean;
-        fields: { pathStr: string; label: string }[];
+        fields: { pathStr: string; label: string; field: SchemaField }[];
     }[] {
         const schema = this.currentContextSchema;
         if (!schema) { return []; }
         const schemaByIri = new Map(this.schemas.filter(s => s.iri).map(s => [s.iri as string, s]));
-        const rootGroup = { groupLabel: '', isRoot: true, fields: [] as { pathStr: string; label: string }[] };
-        const nested: { groupLabel: string; isRoot: false; fields: { pathStr: string; label: string }[] }[] = [];
+        const rootGroup = { groupLabel: '', isRoot: true, fields: [] as { pathStr: string; label: string; field: SchemaField }[] };
+        const nested: { groupLabel: string; isRoot: false; fields: { pathStr: string; label: string; field: SchemaField }[] }[] = [];
 
         for (const f of schema.fields ?? []) {
             if (f.readOnly) { continue; }
@@ -2650,16 +2650,16 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                 const ref = schemaByIri.get(f.type);
                 const refFields = ref?.fields ?? (Array.isArray((f as any).fields) && (f as any).fields.length ? (f as any).fields : []);
                 if (refFields.length) {
-                    const group = { groupLabel: f.title || f.name, isRoot: false as const, fields: [] as { pathStr: string; label: string }[] };
+                    const group = { groupLabel: f.title || f.name, isRoot: false as const, fields: [] as { pathStr: string; label: string; field: SchemaField }[] };
                     this._collectLeafConditionFields(refFields, [f.name], schemaByIri, group.fields);
                     if (group.fields.length) { nested.push(group); }
                 }
             } else {
-                rootGroup.fields.push({ pathStr: f.name, label: f.title || f.name });
+                rootGroup.fields.push({ pathStr: f.name, label: f.title || f.name, field: f });
             }
         }
 
-        const result: { groupLabel: string; isRoot: boolean; fields: { pathStr: string; label: string }[] }[] = [];
+        const result: { groupLabel: string; isRoot: boolean; fields: { pathStr: string; label: string; field: SchemaField }[] }[] = [];
         if (rootGroup.fields.length) { result.push(rootGroup); }
         result.push(...nested);
         return result;
@@ -2669,7 +2669,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         fields: SchemaField[],
         pathParts: string[],
         schemaByIri: Map<string, Schema>,
-        out: { pathStr: string; label: string }[]
+        out: { pathStr: string; label: string; field: SchemaField }[]
     ): void {
         for (const f of fields) {
             if (f.readOnly) { continue; }
@@ -2680,7 +2680,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                     this._collectLeafConditionFields(refFields, [...pathParts, f.name], schemaByIri, out);
                 }
             } else {
-                out.push({ pathStr: [...pathParts, f.name].join('.'), label: f.title || f.name });
+                out.push({ pathStr: [...pathParts, f.name].join('.'), label: f.title || f.name, field: f });
             }
         }
     }
@@ -2747,12 +2747,10 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         return fields.find(f => f.name === parts[parts.length - 1]) ?? null;
     }
 
-    private get _firstConditionField(): SchemaField | null {
+    private get _firstConditionEntry(): { field: SchemaField; fieldPath: string[] } | null {
         for (const group of this.getConditionFieldGroups()) {
-            for (const opt of group.fields) {
-                const f = this._resolveConditionField(opt.pathStr);
-                if (f) { return f; }
-            }
+            const opt = group.fields[0];
+            if (opt) { return { field: opt.field, fieldPath: opt.pathStr.split('.') }; }
         }
         return null;
     }
@@ -2766,6 +2764,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         if (!schema?.conditions?.length) { return false; }
         return schema.conditions.some(c => {
             const ic = c.ifCondition as any;
+            if (!ic) { return false; }
             if ('AND' in ic) { return (ic.AND as any[])?.some((r: any) => r.field?.name === field.name); }
             if ('OR' in ic) { return (ic.OR as any[])?.some((r: any) => r.field?.name === field.name); }
             return ic.field?.name === field.name;
@@ -2780,6 +2779,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public getIfOperator(cond: SchemaCondition): 'SINGLE' | 'AND' | 'OR' {
         const ic = cond.ifCondition as any;
+        if (!ic) { return 'SINGLE'; }
         if ('AND' in ic) { return 'AND'; }
         if ('OR' in ic) { return 'OR'; }
         return 'SINGLE';
@@ -2787,6 +2787,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public getIfRows(cond: SchemaCondition): any[] {
         const ic = cond.ifCondition as any;
+        if (!ic) { return [{ field: null, fieldValue: '' }]; }
         if ('AND' in ic) { return ic.AND || []; }
         if ('OR' in ic) { return ic.OR || []; }
         return [ic];
@@ -2794,7 +2795,8 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public setConditionOperator(cond: SchemaCondition, op: 'SINGLE' | 'AND' | 'OR'): void {
         const rows = this.getIfRows(cond);
-        const first = rows[0] ?? { field: this._firstConditionField, fieldValue: '' };
+        const firstEntry = this._firstConditionEntry;
+        const first = rows[0] ?? { field: firstEntry?.field, fieldValue: '', ...(firstEntry && firstEntry.fieldPath.length > 1 ? { fieldPath: firstEntry.fieldPath } : {}) };
         const predicate = {
             field: first.field,
             fieldValue: first.fieldValue,
@@ -2810,7 +2812,6 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         this.markDirty();
     }
 
-    public getIfRowFieldName(row: any): string { return row?.field?.name ?? ''; }
     public getIfRowValue(row: any): any { return row?.fieldValue ?? ''; }
     public isIfRowEnum(row: any): boolean { return !!(row?.field?.enum?.length); }
     public getIfRowOptions(row: any): string[] { return row?.field?.enum ?? []; }
@@ -2825,14 +2826,15 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             ...(fieldPath.length > 1 ? { fieldPath } : {}),
         };
         const ic = cond.ifCondition as any;
-        if ('AND' in ic) { ic.AND[rowIdx] = predicate; }
-        else if ('OR' in ic) { ic.OR[rowIdx] = predicate; }
+        if (ic && 'AND' in ic) { ic.AND[rowIdx] = predicate; }
+        else if (ic && 'OR' in ic) { ic.OR[rowIdx] = predicate; }
         else { (cond as any).ifCondition = predicate; }
         this.markDirty();
     }
 
     public setIfRowValue(cond: SchemaCondition, rowIdx: number, value: any): void {
         const ic = cond.ifCondition as any;
+        if (!ic) { return; }
         if ('AND' in ic) { ic.AND[rowIdx].fieldValue = value; }
         else if ('OR' in ic) { ic.OR[rowIdx].fieldValue = value; }
         else { ic.fieldValue = value; }
@@ -2841,7 +2843,13 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public addIfRow(cond: SchemaCondition): void {
         const ic = cond.ifCondition as any;
-        const newRow = { field: this._firstConditionField, fieldValue: '' };
+        if (!ic) { return; }
+        const firstEntry = this._firstConditionEntry;
+        const newRow = {
+            field: firstEntry?.field ?? null,
+            fieldValue: '',
+            ...(firstEntry && firstEntry.fieldPath.length > 1 ? { fieldPath: firstEntry.fieldPath } : {}),
+        };
         if ('AND' in ic) { ic.AND.push(newRow); }
         else if ('OR' in ic) { ic.OR.push(newRow); }
         this.markDirty();
@@ -2849,6 +2857,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public removeIfRow(cond: SchemaCondition, rowIdx: number): void {
         const ic = cond.ifCondition as any;
+        if (!ic) { return; }
         if ('AND' in ic && ic.AND.length > 1) { ic.AND.splice(rowIdx, 1); }
         else if ('OR' in ic && ic.OR.length > 1) { ic.OR.splice(rowIdx, 1); }
         this.markDirty();
@@ -3134,10 +3143,14 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public addNewCondition(): void {
         const schema = this.currentContextSchema;
-        const firstField = this._firstConditionField;
-        if (!schema || !firstField) { return; }
+        const firstEntry = this._firstConditionEntry;
+        if (!schema || !firstEntry) { return; }
         const newCond: SchemaCondition = {
-            ifCondition: { field: firstField, fieldValue: '' } as any,
+            ifCondition: {
+                field: firstEntry.field,
+                fieldValue: '',
+                ...(firstEntry.fieldPath.length > 1 ? { fieldPath: firstEntry.fieldPath } : {}),
+            } as any,
             thenFields: [],
             elseFields: [],
         };

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -180,6 +180,7 @@
                   <col style="width: 85px;" />
                   <col style="width: 100px;" />
                   <col style="width: 185px;" />
+                  <col style="width: 185px;" />
                   <col style="width: 100px;" />
                   <col style="width: 140px;" />
                   <col style="width: 110px;" />

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -647,8 +647,8 @@ export class SchemaHelper {
                     elseTargets: elseForbiddenTargets,
                     cleanNode: cleanElse,
                 } = extractCrossTargets(n.else);
-                const thenFields = buildFields(cleanThen);
-                const elseFields = buildFields(cleanElse);
+                const thenFields = buildFields(cleanThen).map(f => fields.find(ef => ef.name === f.name) ?? f);
+                const elseFields = buildFields(cleanElse).map(f => fields.find(ef => ef.name === f.name) ?? f);
                 const allThenTargets = dedupeTargets([...thenTargets, ...elseForbiddenTargets]);
                 const allElseTargets = dedupeTargets([...elseTargets, ...elseRequiredTargets]);
                 const condition: any = { ifCondition, thenFields, elseFields };
@@ -906,6 +906,7 @@ export class SchemaHelper {
             if (!targets?.length) { return undefined; }
             const root: any = {};
             for (const t of targets) {
+                if (!t.field.required) { continue; }
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }
                 let node = root;

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -457,8 +457,30 @@ export class SchemaHelper {
         }
         const results: SchemaCondition[] = [];
 
+        const subSchemas = document.$defs || defs;
+
         const buildFields = (node: any) =>
-            SchemaHelper.parseFields(node, context, schemaCache, document.$defs || defs) as SchemaField[];
+            SchemaHelper.parseFields(node, context, schemaCache, subSchemas) as SchemaField[];
+
+        // refField.fields isn't always inlined; fall back to the parse cache, then a fresh parse.
+        const refFieldsOf = (refField: any): SchemaField[] => {
+            if (refField?.fields?.length) {
+                return refField.fields;
+            }
+            const iri = refField?.type;
+            if (!iri) {
+                return [];
+            }
+            const cached = schemaCache?.get(iri);
+            if (cached?.fields?.length) {
+                return cached.fields;
+            }
+            const subDocument = subSchemas?.[iri];
+            if (!subDocument) {
+                return [];
+            }
+            return SchemaHelper.parseFields(subDocument, context, schemaCache, subSchemas) as SchemaField[];
+        };
 
         const predicatesFromProperties = (
             props: any,
@@ -481,10 +503,11 @@ export class SchemaHelper {
                     }
                 } else if (rule.properties) {
                     const refField = currentFields.find(x => x.name === key && x.isRef);
-                    if (refField && (refField as any).fields?.length) {
+                    const childFields = refFieldsOf(refField);
+                    if (childFields.length) {
                         preds.push(...predicatesFromProperties(
                             rule.properties,
-                            (refField as any).fields,
+                            childFields,
                             [...pathSoFar, key]
                         ));
                     }
@@ -564,7 +587,7 @@ export class SchemaHelper {
                 if (isCrossConstraint) {
                     hasCrossKeys = true;
                     const childPath = [...pathPrefix, key];
-                    const childFields: SchemaField[] = (refField as any).fields || [];
+                    const childFields: SchemaField[] = refFieldsOf(refField);
                     if (Array.isArray(val.required)) {
                         for (const fieldName of val.required) {
                             const childField = childFields.find(f => f.name === fieldName);

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -647,8 +647,8 @@ export class SchemaHelper {
                     elseTargets: elseForbiddenTargets,
                     cleanNode: cleanElse,
                 } = extractCrossTargets(n.else);
-                const thenFields = buildFields(cleanThen).map(f => fields.find(ef => ef.name === f.name) ?? f);
-                const elseFields = buildFields(cleanElse).map(f => fields.find(ef => ef.name === f.name) ?? f);
+                const thenFields = buildFields(cleanThen);
+                const elseFields = buildFields(cleanElse);
                 const allThenTargets = dedupeTargets([...thenTargets, ...elseForbiddenTargets]);
                 const allElseTargets = dedupeTargets([...elseTargets, ...elseRequiredTargets]);
                 const condition: any = { ifCondition, thenFields, elseFields };

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -929,6 +929,7 @@ export class SchemaHelper {
             if (!targets?.length) { return undefined; }
             const root: any = {};
             for (const t of targets) {
+                // Intentional: optional targets are still hidden via buildCrossForbidden elsewhere.
                 if (!t.field.required) { continue; }
                 const path = t.fieldPath;
                 if (!path || path.length < 2) { continue; }

--- a/interfaces/tests/schema-helper-conditions-serialize.test.mjs
+++ b/interfaces/tests/schema-helper-conditions-serialize.test.mjs
@@ -103,7 +103,7 @@ describe('SchemaHelper.buildDocument — condition serialization', () => {
         assert.equal(doc.allOf.length, 1);
         assert.deepEqual(doc.allOf[0].if.properties, { a: { const: 'x' } });
         assert.ok(doc.allOf[0].then.properties.t1);
-        assert.equal(doc.allOf[0].else, undefined);
+        assert.deepEqual(doc.allOf[0].else, { properties: { t1: false } });
     });
 
     it('serialises a multi-predicate AND into if.allOf', () => {
@@ -148,7 +148,7 @@ describe('SchemaHelper.buildDocument — condition serialization', () => {
 
     it('emits else when only elseFields are present', () => {
         const doc = build([{ ifCondition: { field: { name: 'a' }, fieldValue: 1 }, thenFields: [], elseFields: [field('e1', { required: true })] }]);
-        assert.equal(doc.allOf[0].then, undefined);
+        assert.deepEqual(doc.allOf[0].then, { properties: { e1: false } });
         assert.ok(doc.allOf[0].else.properties.e1);
         assert.deepEqual(doc.allOf[0].else.required, ['e1']);
     });
@@ -156,6 +156,71 @@ describe('SchemaHelper.buildDocument — condition serialization', () => {
     it('omits allOf entirely when no conditions are given', () => {
         const doc = build(undefined);
         assert.equal('allOf' in doc, false);
+    });
+});
+
+describe('SchemaHelper — branch-level required round-trip', () => {
+    const fields = [field('a'), field('b')];
+
+    it('required thenField is present in then.required after build', () => {
+        const doc = SchemaHelper.buildDocument(
+            baseSchema(), fields,
+            [{ ifCondition: { field: field('a'), fieldValue: 'x' }, thenFields: [field('b', { required: true })], elseFields: [] }]
+        );
+        assert.deepEqual(doc.allOf[0].then.required, ['b']);
+    });
+
+    it('required elseField is present in else.required after build', () => {
+        const doc = SchemaHelper.buildDocument(
+            baseSchema(), fields,
+            [{ ifCondition: { field: field('a'), fieldValue: 'x' }, thenFields: [], elseFields: [field('b', { required: true })] }]
+        );
+        assert.deepEqual(doc.allOf[0].else.required, ['b']);
+    });
+
+    it('then.required survives parse → thenFields[].required', () => {
+        const doc = {
+            allOf: [{
+                if: { properties: { a: { const: 'x' } } },
+                then: { properties: { b: { type: 'string' } }, required: ['b'] },
+            }],
+        };
+        const [cond] = SchemaHelper.parseConditions(doc, 'ctx:', fields, new Map());
+        assert.equal(cond.thenFields.length, 1);
+        assert.equal(cond.thenFields[0].name, 'b');
+        assert.equal(cond.thenFields[0].required, true);
+    });
+
+    it('else.required survives parse → elseFields[].required', () => {
+        const doc = {
+            allOf: [{
+                if: { properties: { a: { const: 'x' } } },
+                else: { properties: { b: { type: 'string' } }, required: ['b'] },
+            }],
+        };
+        const [cond] = SchemaHelper.parseConditions(doc, 'ctx:', fields, new Map());
+        assert.equal(cond.elseFields.length, 1);
+        assert.equal(cond.elseFields[0].name, 'b');
+        assert.equal(cond.elseFields[0].required, true);
+    });
+
+    it('required thenField survives full build → parse round-trip', () => {
+        const conditions = [{
+            ifCondition: { field: field('a'), fieldValue: 'x' },
+            thenFields: [field('b', { required: true })],
+            elseFields: [],
+        }];
+        const doc = SchemaHelper.buildDocument(baseSchema(), fields, conditions);
+        const [cond] = SchemaHelper.parseConditions(doc, 'ctx:', fields, new Map());
+        assert.equal(cond.thenFields[0].required, true);
+    });
+
+    it('optional thenField is absent from then.required after build', () => {
+        const doc = SchemaHelper.buildDocument(
+            baseSchema(), fields,
+            [{ ifCondition: { field: field('a'), fieldValue: 'x' }, thenFields: [field('b', { required: false })], elseFields: [] }]
+        );
+        assert.deepEqual(doc.allOf[0].then.required, []);
     });
 });
 

--- a/interfaces/tests/schema-helper-cross-schema-conditions.test.mjs
+++ b/interfaces/tests/schema-helper-cross-schema-conditions.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { SchemaHelper } from '../dist/helpers/schema-helper.js';
+
+const field = (name, over = {}) => ({
+    name,
+    title: name,
+    description: name,
+    type: 'string',
+    required: false,
+    isArray: false,
+    isRef: false,
+    readOnly: false,
+    ...over,
+});
+
+const baseSchema = () => ({ uuid: 'u-1', version: '1.0.0', name: 'N', description: 'D', contextURL: 'ctx:' });
+
+describe('SchemaHelper.parseConditions — refFieldsOf fallback', () => {
+    it('resolves a nested IF predicate via schemaCache when the ref field\'s own fields are not inlined', () => {
+        // Regression guard: before refFieldsOf existed, a bare `(refField as any).fields?.length`
+        // check meant that any ref field whose sub-schema fields weren't already attached to the
+        // SchemaField object caused the whole nested predicate to be silently dropped, even when
+        // those fields were available via schemaCache from parsing elsewhere in the same pass.
+        const leaf = field('leaf', { type: 'string' });
+        const subRef = field('sub', { isRef: true, type: '#SubIri', fields: undefined });
+        const rootFields = [subRef];
+
+        const schemaCache = new Map();
+        schemaCache.set('#SubIri', { fields: [leaf], conditions: [] });
+
+        const document = {
+            allOf: [{
+                if: {
+                    properties: { sub: { properties: { leaf: { const: 'go' } }, required: ['leaf'] } },
+                    required: ['sub'],
+                },
+                then: { properties: { c: { type: 'string' } } },
+            }],
+        };
+
+        const [cond] = SchemaHelper.parseConditions(document, 'ctx:', rootFields, schemaCache);
+
+        assert.notEqual(cond.ifCondition, null, 'ifCondition must resolve, not silently drop the nested predicate');
+        assert.equal(cond.ifCondition.field.name, 'leaf');
+        assert.equal(cond.ifCondition.fieldValue, 'go');
+        assert.deepEqual(cond.ifCondition.fieldPath, ['sub', 'leaf']);
+    });
+
+    it('resolves a nested cross-schema target the same way', () => {
+        const leaf = field('leaf', { type: 'string' });
+        const subRef = field('sub', { isRef: true, type: '#SubIri', fields: undefined });
+        const rootFields = [field('trigger'), subRef];
+
+        const schemaCache = new Map();
+        schemaCache.set('#SubIri', { fields: [leaf], conditions: [] });
+
+        const document = {
+            allOf: [{
+                if: { properties: { trigger: { const: 'go' } }, required: ['trigger'] },
+                then: {},
+                else: { properties: { sub: { properties: { leaf: false } } } },
+            }],
+        };
+
+        const [cond] = SchemaHelper.parseConditions(document, 'ctx:', rootFields, schemaCache);
+
+        // A field forbidden (properties.X: false) inside the raw JSON's `else` branch means it's
+        // allowed when the IF is true — so it surfaces as a `thenTargets` entry, not `elseTargets`.
+        assert.ok(cond.thenTargets?.length, 'the cross-schema target must be resolved, not dropped');
+        assert.equal(cond.thenTargets[0].field.name, 'leaf');
+        assert.deepEqual(cond.thenTargets[0].fieldPath, ['sub', 'leaf']);
+    });
+
+    it('still returns no predicate when the ref field is genuinely unresolvable (not in fields, cache, or $defs)', () => {
+        const subRef = field('sub', { isRef: true, type: '#Missing', fields: undefined });
+        const rootFields = [subRef];
+
+        const document = {
+            allOf: [{
+                if: {
+                    properties: { sub: { properties: { leaf: { const: 'go' } }, required: ['leaf'] } },
+                    required: ['sub'],
+                },
+                then: {},
+            }],
+        };
+
+        const [cond] = SchemaHelper.parseConditions(document, 'ctx:', rootFields, new Map());
+        assert.equal(cond.ifCondition, null, 'a genuinely missing sub-schema cannot be invented');
+    });
+});
+
+describe('SchemaHelper.buildDocument — buildCrossRequired optional-target guard', () => {
+    // This guard has been independently flagged as a "bug" twice by different reviews — it is
+    // intentional. An optional cross-schema target must not be force-required in the branch
+    // where it's allowed, but it must still be hidden via buildCrossForbidden in the other branch.
+    it('requires only the required target, but forbids both targets in the opposite branch', () => {
+        const conditions = [{
+            ifCondition: { field: field('trigger'), fieldValue: 'x' },
+            thenFields: [],
+            elseFields: [],
+            thenTargets: [
+                { field: field('leaf1', { required: true }), fieldPath: ['sub', 'leaf1'] },
+                { field: field('leaf2', { required: false }), fieldPath: ['sub', 'leaf2'] },
+            ],
+            elseTargets: [],
+        }];
+        const doc = SchemaHelper.buildDocument(baseSchema(), [field('trigger')], conditions);
+
+        assert.deepEqual(doc.allOf[0].then.properties.sub.required, ['leaf1'],
+            'only the required target is added to then.required');
+        assert.equal(doc.allOf[0].else.properties.sub.properties.leaf1, false,
+            'the required target must still be forbidden in else');
+        assert.equal(doc.allOf[0].else.properties.sub.properties.leaf2, false,
+            'the optional target must also be forbidden in else, even though it was never required');
+    });
+});


### PR DESCRIPTION
**Description**:
- Fixed cross-schema condition targets incorrectly auto-required in then/else blocks.

**Related issue(s)**:

Fixes [#6562](https://github.com/hashgraph/guardian/issues/6562), [#6580](https://github.com/hashgraph/guardian/issues/6580)