### PR TITLE
fix: 6626 invalidate schema listing cache

### DIFF
--- a/api-gateway/src/api/service/schema-template.ts
+++ b/api-gateway/src/api/service/schema-template.ts
@@ -161,7 +161,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.CREATE_SCHEMA_TEMPLATE_VERSION, user.id);
             await guardians.createSchemaTemplateVersionAsync(templateId, owner, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -386,7 +386,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.IMPORT_SCHEMA_TEMPLATE_FILE, user.id);
             await guardians.importSchemaTemplateFileAsync(body, new EntityOwner(user), task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -419,7 +419,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.IMPORT_SCHEMA_TEMPLATE_MESSAGE, user.id);
             await guardians.importSchemaTemplateMessageAsync(messageId, new EntityOwner(user), task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -694,7 +694,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.PUBLISH_SCHEMA_TEMPLATE, user.id);
             await guardians.publishSchemaTemplateAsync(templateId, owner, body, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -748,7 +748,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.applySchemaTemplate(templateId, policyId, owner);
                 taskManager.addStatus(task.taskId, 'Copy template schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Save template binding', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
                 taskManager.addStatus(task.taskId, 'Save template binding', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {
@@ -853,7 +853,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.updateAppliedSchemaTemplate(templateId, policyId, owner, body);
                 taskManager.addStatus(task.taskId, 'Update policy schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Save template snapshot', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
                 taskManager.addStatus(task.taskId, 'Save template snapshot', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {
@@ -909,7 +909,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.detachSchemaTemplate(policyId, owner);
                 taskManager.addStatus(task.taskId, 'Detach template from policy schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Finalize policy binding', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
                 taskManager.addStatus(task.taskId, 'Finalize policy binding', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {

--- a/api-gateway/src/api/service/schema-template.ts
+++ b/api-gateway/src/api/service/schema-template.ts
@@ -5,7 +5,7 @@ import { ApiAcceptedResponse, ApiBody, ApiCreatedResponse, ApiInternalServerErro
 import { AuthUser, Auth } from '#auth';
 import { CacheService, EntityOwner, Guardians, InternalException, ServiceError, TaskManager } from '#helpers';
 import { InternalServerErrorDTO, pageHeader, TaskDTO } from '#middlewares';
-import { PREFIXES } from '#constants';
+import { CACHE_TAG_PREFIXES } from '#constants';
 
 const ONLY_SR = ' Only users with the Standard Registry role are allowed to make the request.';
 
@@ -161,7 +161,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.CREATE_SCHEMA_TEMPLATE_VERSION, user.id);
             await guardians.createSchemaTemplateVersionAsync(templateId, owner, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -386,7 +386,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.IMPORT_SCHEMA_TEMPLATE_FILE, user.id);
             await guardians.importSchemaTemplateFileAsync(body, new EntityOwner(user), task);
-            await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -419,7 +419,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.IMPORT_SCHEMA_TEMPLATE_MESSAGE, user.id);
             await guardians.importSchemaTemplateMessageAsync(messageId, new EntityOwner(user), task);
-            await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -694,7 +694,7 @@ export class SchemaTemplatesApi {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.PUBLISH_SCHEMA_TEMPLATE, user.id);
             await guardians.publishSchemaTemplateAsync(templateId, owner, body, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
             return task;
         } catch (error) {
             await InternalException(error, this.logger, user.id);
@@ -748,7 +748,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.applySchemaTemplate(templateId, policyId, owner);
                 taskManager.addStatus(task.taskId, 'Copy template schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Save template binding', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
                 taskManager.addStatus(task.taskId, 'Save template binding', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {
@@ -853,7 +853,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.updateAppliedSchemaTemplate(templateId, policyId, owner, body);
                 taskManager.addStatus(task.taskId, 'Update policy schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Save template snapshot', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
                 taskManager.addStatus(task.taskId, 'Save template snapshot', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {
@@ -909,7 +909,7 @@ export class SchemaTemplatesApi {
                 const result = await guardians.detachSchemaTemplate(policyId, owner);
                 taskManager.addStatus(task.taskId, 'Detach template from policy schemas', StatusType.COMPLETED);
                 taskManager.addStatus(task.taskId, 'Finalize policy binding', StatusType.PROCESSING);
-                await this.cacheService.invalidateAllTagsByPrefixes([PREFIXES.SCHEMES]);
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
                 taskManager.addStatus(task.taskId, 'Finalize policy binding', StatusType.COMPLETED);
                 taskManager.addResult(task.taskId, result);
             }, async (error) => {

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -1245,7 +1245,7 @@ export class SchemaApi {
             const schemas = await guardians.createSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -1306,7 +1306,7 @@ export class SchemaApi {
             const { iri, topicId, name, copyNested } = body;
             taskManager.addStatus(task.taskId, 'Check schema version', StatusType.PROCESSING);
             await guardians.copySchemaAsync(iri, topicId, name, owner, task, copyNested);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
@@ -1384,7 +1384,7 @@ export class SchemaApi {
             SchemaHelper.updateOwner(newSchema, owner);
 
             await guardians.createSchemaAsync(newSchema, owner, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
@@ -1486,7 +1486,7 @@ export class SchemaApi {
             const schemas = await guardians.updateSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -1583,7 +1583,7 @@ export class SchemaApi {
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchema(schemaId, owner, task, String(includeChildren).toLowerCase() === 'true');
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
@@ -1717,7 +1717,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -1815,7 +1815,7 @@ export class SchemaApi {
                 return;
             }
             await guardians.publishSchemaAsync(schemaId, version, owner, task);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
@@ -2156,7 +2156,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -2242,7 +2242,7 @@ export class SchemaApi {
             const guardians = new Guardians();
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByMessagesAsync([messageId], owner, topicId, task, schemasIds);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
@@ -2333,7 +2333,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -2416,7 +2416,7 @@ export class SchemaApi {
             const guardians = new Guardians();
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByFileAsync(files, owner, topicId, task, schemasIds);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
@@ -2663,7 +2663,7 @@ export class SchemaApi {
             SchemaHelper.updateOwner(newSchema, owner);
             const schema = await guardians.createSystemSchema(newSchema, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return SchemaUtils.toOld(schema);
         } catch (error) {
@@ -2928,7 +2928,7 @@ export class SchemaApi {
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchema(schemaId, owner, task);
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
@@ -3045,7 +3045,7 @@ export class SchemaApi {
             const schemas = await guardians.updateSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -3120,7 +3120,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             await guardians.activeSchema(schemaId, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return null;
         } catch (error) {
@@ -3319,7 +3319,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -3404,7 +3404,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByXlsxAsync(owner, topicId, file, task, schemasIds);
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: 'Unknown error: ' + error.message });
@@ -3574,7 +3574,7 @@ export class SchemaApi {
         try {
             await guardians.deleteSchemasByTopic(topicId, owner);
 
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             return true;
         } catch (error) {
@@ -3739,7 +3739,7 @@ export class SchemaApi {
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchemasByIds(schemaIds, owner, task, String(includeChildren).toLowerCase() === 'true');
-                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -1306,12 +1306,11 @@ export class SchemaApi {
             const { iri, topicId, name, copyNested } = body;
             taskManager.addStatus(task.taskId, 'Check schema version', StatusType.PROCESSING);
             await guardians.copySchemaAsync(iri, topicId, name, owner, task, copyNested);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
-
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -1385,12 +1384,11 @@ export class SchemaApi {
             SchemaHelper.updateOwner(newSchema, owner);
 
             await guardians.createSchemaAsync(newSchema, owner, task);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
-
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -1817,12 +1815,11 @@ export class SchemaApi {
                 return;
             }
             await guardians.publishSchemaAsync(schemaId, version, owner, task);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
-
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2245,12 +2242,11 @@ export class SchemaApi {
             const guardians = new Guardians();
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByMessagesAsync([messageId], owner, topicId, task, schemasIds);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
-
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2420,12 +2416,11 @@ export class SchemaApi {
             const guardians = new Guardians();
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByFileAsync(files, owner, topicId, task, schemasIds);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
-
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2933,12 +2928,11 @@ export class SchemaApi {
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchema(schemaId, owner, task);
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
             });
-
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return task;
         } catch (error) {
@@ -3410,12 +3404,11 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             const schemasIds = (schemas || '').split(',');
             await guardians.importSchemasByXlsxAsync(owner, topicId, file, task, schemasIds);
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: 'Unknown error: ' + error.message });
         });
-        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
-
         return res.status(202).send(task);
     }
 
@@ -3746,12 +3739,11 @@ export class SchemaApi {
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchemasByIds(schemaIds, owner, task, String(includeChildren).toLowerCase() === 'true');
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
             });
-
-            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return task;
         } catch (error) {

--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -24,8 +24,8 @@ import { Examples,
     VersionSchemaDTO,
     ForbiddenErrorDTO
 } from '#middlewares';
-import { CACHE, PREFIXES, SCHEMA_REQUIRED_PROPS } from '#constants';
-import { CacheService, EntityOwner, getCacheKey, Guardians, InternalException, ONLY_SR, SchemaUtils, ServiceError, TaskManager, UseCache, FilenameSanitizer } from '#helpers';
+import { CACHE, CACHE_TAG_PREFIXES, SCHEMA_REQUIRED_PROPS } from '#constants';
+import { CacheService, EntityOwner, Guardians, InternalException, ONLY_SR, SchemaUtils, ServiceError, TaskManager, UseCache, FilenameSanitizer } from '#helpers';
 import process from 'node:process';
 
 @Controller('schema')
@@ -1245,9 +1245,7 @@ export class SchemaApi {
             const schemas = await guardians.createSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -1313,9 +1311,7 @@ export class SchemaApi {
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
 
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -1394,9 +1390,7 @@ export class SchemaApi {
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
 
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -1494,9 +1488,7 @@ export class SchemaApi {
             const schemas = await guardians.updateSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -1591,11 +1583,9 @@ export class SchemaApi {
         try {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
-            const reqUrl = req.url;
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchema(schemaId, owner, task, String(includeChildren).toLowerCase() === 'true');
-                await this.cacheService.invalidate(getCacheKey([reqUrl, ...invalidedCacheKeys], user)).catch(() => null);
+                await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
@@ -1729,9 +1719,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return res.header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -1834,9 +1822,7 @@ export class SchemaApi {
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
 
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2173,9 +2159,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -2266,9 +2250,7 @@ export class SchemaApi {
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
 
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2355,9 +2337,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -2445,9 +2425,7 @@ export class SchemaApi {
             taskManager.addError(task.taskId, { code: 500, message: error.message });
         });
 
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return task;
     }
@@ -2690,9 +2668,7 @@ export class SchemaApi {
             SchemaHelper.updateOwner(newSchema, owner);
             const schema = await guardians.createSystemSchema(newSchema, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return SchemaUtils.toOld(schema);
         } catch (error) {
@@ -2962,8 +2938,7 @@ export class SchemaApi {
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
             });
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return task;
         } catch (error) {
@@ -3076,9 +3051,7 @@ export class SchemaApi {
             const schemas = await guardians.updateSchema(newSchema, owner);
             SchemaHelper.updatePermission(schemas, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return SchemaUtils.toOld(schemas);
         } catch (error) {
@@ -3153,9 +3126,7 @@ export class SchemaApi {
             const owner = new EntityOwner(user);
             await guardians.activeSchema(schemaId, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return null;
         } catch (error) {
@@ -3354,9 +3325,7 @@ export class SchemaApi {
             }, owner);
             SchemaHelper.updatePermission(items, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return res.status(201).header('X-Total-Count', count).send(SchemaUtils.toOld(items));
         } catch (error) {
@@ -3445,9 +3414,7 @@ export class SchemaApi {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: 500, message: 'Unknown error: ' + error.message });
         });
-        const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+        await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
         return res.status(202).send(task);
     }
@@ -3614,9 +3581,7 @@ export class SchemaApi {
         try {
             await guardians.deleteSchemasByTopic(topicId, owner);
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return true;
         } catch (error) {
@@ -3786,8 +3751,7 @@ export class SchemaApi {
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });
             });
 
-            const invalidedCacheKeys = [`${PREFIXES.SCHEMES}schema-with-sub-schemas`];
-            await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheKeys], user))
+            await this.cacheService.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
 
             return task;
         } catch (error) {

--- a/api-gateway/src/constants/cache.ts
+++ b/api-gateway/src/constants/cache.ts
@@ -16,5 +16,7 @@ export const PREFIXES = {
  * has to carry the `tag` part to match anything at all.
  */
 export const TAG_PREFIXES = {
-  SCHEMAS: `${PREFIXES.TAG}/schemas`,
+  // Schemas are served by two controllers: `/schemas/...` and the single
+  // schema route of `@Controller('schema')`.
+  SCHEMAS: [`${PREFIXES.TAG}/schemas`, `${PREFIXES.TAG}/schema/`],
 }

--- a/api-gateway/src/constants/cache.ts
+++ b/api-gateway/src/constants/cache.ts
@@ -8,3 +8,13 @@ export const PREFIXES = {
   CACHE: 'cache',
   TAG: 'tag'
 }
+
+/**
+ * Prefixes of the cache tags a mutation invalidates in bulk.
+ *
+ * A tag is `<TAG prefix><request path without query>:<user hash>`, so a prefix
+ * has to carry the `tag` part to match anything at all.
+ */
+export const TAG_PREFIXES = {
+  SCHEMAS: `${PREFIXES.TAG}/schemas`,
+}

--- a/api-gateway/src/constants/index.ts
+++ b/api-gateway/src/constants/index.ts
@@ -1,6 +1,6 @@
 export { META_DATA } from './meta-data.js';
 
-export { CACHE, PREFIXES as CACHE_PREFIXES } from './cache.js';
+export { CACHE, PREFIXES as CACHE_PREFIXES, TAG_PREFIXES as CACHE_TAG_PREFIXES } from './cache.js';
 
 export { PREFIXES } from './routes.js';
 

--- a/api-gateway/src/helpers/interceptors/cache.ts
+++ b/api-gateway/src/helpers/interceptors/cache.ts
@@ -48,7 +48,7 @@ export class CacheInterceptor implements NestInterceptor {
         const { url: route } = request;
 
         const [cacheKey] = getCacheKey([route], user, CACHE_PREFIXES.CACHE);
-        const [cacheTag] = getCacheKey([route.split('?')[0]], user);
+        const [cacheTag] = getCacheKey([route], user);
 
         return of(null).pipe(
             switchMap(async () => {

--- a/api-gateway/src/helpers/interceptors/utils/cache.ts
+++ b/api-gateway/src/helpers/interceptors/utils/cache.ts
@@ -16,6 +16,12 @@ export function getCacheKey(routes: string[], user: IAuthUser | null, prefix: st
         } catch (e) {
             //
         }
+        if (prefix === CACHE_PREFIXES.TAG) {
+            // A tag groups every cached response of a route, whatever its query
+            // string, so it must be built from the path alone - otherwise a
+            // mutation carrying query params invalidates a tag that never exists.
+            normalized = normalized.split('?')[0];
+        }
         return `${prefix}${normalized}:${hashUser}`;
     });
 }

--- a/api-gateway/tests/cache-invalidation.test.js
+++ b/api-gateway/tests/cache-invalidation.test.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { getCacheKey } from '../dist/helpers/interceptors/utils/cache.js';
+import { CacheService } from '../dist/helpers/cache-service.js';
+import { CACHE_PREFIXES, CACHE_TAG_PREFIXES } from '../dist/constants/index.js';
+
+class FakeCacheClient {
+    constructor() {
+        this.values = new Map();
+        this.tags = new Map();
+    }
+
+    async set(key, value) {
+        this.values.set(key, value);
+    }
+
+    async get(key) {
+        return this.values.get(key) ?? null;
+    }
+
+    async sadd(tag, key) {
+        if (!this.tags.has(tag)) {
+            this.tags.set(tag, new Set());
+        }
+        this.tags.get(tag).add(key);
+    }
+
+    async smembers(tag) {
+        return Array.from(this.tags.get(tag) ?? []);
+    }
+
+    async del(keys) {
+        for (const key of [].concat(keys)) {
+            this.values.delete(key);
+            this.tags.delete(key);
+        }
+    }
+
+    async keys(pattern) {
+        const prefix = pattern.replace(/\*$/, '');
+        return Array.from(this.tags.keys()).filter(tag => tag.startsWith(prefix));
+    }
+}
+
+describe('cache invalidation', () => {
+    const user = { id: 'u1', did: 'did:hedera:1' };
+
+    describe('getCacheKey', () => {
+        it('strips the query string from a tag', () => {
+            const [withQuery] = getCacheKey(['/schemas/0.0.1?pageIndex=0'], user);
+            const [withoutQuery] = getCacheKey(['/schemas/0.0.1'], user);
+            assert.equal(withQuery, withoutQuery);
+        });
+
+        it('keeps the query string in a cache key', () => {
+            const [withQuery] = getCacheKey(['/schemas/0.0.1?pageIndex=0'], user, CACHE_PREFIXES.CACHE);
+            const [withoutQuery] = getCacheKey(['/schemas/0.0.1'], user, CACHE_PREFIXES.CACHE);
+            assert.notEqual(withQuery, withoutQuery);
+            assert.ok(withQuery.includes('?pageIndex=0'));
+        });
+
+        it('lets a mutation carrying query params invalidate the tag of its own route', async () => {
+            const client = new FakeCacheClient();
+            const service = new CacheService(client);
+
+            const [readKey] = getCacheKey(['/schemas/id1'], user, CACHE_PREFIXES.CACHE);
+            const [readTag] = getCacheKey(['/schemas/id1'], user);
+            await service.set(readKey, 'cached', 600, readTag);
+
+            // The delete handler sees `/schemas/id1?includeChildren=false`.
+            await service.invalidate(getCacheKey(['/schemas/id1?includeChildren=false'], user));
+
+            assert.equal(await service.get(readKey), null);
+        });
+    });
+
+    describe('CacheService.invalidateAllTagsByPrefixes', () => {
+        it('drops every schema listing cached for the user', async () => {
+            const client = new FakeCacheClient();
+            const service = new CacheService(client);
+
+            const routes = ['/schemas', '/schemas/0.0.1', '/schemas/list/all', '/schemas/schema-with-sub-schemas'];
+            for (const route of routes) {
+                const [key] = getCacheKey([route], user, CACHE_PREFIXES.CACHE);
+                const [tag] = getCacheKey([route], user);
+                await service.set(key, 'cached', 600, tag);
+            }
+            const [otherKey] = getCacheKey(['/policies'], user, CACHE_PREFIXES.CACHE);
+            const [otherTag] = getCacheKey(['/policies'], user);
+            await service.set(otherKey, 'cached', 600, otherTag);
+
+            await service.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+
+            for (const route of routes) {
+                const [key] = getCacheKey([route], user, CACHE_PREFIXES.CACHE);
+                assert.equal(await service.get(key), null, `${route} should have been invalidated`);
+            }
+            assert.equal(await service.get(otherKey), 'cached');
+        });
+
+        it('matches the prefix a tag is actually stored under', () => {
+            const [tag] = getCacheKey(['/schemas/0.0.1'], user);
+            assert.ok(tag.startsWith(CACHE_TAG_PREFIXES.SCHEMAS));
+        });
+    });
+});

--- a/api-gateway/tests/cache-invalidation.test.js
+++ b/api-gateway/tests/cache-invalidation.test.js
@@ -78,7 +78,7 @@ describe('cache invalidation', () => {
             const client = new FakeCacheClient();
             const service = new CacheService(client);
 
-            const routes = ['/schemas', '/schemas/0.0.1', '/schemas/list/all', '/schemas/schema-with-sub-schemas'];
+            const routes = ['/schemas', '/schemas/0.0.1', '/schemas/list/all', '/schemas/schema-with-sub-schemas', '/schema/id1'];
             for (const route of routes) {
                 const [key] = getCacheKey([route], user, CACHE_PREFIXES.CACHE);
                 const [tag] = getCacheKey([route], user);
@@ -88,7 +88,7 @@ describe('cache invalidation', () => {
             const [otherTag] = getCacheKey(['/policies'], user);
             await service.set(otherKey, 'cached', 600, otherTag);
 
-            await service.invalidateAllTagsByPrefixes([CACHE_TAG_PREFIXES.SCHEMAS]);
+            await service.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS);
 
             for (const route of routes) {
                 const [key] = getCacheKey([route], user, CACHE_PREFIXES.CACHE);
@@ -97,9 +97,11 @@ describe('cache invalidation', () => {
             assert.equal(await service.get(otherKey), 'cached');
         });
 
-        it('matches the prefix a tag is actually stored under', () => {
-            const [tag] = getCacheKey(['/schemas/0.0.1'], user);
-            assert.ok(tag.startsWith(CACHE_TAG_PREFIXES.SCHEMAS));
+        it('matches the prefixes a tag is actually stored under', () => {
+            const [listing] = getCacheKey(['/schemas/0.0.1'], user);
+            const [single] = getCacheKey(['/schema/id1'], user);
+            assert.ok(CACHE_TAG_PREFIXES.SCHEMAS.some(prefix => listing.startsWith(prefix)));
+            assert.ok(CACHE_TAG_PREFIXES.SCHEMAS.some(prefix => single.startsWith(prefix)));
         });
     });
 });


### PR DESCRIPTION
### Description

Closes #6626. Deleting a schema left every cached schema listing serving the deleted schema for the full cache TTL, because the invalidation never matched the tag the listings are stored under.

- Strip the query string when building a cache tag, so a mutation carrying query params invalidates the tag its readers actually use
- Invalidate the whole schema tag prefix on every schema mutation instead of the tag of the mutated route
- Carry the `tag` prefix in the bulk invalidation constant, which the previous `/schemas/` prefix lacked, and cover both the `/schemas/...` and `/schema/{schemaId}` routes
- Run the invalidation of task based mutations after the task completes, so a listing read while the task is still processing is not cached again in its pre-mutation state
- Add unit tests for tag building and prefix invalidation
