### PR TITLE
feat: 6647 show expression state in block inspector

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/custom-logic-config/custom-logic-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/custom-logic-config/custom-logic-config.component.html
@@ -68,12 +68,10 @@
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Expression</td>
       <td class="propRowCell">
-        <input
-          class="prop-input code-preview"
-          type="text"
-          [(ngModel)]="properties.expression"
-          [readonly]="true"
-          (click)="editExpression($event)">
+        <expression-property
+          [value]="properties.expression"
+          [readonly]="readonly"
+          (edit)="editExpression($event)"></expression-property>
       </td>
     </tr>
   </table>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/data-transformation-config/data-transformation-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/data-transformation-config/data-transformation-config.component.html
@@ -6,8 +6,8 @@
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Expression</td>
       <td class="propRowCell">
-        <input class="prop-input code-preview" type="text" [(ngModel)]="properties.expression" [readonly]="true"
-          (click)="editExpression($event)">
+        <expression-property [value]="properties.expression" [readonly]="readonly"
+          (edit)="editExpression($event)"></expression-property>
       </td>
     </tr>
   </table>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/math-config/math-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/calculate/math-config/math-config.component.html
@@ -5,8 +5,8 @@
       <td class="propRowCol"></td>
       <td class="propRowCell cellName">Expression</td>
       <td class="propRowCell">
-        <input class="prop-input code-preview" type="text" [(ngModel)]="properties.expression" [readonly]="true"
-          (click)="editExpression($event)">
+        <expression-property [value]="properties.expression" [readonly]="readonly"
+          (edit)="editExpression($event)"></expression-property>
       </td>
     </tr>
   </table>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/common-property/common-property.component.html
@@ -92,13 +92,11 @@
               } {{ property.label }}
             </td>
             <td class="propRowCell">
-              <input
-                class="prop-input code-preview"
-                [(ngModel)]="value"
-                [readonly]="true"
-                (click)="editCode($event)"
-                (blur)="onSave()"
-                >
+              <expression-property
+                [value]="value"
+                [readonly]="readonly"
+                (edit)="editCode($event)"
+                ></expression-property>
             </td>
           </tr>
         }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.html
@@ -1,0 +1,19 @@
+<button
+  type="button"
+  class="expression-button"
+  [class.expression-empty]="empty"
+  [class.expression-readonly]="readonly"
+  [attr.title]="title"
+  (click)="onClick($event)">
+  @if (readonly) {
+    <svg class="expression-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M1 8s2.5-4.5 7-4.5S15 8 15 8s-2.5 4.5-7 4.5S1 8 1 8Z" stroke="currentColor" stroke-width="1.3"/>
+      <circle cx="8" cy="8" r="1.9" stroke="currentColor" stroke-width="1.3"/>
+    </svg>
+  } @else {
+    <svg class="expression-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M5.5 4 1.5 8l4 4M10.5 4l4 4-4 4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  }
+  <span class="expression-label">{{ label }}</span>
+</button>

--- a/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.scss
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.scss
@@ -1,0 +1,59 @@
+:host {
+    display: block;
+    width: 100%;
+    // .grid-setting[readonly="true"] disables pointer events for the whole
+    // inspector. The expression is only reachable through this button, so it
+    // has to stay clickable there - the dialog opens read-only anyway.
+    pointer-events: auto;
+}
+
+.expression-button {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    height: var(--pc-control-height);
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border: 1px solid var(--pc-control-border-color);
+    border-radius: var(--pc-control-border-radius);
+    background: var(--guardian-background, #fff);
+    color: var(--guardian-font-color, #23252E);
+    font-size: var(--pc-row-font-size);
+    font-family: var(--pc-row-font-family);
+    font-style: var(--pc-row-font-style);
+    font-weight: 400;
+    line-height: 18px;
+    text-align: left;
+    outline: none;
+    cursor: pointer;
+
+    &:hover {
+        border-color: var(--guardian-primary-color);
+    }
+
+    &:focus-visible {
+        border-color: var(--guardian-primary-color);
+    }
+}
+
+.expression-icon {
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
+    color: var(--guardian-success-color, #19BE47);
+}
+
+.expression-label {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.expression-empty,
+.expression-readonly {
+    .expression-icon,
+    .expression-label {
+        color: var(--guardian-disabled-color, #848FA9);
+    }
+}

--- a/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
@@ -68,11 +68,26 @@ export class ExpressionPropertyComponent implements OnChanges {
         return parts.join(', ');
     }
 
-    private static count(parts: string[], items: any, name: string): void {
-        const size = Array.isArray(items) ? items.length : 0;
+    private static count(parts: string[], groups: any, name: string): void {
+        const size = ExpressionPropertyComponent.leaves(groups);
         if (size) {
             parts.push(size === 1 ? `1 ${name}` : `${size} ${name}s`);
         }
+    }
+
+    /**
+     * Variables, formulas and outputs are stored as an array of tabs, each
+     * holding the items - counting the array itself only ever counts tabs.
+     */
+    private static leaves(items: any): number {
+        if (!Array.isArray(items)) {
+            return 0;
+        }
+        return items.reduce((sum: number, item: any) => {
+            return sum + (item && Array.isArray(item.items)
+                ? ExpressionPropertyComponent.leaves(item.items)
+                : 1);
+        }, 0);
     }
 
     public onClick($event: MouseEvent): void {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, ViewEncapsulation } from '@angular/core';
 
 /**
  * Trigger for the "Expression" property.
@@ -12,28 +12,28 @@ import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angu
     encapsulation: ViewEncapsulation.Emulated,
     standalone: false
 })
-export class ExpressionPropertyComponent {
+export class ExpressionPropertyComponent implements OnChanges {
     @Input('value') value: any;
     @Input('readonly') readonly: boolean = false;
     @Output('edit') edit = new EventEmitter<MouseEvent>();
 
-    public get empty(): boolean {
-        return !this.summary;
-    }
-
-    public get label(): string {
-        return this.summary || 'Not set';
-    }
-
     /**
-     * Full text for the tooltip – the button itself truncates.
+     * Summarising the expression walks its whole source, so it is computed
+     * when the inputs change rather than on every change detection pass.
      */
-    public get title(): string {
+    public empty: boolean = true;
+    public label: string = 'Not set';
+    public title: string = '';
+
+    public ngOnChanges(): void {
+        const summary = this.summarize();
         const action = this.readonly ? 'View expression' : 'Edit expression';
-        return this.empty ? action : `${this.summary} – ${action.toLowerCase()}`;
+        this.empty = !summary;
+        this.label = summary || 'Not set';
+        this.title = summary ? `${summary} – ${action.toLowerCase()}` : action;
     }
 
-    private get summary(): string {
+    private summarize(): string {
         const value = this.value;
         if (!value) {
             return '';
@@ -48,9 +48,11 @@ export class ExpressionPropertyComponent {
     }
 
     private static codeSummary(value: string): string {
-        if (!value.trim()) {
+        if (!value) {
             return '';
         }
+        // Validation only rejects a falsy expression, so whitespace counts as
+        // set - reporting it as empty would contradict the validator.
         const lines = value.split('\n').length;
         return lines === 1 ? '1 line' : `${lines} lines`;
     }
@@ -60,7 +62,7 @@ export class ExpressionPropertyComponent {
         ExpressionPropertyComponent.count(parts, value.variables, 'variable');
         ExpressionPropertyComponent.count(parts, value.formulas, 'formula');
         ExpressionPropertyComponent.count(parts, value.outputs, 'output');
-        if (!parts.length && typeof value.code === 'string' && value.code.trim()) {
+        if (!parts.length && typeof value.code === 'string' && value.code) {
             parts.push(ExpressionPropertyComponent.codeSummary(value.code));
         }
         return parts.join(', ');

--- a/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/expression-property/expression-property.component.ts
@@ -1,0 +1,79 @@
+import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+
+/**
+ * Trigger for the "Expression" property.
+ * Shows whether the expression is set and a short summary of its content,
+ * instead of dumping the raw source (or an object) into a text input.
+ */
+@Component({
+    selector: 'expression-property',
+    templateUrl: './expression-property.component.html',
+    styleUrls: ['./expression-property.component.scss'],
+    encapsulation: ViewEncapsulation.Emulated,
+    standalone: false
+})
+export class ExpressionPropertyComponent {
+    @Input('value') value: any;
+    @Input('readonly') readonly: boolean = false;
+    @Output('edit') edit = new EventEmitter<MouseEvent>();
+
+    public get empty(): boolean {
+        return !this.summary;
+    }
+
+    public get label(): string {
+        return this.summary || 'Not set';
+    }
+
+    /**
+     * Full text for the tooltip – the button itself truncates.
+     */
+    public get title(): string {
+        const action = this.readonly ? 'View expression' : 'Edit expression';
+        return this.empty ? action : `${this.summary} – ${action.toLowerCase()}`;
+    }
+
+    private get summary(): string {
+        const value = this.value;
+        if (!value) {
+            return '';
+        }
+        if (typeof value === 'string') {
+            return ExpressionPropertyComponent.codeSummary(value);
+        }
+        if (typeof value === 'object') {
+            return ExpressionPropertyComponent.mathSummary(value);
+        }
+        return '';
+    }
+
+    private static codeSummary(value: string): string {
+        if (!value.trim()) {
+            return '';
+        }
+        const lines = value.split('\n').length;
+        return lines === 1 ? '1 line' : `${lines} lines`;
+    }
+
+    private static mathSummary(value: any): string {
+        const parts: string[] = [];
+        ExpressionPropertyComponent.count(parts, value.variables, 'variable');
+        ExpressionPropertyComponent.count(parts, value.formulas, 'formula');
+        ExpressionPropertyComponent.count(parts, value.outputs, 'output');
+        if (!parts.length && typeof value.code === 'string' && value.code.trim()) {
+            parts.push(ExpressionPropertyComponent.codeSummary(value.code));
+        }
+        return parts.join(', ');
+    }
+
+    private static count(parts: string[], items: any, name: string): void {
+        const size = Array.isArray(items) ? items.length : 0;
+        if (size) {
+            parts.push(size === 1 ? `1 ${name}` : `${size} ${name}s`);
+        }
+    }
+
+    public onClick($event: MouseEvent): void {
+        this.edit.emit($event);
+    }
+}

--- a/frontend/src/app/modules/policy-engine/policy-engine.module.ts
+++ b/frontend/src/app/modules/policy-engine/policy-engine.module.ts
@@ -181,6 +181,7 @@ import { GlobalEventsReaderBlockComponent } from './policy-viewer/blocks/global-
 import { GlobalEventsReaderFiltersDialogComponent } from './policy-viewer/dialogs/global-events-reader-filters-dialog/global-events-reader-filters-dialog.component';
 import { AddGlobalEventTopicDialogComponent } from './policy-viewer/dialogs/add-global-event-topic/add-global-event-topic-dialog.component';
 import { MathConfigComponent } from './policy-configuration/blocks/calculate/math-config/math-config.component';
+import { ExpressionPropertyComponent } from './policy-configuration/expression-property/expression-property.component';
 import { MathEditorDialogComponent } from './dialogs/math-editor-dialog/math-editor-dialog.component';
 import { FieldLinkDialog } from './dialogs/field-link-dialog/field-link-dialog.component';
 import { ChangeBlockSettingsDialog } from './dialogs/change-block-settings-dialog/change-block-settings-dialog.component';
@@ -237,6 +238,7 @@ import { ApplySchemaTemplateDialog } from './dialogs/apply-schema-template-dialo
         ReplaceSchemasDialogComponent,
         ExportPolicyDialog,
         MathConfigComponent,
+        ExpressionPropertyComponent,
         CalculateConfigComponent,
         CalculateMathConfigComponent,
         JsonPropertiesComponent,


### PR DESCRIPTION
### Description

The Expression field in the block inspector rendered raw source inside a one-line text input, which is hard to read and, for `mathBlock`, displayed `[object Object]` because that block stores an object there. It also gave no indication of whether the expression was set, even though an empty value fails validation.

- Add an `expression-property` control that opens the existing code / formula editor and reports the state of the field instead of its raw content
- Show "Not set" in muted text when the expression is empty, and a content summary – line count for code, variable and formula counts for `mathBlock` – when it is set
- Tint the icon green only when the expression is set and the policy is editable, and expose the full summary through the tooltip when the label truncates
- Use the control for `mathBlock`, `customLogicBlock` and the generic `Code` property renderer, which covers `transformationUIAddon` and `dataTransformationAddon`
- Keep the control clickable inside the read-only inspector, so the expression stays viewable in a published policy

Resolves #6647
