### PR TITLE
fix: 6610 delete draft tokens when policy is deleted

### DIFF
--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -170,6 +170,28 @@ export function resolvePolicyAccessCode(
 }
 
 /**
+ * Select draft tokens that no other policy references
+ * @param tokens
+ * @param tokenIdsUsedElsewhere
+ */
+export function resolveDraftTokensToDelete(
+    tokens: Token[],
+    tokenIdsUsedElsewhere: Set<string>
+): Token[] {
+    const result: Token[] = [];
+    for (const token of tokens) {
+        if (!token.draftToken) {
+            continue;
+        }
+        if (token.tokenId && tokenIdsUsedElsewhere.has(token.tokenId)) {
+            continue;
+        }
+        result.push(token);
+    }
+    return result;
+}
+
+/**
  * Policy engine service
  */
 @Singleton
@@ -798,6 +820,41 @@ export class PolicyEngine extends NatsService {
     }
 
     /**
+     * Delete draft tokens that belong only to this policy
+     * @param policyToDelete
+     */
+    private async deletePolicyTokens(policyToDelete: Policy): Promise<void> {
+        const tokenIds = findAllEntities(policyToDelete.config, ['tokenId']);
+        const candidates = await DatabaseServer.getTokens({
+            $or: [
+                { tokenId: { $in: tokenIds } },
+                { policyId: policyToDelete.id.toString() }
+            ],
+            owner: policyToDelete.owner,
+            draftToken: true
+        });
+        if (!candidates.length) {
+            return;
+        }
+        const otherPolicies = await DatabaseServer.getPolicies({
+            owner: policyToDelete.owner
+        });
+        const tokenIdsUsedElsewhere = new Set<string>();
+        for (const policy of otherPolicies) {
+            if (policy.id === policyToDelete.id) {
+                continue;
+            }
+            for (const tokenId of findAllEntities(policy.config, ['tokenId'])) {
+                tokenIdsUsedElsewhere.add(tokenId);
+            }
+        }
+        const databaseServer = new DatabaseServer();
+        for (const token of resolveDraftTokensToDelete(candidates, tokenIdsUsedElsewhere)) {
+            await databaseServer.deleteEntity(Token, token.id);
+        }
+    }
+
+    /**
      * Delete policy
      * @param policyId Policy ID
      * @param owner User
@@ -815,6 +872,7 @@ export class PolicyEngine extends NatsService {
         const STEP_DELETE_INSTANCE = 'Delete policy instance';
         const STEP_DELETE_SCHEMAS = 'Delete schemas';
         const STEP_DELETE_ARTIFACTS = 'Delete artifacts';
+        const STEP_DELETE_TOKENS = 'Delete tokens';
         const STEP_DELETE_TESTS = 'Delete tests';
         const STEP_DELETE_CREDENTIALS = 'Delete credentials';
         const STEP_DELETE_POLICY = 'Delete policy from DB';
@@ -823,6 +881,7 @@ export class PolicyEngine extends NatsService {
         notifier.addStep(STEP_DELETE_INSTANCE);
         notifier.addStep(STEP_DELETE_SCHEMAS);
         notifier.addStep(STEP_DELETE_ARTIFACTS);
+        notifier.addStep(STEP_DELETE_TOKENS);
         notifier.addStep(STEP_DELETE_TESTS);
         notifier.addStep(STEP_DELETE_CREDENTIALS);
         notifier.addStep(STEP_DELETE_POLICY);
@@ -867,6 +926,10 @@ export class PolicyEngine extends NatsService {
         }
         notifier.completeStep(STEP_DELETE_ARTIFACTS);
 
+        notifier.startStep(STEP_DELETE_TOKENS);
+        await this.deletePolicyTokens(policyToDelete);
+        notifier.completeStep(STEP_DELETE_TOKENS);
+
         notifier.startStep(STEP_DELETE_TESTS);
         await DatabaseServer.deletePolicyTests(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_TESTS);
@@ -902,6 +965,7 @@ export class PolicyEngine extends NatsService {
         const STEP_DELETE_INSTANCE = 'Delete policy instance';
         const STEP_DELETE_SCHEMAS = 'Delete schemas';
         const STEP_DELETE_ARTIFACTS = 'Delete artifacts';
+        const STEP_DELETE_TOKENS = 'Delete tokens';
         const STEP_DELETE_TESTS = 'Delete tests';
         const STEP_DELETE_CREDENTIALS = 'Delete credentials';
         const STEP_DELETE_POLICY = 'Delete policy from DB';
@@ -910,6 +974,7 @@ export class PolicyEngine extends NatsService {
         notifier.addStep(STEP_DELETE_INSTANCE);
         notifier.addStep(STEP_DELETE_SCHEMAS);
         notifier.addStep(STEP_DELETE_ARTIFACTS);
+        notifier.addStep(STEP_DELETE_TOKENS);
         notifier.addStep(STEP_DELETE_TESTS);
         notifier.addStep(STEP_DELETE_CREDENTIALS);
         notifier.addStep(STEP_DELETE_POLICY);
@@ -955,6 +1020,10 @@ export class PolicyEngine extends NatsService {
         }
         notifier.completeStep(STEP_DELETE_ARTIFACTS);
 
+        notifier.startStep(STEP_DELETE_TOKENS);
+        await this.deletePolicyTokens(policyToDelete);
+        notifier.completeStep(STEP_DELETE_TOKENS);
+
         notifier.startStep(STEP_DELETE_TESTS);
         await DatabaseServer.deletePolicyTests(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_TESTS);
@@ -989,6 +1058,7 @@ export class PolicyEngine extends NatsService {
         // <-- Steps
         const STEP_DELETE_SCHEMAS = 'Delete schemas';
         const STEP_DELETE_ARTIFACTS = 'Delete artifacts';
+        const STEP_DELETE_TOKENS = 'Delete tokens';
         const STEP_DELETE_TESTS = 'Delete tests';
         const STEP_DELETE_CREDENTIALS = 'Delete credentials';
         const STEP_DELETE_POLICY_MESSAGE = 'Publishing delete policy message';
@@ -997,6 +1067,7 @@ export class PolicyEngine extends NatsService {
 
         notifier.addStep(STEP_DELETE_SCHEMAS);
         notifier.addStep(STEP_DELETE_ARTIFACTS);
+        notifier.addStep(STEP_DELETE_TOKENS);
         notifier.addStep(STEP_DELETE_TESTS);
         notifier.addStep(STEP_DELETE_CREDENTIALS);
         notifier.addStep(STEP_DELETE_POLICY_MESSAGE);
@@ -1040,6 +1111,10 @@ export class PolicyEngine extends NatsService {
             await DatabaseServer.removeArtifact(artifact);
         }
         notifier.completeStep(STEP_DELETE_ARTIFACTS);
+
+        notifier.startStep(STEP_DELETE_TOKENS);
+        await this.deletePolicyTokens(policyToDelete);
+        notifier.completeStep(STEP_DELETE_TOKENS);
 
         notifier.startStep(STEP_DELETE_TESTS);
         await DatabaseServer.deletePolicyTests(policyToDelete.id);

--- a/guardian-service/tests/unit/policy-engine-delete-policy-tokens.test.mjs
+++ b/guardian-service/tests/unit/policy-engine-delete-policy-tokens.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { resolveDraftTokensToDelete } from '../../dist/policy-engine/policy-engine.js';
+
+describe('resolveDraftTokensToDelete', () => {
+    it('returns a draft token that no other policy references', () => {
+        const token = { tokenId: 'draft-1', draftToken: true };
+
+        const result = resolveDraftTokensToDelete([token], new Set());
+
+        assert.deepEqual(result, [token]);
+    });
+
+    it('never returns a token with draftToken false', () => {
+        const published = { tokenId: '0.0.10025736', draftToken: false };
+
+        assert.deepEqual(resolveDraftTokensToDelete([published], new Set()), []);
+        assert.deepEqual(
+            resolveDraftTokensToDelete([published], new Set(['0.0.10025736'])),
+            []
+        );
+    });
+
+    it('never returns a token whose draftToken is missing or undefined', () => {
+        const missing = { tokenId: 'dynamic-1' };
+        const undef = { tokenId: 'dynamic-2', draftToken: undefined };
+
+        assert.deepEqual(resolveDraftTokensToDelete([missing, undef], new Set()), []);
+    });
+
+    it('does not return a draft token another policy still references', () => {
+        const shared = { tokenId: 'draft-shared', draftToken: true };
+
+        const result = resolveDraftTokensToDelete([shared], new Set(['draft-shared']));
+
+        assert.deepEqual(result, []);
+    });
+
+    it('keeps the unreferenced drafts and drops the referenced one', () => {
+        const free1 = { tokenId: 'draft-1', draftToken: true };
+        const shared = { tokenId: 'draft-shared', draftToken: true };
+        const free2 = { tokenId: 'draft-2', draftToken: true };
+
+        const result = resolveDraftTokensToDelete(
+            [free1, shared, free2],
+            new Set(['draft-shared'])
+        );
+
+        assert.deepEqual(result, [free1, free2]);
+    });
+
+    it('returns a draft token that has no tokenId instead of throwing', () => {
+        const noId = { draftToken: true };
+
+        const result = resolveDraftTokensToDelete([noId], new Set(['draft-1']));
+
+        assert.deepEqual(result, [noId]);
+    });
+
+    it('returns an empty array for an empty candidate list', () => {
+        assert.deepEqual(resolveDraftTokensToDelete([], new Set()), []);
+        assert.deepEqual(resolveDraftTokensToDelete([], new Set(['draft-1'])), []);
+    });
+
+    it('does not mutate the candidate list or the set it is given', () => {
+        const tokens = [
+            { tokenId: 'draft-1', draftToken: true },
+            { tokenId: '0.0.10025736', draftToken: false }
+        ];
+        const used = new Set(['draft-other']);
+
+        resolveDraftTokensToDelete(tokens, used);
+
+        assert.equal(tokens.length, 2);
+        assert.equal(tokens[0].tokenId, 'draft-1');
+        assert.equal(tokens[1].tokenId, '0.0.10025736');
+        assert.deepEqual([...used], ['draft-other']);
+    });
+});


### PR DESCRIPTION
**Description**:

When a draft policy is deleted, the tokens that were imported with it stayed behind as orphaned rows on the List of Tokens page. No delete path in the policy engine touched tokens at all.

Add a Delete tokens step to all three policy delete methods (deleteDemoPolicy, deleteViewPolicy, deletePolicy). The step finds the policy's draft tokens by two links — tokenId values in policy.config and a stored policyId — filters to draftToken: true and the policy's owner, skips any token another surviving policy still references, and removes the remaining rows directly from the database. Tokens that exist on the Hedera network (draftToken: false) are never selected and are not touched. Add resolveDraftTokensToDelete as a pure exported function so the selection logic is unit-testable without a database.

Fixes #6610

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
