### PR TITLE
fix: invalidate schema cache after deletion

### DIFF
--- a/api-gateway/src/api/service/schema.ts
+++ b/api-gateway/src/api/service/schema.ts
@@ -1581,9 +1581,17 @@ export class SchemaApi {
         try {
             const taskManager = new TaskManager();
             const task = taskManager.start(TaskAction.DELETE_SCHEMAS, user.id);
+
+            // The deletion itself runs asynchronously in guardian-service, so the
+            // cache can only be invalidated once the task reports completion -
+            // invalidating right after the RPC ack would leave the listing cache
+            // free to be re-populated with the pre-deletion state.
+            taskManager.registerCallback(task, async () => {
+                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
+            });
+
             RunFunctionAsync<ServiceError>(async () => {
                 await guardians.deleteSchema(schemaId, owner, task, String(includeChildren).toLowerCase() === 'true');
-                await this.cacheService.invalidateAllTagsByPrefixes(CACHE_TAG_PREFIXES.SCHEMAS).catch(() => null);
             }, async (error) => {
                 await this.logger.error(error, ['API_GATEWAY'], user.id);
                 taskManager.addError(task.taskId, { code: error.code || 500, message: error.message });

--- a/api-gateway/src/helpers/task-manager.ts
+++ b/api-gateway/src/helpers/task-manager.ts
@@ -275,8 +275,16 @@ export class TaskManager {
             return;
         }
 
+        // A task can be completed twice (a result followed by an error, or the
+        // other way around): the callback has to run once, otherwise the second
+        // run would clear the pending flag while the first one is still going.
+        this.callbacks.delete(task.taskId);
+        task.callbackPending = true;
         callback(task)
-            .finally(() => this.cleanupAfterCallback(taskId));
+            .finally(() => {
+                task.callbackPending = false;
+                this.cleanupAfterCallback(taskId);
+            });
     }
 
     /**
@@ -338,7 +346,20 @@ export class TaskManager {
     ): Task {
         const task = this.tasks[taskId];
         if (task && task.userId === userId) {
-            return this.tasks[taskId];
+            if (task.callbackPending) {
+                // The completion callback (e.g. cache invalidation) is still
+                // running: hide the result until it is done, otherwise a client
+                // polling this endpoint can act on a state the gateway has not
+                // caught up with yet.
+                const pending: Task = Object.assign(
+                    Object.create(Object.getPrototypeOf(task)),
+                    task
+                );
+                pending.result = undefined;
+                pending.error = undefined;
+                return pending;
+            }
+            return task;
         } else if (skipIfNotFound) {
             return;
         } else {
@@ -379,9 +400,9 @@ export class TaskManager {
             taskId: task.taskId,
             action: task.action,
             expectation: task.expectation,
-            completed: task.result !== null,
-            failed: task.error !== null,
-            error: task.error
+            completed: !task.callbackPending && task.result !== null,
+            failed: !task.callbackPending && task.error !== null,
+            error: !task.callbackPending && task.error
                 ? { message: task.error.message ?? 'Task failed' }
                 : null,
         };
@@ -476,6 +497,10 @@ class Task {
      * Info of task
      */
     public info: any;
+    /**
+     * Completion callback is still running
+     */
+    public callbackPending: boolean = false;
 
     constructor(
         public action: TaskAction | string,

--- a/e2e-tests/cypress/e2e/api-tests/011_schemas/nestedSchemasDeletion.cy.js
+++ b/e2e-tests/cypress/e2e/api-tests/011_schemas/nestedSchemasDeletion.cy.js
@@ -31,23 +31,6 @@ context('Schema', { tags: ['schema', 'thirdPool', 'all'] }, () => {
         return cy.wrap(response.body, { log: false });
     });
 
-    // Single-schema DELETE is task-based on both sides: api-gateway invalidates the schema cache
-    // right after guardian-service's fire-and-forget ack, not after the actual deletion (which runs
-    // in guardian-service's own background task and is only guaranteed done once waitForTask below
-    // resolves). A read in that window caches the pre-deletion list for the full 10-minute TTL, so
-    // listing right after a single-schema delete needs an uncached read. Topic-wide deletion doesn't
-    // have this problem (both sides handle it synchronously), so listTopicSchemas is fine there.
-    // See <follow-up issue>.
-    const listTopicSchemasAfterDelete = (authorization) => cy.request({
-        method: METHOD.GET,
-        url: API.ApiServer + API.Schemas + topicId,
-        headers: { authorization },
-        qs: { cacheBust: `${runId}_${Date.now()}` },
-    }).then((response) => {
-        expect(response.status).to.eq(STATUS_CODE.OK);
-        return cy.wrap(response.body, { log: false });
-    });
-
     const findSchema = (list, uuid, name) => {
         const schema = list.find((item) => item?.uuid === uuid);
         expect(schema, `${name} in the schemas of topic ${topicId}`).to.not.be.undefined;
@@ -148,7 +131,7 @@ context('Schema', { tags: ['schema', 'thirdPool', 'all'] }, () => {
     it('Delete schema without child deletion', () => {
         Authorization.getAccessToken(SRUsername).then((authorization) => {
             deleteSchema(authorization, schemaBId, false);
-            listTopicSchemasAfterDelete(authorization).then((list) => {
+            listTopicSchemas(authorization).then((list) => {
                 expect(list.length).eql(1);
                 expect(list.at(0).id).eql(schemaAId);
             });
@@ -159,7 +142,7 @@ context('Schema', { tags: ['schema', 'thirdPool', 'all'] }, () => {
         Authorization.getAccessToken(SRUsername).then((authorization) => {
             createSchemaB(authorization)
                 .then(() => deleteSchema(authorization, schemaBId, true))
-                .then(() => listTopicSchemasAfterDelete(authorization))
+                .then(() => listTopicSchemas(authorization))
                 .then((list) => {
                     expect(list.length).eql(0);
                 });

--- a/guardian-service/src/api/schema.service.ts
+++ b/guardian-service/src/api/schema.service.ts
@@ -1792,11 +1792,14 @@ export async function schemaAPI(logger: PinoLogger): Promise<void> {
             const notifier = await NewNotifier.create(task);
 
             RunFunctionAsync(async () => {
+                // the returned value is discarded here, so these have to be thrown:
+                // the caller only learns about them through the task, and a task that
+                // is never failed is polled until it times out
                 if (!schemaIds || schemaIds?.length <= 0) {
-                    return new MessageError('Invalid schema ids');
+                    throw new Error('Invalid schema ids');
                 }
                 if (!owner) {
-                    return new MessageError('Invalid schema owner');
+                    throw new Error('Invalid schema owner');
                 }
 
                 const schemas = await DatabaseServer.getSchemas({
@@ -1804,7 +1807,7 @@ export async function schemaAPI(logger: PinoLogger): Promise<void> {
                     owner: owner.owner
                 });
                 if (!schemas || schemas?.length <= 0) {
-                    return new MessageError('Schemas is not found');
+                    throw new Error('Schemas is not found');
                 }
 
                 const childSchemas = new Map<string, SchemaCollection>();


### PR DESCRIPTION
### Description

Closes #6661. `DELETE /schemas/{schemaId}` invalidated the schema cache right after guardian-service's asynchronous ack rather than after the deletion itself, so a listing read in that window re-populated the cache with the pre-deletion state and kept it for the full TTL.

- Invalidate the schema cache from a task completion callback instead of immediately after the RPC ack
- Hold back a task's result and error while its completion callback is still running, so a client polling the task cannot act before the callback finished
- Run a task completion callback only once when a task reports both a result and an error
- Fail the delete task on invalid ids, missing owner and missing schemas, instead of leaving it without a result
- Read the post-delete schema listing through the plain helper, without the cache-busting query parameter
