### PR TITLE
fix: invalidate accounts cache on mutations

### DIFF
--- a/api-gateway/src/api/service/account.ts
+++ b/api-gateway/src/api/service/account.ts
@@ -31,11 +31,11 @@ import {
     OTPStatusResponseDTO
 } from '#middlewares';
 import { Auth, AuthUser, checkPermission } from '#auth';
-import { EntityOwner, Guardians, InternalException, PolicyEngine, ServiceError, TaskManager, UseCache, Users } from '#helpers';
+import { CacheService, EntityOwner, Guardians, InternalException, PolicyEngine, ServiceError, TaskManager, UseCache, Users } from '#helpers';
 import { PolicyListResponse } from '../../entities/policy.js';
 import { StandardRegistryAccountResponse } from '../../entities/account.js';
 import { ApplicationEnvironment } from '../../environment.js';
-import { CACHE } from '#constants';
+import { CACHE, CACHE_TAG_PREFIXES } from '#constants';
 
 /**
  * User account route
@@ -44,7 +44,11 @@ import { CACHE } from '#constants';
 @ApiTags('accounts')
 export class AccountApi {
 
-    constructor(@Inject('GUARDIANS') public readonly client: ClientProxy, private readonly logger: PinoLogger) {
+    constructor(
+        @Inject('GUARDIANS') public readonly client: ClientProxy,
+        private readonly cacheService: CacheService,
+        private readonly logger: PinoLogger
+    ) {
     }
 
     /**
@@ -177,6 +181,9 @@ export class AccountApi {
                 'Next register your account in hedera',
                 childUser.id,
             );
+
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+
             return childUser;
         } catch (error) {
             await this.logger.error(error, ['API_GATEWAY'], parentUser?.id);
@@ -321,6 +328,10 @@ export class AccountApi {
 
         // After the task completes, transfer ownership to the newly created user
         taskManager.registerCallback(task, async (completedTask) => {
+            // The account only exists once the task is done, so the listing cache
+            // cannot be dropped when the request returns.
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS).catch(() => null);
+
             if (completedTask.result?.username) {
                 try {
                     const usersService = new Users();
@@ -478,7 +489,11 @@ export class AccountApi {
         try {
             const { username, oldPassword, newPassword } = body;
             const users = new Users();
-            return await users.changeUserPassword(user, username, oldPassword, newPassword);
+            const result = await users.changeUserPassword(user, username, oldPassword, newPassword);
+
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+
+            return result;
         } catch (error) {
             await this.logger.warn(error.message, ['API_GATEWAY'], null);
             throw new HttpException(error.message, error.code || HttpStatus.UNAUTHORIZED);
@@ -828,6 +843,8 @@ export class AccountApi {
             const token = body.token;
             const result = await users.otpConfirmSecret(user.id, token);
 
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+
             return result;
 
         } catch (error) {
@@ -893,6 +910,8 @@ export class AccountApi {
         const users = new Users();
         try {
             const result = await users.otpDeactivate(user.id);
+
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
 
             return result;
 

--- a/api-gateway/src/api/service/account.ts
+++ b/api-gateway/src/api/service/account.ts
@@ -52,6 +52,24 @@ export class AccountApi {
     }
 
     /**
+     * Drops every cached accounts response.
+     *
+     * The mutation is already applied when this runs, so a cache failure must
+     * not turn a successful request into an error - it is logged instead.
+     */
+    private async invalidateAccountsCache(userId: string | null): Promise<void> {
+        try {
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+        } catch (error) {
+            await this.logger.warn(
+                `Failed to invalidate the accounts cache: ${error.message}`,
+                ['API_GATEWAY'],
+                userId
+            );
+        }
+    }
+
+    /**
      * getSession
      * @param headers
      */
@@ -182,7 +200,7 @@ export class AccountApi {
                 childUser.id,
             );
 
-            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+            await this.invalidateAccountsCache(childUser.id);
 
             return childUser;
         } catch (error) {
@@ -330,7 +348,7 @@ export class AccountApi {
         taskManager.registerCallback(task, async (completedTask) => {
             // The account only exists once the task is done, so the listing cache
             // cannot be dropped when the request returns.
-            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS).catch(() => null);
+            await this.invalidateAccountsCache(parentUser?.id ?? null);
 
             if (completedTask.result?.username) {
                 try {
@@ -491,7 +509,7 @@ export class AccountApi {
             const users = new Users();
             const result = await users.changeUserPassword(user, username, oldPassword, newPassword);
 
-            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+            await this.invalidateAccountsCache(user.id);
 
             return result;
         } catch (error) {
@@ -843,7 +861,7 @@ export class AccountApi {
             const token = body.token;
             const result = await users.otpConfirmSecret(user.id, token);
 
-            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+            await this.invalidateAccountsCache(user.id);
 
             return result;
 
@@ -911,7 +929,7 @@ export class AccountApi {
         try {
             const result = await users.otpDeactivate(user.id);
 
-            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+            await this.invalidateAccountsCache(user.id);
 
             return result;
 

--- a/api-gateway/src/api/service/profile.ts
+++ b/api-gateway/src/api/service/profile.ts
@@ -22,12 +22,32 @@ import {
 } from '#middlewares';
 import { Auth, AuthUser } from '#auth';
 import { CacheService, getCacheKey, Guardians, InternalException, ServiceError, TaskManager, UseCache } from '#helpers';
-import { CACHE, PREFIXES } from '#constants';
+import { CACHE, CACHE_TAG_PREFIXES, PREFIXES } from '#constants';
 
 @Controller('profiles')
 @ApiTags('profiles')
 export class ProfileApi {
     constructor(private readonly cacheService: CacheService, private readonly logger: PinoLogger) {
+    }
+
+    /**
+     * Drops every cached accounts response.
+     *
+     * Setting up or restoring a profile assigns the DID and Hedera account the
+     * accounts listing reports, so those cached responses go stale too. The
+     * profile is already saved when this runs, hence a cache failure is logged
+     * rather than propagated.
+     */
+    private async invalidateAccountsCache(userId: string | null): Promise<void> {
+        try {
+            await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.ACCOUNTS);
+        } catch (error) {
+            await this.logger.warn(
+                `Failed to invalidate the accounts cache: ${error.message}`,
+                ['API_GATEWAY'],
+                userId
+            );
+        }
     }
 
     /**
@@ -144,6 +164,7 @@ export class ProfileApi {
         const invalidedCacheTags = [`/${PREFIXES.PROFILES}/${username}`];
 
         await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheTags], user))
+        await this.invalidateAccountsCache(user.id);
     }
 
     /**
@@ -213,6 +234,7 @@ export class ProfileApi {
             await this.cacheService.invalidate(
                 getCacheKey([req.url, ...invalidedCacheTags], user)
             );
+            await this.invalidateAccountsCache(user.id);
         });
 
         RunFunctionAsync<ServiceError>(async () => {
@@ -347,6 +369,7 @@ export class ProfileApi {
             await guardians.restoreUserProfileCommonAsync(user, username, profile, task);
 
             await this.cacheService.invalidate(getCacheKey([req.url, ...invalidedCacheTags], user))
+            await this.invalidateAccountsCache(user.id);
         }, async (error) => {
             await this.logger.error(error, ['API_GATEWAY'], user.id);
             taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });

--- a/api-gateway/src/constants/cache.ts
+++ b/api-gateway/src/constants/cache.ts
@@ -19,4 +19,7 @@ export const TAG_PREFIXES = {
   // Schemas are served by two controllers: `/schemas/...` and the single
   // schema route of `@Controller('schema')`.
   SCHEMAS: [`${PREFIXES.TAG}/schemas`, `${PREFIXES.TAG}/schema/`],
+  // Every cached route of `@Controller('accounts')`: the listing, the session,
+  // the standard registries and the balance.
+  ACCOUNTS: [`${PREFIXES.TAG}/accounts`],
 }

--- a/e2e-tests/cypress/e2e/api-tests/000_accounts_tests/getAccounts.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/000_accounts_tests/getAccounts.cy.js
@@ -10,15 +10,10 @@ context('Get accounts', { tags: ['accounts', 'firstPool', 'all'] }, () => {
     const UserUsername = Cypress.env('User');
     const accountsUrl = API.ApiServer + API.Accounts;
 
-    // `GET /accounts` is cached per (url + user) for 10 minutes and `account.ts` has no cache
-    // invalidation at all, so registering a user leaves the cached listing stale. Reading a list
-    // that must reflect a just-created account needs a unique query string to miss the cache.
-    // See <follow-up issue>: once the accounts routes get tag-prefix invalidation like schemas
-    // (#6634) and tools, this can go.
-    const getAccounts = ({ authorization, failOnStatusCode = true, bustCache = false } = {}) =>
+    const getAccounts = ({ authorization, failOnStatusCode = true } = {}) =>
         cy.request({
             method: METHOD.GET,
-            url: bustCache ? `${accountsUrl}?_=${Date.now()}` : accountsUrl,
+            url: accountsUrl,
             headers: { authorization },
             failOnStatusCode,
         });
@@ -96,7 +91,7 @@ context('Get accounts', { tags: ['accounts', 'firstPool', 'all'] }, () => {
             expect(response.body).to.have.property('role', 'USER');
 
             Authorization.getAccessToken(SRUsername).then((authorization) => {
-                getAccounts({ authorization, bustCache: true }).then((listResponse) => {
+                getAccounts({ authorization }).then((listResponse) => {
                     expect(listResponse.status).to.eq(STATUS_CODE.OK);
                     const usernames = listResponse.body.map(v => v.username);
                     expect(usernames).to.include(name);


### PR DESCRIPTION
### Description

Closes #6660. The cached accounts responses had no invalidation at all, so a newly registered account was missing from `GET /accounts` for up to 10 minutes.

- Add an `ACCOUNTS` tag prefix and invalidate it on every account mutation: register, push onboarding, password change and the OTP confirm/deactivate endpoints.
- Invalidate the same prefix from profile setup and restore, which assign the DID and Hedera account the accounts listing reports.
- Log a cache failure instead of propagating it, so an already-applied mutation is not reported as a failed request.
- Remove the `bustCache` query-string workaround from the `getAccounts` e2e spec.