### PR TITLE
fix: build arm64 prod deps without QEMU

### DIFF
--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace ai-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production ai-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production ai-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/analytics-service/Dockerfile
+++ b/analytics-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace analytics-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production analytics-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production analytics-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -33,13 +28,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace api-gateway run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production api-gateway
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production api-gateway
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/api-gateway/Dockerfile.demo
+++ b/api-gateway/Dockerfile.demo
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -33,13 +28,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace api-gateway run build:demo
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production api-gateway
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production api-gateway
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/application-events/Dockerfile
+++ b/application-events/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace application-events run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production application-events
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production application-events
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -33,13 +28,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace auth-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production auth-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production auth-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/auth-service/Dockerfile.demo
+++ b/auth-service/Dockerfile.demo
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -33,13 +28,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace auth-service run build:demo
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production auth-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production auth-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/guardian-service/Dockerfile
+++ b/guardian-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace guardian-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production guardian-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production guardian-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/indexer-api-gateway/Dockerfile
+++ b/indexer-api-gateway/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -33,13 +28,18 @@ RUN yarn workspace @indexer/interfaces run build \
  && yarn workspace @indexer/common run build \
  && yarn workspace indexer-api-gateway run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production indexer-api-gateway
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production indexer-api-gateway
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/indexer-service/Dockerfile
+++ b/indexer-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @indexer/interfaces run build \
  && yarn workspace @indexer/common run build \
  && yarn workspace indexer-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production indexer-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production indexer-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/indexer-worker-service/Dockerfile
+++ b/indexer-worker-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @indexer/interfaces run build \
  && yarn workspace @indexer/common run build \
  && yarn workspace indexer-worker-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production indexer-worker-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production indexer-worker-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/logger-service/Dockerfile
+++ b/logger-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace logger-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production logger-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production logger-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/mrv-sender/Dockerfile
+++ b/mrv-sender/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -26,13 +21,18 @@ COPY --link mrv-sender/tsconfig*.json mrv-sender/
 COPY --link mrv-sender/src mrv-sender/src/
 RUN yarn workspace mrv-sender run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production mrv-sender
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production mrv-sender
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace notification-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production notification-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production notification-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/policy-service/Dockerfile
+++ b/policy-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace policy-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production policy-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production policy-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/queue-service/Dockerfile
+++ b/queue-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace queue-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production queue-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production queue-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/topic-listener-service/Dockerfile
+++ b/topic-listener-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace topic-listener-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production topic-listener-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production topic-listener-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/topic-viewer/Dockerfile
+++ b/topic-viewer/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -26,13 +21,18 @@ COPY --link topic-viewer/tsconfig*.json topic-viewer/
 COPY --link topic-viewer/src topic-viewer/src/
 RUN yarn workspace topic-viewer run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production topic-viewer
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production topic-viewer
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/tree-viewer/Dockerfile
+++ b/tree-viewer/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -26,13 +21,18 @@ COPY --link tree-viewer/tsconfig*.json tree-viewer/
 COPY --link tree-viewer/src tree-viewer/src/
 RUN yarn workspace tree-viewer run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production tree-viewer
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production tree-viewer
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image

--- a/worker-service/Dockerfile
+++ b/worker-service/Dockerfile
@@ -7,11 +7,6 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app
 RUN corepack enable
 
-# Production deps: native to the target arch
-FROM node:${NODE_VERSION} AS base-target
-WORKDIR /usr/local/app
-RUN corepack enable
-
 # Stage 1: Install all dependencies for building.
 FROM base AS deps-dev
 COPY --link package.json yarn.lock .yarnrc.yml ./
@@ -32,13 +27,18 @@ RUN yarn workspace @guardian/interfaces run build \
  && yarn workspace @guardian/common run build \
  && yarn workspace worker-service run build:prod
 
-# Stage 3: FOCUSED production install TARGET platform.
-FROM base-target AS deps-prod
+# Stage 3: FOCUSED production install for the target arch, run on the
+# builder's arch with the target declared to Yarn instead of emulated.
+FROM base AS deps-prod
+ARG TARGETOS
+ARG TARGETARCH
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn .yarn
 COPY --link --parents */package.json ./
 RUN --mount=type=cache,target=/root/.yarn/berry/cache,sharing=private \
-    yarn workspaces focus --production worker-service
+    printf '\nsupportedArchitectures:\n  os: ["%s"]\n  cpu: ["%s"]\n' \
+      "${TARGETOS}" "$(echo "${TARGETARCH}" | sed 's/^amd64$/x64/')" >> .yarnrc.yml \
+ && yarn workspaces focus --production worker-service
 
 # Stage 4: Create the final image.
 FROM node:${NODE_VERSION} AS image


### PR DESCRIPTION
### Description

Multi-platform image builds failed on the `linux/arm64` leg: Yarn crashed with `qemu: uncaught target signal 4 (Illegal instruction)` during the link step of the focused production install, roughly five minutes into the stage.

- Run the focused production install on the builder’s native architecture instead of under QEMU emulation.
- Declare the target `os`/`cpu` to Yarn via `supportedArchitectures`, so platform-gated packages still resolve for the target architecture.
- Drop the now-unused `base-target` stage from all 20 affected Dockerfiles, including the `api-gateway` and `auth-service` demo variants.