### PR TITLE
feat: 6641 make schema import errors and warnings visible

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.html
@@ -108,6 +108,14 @@
     </div>
   }
 </div>
+@if (errors.length > 0) {
+  <div class="issues-summary" [class.has-errors]="errorCount > 0">
+    <div class="issues-summary-counts">{{ issuesSummary }}</div>
+    <div class="issues-summary-hint">
+      See the details in the Warning &amp; Errors list at the end of the schemas above.
+    </div>
+  </div>
+}
 <div class="dialog-footer">
   <div class="action-buttons">
     <div class="dialog-button cancel-button">

--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.scss
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.scss
@@ -16,6 +16,34 @@ form {
     position: relative;
 }
 
+.issues-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 16px;
+    padding: 12px 16px;
+    border: 1px solid var(--color-accent-yellow-1, #DA9B22);
+    border-radius: 6px;
+    color: var(--color-accent-yellow-1, #DA9B22);
+    font-family: Inter, sans-serif;
+    font-style: normal;
+}
+
+.issues-summary.has-errors {
+    border-color: var(--color-accent-red-1, #FF432A);
+    color: var(--color-accent-red-1, #FF432A);
+}
+
+.issues-summary-counts {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.issues-summary-hint {
+    font-size: 12px;
+    font-weight: 400;
+}
+
 .schema-header {
     font-size: 18px;
     line-height: 32px;

--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.spec.ts
@@ -1,0 +1,106 @@
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SchemaViewDialog } from './schema-view-dialog.component';
+
+describe('SchemaViewDialog', () => {
+
+    function createComponent(data: any = {}): SchemaViewDialog {
+        const ref = {} as DynamicDialogRef;
+        const config = { data } as DynamicDialogConfig;
+        const component = new SchemaViewDialog(ref, config);
+        component.ngOnInit();
+        return component;
+    }
+
+    function issues(count: number, type: string): any[] {
+        const result: any[] = [];
+        for (let i = 0; i < count; i++) {
+            result.push({ type, text: `${type} ${i}` });
+        }
+        return result;
+    }
+
+    describe('counts', () => {
+        it('should count errors and warnings separately', () => {
+            const c = createComponent({ errors: [...issues(3, 'error'), ...issues(5, 'warning')] });
+            expect(c.errorCount).toBe(3);
+            expect(c.warningCount).toBe(5);
+        });
+
+        it('should count nothing when there are no errors', () => {
+            const c = createComponent({ errors: [] });
+            expect(c.errorCount).toBe(0);
+            expect(c.warningCount).toBe(0);
+        });
+
+        it('should not count an entry with an unknown type', () => {
+            const c = createComponent({ errors: issues(2, 'info') });
+            expect(c.errorCount).toBe(0);
+            expect(c.warningCount).toBe(0);
+        });
+    });
+
+    describe('issuesSummary', () => {
+        it('should name both counts when both are present', () => {
+            const c = createComponent({ errors: [...issues(3, 'error'), ...issues(5, 'warning')] });
+            expect(c.issuesSummary).toBe('3 errors, 5 warnings');
+        });
+
+        it('should name only errors when there are no warnings', () => {
+            const c = createComponent({ errors: issues(2, 'error') });
+            expect(c.issuesSummary).toBe('2 errors');
+        });
+
+        it('should name only warnings when there are no errors', () => {
+            const c = createComponent({ errors: issues(4, 'warning') });
+            expect(c.issuesSummary).toBe('4 warnings');
+        });
+
+        it('should use the singular form for one error', () => {
+            const c = createComponent({ errors: issues(1, 'error') });
+            expect(c.issuesSummary).toBe('1 error');
+        });
+
+        it('should use the singular form for one warning', () => {
+            const c = createComponent({ errors: issues(1, 'warning') });
+            expect(c.issuesSummary).toBe('1 warning');
+        });
+
+        it('should be empty when there are no entries', () => {
+            const c = createComponent({ errors: [] });
+            expect(c.issuesSummary).toBe('');
+        });
+
+        it('should be empty when errors are missing from the dialog data', () => {
+            const c = createComponent({});
+            expect(c.errors).toEqual([]);
+            expect(c.issuesSummary).toBe('');
+        });
+
+        it('should fall back to an issue count when no entry has a known type', () => {
+            const c = createComponent({ errors: issues(2, 'info') });
+            expect(c.issuesSummary).toBe('2 issues');
+        });
+
+        it('should use the singular fallback for a single unknown entry', () => {
+            const c = createComponent({ errors: issues(1, 'info') });
+            expect(c.issuesSummary).toBe('1 issue');
+        });
+    });
+
+    describe('__path', () => {
+        it('should prefer the cell over the row and the column', () => {
+            const c = createComponent({ errors: [{ type: 'error', cell: 'B4', row: 4, col: 2 }] });
+            expect(c.errors[0].__path).toBe('Cell: B4');
+        });
+
+        it('should use the row when there is no cell', () => {
+            const c = createComponent({ errors: [{ type: 'error', row: 7, col: 2 }] });
+            expect(c.errors[0].__path).toBe('Row: 7');
+        });
+
+        it('should use the column when there is no cell and no row', () => {
+            const c = createComponent({ errors: [{ type: 'warning', col: 3 }] });
+            expect(c.errors[0].__path).toBe('Col: 3');
+        });
+    });
+});

--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.spec.ts
@@ -1,12 +1,30 @@
-import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { DialogService, DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SchemaViewDialog } from './schema-view-dialog.component';
 
 describe('SchemaViewDialog', () => {
 
+    let closedWith: any;
+    let confirmConfig: any;
+    let confirmOpened: number;
+    let confirmResult: string | undefined;
+
     function createComponent(data: any = {}): SchemaViewDialog {
-        const ref = {} as DynamicDialogRef;
+        closedWith = undefined;
+        confirmConfig = undefined;
+        confirmOpened = 0;
+        const ref = {
+            close: (value: any) => { closedWith = value; }
+        } as DynamicDialogRef;
         const config = { data } as DynamicDialogConfig;
-        const component = new SchemaViewDialog(ref, config);
+        const dialogService = {
+            open: (component: any, openConfig: any) => {
+                confirmOpened++;
+                confirmConfig = openConfig;
+                return { onClose: of(confirmResult) };
+            }
+        } as DialogService;
+        const component = new SchemaViewDialog(ref, config, dialogService);
         component.ngOnInit();
         return component;
     }
@@ -101,6 +119,76 @@ describe('SchemaViewDialog', () => {
         it('should use the column when there is no cell and no row', () => {
             const c = createComponent({ errors: [{ type: 'warning', col: 3 }] });
             expect(c.errors[0].__path).toBe('Col: 3');
+        });
+    });
+
+    describe('onImport', () => {
+
+        it('should import without asking when there are no entries', () => {
+            const c = createComponent({ errors: [], topicId: 'topic-1' });
+            c.onImport();
+            expect(confirmOpened).toBe(0);
+            expect(closedWith).toEqual({ topicId: 'topic-1' });
+        });
+
+        it('should import without asking when there are only warnings', () => {
+            const c = createComponent({ errors: issues(3, 'warning'), topicId: 'topic-1' });
+            c.onImport();
+            expect(confirmOpened).toBe(0);
+            expect(closedWith).toEqual({ topicId: 'topic-1' });
+        });
+
+        it('should ask before importing when there is at least one error', () => {
+            confirmResult = undefined;
+            const c = createComponent({ errors: issues(4, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(confirmOpened).toBe(1);
+            expect(closedWith).toBeUndefined();
+        });
+
+        it('should name the error count in the confirmation text', () => {
+            confirmResult = undefined;
+            const c = createComponent({
+                errors: [...issues(4, 'error'), ...issues(2, 'warning')],
+                topicId: 'topic-1'
+            });
+            c.onImport();
+            expect(confirmConfig.data.text).toBe('This import has 4 errors. Import anyway?');
+        });
+
+        it('should use the singular form for one error', () => {
+            confirmResult = undefined;
+            const c = createComponent({ errors: issues(1, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(confirmConfig.data.text).toBe('This import has 1 error. Import anyway?');
+        });
+
+        it('should offer a cancel and an import button', () => {
+            confirmResult = undefined;
+            const c = createComponent({ errors: issues(2, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(confirmConfig.data.buttons.map((b: any) => b.name)).toEqual(['Cancel', 'Import']);
+        });
+
+        it('should import when the confirmation is accepted', () => {
+            confirmResult = 'Import';
+            const c = createComponent({ errors: issues(2, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(closedWith).toEqual({ topicId: 'topic-1' });
+        });
+
+        it('should not import when the confirmation is cancelled', () => {
+            confirmResult = 'Cancel';
+            const c = createComponent({ errors: issues(2, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(closedWith).toBeUndefined();
+        });
+
+        it('should not import when the confirmation is dismissed', () => {
+            confirmResult = undefined;
+            const c = createComponent({ errors: issues(2, 'error'), topicId: 'topic-1' });
+            c.onImport();
+            expect(closedWith).toBeUndefined();
         });
     });
 });

--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Inject} from '@angular/core';
-import {DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {DialogService, DynamicDialogConfig, DynamicDialogRef} from 'primeng/dynamicdialog';
+import {CustomConfirmDialogComponent} from '../../common/custom-confirm-dialog/custom-confirm-dialog.component';
 
 /**
  * Dialog for preview schema.
@@ -26,6 +27,7 @@ export class SchemaViewDialog {
     constructor(
         private dialogRef: DynamicDialogRef,
         private config: DynamicDialogConfig,
+        private dialogService: DialogService,
     ) {
         const data = this.config.data
 
@@ -83,7 +85,35 @@ export class SchemaViewDialog {
     }
 
     onImport() {
+        if (this.errorCount > 0) {
+            this.confirmImportWithErrors();
+            return;
+        }
         this.dialogRef.close({topicId: this.topicId});
+    }
+
+    private confirmImportWithErrors(): void {
+        const confirmRef = this.dialogService.open(CustomConfirmDialogComponent, {
+            showHeader: false,
+            width: '640px',
+            styleClass: 'guardian-dialog',
+            data: {
+                header: 'Import With Errors',
+                text: `This import has ${this.errorCount} ${this.errorCount === 1 ? 'error' : 'errors'}. Import anyway?`,
+                buttons: [{
+                    name: 'Cancel',
+                    class: 'secondary'
+                }, {
+                    name: 'Import',
+                    class: 'primary'
+                }]
+            }
+        });
+        confirmRef?.onClose.subscribe((result: string) => {
+            if (result === 'Import') {
+                this.dialogRef.close({topicId: this.topicId});
+            }
+        });
     }
 
     onNewVersionClick(messageId: string) {

--- a/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.ts
+++ b/frontend/src/app/modules/schema-engine/schema-view-dialog/schema-view-dialog.component.ts
@@ -19,6 +19,9 @@ export class SchemaViewDialog {
     tools: any[];
     errors: any[];
     schemaType: string;
+    errorCount: number = 0;
+    warningCount: number = 0;
+    issuesSummary: string = '';
 
     constructor(
         private dialogRef: DynamicDialogRef,
@@ -44,8 +47,31 @@ export class SchemaViewDialog {
                 } else if (error.col) {
                     error.__path = `Col: ${error.col}`;
                 }
+                if (error.type === 'error') {
+                    this.errorCount++;
+                } else if (error.type === 'warning') {
+                    this.warningCount++;
+                }
             }
+            this.issuesSummary = this.buildIssuesSummary();
         }
+    }
+
+    private buildIssuesSummary(): string {
+        const parts: string[] = [];
+        if (this.errorCount > 0) {
+            parts.push(`${this.errorCount} ${this.errorCount === 1 ? 'error' : 'errors'}`);
+        }
+        if (this.warningCount > 0) {
+            parts.push(`${this.warningCount} ${this.warningCount === 1 ? 'warning' : 'warnings'}`);
+        }
+        if (parts.length === 0) {
+            if (this.errors.length === 0) {
+                return '';
+            }
+            return `${this.errors.length} ${this.errors.length === 1 ? 'issue' : 'issues'}`;
+        }
+        return parts.join(', ');
     }
 
     ngOnInit() {

--- a/frontend/src/app/themes/guardian/dialog.scss
+++ b/frontend/src/app/themes/guardian/dialog.scss
@@ -149,6 +149,39 @@
     }
 }
 
+.guardian-dialog.schema-import-preview {
+    .p-dialog-content {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    app-schema-view-dialog {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+
+    .dialog-header {
+        flex: 0 0 auto;
+    }
+
+    .issues-summary {
+        flex: 0 0 auto;
+    }
+
+    .dialog-footer {
+        flex: 0 0 auto;
+    }
+
+    .dialog-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
+    }
+}
+
 .draft-dialog {
     .action-buttons button {
         padding: 5px 24px;

--- a/frontend/src/app/views/schemas/schemas.component.ts
+++ b/frontend/src/app/views/schemas/schemas.component.ts
@@ -1230,7 +1230,7 @@ export class SchemaConfigComponent implements OnInit {
         const { type, data, schemas, errors } = result;
         const dialogRef = this.dialog.open(SchemaViewDialog, {
             width: '90%',
-            styleClass: 'guardian-dialog',
+            styleClass: 'guardian-dialog schema-import-preview',
             showHeader: false,
             data: {
                 schemas,


### PR DESCRIPTION
**Description**:

When a schema file is imported, the preview dialog lists every schema it found and puts the warnings and errors at the  very end of that list. With a large workbook the problems are several screens below the fold, so the user reaches the Import button without ever having seen them and imports a file that is already known to be broken.

The preview now carries a summary line directly above its footer, which stays in view while the list scrolls. It counts the problems the file has — for example "3 errors, 5 warnings" — and points to the detailed list at the end of the schemas. When the file carries hard errors, pressing Import no longer starts the import: a confirmation asks whether to import anyway, and the import runs only if it is accepted. A file with warnings only, or with no problems at all, imports exactly as before.

The Import button itself was deliberately left enabled. Importing a schema with errors is supported on purpose — the broken schemas are saved and marked Incomplete so they can be fixed in place — so the change makes the problems
impossible to miss rather than blocking the action. The detailed list of warnings and errors was not moved, and the shared dialog styling was not changed.

Resolves #6641

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)