### PR TITLE
fix: 6596 left-align policy action menu labels

### DIFF
--- a/frontend/src/app/modules/policy-engine/policies/policies.component.scss
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.scss
@@ -317,6 +317,14 @@
         padding: 0 12px;
     }
 
+    ::ng-deep .p-button-label {
+        text-align: left;
+    }
+
+    ::ng-deep .p-button-outlined > svg-icon {
+        flex-shrink: 0;
+    }
+
     ::ng-deep .accent-color-red {
         fill: var(--color-accent-red-1) !important;
         color: var(--color-accent-red-1) !important;


### PR DESCRIPTION
### Description

Closes #6596. In the policy action menu the schema-related items wrapped to two lines, and PrimeNG's default centred button label left those lines misaligned against the single-line items such as "Export policy".

- Left-align the label inside policy action menu buttons so wrapped lines start at the same edge as the icon
- Keep the menu item icon from shrinking when its label spans two lines
