### PR TITLE
fix: 6601 token ID link does not open hashscan

### DIFF
--- a/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.html
+++ b/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.html
@@ -1,3 +1,4 @@
-<a [href]="url" class="hedera-link" target="_blank">
+<!-- Without a network the anchor has no href, and the inactive style drops the link colour and underline. -->
+<a [attr.href]="url || null" class="hedera-link" [class.hedera-link-inactive]="!url" target="_blank">
     <ng-content></ng-content>
 </a>

--- a/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.scss
+++ b/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.scss
@@ -8,3 +8,8 @@
     border-bottom: 1px solid var(--color-primary);
     text-transform: capitalize;
 }
+
+.hedera-link-inactive {
+    color: var(--color-grey-5);
+    border-bottom: none;
+}

--- a/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.spec.ts
+++ b/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.spec.ts
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable, Subject, of, throwError } from 'rxjs';
+import { SettingsService } from 'src/app/services/settings.service';
+import { HederaExplorer } from './hedera-explorer.component';
+
+@Component({
+    template: `<hedera-explorer [params]="tokenId" type="tokens">{{ tokenId }}</hedera-explorer>`,
+    standalone: false
+})
+class HostComponent {
+    tokenId: string | null = '0.0.10004069';
+}
+
+describe('HederaExplorer', () => {
+    let net: Observable<string>;
+
+    function build(): ComponentFixture<HostComponent> {
+        TestBed.configureTestingModule({
+            declarations: [HederaExplorer, HostComponent],
+            providers: [{ provide: SettingsService, useValue: { getHederaNet: () => net } }]
+        });
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        return fixture;
+    }
+
+    function href(fixture: ComponentFixture<HostComponent>): string | null {
+        return fixture.nativeElement.querySelector('a').getAttribute('href');
+    }
+
+    function inactive(fixture: ComponentFixture<HostComponent>): boolean {
+        return fixture.nativeElement.querySelector('a').classList.contains('hedera-link-inactive');
+    }
+
+    it('links to hashscan for a token id', () => {
+        net = of('testnet');
+        const fixture = build();
+        expect(href(fixture)).toBe('https://hashscan.io/testnet/token/0.0.10004069');
+        expect(inactive(fixture)).toBeFalse();
+    });
+
+    it('links to hashscan when the network arrives after render', () => {
+        const network = new Subject<string>();
+        net = network.asObservable();
+        const fixture = build();
+        expect(href(fixture)).toBeNull();
+
+        network.next('testnet');
+        fixture.detectChanges();
+        expect(href(fixture)).toBe('https://hashscan.io/testnet/token/0.0.10004069');
+    });
+
+    it('renders no link when the network is unavailable', () => {
+        net = throwError(() => new Error('401'));
+        const fixture = build();
+        expect(href(fixture)).toBeNull();
+        expect(inactive(fixture)).toBeTrue();
+    });
+
+    it('renders no link for an unknown network', () => {
+        net = of('unknown-net');
+        expect(href(build())).toBeNull();
+    });
+});

--- a/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.ts
+++ b/frontend/src/app/modules/common/hedera-explorer/hedera-explorer.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, SimpleChanges } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SettingsService } from 'src/app/services/settings.service';
 import { environment } from 'src/environments/environment';
 
@@ -11,33 +12,65 @@ import { environment } from 'src/environments/environment';
     styleUrls: ['./hedera-explorer.component.scss'],
     standalone: false
 })
-export class HederaExplorer {
-    url: string;
+export class HederaExplorer implements OnInit, OnChanges, OnDestroy {
+    /**
+     * Explorer link, empty until the network is known - without it the link
+     * would point at a nonexistent explorer page.
+     */
+    public url: string = '';
 
     @Input('type') type!: string;
     @Input('params') params!: string | null;
     @Input('subType') subType!: string;
     @Input('subParams') subParams!: string | null;
 
-    constructor(private settingsService: SettingsService) {
-        this.url = '';
+    private network: string = '';
+    private subscription?: Subscription;
+
+    constructor(
+        private settingsService: SettingsService,
+        private changeDetector: ChangeDetectorRef
+    ) {
     }
 
-    ngOnChanges(changes: SimpleChanges): void {
+    ngOnInit(): void {
+        this.subscription = this.settingsService.getHederaNet().subscribe({
+            next: (net: string) => {
+                this.network = net;
+                this.updateUrl();
+                this.changeDetector.markForCheck();
+            },
+            // The link stays hidden while the network is unknown, so a failed
+            // lookup needs no handling beyond keeping the stream from throwing.
+            error: () => { }
+        });
+    }
+
+    ngOnChanges(): void {
+        this.updateUrl();
+    }
+
+    ngOnDestroy(): void {
+        this.subscription?.unsubscribe();
+    }
+
+    private updateUrl(): void {
         const networkMap: any = environment.explorerSettings.networkMap;
         const typeMap: any = environment.explorerSettings.typeMap;
-        this.settingsService.getHederaNet().subscribe((res: string) => {
-            const network = networkMap[res] ? ('/' + networkMap[res]) : '';
-            const type = typeMap[this.type] ? ('/' + typeMap[this.type]) : '';
-            const params = this.params ? ('/' + this.params) : '';
-            const subType = typeMap[this.subType] ? ('/' + typeMap[this.subType]) : '';
-            const subParams = this.subParams ? ('/' + this.subParams) : '';
-            this.url = environment.explorerSettings.url
-                .replace('/${network}', network)
-                .replace('/${type}', type)
-                .replace('/${value}', params)
-                .replace('/${subType}', subType)
-                .replace('/${subValue}', subParams);
-        });
+        if (!networkMap[this.network]) {
+            this.url = '';
+            return;
+        }
+        const network = '/' + networkMap[this.network];
+        const type = typeMap[this.type] ? ('/' + typeMap[this.type]) : '';
+        const params = this.params ? ('/' + this.params) : '';
+        const subType = typeMap[this.subType] ? ('/' + typeMap[this.subType]) : '';
+        const subParams = this.subParams ? ('/' + this.subParams) : '';
+        this.url = environment.explorerSettings.url
+            .replace('/${network}', network)
+            .replace('/${type}', type)
+            .replace('/${value}', params)
+            .replace('/${subType}', subType)
+            .replace('/${subValue}', subParams);
     }
 }

--- a/frontend/src/app/services/settings.service.spec.ts
+++ b/frontend/src/app/services/settings.service.spec.ts
@@ -1,0 +1,47 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { API_BASE_URL } from './api';
+import { SettingsService } from './settings.service';
+
+const ENVIRONMENT_URL = `${API_BASE_URL}/settings/environment`;
+
+describe('SettingsService', () => {
+    let service: SettingsService;
+    let http: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [SettingsService]
+        });
+        service = TestBed.inject(SettingsService);
+        http = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        http.verify();
+    });
+
+    it('caches the network after a successful lookup', () => {
+        const values: string[] = [];
+        service.getHederaNet().subscribe((res) => values.push(res));
+        http.expectOne(ENVIRONMENT_URL).flush('testnet');
+
+        service.getHederaNet().subscribe((res) => values.push(res));
+        http.expectNone(ENVIRONMENT_URL);
+
+        expect(values).toEqual(['testnet', 'testnet']);
+    });
+
+    it('retries after a failed lookup instead of replaying the error', () => {
+        service.getHederaNet().subscribe({ error: () => { } });
+        http.expectOne(ENVIRONMENT_URL)
+            .flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+
+        let network = '';
+        service.getHederaNet().subscribe((res) => network = res);
+        http.expectOne(ENVIRONMENT_URL).flush('testnet');
+
+        expect(network).toBe('testnet');
+    });
+});

--- a/frontend/src/app/services/settings.service.ts
+++ b/frontend/src/app/services/settings.service.ts
@@ -30,6 +30,8 @@ export class SettingsService {
         if (!this.hederaNet) {
             this.hederaNet = this.getRemoteHederaNet().pipe(
                 filter((res) => !!res),
+                // shareReplay resets on error, so a failed lookup is retried
+                // by the next consumer instead of replaying the error.
                 shareReplay(1)
             );
         }


### PR DESCRIPTION
### Description

Closes #6601. The token ID on the List of Tokens page did not open hashscan: the explorer component built its URL inside a subscription started from `ngOnChanges`, and the network name resolves after the row is rendered, so the anchor kept an empty `href`.

- Resolve the network once in `ngOnInit` and mark the view for check when it arrives
- Rebuild the explorer URL only when the inputs or the network change
- Drop the `href` and the link styling while the network is unknown, so the value reads as plain text instead of a dead link
- Cover the explorer URL and the network lookup with unit tests
