### PR TITLE
fix: 6607 hide side panels in code view

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -264,7 +264,7 @@
       </div>
       <div (cdkDropListDropped)="onDroppedSection($event)" [cdkDropListData]="options.configurationOrder" cdkDropList
         cdkDropListOrientation="horizontal" class="main-container">
-        @for (configuration of options.configurationOrder; track configuration; let last = $last) {
+        @for (configuration of visibleConfigurations; track configuration; let last = $last) {
           @switch (configuration.id) {
             @case ('blocks') {
               <ng-container
@@ -272,7 +272,7 @@
             }
             @case ('tree') {
               <ng-container
-              *ngTemplateOutlet="configurationTree; context: { last, size: configuration.size, id: configuration.id }"></ng-container>
+              *ngTemplateOutlet="configurationTree; context: { last, size: isTree ? configuration.size : 'auto', id: configuration.id }"></ng-container>
             }
             @case ('properties') {
               <ng-container

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -342,6 +342,13 @@ export class PolicyConfigurationComponent implements OnInit {
         return this.currentView === 'blocks';
     }
 
+    public get visibleConfigurations(): OrderOption[] {
+        if (this.isTree) {
+            return this.options.configurationOrder;
+        }
+        return this.options.configurationOrder.filter((item) => item.id === 'tree');
+    }
+
     public get isModuleValid(): boolean {
         return this.rootTemplate?.valid;
     }


### PR DESCRIPTION
### Description

Closes #6607. In JSON/YAML view the policy configuration screen kept the blocks library and the properties panels on screen, which wasted space and let the same policy be edited from the code and the panels at the same time.

- Render only the code editor section while the JSON or YAML view is active, dropping the blocks library, the properties panel and their resize handles.
- Let the editor section fill the available width in code view, even when the user had previously resized it.
- Keep the stored panel order and sizes intact so switching back to Tree restores the earlier layout.
