### PR TITLE
feat: 6502 Display Entire MathBlock Formula Tab Name

### DIFF
--- a/frontend/src/app/modules/common/pages-control/pages-control.component.html
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.html
@@ -30,6 +30,8 @@
         [attr.selected]="item === current"
         [attr.hidden]="i < index"
         (click)="onSelect(item)"
+        pTooltip="{{ item[labelField] }}"
+        tooltipPosition="top"
         >
         <div class="guardian-pages-item-name">
           {{item[labelField]}}
@@ -60,6 +62,8 @@
         class="menu-item"
         [attr.selected]="item === current"
         (click)="onSelect(item, menu)"
+        pTooltip="{{ item[labelField] }}"
+        tooltipPosition="top"
         >
         <div class="menu-item-name">
           {{item[labelField]}}

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.html
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.html
@@ -1,25 +1,10 @@
 <div class="guardian-pages-control">
   <div class="guardian-pages-nav">
-    <div class="guardian-pages-nav-left guardian-icon-button" (click)="onLeft()">
-      <svg-icon
-        class="icon-btn svg-icon"
-        src="/assets/images/icons/collapse-left.svg"
-        svgClass="icon-color-primary"
-        [svgClass]="isFirst ? 'icon-color-disabled' : 'icon-color-primary'">
-      </svg-icon>
-    </div>
     <div class="guardian-pages-nav-more guardian-icon-button" (click)="onMore($event, menu, itemMenu)">
       <svg-icon
         class="icon-btn svg-icon"
         src="/assets/images/icons/menu-2.svg"
         svgClass="icon-color-primary">
-      </svg-icon>
-    </div>
-    <div class="guardian-pages-nav-right guardian-icon-button" (click)="onRight()">
-      <svg-icon
-        class="icon-btn svg-icon"
-        src="/assets/images/icons/collapse-right.svg"
-        [svgClass]="isLast ? 'icon-color-disabled' : 'icon-color-primary'">
       </svg-icon>
     </div>
   </div>
@@ -59,7 +44,7 @@
   <div class="menu-items">
     @for (item of items; track item) {
       <div
-        class="menu-item"
+        class="menu-item formula-tab-item"
         [attr.selected]="item === current"
         (click)="onSelect(item, menu)"
         pTooltip="{{ item[labelField] }}"

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.html
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.html
@@ -9,11 +9,10 @@
     </div>
   </div>
   <div class="guardian-pages-container">
-    @for (item of items; track item; let i = $index) {
+    @for (item of items; track item) {
       <div
         class="guardian-pages-item"
         [attr.selected]="item === current"
-        [attr.hidden]="i < index"
         (click)="onSelect(item)"
         pTooltip="{{ item[labelField] }}"
         tooltipPosition="top"
@@ -44,7 +43,7 @@
   <div class="menu-items">
     @for (item of items; track item) {
       <div
-        class="menu-item formula-tab-item"
+        class="menu-item"
         [attr.selected]="item === current"
         (click)="onSelect(item, menu)"
         pTooltip="{{ item[labelField] }}"

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.scss
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.scss
@@ -14,7 +14,12 @@
 
 .menu-items {
     max-height: 300px;
+    max-width: 400px;
     overflow: auto;
+
+    .formula-tab-item {
+        max-width: 400px;
+    }
 }
 
 .menu-item-name {

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.scss
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.scss
@@ -14,16 +14,12 @@
 
 .menu-items {
     max-height: 300px;
-    max-width: 400px;
     overflow: auto;
-
-    .formula-tab-item {
-        max-width: 400px;
-    }
 }
 
 .menu-item-name {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    max-width: 400px;
 }

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.ts
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Inject, Input, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/core';
 
 /**
  * menu button.

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.ts
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.ts
@@ -93,24 +93,10 @@ export class PagesControl {
         this.rename.emit(item);
     }
 
-    onLeft() {
-        if (this.index > 0) {
-            this.index--;
-        }
-        this.updateView();
-    }
-
     onMore($event: MouseEvent, overlayPanel: any, otherPanel: any) {
         $event?.stopPropagation();
         overlayPanel.toggle(event);
         otherPanel?.hide();
-    }
-
-    onRight() {
-        if (this.index < this.items.length - 1) {
-            this.index++;
-        }
-        this.updateView();
     }
 
     onMenu($event: MouseEvent, page: any, overlayPanel: any, otherPanel: any) {

--- a/frontend/src/app/modules/common/pages-control/pages-control.component.ts
+++ b/frontend/src/app/modules/common/pages-control/pages-control.component.ts
@@ -20,16 +20,6 @@ export class PagesControl {
     @Output('delete') delete = new EventEmitter<any>();
     @Output('rename') rename = new EventEmitter<any>();
 
-    public index: number = 0;
-
-    public get isFirst() {
-        return this.index < 1;
-    }
-
-    public get isLast() {
-        return this.index + 1 >= this.items?.length;
-    }
-
     public readonly menuData = [{
         tooltip: 'Rename',
         icon: 'edit',
@@ -51,31 +41,9 @@ export class PagesControl {
         }
     }];
 
-    constructor() {
-    }
-
-    private updateView() {
-        if (this.index >= this.items.length) {
-            this.index = 0;
-        }
-        if (this.index < 0) {
-            this.index = 0;
-        }
-    }
-
-    ngOnChanges(changes: SimpleChanges): void {
-        this.items = this.items || [];
-        this.updateView();
-    }
-
-    ngAfterViewInit(): void {
-
-    }
-
     onSelect(item: any, overlayPanel?: any) {
         if (overlayPanel) {
             overlayPanel.toggle(false);
-            this.index = this.items.findIndex((e) => e === item);
         }
         this.current = item;
         this.select.emit(this.current);

--- a/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-editor-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/dialogs/math-editor-dialog/math-editor-dialog.component.scss
@@ -108,7 +108,7 @@
         padding: 0px;
 
         &.pages {
-            bottom: 40px;
+            bottom: 54px;
         }
     }
 

--- a/frontend/src/app/themes/guardian/menu.scss
+++ b/frontend/src/app/themes/guardian/menu.scss
@@ -17,7 +17,6 @@
         padding: 8px 16px;
         min-width: 100px;
         cursor: pointer;
-        max-width: 150px;
         user-select: none;
 
         &[selected="true"] {

--- a/frontend/src/app/themes/guardian/pages.scss
+++ b/frontend/src/app/themes/guardian/pages.scss
@@ -37,10 +37,6 @@
             user-select: none;
             margin-right: 8px;
 
-            &[hidden="true"] {
-                display: none !important;
-            }
-
             .guardian-pages-item-name {
                 pointer-events: none;
                 font-family: Inter;

--- a/frontend/src/app/themes/guardian/pages.scss
+++ b/frontend/src/app/themes/guardian/pages.scss
@@ -16,7 +16,8 @@
 
     .guardian-pages-container {
         width: fit-content;
-        overflow: scroll;
+        overflow-x: auto;
+        overflow-y: hidden;
         display: flex;
         flex-direction: row;
         margin: 0px 8px;

--- a/frontend/src/app/themes/guardian/pages.scss
+++ b/frontend/src/app/themes/guardian/pages.scss
@@ -1,42 +1,29 @@
 .guardian-pages-control {
-    height: 32px;
+    height: 42px;
     width: 100%;
     display: flex;
     flex-direction: row;
 
     .guardian-pages-nav {
-        height: 32px;
-        width: 96px;
-        min-width: 96px;
         display: flex;
         flex-direction: row;
 
-        .guardian-pages-nav-left {
-            height: 32px;
-            width: 32px;
-        }
-
         .guardian-pages-nav-more {
-            height: 32px;
-            width: 32px;
-        }
-
-        .guardian-pages-nav-right {
-            height: 32px;
-            width: 32px;
+            height: 38px;
+            width: 38px;
         }
     }
 
     .guardian-pages-container {
         width: fit-content;
-        overflow: hidden;
+        overflow: scroll;
         display: flex;
         flex-direction: row;
         margin: 0px 8px;
 
         .guardian-pages-item {
             width: auto;
-            max-width: 150px;
+            max-width: 250px;
             position: relative;
             border: 1px solid var(--guardian-primary-color, #4169E2);
             border-bottom: 0px;

--- a/frontend/src/assets/images/icons/collapse-left.svg
+++ b/frontend/src/assets/images/icons/collapse-left.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="m 15,6 -6,6 6,6 z" />
-</svg>

--- a/frontend/src/assets/images/icons/collapse-right.svg
+++ b/frontend/src/assets/images/icons/collapse-right.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M 9,18 15,12 9,6 Z" />
-</svg>


### PR DESCRIPTION
**Description**:
* Added tooltips for math block formulas tabs
* Added scrollbar
* Removed left/right nav buttons
* Improved styles and UX of navigating formulas tabs 

**Related issue(s)**:

Resolves: [#6502](https://github.com/hashgraph/guardian/issues/6502)
