### PR TITLE
fix: 6514 make scalar api generation play well with gitbook api reference

### DIFF
--- a/api-gateway/src/helpers/swagger-tags.ts
+++ b/api-gateway/src/helpers/swagger-tags.ts
@@ -13,6 +13,7 @@ interface ScalarTag {
     name: string;
     description?: string;
     'x-displayName'?: string;
+    parent?: string;
 }
 
 interface ScalarTagGroup {
@@ -333,10 +334,14 @@ export function applyScalarTagMetadata(document: OpenAPIObject): void {
     const groups = new Map<string, ScalarTagGroup>();
     const tags: ScalarTag[] = [];
 
-    // Register containers (tags without a parent) as groups, preserving order.
+    // Register containers (tags without a parent) as groups and real tags, preserving order.
     for (const tag of swaggerTags) {
         if (!tag['x-parent']) {
             groups.set(tag.name, { name: tag['x-page-title'] ?? tag.name, tags: [] });
+            tags.push({
+                name: tag.name,
+                'x-displayName': tag['x-page-title'],
+            });
         }
     }
 
@@ -351,6 +356,7 @@ export function applyScalarTagMetadata(document: OpenAPIObject): void {
             name: tag.name,
             description: tag['x-page-description'],
             'x-displayName': tag['x-page-title'],
+            parent,
         });
     }
 


### PR DESCRIPTION
### Pull Request Description

fix: 6514 make scalar api generation play well with gitbook api reference

* gitbook handles parent tag differently with the OpenApi 3.2
* Added parent?: string to the ScalarTag interface
* The Scalar PR #6513 converted the tag hierarchy into x-tagGroups for Scalar's sidebar grouping but never wrote parent into the YAML output. GitBook requires parent on each tag (OpenAPI 3.2 field, no x- prefix) and needs the parent tags to exist as real entries in the tags array to resolve the hierarchy. Without both, GitBook rendered the tags as a flat list with no grouping.
* The same tag data now satisfies both renderers: x-tagGroups for Scalar's sidebar, parent for GitBook's page hierarchy.

Story: 6514, 5619
Reviewed-by: na
Test-scope: local, gitbook

Signed-off-by: Daniel Swid <daniel.swid@hashgraph.com>