### PR TITLE
fix: hide AI search when not configured

### DIFF
--- a/frontend/src/app/views/policy-search/policy-search.component.html
+++ b/frontend/src/app/views/policy-search/policy-search.component.html
@@ -7,13 +7,17 @@
         [value]="selectedIndex"
         [ngStyle]="{'height': 'calc(100vh - 120px)'}">
         <p-tablist>
-          <p-tab [value]="0">Search with AI</p-tab>
+          @if (aiSearchEnabled) {
+            <p-tab [value]="0">Search with AI</p-tab>
+          }
           <p-tab [value]="1">Guided Search</p-tab>
         </p-tablist>
         <p-tabpanels>
-          <p-tabpanel [value]="0">
-            <app-policy-ai-search class="possible-problems-with-empty-tab-here"></app-policy-ai-search>
-          </p-tabpanel>
+          @if (aiSearchEnabled) {
+            <p-tabpanel [value]="0">
+              <app-policy-ai-search class="possible-problems-with-empty-tab-here"></app-policy-ai-search>
+            </p-tabpanel>
+          }
           <p-tabpanel [value]="1">
             <app-policy-guided-search></app-policy-guided-search>
           </p-tabpanel>

--- a/frontend/src/app/views/policy-search/policy-search.component.ts
+++ b/frontend/src/app/views/policy-search/policy-search.component.ts
@@ -6,6 +6,7 @@ import {HeaderPropsService} from 'src/app/services/header-props.service';
 import {TagsService} from 'src/app/services/tag.service';
 import {IUser} from '@guardian/interfaces';
 import {ProfileService} from '../../services/profile.service';
+import {environment} from '../../../environments/environment';
 
 /**
  * The page with guided policy search
@@ -18,11 +19,17 @@ import {ProfileService} from '../../services/profile.service';
 })
 export class PolicySearchComponent implements OnInit {
     loading: boolean = false;
-    selectedIndex: number = 0;
+    // AI search is optional: the tab is hidden when the AI service is not configured.
+    readonly aiSearchEnabled: boolean = environment.isAISearchConfigured;
+    selectedIndex: number = this.aiSearchEnabled ? 0 : 1;
     isConfirmed: boolean = false;
 
     private subscription = new Subscription();
     private tabs = ['policy-ai-search', 'policy-guided-search'];
+
+    private get defaultIndex(): number {
+        return this.aiSearchEnabled ? 0 : 1;
+    }
 
     constructor(
         public tagsService: TagsService,
@@ -38,11 +45,14 @@ export class PolicySearchComponent implements OnInit {
         this.loadProfile();
         this.route.queryParams.subscribe((params) => {
             const tab = this.route.snapshot.queryParams['tab'] || '';
-            this.selectedIndex = 0;
+            this.selectedIndex = this.defaultIndex;
             for (let index = 0; index < this.tabs.length; index++) {
                 if (tab === this.tabs[index]) {
                     this.selectedIndex = index;
                 }
+            }
+            if (!this.aiSearchEnabled && this.selectedIndex === 0) {
+                this.selectedIndex = this.defaultIndex;
             }
         })
     }
@@ -66,7 +76,7 @@ export class PolicySearchComponent implements OnInit {
     }
 
     onChange(index: string | number | undefined) {
-        this.selectedIndex = typeof index === 'number' ? index : 0;
+        this.selectedIndex = typeof index === 'number' ? index : this.defaultIndex;
         this.router.navigate(['/policy-search'], {
             queryParams: {tab: this.tabs[this.selectedIndex]}
         });

--- a/frontend/src/environments/environment.demo.ts
+++ b/frontend/src/environments/environment.demo.ts
@@ -4,6 +4,7 @@ export const environment = {
     displayDemoAccounts: true,
     accessTokenUpdateInterval: 29 * 1000,
     isMeecoConfigured: false,
+    isAISearchConfigured: false,
     requireAuthorizationPopup: true,
     explorerSettings: {
         url: 'https://hashscan.io/${network}/${type}/${value}/${subType}/${subValue}',

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -4,6 +4,7 @@ export const environment = {
     displayDemoAccounts: false,
     accessTokenUpdateInterval: 29 * 1000,
     isMeecoConfigured: false,
+    isAISearchConfigured: false,
     requireAuthorizationPopup: true,
     explorerSettings: {
         url: 'https://hashscan.io/${network}/${type}/${value}/${subType}/${subValue}',

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -8,6 +8,7 @@ export const environment = {
     accessTokenUpdateInterval: 29 * 1000,
     displayDemoAccounts: true,
     isMeecoConfigured: true,
+    isAISearchConfigured: false,
     requireAuthorizationPopup: true,
     explorerSettings: {
         url: 'https://hashscan.io/${network}/${type}/${value}/${subType}/${subValue}',


### PR DESCRIPTION
### Description

Closes #6602. The "Search with AI" tab on the Search for Policies page was always rendered, so instances running without a configured AI service showed a tab that errors on use. Gate it behind a build-time environment flag, following the existing `isMeecoConfigured` pattern for optional services.

- Add `isAISearchConfigured` to the default, prod and demo environments, off by default
- Hide the AI tab and its panel when the flag is off
- Default to Guided Search, and fall back to it when the URL requests the hidden AI tab
