### PR TITLE
fix: show copy mode state in overflow menu

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.html
@@ -1358,14 +1358,16 @@
     @if (!readonly && isTree) {
       <div class="overflow-menu-divider"></div>
       <div (click)="onSuggestionsClick(); overflowMenu.hide()" class="toolbar-menu"
-        [ngClass]="{'btn-mode-active': isSuggestionsEnabled}">
+        [attr.active]="isSuggestionsEnabled ? true : null">
         <svg-icon src="/assets/images/icons/assistant.svg" svgClass="icon-style-assistant"></svg-icon>
         <span>Suggestions</span>
+        @if (isSuggestionsEnabled) { <i class="pi pi-check overflow-check"></i> }
       </div>
       <div (click)="copyBlocksMode=!copyBlocksMode; overflowMenu.hide()" class="toolbar-menu"
-        [ngClass]="{'btn-mode-active': copyBlocksMode}">
+        [attr.active]="copyBlocksMode ? true : null">
         <i class="pi pi-copy"></i>
         <span>Copy Mode</span>
+        @if (copyBlocksMode) { <i class="pi pi-check overflow-check"></i> }
       </div>
       @if (
         user.MODULES_MODULE_CREATE &&


### PR DESCRIPTION
### Description

In the policy configurator's overflow ("...") menu, the Copy Mode item gave no indication of whether the mode was on – it relied on a background highlight class that the overflow menu stylesheet does not target.

- Mark Copy Mode as active with the same check mark markup used by the Event display and Theme items
- Apply the same treatment to the Suggestions toggle in the same group
