### PR TITLE
fix(indexer): skip allOf conditions with no if.properties (parseConditions TypeError)

### DIFF
--- a/indexer-interfaces/src/helpers/schema-helper.ts
+++ b/indexer-interfaces/src/helpers/schema-helper.ts
@@ -221,7 +221,7 @@ export class SchemaHelper {
         const allOf = Object.keys(document.allOf);
         for (const oneOf of allOf) {
             const condition = document.allOf[oneOf];
-            if (!condition.if) {
+            if (!condition.if?.properties) {
                 continue;
             }
 

--- a/indexer-service/src/analytics/compare/models/schema-document.model.ts
+++ b/indexer-service/src/analytics/compare/models/schema-document.model.ts
@@ -96,7 +96,7 @@ export class SchemaDocumentModel {
         const combinedDefs = document.$defs || defs;
 
         for (const condition of document.allOf) {
-            if (!condition.if) {
+            if (!condition.if?.properties) {
                 continue;
             }
             const ifConditionFieldName = Object.keys(condition.if.properties)[0];


### PR DESCRIPTION
## Problem

`parseConditions` checks `condition.if` and then immediately calls `Object.keys(condition.if.properties)`. For a schema whose `if` carries no `properties`, `Object.keys(undefined)` throws and takes down the whole schema parse:

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at SchemaDocumentModel.parseConditions (schema-document.model.js:79:49)
    at new SchemaDocumentModel (schema-document.model.js:27:32)
    at SchemaDocumentModel.parseFields (schema-document.model.js:51:33)
    at new SchemaDocumentModel (schema-document.model.js:26:28)
    at SchemaDocumentModel.from (schema-document.model.js:186:16)
    at new SchemaModel (schema.model.js:105:49)
    at SchemaModel.fromEntity (schema.model.js:254:29)
```

Observed on a production indexer during the policy synchronisation task:

```
Sync Policies: load policies
Sync Policies: load files 136
Sync Policies: update data
TypeError: Cannot convert undefined or null to object
```

The exception escapes `SchemaModel.fromEntity`, so the analytics pass for that schema is abandoned. Because it depends only on the stored schema document, it repeats on every sync cycle.

## Change

One line at each of the two affected call sites — `if (!condition.if?.properties)` in place of `if (!condition.if)`:

- `indexer-service/src/analytics/compare/models/schema-document.model.ts` — the site in the stack trace
- `indexer-interfaces/src/helpers/schema-helper.ts` — same shape, reached from schema rendering rather than analytics, and would throw on the same document

Only `null`/`undefined` cause `Object.keys` to throw, so a truthiness check on `properties` is sufficient. A condition with no `if.properties` has no field name to resolve, so skipping it matches the existing behaviour a few lines below, where a condition whose field is not in the schema is skipped too.

## Precedent in this repo

`guardian-service` already guards the same access in its copy of the model — `guardian-service/src/analytics/compare/models/schema-document.model.ts`:

```ts
if (condition.if.properties && typeof condition.if.properties === 'object') {
```

The two indexer copies were never brought in line. This does that, with the minimum diff.

## Notes for review

- No behaviour change for well-formed schemas: conditions that carry `if.properties` take exactly the path they did before.
- Kept deliberately small and free of refactoring so it is easy to review and backport.
