### PR TITLE
feat: 6600 add dry-run progress bar

### DIFF
--- a/api-gateway/src/api/service/policy.ts
+++ b/api-gateway/src/api/service/policy.ts
@@ -1896,6 +1896,71 @@ export class PolicyApi {
     }
 
     /**
+     * Go to dry-run policy (async)
+     */
+    @Put('/push/:policyId/dry-run')
+    @Auth(
+        Permissions.POLICIES_POLICY_UPDATE,
+        // UserRole.STANDARD_REGISTRY,
+    )
+    @ApiOperation({
+        summary: 'Dry Run policy.',
+        description:
+            'Switches the specified policy into dry-run mode asynchronously and returns the task of the operation, so that its progress can be tracked. Dry-run mode is intended for testing and simulation without executing real transactions.' +
+            ONLY_SR,
+    })
+    @ApiParam({
+        name: 'policyId',
+        type: String,
+        description: 'Policy Id',
+        required: true,
+        example: Examples.DB_ID
+    })
+    @ApiBody({
+        description: 'Options.',
+        type: Object,
+    })
+    @ApiAcceptedResponse({
+        description: 'Successful operation.',
+        type: TaskDTO,
+        example: {
+            taskId: 'c51e15d5-b484-49e9-b267-84b1de3585b4',
+            expectation: 6,
+            action: 'Dry-run policy',
+            userId: '69c2cfc021d39e7b6d15e236'
+        }
+    })
+    @ApiInternalServerErrorResponse({
+        description: 'Internal server error.',
+        type: InternalServerErrorDTO,
+        example: { statusCode: 500, message: 'Error message' }
+    })
+    @ApiExtraModels(TaskDTO, InternalServerErrorDTO)
+    @HttpCode(HttpStatus.ACCEPTED)
+    async dryRunPolicyAsync(
+        @AuthUser() user: IAuthUser,
+        @Param('policyId') policyId: string,
+        @Body() body: any,
+        @Req() req
+    ): Promise<TaskDTO> {
+        const taskManager = new TaskManager();
+        const task = taskManager.start(TaskAction.DRY_RUN_POLICY, user.id);
+        const enableMock = !!body?.enableMock;
+        RunFunctionAsync<ServiceError>(async () => {
+            const engineService = new PolicyEngine();
+            await engineService.dryRunPolicyAsync(policyId, new EntityOwner(user), enableMock, task);
+        }, async (error) => {
+            await this.logger.error(error, ['API_GATEWAY'], user.id);
+            taskManager.addError(task.taskId, { code: 500, message: error.message || error });
+        });
+
+        const invalidedCacheTags = [`${PREFIXES.POLICIES}${policyId}/navigation`, `${PREFIXES.POLICIES}${policyId}/groups`];
+        await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheTags], user));
+
+        return task;
+    }
+
+    /**
      * Go to dry-run policy
      */
     @Put('/:policyId/dry-run')

--- a/api-gateway/src/helpers/policy-engine.ts
+++ b/api-gateway/src/helpers/policy-engine.ts
@@ -233,6 +233,22 @@ export class PolicyEngine extends NatsService {
     }
 
     /**
+     * Async dry-run policy
+     * @param policyId
+     * @param owner
+     * @param enableMock
+     * @param task
+     */
+    public async dryRunPolicyAsync(
+        policyId: string,
+        owner: IOwner,
+        enableMock: boolean,
+        task: NewTask
+    ): Promise<NewTask> {
+        return await this.sendMessage(PolicyEngineEvents.DRY_RUN_POLICIES_ASYNC, { policyId, owner, enableMock, task });
+    }
+
+    /**
      * Dry-run policy
      * @param policyId
      * @param owner

--- a/api-gateway/src/helpers/task-manager.ts
+++ b/api-gateway/src/helpers/task-manager.ts
@@ -61,6 +61,7 @@ export class TaskManager {
         [TaskAction.CREATE_POLICY, 8],
         [TaskAction.WIZARD_CREATE_POLICY, 8],
         [TaskAction.PUBLISH_POLICY, 13],
+        [TaskAction.DRY_RUN_POLICY, 6],
         [TaskAction.IMPORT_POLICY_FILE, 15],
         [TaskAction.IMPORT_POLICY_MESSAGE, 17],
         [TaskAction.PUBLISH_SCHEMA, 8],

--- a/common/src/notification/notification-events.ts
+++ b/common/src/notification/notification-events.ts
@@ -7,6 +7,7 @@ export const notificationActionMap = new Map<TaskAction, NotificationAction>([
     [TaskAction.CREATE_POLICY, NotificationAction.POLICY_CONFIGURATION],
     [TaskAction.WIZARD_CREATE_POLICY, NotificationAction.POLICY_CONFIGURATION],
     [TaskAction.PUBLISH_POLICY, NotificationAction.POLICY_CONFIGURATION],
+    [TaskAction.DRY_RUN_POLICY, NotificationAction.POLICY_CONFIGURATION],
     [TaskAction.IMPORT_POLICY_FILE, NotificationAction.POLICY_CONFIGURATION],
     [TaskAction.IMPORT_POLICY_MESSAGE, NotificationAction.POLICY_CONFIGURATION],
     [TaskAction.IMPORT_TOOL_FILE, NotificationAction.POLICY_CONFIGURATION],
@@ -35,6 +36,7 @@ export const taskResultTitleMap = new Map<TaskAction, string>([
     [TaskAction.CREATE_TOOL, 'Tool created'],
     [TaskAction.WIZARD_CREATE_POLICY, 'Policy created'],
     [TaskAction.PUBLISH_POLICY, 'Policy published'],
+    [TaskAction.DRY_RUN_POLICY, 'Dry-run started'],
     [TaskAction.IMPORT_POLICY_FILE, 'Policy imported'],
     [TaskAction.IMPORT_POLICY_MESSAGE, 'Policy imported'],
     [TaskAction.IMPORT_TOOL_FILE, 'Tool imported'],
@@ -67,6 +69,8 @@ export function getNotificationResultMessage(action: TaskAction, result: any) {
             return `Policy ${result} created`;
         case TaskAction.PUBLISH_POLICY:
             return `Policy ${result.policyId} published`;
+        case TaskAction.DRY_RUN_POLICY:
+            return `Policy ${result.policyId} started in dry-run mode`;
         case TaskAction.PUBLISH_POLICY_LABEL:
             return `Policy ${result.id} published`;
         case TaskAction.IMPORT_POLICY_FILE:
@@ -101,6 +105,7 @@ export function getNotificationResultMessage(action: TaskAction, result: any) {
 export function getNotificationResultTitle(action: TaskAction, result: any) {
     switch (action) {
         case TaskAction.PUBLISH_POLICY:
+        case TaskAction.DRY_RUN_POLICY:
             if (!result.isValid) {
                 return;
             }
@@ -119,6 +124,7 @@ export function getNotificationResult(action: TaskAction, result: any) {
         case TaskAction.WIZARD_CREATE_POLICY:
             return result.policyId;
         case TaskAction.PUBLISH_POLICY:
+        case TaskAction.DRY_RUN_POLICY:
             return result.policyId;
         case TaskAction.IMPORT_POLICY_FILE:
             return result.policyId;

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -307,6 +307,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
                     });
                 }, 500);
                 break;
+            case TaskAction.DRY_RUN_POLICY:
             case TaskAction.PUBLISH_POLICY:
                 if (result) {
                     const { isValid, errors, policyId } = result;
@@ -333,7 +334,22 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
                             'The policy is invalid',
                             { sticky: true, logMessage: msg }
                         );
+                        // The configuration page is the only place the block errors
+                        // can be shown, so go there instead of back to the origin.
                         this._configurationErrors.set(policyId, errors);
+                        setTimeout(() => {
+                            this.router.navigate(['policy-configuration'], {
+                                queryParams: {
+                                    policyId,
+                                },
+                                replaceUrl: true,
+                            });
+                        }, 500);
+                        break;
+                    }
+                    if (this.last) {
+                        this.redirect(this.last);
+                        return;
                     }
                     setTimeout(() => {
                         this.router.navigate(['policy-configuration'], {

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -348,7 +348,8 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
                         break;
                     }
                     if (this.last) {
-                        this.redirect(this.last);
+                        // Replace the task page so it is not left in the history.
+                        this.redirect(this.last, true);
                         return;
                     }
                     setTimeout(() => {
@@ -594,7 +595,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
         this.applyChanges();
     }
 
-    private redirect(urlString: string) {
+    private redirect(urlString: string, replaceUrl: boolean = false) {
         const url = new URL(urlString);
         const path = [url.pathname];
         const queryParams: any = {};
@@ -610,7 +611,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             }
         }
         setTimeout(() => {
-            this.router.navigate(path, { queryParams });
+            this.router.navigate(path, { queryParams, replaceUrl });
         }, 500);
 
     }

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -30,6 +30,9 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
     private last?: any;
     private redir?: boolean;
     private lastTimestamp: number = 0;
+    // The finished task arrives both over the websocket and from the initial
+    // request, so the result must only be handled once.
+    private resultHandled: boolean = false;
 
     @Input('taskId') inputTaskId?: string;
     @Output() completed = new EventEmitter<string>();
@@ -88,6 +91,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             this.statusesCount = 0;
             this.statuses.length = 0;
             this.progressValue = 0;
+            this.resultHandled = false;
         }
     }
 
@@ -130,9 +134,15 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
         }
         if (result) {
             this.progressValue = 100;
-            this.setResult(result);
+            if (!this.resultHandled) {
+                this.resultHandled = true;
+                this.setResult(result);
+            }
         } else if (error) {
-            this.setError(error);
+            if (!this.resultHandled) {
+                this.resultHandled = true;
+                this.setError(error);
+            }
         }
     }
 

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -994,48 +994,21 @@ export class PoliciesComponent implements OnInit {
     private executeDryRun(element: any, enableMock: boolean) {
         this.loading = true;
         this.policyEngineService
-            .dryRun(element.id, { enableMock })
+            .pushDryRun(element.id, { enableMock })
             .pipe(takeUntil(this._destroy$))
             .subscribe(
-                    (data: any) => {
-                        const { policies, isValid, errors } = data;
-                        if (!isValid) {
-                            let text = [];
-                            const blocks = errors.blocks;
-                            const invalidBlocks = blocks.filter(
-                                (block: any) => !block.isValid
-                            );
-                            for (let i = 0; i < invalidBlocks.length; i++) {
-                                const block = invalidBlocks[i];
-                                for (let j = 0; j < block.errors.length; j++) {
-                                    const error = block.errors[j];
-                                    if (block.id) {
-                                        text.push(`${block.id}: ${error}`);
-                                    } else {
-                                        text.push(error);
-                                    }
-                                }
-                            }
-                            const msg = text.join('\n');
-                            this.toastService.error(
-                                msg,
-                                'The policy is invalid',
-                                { sticky: true, logMessage: msg }
-                            );
-                            this._configurationErrors.set(element.id, errors);
-                            this.router.navigate(['policy-configuration'], {
-                                queryParams: {
-                                    policyId: element.id,
-                                },
-                                replaceUrl: true,
-                            });
-                        }
-                        this.loadAllPolicy();
-                    },
-                    (e) => {
-                        this.loading = false;
-                    }
-                );
+                (result) => {
+                    const { taskId } = result;
+                    this.router.navigate(['task', taskId], {
+                        queryParams: {
+                            last: btoa(location.href),
+                        },
+                    });
+                },
+                (e) => {
+                    this.loading = false;
+                }
+            );
     }
 
     private draft(element: any) {

--- a/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/policy-configuration/policy-configuration.component.ts
@@ -1313,21 +1313,16 @@ export class PolicyConfigurationComponent implements OnInit {
     private executeDryRun(enableMock: boolean) {
         this.loading = true;
         this.policyEngineService
-            .dryRun(this.policyId, { enableMock })
+            .pushDryRun(this.policyId, { enableMock })
             .pipe(takeUntil(this._destroy$))
-            .subscribe((data: any) => {
-                const { policies, isValid, errors } = data;
-                if (isValid) {
-                    this.clearState();
-                    this.loadData();
-                } else {
-                    this.setErrors(errors, 'policy');
-
-                    this.emptyWarningsStates()
-                    this.emptyInfosStates()
-
-                    this.loading = false;
-                }
+            .subscribe((result) => {
+                const { taskId } = result;
+                this.clearState();
+                this.router.navigate(['task', taskId], {
+                    queryParams: {
+                        last: btoa(location.href),
+                    },
+                });
             }, (e) => {
                 console.error(e.error);
                 this.loading = false;

--- a/frontend/src/app/services/policy-engine.service.ts
+++ b/frontend/src/app/services/policy-engine.service.ts
@@ -117,6 +117,13 @@ export class PolicyEngineService {
         return this.http.put<{ taskId: string, expectation: number }>(`${this.url}/push/${policyId}/publish`, options);
     }
 
+    public pushDryRun(
+        policyId: string,
+        options: { enableMock: boolean }
+    ): Observable<{ taskId: string, expectation: number }> {
+        return this.http.put<{ taskId: string, expectation: number }>(`${this.url}/push/${policyId}/dry-run`, options);
+    }
+
     public pushDelete(policyId: string): Observable<{ taskId: string, expectation: number }> {
         return this.http.delete<{ taskId: string, expectation: number }>(`${this.url}/push/${policyId}`);
     }

--- a/guardian-service/src/policy-engine/policy-engine.service.ts
+++ b/guardian-service/src/policy-engine/policy-engine.service.ts
@@ -1628,56 +1628,48 @@ export class PolicyEngineService {
             }): Promise<IMessageResponse<any>> => {
                 try {
                     const { policyId, owner, enableMock } = msg;
-
-                    const model = await DatabaseServer.getPolicyById(policyId);
-                    await this.policyEngine.accessPolicy(model, owner, 'publish');
-
-                    if (!model.config) {
-                        throw new Error('The policy is empty');
-                    }
-                    if (model.status === PolicyStatus.PUBLISH) {
-                        throw new Error(`Policy published`);
-                    }
-                    if (model.status === PolicyStatus.DISCONTINUED) {
-                        throw new Error(`Policy is discontinued`);
-                    }
-                    if (model.status === PolicyStatus.DRY_RUN) {
-                        throw new Error(`Policy already in Dry Run`);
-                    }
-                    if (model.status === PolicyStatus.PUBLISH_ERROR) {
-                        throw new Error(`Failed policy cannot be started in dry run mode`);
-                    }
-                    if (model.status === PolicyStatus.DEMO) {
-                        throw new Error(`Policy imported in demo mode`);
-                    }
-                    if (model.status === PolicyStatus.VIEW) {
-                        throw new Error(`Policy imported in view mode`);
-                    }
-
-                    const errors = await this.policyEngine.validateModel(policyId, true);
-                    const isValid = !errors.blocks.some(block => !block.isValid);
-                    if (isValid) {
-                        await this.policyEngine.dryRunPolicy(model, owner, 'Dry Run', false, logger, enableMock);
-                        await this.policyEngine.generateModel(model.id.toString(), enableMock);
-                    }
-
-                    const savepointsCount = await DatabaseServer.getSavepointsCount(policyId);
-
-                    if (savepointsCount === 0) {
-                        await DatabaseServer.nullifyInitialDryRunSavepointIds();
-                    } else {
-                        await DatabaseServer.removeDryRunWithEmptySavepoint(policyId);
-                        PolicyDataMigrator.clearRunCacheByPolicyId(policyId);
-                    }
-
+                    const result = await this.policyEngine.validateAndDryRunPolicy(
+                        policyId,
+                        owner,
+                        enableMock,
+                        NewNotifier.empty(),
+                        logger
+                    );
                     return new MessageResponse({
-                        isValid,
-                        errors
+                        isValid: result.isValid,
+                        errors: result.errors
                     });
                 } catch (error) {
                     await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
                     return new MessageError(error);
                 }
+            });
+
+        this.channel.getMessages<any, any>(PolicyEngineEvents.DRY_RUN_POLICIES_ASYNC,
+            async (msg: {
+                policyId: string,
+                owner: IOwner,
+                enableMock: boolean,
+                task: any
+            }): Promise<IMessageResponse<any>> => {
+                const { policyId, owner, enableMock, task } = msg;
+                const notifier = await NewNotifier.create(task);
+
+                RunFunctionAsync(async () => {
+                    const result = await this.policyEngine.validateAndDryRunPolicy(
+                        policyId,
+                        owner,
+                        enableMock,
+                        notifier,
+                        logger
+                    );
+                    notifier.result(result);
+                }, async (error) => {
+                    await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
+                    notifier.fail(error);
+                });
+
+                return new MessageResponse(task);
             });
 
         this.channel.getMessages<any, any>(PolicyEngineEvents.DISCONTINUE_POLICY,

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -36,6 +36,7 @@ import {
     MockHelper,
     MultiPolicy,
     NatsService,
+    NewNotifier,
     NotificationHelper, PinoLogger,
     Policy,
     PolicyImportExport,
@@ -1222,7 +1223,8 @@ export class PolicyEngine extends NatsService {
         model: Policy,
         user: IOwner,
         accountId: string,
-        mockId: string
+        mockId: string,
+        notifier: INotificationStep = NewNotifier.empty()
     ): Promise<Policy> {
         const schemas = await DatabaseServer.getSchemas({ topicId: model.topicId });
 
@@ -1230,10 +1232,20 @@ export class PolicyEngine extends NatsService {
         const updatedSchemas: SchemaCollection[] = [];
         const mockRows: any[] = [];
 
+        const STEP_SAVE_MOCK_DATA = 'Save mock data';
+        const pendingCount = schemas.filter((schema) => schema.status !== SchemaStatus.PUBLISHED).length;
+
+        notifier.start();
+        // Mock data is persisted in a single batch after the loop, so it needs one extra step.
+        notifier.setEstimate(mockId ? pendingCount + 1 : pendingCount);
+
         for (const schema of schemas) {
             if (schema.status === SchemaStatus.PUBLISHED) {
                 continue;
             }
+
+            const schemaStep = notifier.addStep(`${schema.name || '-'}`, 1, true);
+            schemaStep.start();
 
             schema.context = generateSchemaContext(schema);
             SchemaHelper.updateIRI(schema);
@@ -1263,7 +1275,12 @@ export class PolicyEngine extends NatsService {
                 }
                 mockRows.push(MockHelper.getMessageRecord(topicId, message.toMessage(), accountId));
             }
+
+            schemaStep.complete();
         }
+
+        const mockStep = mockId ? notifier.addStep(STEP_SAVE_MOCK_DATA, 1) : null;
+        mockStep?.start();
 
         // Independent bulk writes to different collections - run them concurrently.
         await Promise.all([
@@ -1271,6 +1288,9 @@ export class PolicyEngine extends NatsService {
             DatabaseServer.saveMockBatch(mockId, mockRows)
         ]);
 
+        mockStep?.complete();
+
+        notifier.complete();
         return model;
     }
 
@@ -1784,6 +1804,8 @@ export class PolicyEngine extends NatsService {
      * @param version
      * @param demo
      * @param logger
+     * @param enableMock
+     * @param notifier
      */
     public async dryRunPolicy(
         model: Policy,
@@ -1791,14 +1813,37 @@ export class PolicyEngine extends NatsService {
         version: string,
         demo: boolean,
         logger: PinoLogger,
-        enableMock: boolean
+        enableMock: boolean,
+        notifier: INotificationStep = NewNotifier.empty()
     ): Promise<Policy> {
+        // <-- Steps
+        const STEP_RESOLVE_ACCOUNT = 'Resolve Hedera account';
+        const STEP_PUBLISH_TOPIC = 'Publish policy topic';
+        const STEP_PUBLISH_SCHEMAS = 'Publish schemas';
+        const STEP_CREATE_TOPIC = 'Create instance topic';
+        const STEP_PUBLISH_MESSAGE = 'Publish policy message';
+        const STEP_CREATE_VC = 'Create policy credential';
+        const STEP_CREATE_USER = 'Create virtual user';
+        const STEP_SAVE = 'Save policy';
+        // Steps -->
+
+        notifier.addStep(STEP_RESOLVE_ACCOUNT, 2);
+        notifier.addStep(STEP_PUBLISH_TOPIC, 3);
+        notifier.addStep(STEP_PUBLISH_SCHEMAS, 70);
+        notifier.addStep(STEP_CREATE_TOPIC, 5);
+        notifier.addStep(STEP_PUBLISH_MESSAGE, 8);
+        notifier.addStep(STEP_CREATE_VC, 5);
+        notifier.addStep(STEP_CREATE_USER, 2);
+        notifier.addStep(STEP_SAVE, 5);
+        notifier.start();
+
         if (demo) {
             logger.info('Demo Policy', ['GUARDIAN_SERVICE'], user.id);
         } else {
             logger.info('Dry-run Policy', ['GUARDIAN_SERVICE'], user.id);
         }
 
+        notifier.startStep(STEP_RESOLVE_ACCOUNT);
         const dryRunId = model.id.toString();
         const databaseServer = new DatabaseServer(dryRunId);
         const root = await this.users.getHederaAccount(user.owner, user.id);
@@ -1807,6 +1852,7 @@ export class PolicyEngine extends NatsService {
         )
 
         const mockId = enableMock ? dryRunId : null;
+        notifier.completeStep(STEP_RESOLVE_ACCOUNT);
 
         // Create Services
         const messageServer = new MessageServer({
@@ -1817,6 +1863,7 @@ export class PolicyEngine extends NatsService {
         }).setTopicObject(policyTopic);
         const topicHelper = new TopicHelper(root.hederaAccountId, root.hederaAccountKey, root.signOptions, dryRunId);
 
+        notifier.startStep(STEP_PUBLISH_TOPIC);
         const topicMessage = await MessageServer.getTopic(policyTopic.topicId, user.id, {});
         await messageServer.sendMessage(topicMessage, {
             sendToIPFS: true,
@@ -1825,9 +1872,17 @@ export class PolicyEngine extends NatsService {
             interception: null,
             mockId
         });
+        notifier.completeStep(STEP_PUBLISH_TOPIC);
 
         //'Publish' policy schemas
-        model = await this.dryRunSchemas(model, user, root.hederaAccountId, mockId);
+        notifier.startStep(STEP_PUBLISH_SCHEMAS);
+        model = await this.dryRunSchemas(
+            model,
+            user,
+            root.hederaAccountId,
+            mockId,
+            notifier.getStep(STEP_PUBLISH_SCHEMAS)
+        );
         model.status = demo ? PolicyStatus.DEMO : PolicyStatus.DRY_RUN;
         model.version = version;
 
@@ -1835,8 +1890,10 @@ export class PolicyEngine extends NatsService {
         if (demo || savepointsCount === 0) {
             this.regenerateIds(model.config);
         }
+        notifier.completeStep(STEP_PUBLISH_SCHEMAS);
 
         //Create instance topic
+        notifier.startStep(STEP_CREATE_TOPIC);
         const instancePolicyTopic = await topicHelper.create(
             {
                 type: TopicType.InstancePolicyTopic,
@@ -1859,8 +1916,10 @@ export class PolicyEngine extends NatsService {
         await databaseServer.saveTopic(instancePolicyTopic.toObject());
 
         model.instanceTopicId = instancePolicyTopic.topicId;
+        notifier.completeStep(STEP_CREATE_TOPIC);
 
         //Send Message
+        notifier.startStep(STEP_PUBLISH_MESSAGE);
         const zip = await PolicyImportExport.generate(model);
         const buffer = await zip.generateAsync({
             type: 'arraybuffer',
@@ -1886,8 +1945,10 @@ export class PolicyEngine extends NatsService {
             userId: user.id,
             mockId
         });
+        notifier.completeStep(STEP_PUBLISH_MESSAGE);
 
         //Create Policy VC
+        notifier.startStep(STEP_CREATE_VC);
         const messageId = result.getId();
         const url = result.getUrl();
         let credentialSubject: any = {
@@ -1918,8 +1979,10 @@ export class PolicyEngine extends NatsService {
             type: SchemaEntity.POLICY,
             policyId: `${model.id}`
         });
+        notifier.completeStep(STEP_CREATE_VC);
 
         //Create default user
+        notifier.startStep(STEP_CREATE_USER);
         await databaseServer.createVirtualUser(
             'Administrator',
             root.did,
@@ -1927,7 +1990,9 @@ export class PolicyEngine extends NatsService {
             root.hederaAccountKey,
             true
         );
+        notifier.completeStep(STEP_CREATE_USER);
 
+        notifier.startStep(STEP_SAVE);
         let [, retVal] = await Promise.all([
             //Update dry-run table (mark readonly rows)
             DatabaseServer.setSystemMode(dryRunId, true),
@@ -1936,8 +2001,10 @@ export class PolicyEngine extends NatsService {
         ]);
 
         retVal = await PolicyImportExportHelper.updatePolicyComponents(retVal, logger, user.id);
+        notifier.completeStep(STEP_SAVE);
 
         logger.info('Run Policy', ['GUARDIAN_SERVICE'], user.id);
+        notifier.complete();
         return retVal;
     }
 
@@ -2104,6 +2171,103 @@ export class PolicyEngine extends NatsService {
                 errors
             };
         }
+    }
+
+    /**
+     * Validate and dry-run policy
+     * @param policyId
+     * @param owner
+     * @param enableMock
+     * @param notifier
+     * @param logger
+     */
+    public async validateAndDryRunPolicy(
+        policyId: string,
+        owner: IOwner,
+        enableMock: boolean,
+        notifier: INotificationStep,
+        logger: PinoLogger
+    ): Promise<IPublishResult> {
+        // <-- Steps
+        const STEP_FIND_POLICY = 'Find policy';
+        const STEP_VALIDATE_POLICY = 'Validate policy';
+        const STEP_DRY_RUN_POLICY = 'Start dry-run';
+        const STEP_RUN_POLICY = 'Run policy';
+        // Steps -->
+
+        notifier.addStep(STEP_FIND_POLICY, 1);
+        notifier.addStep(STEP_VALIDATE_POLICY, 5);
+        notifier.addStep(STEP_DRY_RUN_POLICY, 80);
+        notifier.addStep(STEP_RUN_POLICY, 14);
+        notifier.start();
+
+        notifier.startStep(STEP_FIND_POLICY);
+        const model = await DatabaseServer.getPolicyById(policyId);
+        await this.accessPolicy(model, owner, 'publish');
+
+        if (!model.config) {
+            throw new Error('The policy is empty');
+        }
+        if (model.status === PolicyStatus.PUBLISH) {
+            throw new Error(`Policy published`);
+        }
+        if (model.status === PolicyStatus.DISCONTINUED) {
+            throw new Error(`Policy is discontinued`);
+        }
+        if (model.status === PolicyStatus.DRY_RUN) {
+            throw new Error(`Policy already in Dry Run`);
+        }
+        if (model.status === PolicyStatus.PUBLISH_ERROR) {
+            throw new Error(`Failed policy cannot be started in dry run mode`);
+        }
+        if (model.status === PolicyStatus.DEMO) {
+            throw new Error(`Policy imported in demo mode`);
+        }
+        if (model.status === PolicyStatus.VIEW) {
+            throw new Error(`Policy imported in view mode`);
+        }
+        notifier.completeStep(STEP_FIND_POLICY);
+
+        notifier.startStep(STEP_VALIDATE_POLICY);
+        const errors = await this.validateModel(policyId, true);
+        const isValid = !errors.blocks.some(block => !block.isValid);
+        notifier.completeStep(STEP_VALIDATE_POLICY);
+
+        if (isValid) {
+            notifier.startStep(STEP_DRY_RUN_POLICY);
+            await this.dryRunPolicy(
+                model,
+                owner,
+                'Dry Run',
+                false,
+                logger,
+                enableMock,
+                notifier.getStep(STEP_DRY_RUN_POLICY)
+            );
+            notifier.completeStep(STEP_DRY_RUN_POLICY);
+
+            notifier.startStep(STEP_RUN_POLICY);
+            await this.generateModel(policyId, enableMock);
+            notifier.completeStep(STEP_RUN_POLICY);
+        } else {
+            notifier.skipStep(STEP_DRY_RUN_POLICY);
+            notifier.skipStep(STEP_RUN_POLICY);
+        }
+
+        const savepointsCount = await DatabaseServer.getSavepointsCount(policyId);
+        if (savepointsCount === 0) {
+            await DatabaseServer.nullifyInitialDryRunSavepointIds();
+        } else {
+            await DatabaseServer.removeDryRunWithEmptySavepoint(policyId);
+            PolicyDataMigrator.clearRunCacheByPolicyId(policyId);
+        }
+
+        notifier.complete();
+        return {
+            policyId: model.id.toString(),
+            isValid,
+            errors
+        };
     }
 
     /**

--- a/interfaces/src/type/messages/policy-engine-events.ts
+++ b/interfaces/src/type/messages/policy-engine-events.ts
@@ -23,6 +23,7 @@ export enum PolicyEngineEvents {
     PUBLISH_POLICIES = 'policy-engine-event-publish-policies',
     PUBLISH_POLICIES_ASYNC = 'policy-engine-event-publish-policies-async',
     DRY_RUN_POLICIES = 'policy-engine-event-dry-run-policies',
+    DRY_RUN_POLICIES_ASYNC = 'policy-engine-event-dry-run-policies-async',
     DRAFT_POLICIES = 'policy-engine-event-draft-policies',
     DISCONNECT_POLICY = 'policy-engine-event-disconnect-policy',
     RECONNECT_POLICY = 'policy-engine-event-reconnect-policy',

--- a/interfaces/src/type/task-action.type.ts
+++ b/interfaces/src/type/task-action.type.ts
@@ -2,6 +2,7 @@ export enum TaskAction {
     CREATE_POLICY = 'Create policy',
     WIZARD_CREATE_POLICY = 'Create Policy',
     PUBLISH_POLICY = 'Publish policy',
+    DRY_RUN_POLICY = 'Dry-run policy',
     IMPORT_POLICY_FILE = 'Import policy file',
     IMPORT_POLICY_MESSAGE = 'Import policy message',
     PUBLISH_SCHEMA = 'Publish schema',


### PR DESCRIPTION
### Description

Closes #6600. Starting dry-run mode on a complex policy such as VM0047 could take several minutes with no feedback at all. Dry-run now runs as an async task and reports its progress through the same step tree used when publishing a policy.

- Add `TaskAction.DRY_RUN_POLICY` and the `DRY_RUN_POLICIES_ASYNC` policy engine event
- Add `PUT /policies/push/{policyId}/dry-run`, returning a task so its progress can be tracked, and keep the existing synchronous endpoint unchanged
- Extract the dry-run status checks, validation and savepoint cleanup into `validateAndDryRunPolicy`, shared by the synchronous and async paths
- Report dry-run progress as four top-level steps: find policy, validate policy, start dry-run and run policy, skipping the last two when validation fails
- Report the dry-run itself as eight steps, weighted towards schema publishing, with a child step per schema so the bar advances schema by schema
- Report a separate step for persisting mock data when mock mode is enabled
- Send the user to the progress page when dry-run is started from the policies list or the policy configurator
- Return to the page publish or dry-run was started from once it succeeds, instead of always opening the policy configurator, and keep opening the configurator when validation fails so the block errors are visible