### PR TITLE
fix: refresh policy list after group delete

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/delete-dialog/delete-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/dialogs/delete-dialog/delete-dialog.component.scss
@@ -19,11 +19,11 @@
 }
 
 .dialog-body {
-    height: 5vh;
-    max-height: 5vh;
-    overflow: auto;
     min-height: 70px;
     margin-bottom: 16px;
+    // The theme caps .dialog-body with !important, which scrolls the policy list inside the body.
+    max-height: none !important;
+    overflow: visible !important;
 }
 
 .dialog-footer {
@@ -37,4 +37,22 @@
     font-weight: 500;
     line-height: 18px;
     margin-top: 25px;
+
+    &+.confirmation-text {
+        margin-top: 12px;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 20px;
+    }
+
+    li {
+        margin-top: 8px;
+    }
+
+    li p {
+        margin: 0;
+        word-break: break-word;
+    }
 }

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -2266,12 +2266,14 @@ export class PoliciesComponent implements OnInit {
                                     //
                                 })
 
-                                return this.indexedDb.clearByKeyPrefixAcrossStores(
+                                await this.indexedDb.clearByKeyPrefixAcrossStores(
                                     DB_NAME.HIDE_EVENTS_UI_STATE,
                                     [STORES_NAME.POLICY_HIDE_EVENTS_STORE],
                                     `${policyId}`
                                 );
                             }
+
+                            this.onClearSelection();
 
                             const { taskId, expectation } = result;
                             this.router.navigate(['task', taskId], {


### PR DESCRIPTION
### Description

Closes #6598. Deleting policies through the multi-select option completed on the backend but the UI stayed on the stale list: the IndexedDB cleanup loop ended with a `return`, which exited the success callback on its first iteration and skipped the navigation to the async task page, so no progress bar was shown and the list was never refreshed. The confirmation dialog also pinned its body to `5vh`, clipping the list of selected policies into a scroll area that showed almost nothing.

- Await the last IndexedDB cleanup call instead of returning it, so every selected policy is cleaned up and the navigation to the task progress page runs.
- Clear the current selection before navigating, so the bottom selection bar is not left holding deleted policies.
- Let the delete dialog body grow with its content instead of scrolling inside a fixed 5vh box, so every selected policy is visible.
- Tighten the spacing of the policy list in the dialog and wrap long policy names.
