### PR TITLE
fix: respect docs widget setting on load

### DIFF
--- a/frontend/src/app/services/doc-widget.service.ts
+++ b/frontend/src/app/services/doc-widget.service.ts
@@ -6,6 +6,8 @@ import { Injectable } from '@angular/core';
 export class DocWidgetService {
     public readonly available: boolean = window.location.protocol === 'https:';
 
+    private pending: boolean = false;
+
     public isEnabled(): boolean {
         try {
             return localStorage.getItem('SHOW_DOC_WIDGET') !== 'false';
@@ -20,23 +22,54 @@ export class DocWidgetService {
         } catch (error) {
             console.error(error);
         }
-        const gitBook = (window as any).GitBook;
-        if (gitBook) {
-            if (value) {
+        this.apply();
+    }
+
+    public applyOnStartup(): void {
+        this.apply();
+    }
+
+    /**
+     * The stored value is read when the widget is actually available, so a
+     * pending call cannot overwrite a newer choice made while it was waiting.
+     */
+    private apply(): void {
+        this.whenReady((gitBook) => {
+            if (this.isEnabled()) {
                 gitBook('show');
             } else {
                 gitBook('close');
                 gitBook('hide');
             }
-        }
+        });
     }
 
-    public applyOnStartup(): void {
-        if (!this.isEnabled()) {
-            const gitBook = (window as any).GitBook;
-            if (gitBook) {
-                gitBook('hide');
-            }
+    /**
+     * The GitBook script is loaded asynchronously from index.html, so it may not
+     * be available yet when the application bootstraps.
+     */
+    private whenReady(callback: (gitBook: any) => void): void {
+        const gitBook = (window as any).GitBook;
+        if (gitBook) {
+            callback(gitBook);
+            return;
         }
+        if (!this.available || this.pending) {
+            return;
+        }
+        this.pending = true;
+        const interval = setInterval(() => {
+            const loaded = (window as any).GitBook;
+            if (loaded) {
+                this.stopWaiting(interval);
+                callback(loaded);
+            }
+        }, 100);
+        setTimeout(() => this.stopWaiting(interval), 30000);
+    }
+
+    private stopWaiting(interval: any): void {
+        clearInterval(interval);
+        this.pending = false;
     }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -21,6 +21,7 @@
     <script>
         if (window.location.protocol === 'https:') {
             const STORAGE_KEY = 'gitbook-widget-pos';
+            const ENABLED_KEY = 'SHOW_DOC_WIDGET';
             const BUTTON_ID = 'gitbook-widget-button';
             const WINDOW_ID = 'gitbook-widget-window';
             const TARGET_IFRAME_ID = 'gitbook-widget-iframe';
@@ -48,6 +49,14 @@
             const setStyles = (el, styles) => {
                 for (const [prop, val] of Object.entries(styles)) {
                     el.style.setProperty(prop, String(val), 'important');
+                }
+            };
+
+            const isWidgetEnabled = () => {
+                try {
+                    return localStorage.getItem(ENABLED_KEY) !== 'false';
+                } catch {
+                    return true;
                 }
             };
 
@@ -413,7 +422,12 @@
                     button: { label: 'See Docs', icon: 'assistant' },
                     tabs: ['assistant', 'docs']
                 });
-                window.GitBook('show');
+                if (isWidgetEnabled()) {
+                    window.GitBook('show');
+                } else {
+                    window.GitBook('close');
+                    window.GitBook('hide');
+                }
                 bootWidget();
             };
             document.head.appendChild(script);


### PR DESCRIPTION
### Description

Closes #6627. The docs widget appeared on startup even when it was switched off in the profile, because the GitBook embed script always called `show()` once it loaded, while the Angular-side correction ran earlier and silently did nothing when the script was not yet on the page.

- Read the `SHOW_DOC_WIDGET` preference in `index.html` and hide the widget instead of showing it when the preference is off.
- Wait for the GitBook script before applying the state in `DocWidgetService`, so the startup pass is no longer lost in a race with the embed script.
- Read the stored preference at the moment the widget becomes available, so a toggle made while waiting is not overwritten.
