### PR TITLE
fix(indexer): reconnect to NATS forever (maxReconnectAttempts: -1)

### DIFF
--- a/indexer-api-gateway/src/app.module.ts
+++ b/indexer-api-gateway/src/app.module.ts
@@ -27,6 +27,7 @@ const JSON_REQUEST_LIMIT = process.env.JSON_REQUEST_LIMIT || '1mb';
                 options: {
                     name: `${process.env.SERVICE_CHANNEL}`,
                     servers: [`nats://${process.env.MQ_ADDRESS}:4222`],
+                    maxReconnectAttempts: -1, // reconnect forever
                 },
             },
         ]),

--- a/indexer-api-gateway/src/app.ts
+++ b/indexer-api-gateway/src/app.ts
@@ -29,6 +29,7 @@ Promise.all([
                     name: channelName,
                     queue: 'INDEXER_API_SERVICES',
                     servers: [`nats://${process.env.MQ_ADDRESS}:4222`],
+                    maxReconnectAttempts: -1, // reconnect forever
                 },
                 // tls: GenerateTLSOptionsNats()
             });

--- a/indexer-service/src/app.ts
+++ b/indexer-service/src/app.ts
@@ -72,6 +72,7 @@ async function updateIndexes() {
                 options: {
                     name: channelName,
                     servers: [`nats://${process.env.MQ_ADDRESS}:4222`],
+                    maxReconnectAttempts: -1, // reconnect forever
                 },
             },
         ]),
@@ -112,7 +113,8 @@ Promise.all([
             name: channelName,
             queue: 'INDEXER_SERVICES',
             servers: [`nats://${process.env.MQ_ADDRESS}:4222`],
-            tls: GenerateTLSOptionsNats()
+            tls: GenerateTLSOptionsNats(),
+            maxReconnectAttempts: -1 // reconnect forever
         },
     }),
 ]).then(

--- a/indexer-worker-service/src/app.ts
+++ b/indexer-worker-service/src/app.ts
@@ -19,7 +19,8 @@ const channelName = (process.env.SERVICE_CHANNEL || `indexer-worker.${Utils.Gene
                 name: channelName,
                 servers: [
                     `nats://${process.env.MQ_ADDRESS}:4222`
-                ]
+                ],
+                maxReconnectAttempts: -1 // reconnect forever
             }
         }])
     ],
@@ -47,7 +48,8 @@ Promise.all([
             servers: [
                 `nats://${process.env.MQ_ADDRESS}:4222`
             ],
-            tls: GenerateTLSOptionsNats()
+            tls: GenerateTLSOptionsNats(),
+            maxReconnectAttempts: -1 // reconnect forever
         },
     }),
 ]).then(async values => {


### PR DESCRIPTION
## Problem

All six indexer NATS registrations pass only `{name, servers, queue?}`, so `nats.js`'s default `maxReconnectAttempts: 10` applies. Once those ten attempts are exhausted the client stays **closed for the life of the process** and never retries again. Any NATS restart - a Kubernetes node image upgrade, drain, pod reschedule, or a NATS chart upgrade - therefore takes the indexer down until every dependent pod is restarted by hand.

We hit this in production. A node event moved the NATS pod; the indexer api-gateway stayed up with a dead client and returned HTTP 500 for ~20 hours:

```
"GET /api/v1/mainnet/entities/vc-documents?…&pageSize=100" 500 52 "-" "node"
[Nest] ERROR [ExceptionsHandler] Error: Connection lost. Trying to reconnect...    (×1346)
```

The message is misleading - it was not trying to reconnect any more. Restarting the gateway/service/worker pods fixed it immediately, and the 500s went to zero.

Guardian's own MQ wrapper already handles this correctly in `common/src/mq/message-broker-channel.ts`:

```ts
return connect({
    tls: GenerateTLSOptionsNats(),
    servers: [process.env.MQ_ADDRESS],
    name: connectionName,
    reconnectDelayHandler: () => 2000,
    maxReconnectAttempts: -1 // reconnect forever
});
```

That is precisely why the guardian services rode through the same node event while the indexer services did not.

## Change

`maxReconnectAttempts: -1` on each of the six indexer NATS registrations - one line each:

| file | registration |
|---|---|
| `indexer-api-gateway/src/app.ts` | microservice, queue `INDEXER_API_SERVICES` |
| `indexer-api-gateway/src/app.module.ts` | client `INDEXER_API` |
| `indexer-service/src/app.ts` | client `INDEXER_API` |
| `indexer-service/src/app.ts` | microservice, queue `INDEXER_SERVICES` |
| `indexer-worker-service/src/app.ts` | client `INDEXER_WORKERS_API` |
| `indexer-worker-service/src/app.ts` | microservice, queue `INDEXER_WORKERS` |

`9 insertions(+), 3 deletions(-)`; the three deletions are only trailing commas added to the preceding lines. No new files, no refactor, no behaviour change while NATS is reachable - it only removes the give-up-after-10 ceiling.

`maxReconnectAttempts` is declared in `NatsOptions` in `@nestjs/microservices` (`interfaces/microservice-configuration.interface.d.ts`), so no type changes are needed.

## Testing

Verified in production by observation rather than by an automated test: with the old settings, restarting NATS wedged the gateway until its pod was recycled; the reconnect ceiling is the only difference.

I did not add a unit test - the change is a single literal passed to the NATS client, so a test would assert the constant rather than the reconnect behaviour, and exercising the real behaviour needs a NATS instance that can be stopped and started mid-test. Happy to add an integration-level test if the team wants one and can point me at the right harness.

Reproduction on any Kubernetes deployment: `kubectl -n <ns> delete pod <nats-pod>`. Before this change the indexer API returns 500 indefinitely; after it, requests recover on their own once NATS is back.

Related consideration, deliberately out of scope: the indexer liveness probes do not reflect NATS connection state, so a wedged client is not recycled automatically. Worth a separate change.
