### PR TITLE
fix: static color coding in blocks library

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -338,7 +338,7 @@
                       <div class="components-group-body readonly-status">
                         @for (item of componentsList.favorites; track item) {
                           <div
-                            class="components-group-item">
+                            [attr.block-type]="item.header" class="components-group-item">
                             <div (click)="onAdd(item)" [attr.block-type]="item.header"
                               [cdkDragData]="item.data" cdkDrag class="drag-btn">
                               <div class="drag-component">
@@ -368,7 +368,7 @@
                     <div class="components-group-body readonly-status">
                       @for (item of componentsList.uiComponents; track item) {
                         <div
-                          class="components-group-item">
+                          [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAdd(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component">
@@ -397,7 +397,7 @@
                     <div class="components-group-body readonly-status">
                       @for (item of componentsList.serverBlocks; track item) {
                         <div
-                          class="components-group-item">
+                          [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAdd(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component">
@@ -425,7 +425,7 @@
                     </div>
                     <div class="components-group-body readonly-status">
                       @for (item of componentsList.addons; track item) {
-                        <div class="components-group-item">
+                        <div [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAdd(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component">
@@ -454,7 +454,7 @@
                       <div class="components-group-body readonly-status">
                         @for (item of componentsList.unGrouped; track item) {
                           <div
-                            class="components-group-item">
+                            [attr.block-type]="item.header" class="components-group-item">
                             <div (click)="onAdd(item)" [attr.block-type]="item.header"
                               [cdkDragData]="item.data" cdkDrag class="drag-btn">
                               <div class="drag-component">
@@ -493,7 +493,7 @@
                       </div>
                       <div class="components-group-body readonly-status">
                         @for (item of modulesList.favorites; track item) {
-                          <div class="components-group-item">
+                          <div [attr.block-type]="item.header" class="components-group-item">
                             <div (click)="onAddModule(item)" [attr.block-type]="item.header"
                               [cdkDragData]="item.data" cdkDrag class="drag-btn">
                               <div class="drag-component drag-module">
@@ -531,7 +531,7 @@
                     <div class="components-group-body readonly-status">
                       @for (item of modulesList.defaultModules; track item) {
                         <div
-                          class="components-group-item">
+                          [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAddModule(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component drag-module">
@@ -568,7 +568,7 @@
                     <div class="components-group-body readonly-status">
                       @for (item of modulesList.customModules; track item) {
                         <div
-                          class="components-group-item">
+                          [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAddModule(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component drag-module">
@@ -613,7 +613,7 @@
                     </div>
                     <div class="components-group-body readonly-status">
                       @for (item of modulesList.customTools; track item) {
-                        <div class="components-group-item">
+                        <div [attr.block-type]="item.header" class="components-group-item">
                           <div (click)="onAddTool(item)" [attr.block-type]="item.header"
                             [cdkDragData]="item.data" cdkDrag class="drag-btn">
                             <div class="drag-component drag-module">

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -1311,10 +1311,7 @@
                 --pc-library-icon-color: var(--pc-tool-block-accent);
             }
 
-            .component-btn-icon,
-            .drag-component-icon {
-                color: var(--pc-library-icon-color);
-
+            .component-btn-icon {
                 svg-icon,
                 svg,
                 i {
@@ -1380,7 +1377,7 @@
                 height: 20px;
                 font-size: 16px;
                 pointer-events: none;
-                color: var(--pc-active-icon-color);
+                color: var(--pc-library-icon-color, var(--pc-module-block-accent));
             }
 
             > span {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.scss
@@ -47,6 +47,7 @@
     --pc-server-block-accent: #2aa9c4;
     --pc-addon-block-accent: #e08a1e;
     --pc-tool-block-accent: #c37a29;
+    --pc-module-block-accent: var(--guardian-grey-color-3, #AAB7C4);
 
     --pc-ui-block-background-color: color-mix(in srgb, var(--pc-ui-block-accent) 12%, var(--guardian-background, #fff));
     --pc-server-block-background-color: color-mix(in srgb, var(--pc-server-block-accent) 12%, var(--guardian-background, #fff));
@@ -1283,12 +1284,44 @@
             display: none;
         }
 
+        // Library colour coding is deliberately static: it maps a block to its type,
+        // so it must stay readable regardless of the customer's brand colours. Every
+        // value below resolves to a --pc-*-block-accent, never to --color-primary.
         .components-group-item {
+            --pc-library-icon-color: var(--pc-module-block-accent);
             position: relative;
             width: 100%;
             max-width: 100%;
             height: auto;
             overflow: hidden;
+
+            &[block-type="UI Components"] {
+                --pc-library-icon-color: var(--pc-ui-block-accent);
+            }
+
+            &[block-type="Server Blocks"] {
+                --pc-library-icon-color: var(--pc-server-block-accent);
+            }
+
+            &[block-type="Addons"] {
+                --pc-library-icon-color: var(--pc-addon-block-accent);
+            }
+
+            &[block-type="Tool"] {
+                --pc-library-icon-color: var(--pc-tool-block-accent);
+            }
+
+            .component-btn-icon,
+            .drag-component-icon {
+                color: var(--pc-library-icon-color);
+
+                svg-icon,
+                svg,
+                i {
+                    color: var(--pc-library-icon-color);
+                    fill: var(--pc-library-icon-color);
+                }
+            }
 
             .drag-btn {
                 position: absolute !important;


### PR DESCRIPTION
### Description

Closes #6595. Block library items in the policy configurator took their icon colour from the brand primary, so updating brand colours replaced the type-based colour coding shown by the group dots.

- Tag every block library item with its block type so mixed groups (Favorites, unGrouped) colour per item.
- Drive library icon colour from the static block-type accents: UI purple, Server cyan, Addons orange, Tool brown.
- Add a static `--pc-module-block-accent` for modules and any item without a type.

<img width="585" height="528" alt="image" src="https://github.com/user-attachments/assets/0178f59b-4ac5-4d87-a1d7-c91dafad1af5" />