### PR TITLE
feat: 6538 clearer menu labels and page help text

### DIFF
--- a/frontend/src/app/modules/artifact-engine/artifact-config/artifact-config.component.html
+++ b/frontend/src/app/modules/artifact-engine/artifact-config/artifact-config.component.html
@@ -15,7 +15,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Artifacts</div>
+  <guardian-page-header pageTitle="Artifacts" helpKey="artifacts"></guardian-page-header>
 </ng-template>
 
 <ng-template #actionsContainer>

--- a/frontend/src/app/modules/common/common-components.module.ts
+++ b/frontend/src/app/modules/common/common-components.module.ts
@@ -35,6 +35,7 @@ import { CustomConfirmDialogComponent } from './custom-confirm-dialog/custom-con
 import { TreeGraphComponent } from './tree-graph/tree-graph.component';
 import { GuardianSwitchButton } from './guardian-switch-button/guardian-switch-button.component';
 import { GuardianTabsSwitch } from './guardian-tabs-switch/guardian-tabs-switch.component';
+import { GuardianPageHeader } from './guardian-page-header/guardian-page-header.component';
 import { ImportEntityDialog } from './import-entity-dialog/import-entity-dialog.component';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { GuardianDialogService } from '../../services/guardian-dialog.service';
@@ -83,6 +84,7 @@ import { ProgressSpinnerModule } from 'primeng/progressspinner';
         TreeGraphComponent,
         GuardianSwitchButton,
         GuardianTabsSwitch,
+        GuardianPageHeader,
         ImportEntityDialog,
         MathLiveComponent,
         MenuButton,
@@ -150,6 +152,7 @@ import { ProgressSpinnerModule } from 'primeng/progressspinner';
         TreeGraphComponent,
         GuardianSwitchButton,
         GuardianTabsSwitch,
+        GuardianPageHeader,
         ImportEntityDialog,
         MathLiveComponent,
         MenuButton,

--- a/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.html
+++ b/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.html
@@ -1,0 +1,7 @@
+<div class="guardian-user-page-header guardian-user-page-header--with-help">
+    <span class="page-header-title">{{ pageTitle }}</span>
+    <ng-content></ng-content>
+</div>
+@if (helpText) {
+    <div class="page-header-help-text">{{ helpText }}</div>
+}

--- a/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.scss
+++ b/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.scss
@@ -1,0 +1,14 @@
+:host {
+    display: block;
+    margin-bottom: var(--guardian-page-header-block-gap);
+}
+
+.page-header-help-text {
+    max-width: 820px;
+    padding: var(--guardian-page-header-padding);
+    margin-top: 6px;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 1.55;
+    color: var(--color-grey-6);
+}

--- a/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.ts
+++ b/frontend/src/app/modules/common/guardian-page-header/guardian-page-header.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input } from '@angular/core';
+import { PAGE_HELP_TEXT } from './page-help-text';
+
+/**
+ * Page title with optional help text underneath explaining what the page is for.
+ * Pass `helpKey` to pull the copy from PAGE_HELP_TEXT, or `description` to set it
+ * directly. Anything projected as content is rendered inside the title row.
+ *
+ * The title input is `pageTitle`, not `title`: a static `title` attribute is also
+ * written to the host element by Angular, which would show a native tooltip over
+ * the whole header.
+ */
+@Component({
+    selector: 'guardian-page-header',
+    templateUrl: './guardian-page-header.component.html',
+    styleUrls: ['./guardian-page-header.component.scss'],
+    standalone: false
+})
+export class GuardianPageHeader {
+    @Input('pageTitle') pageTitle: string = '';
+    @Input('description') description: string = '';
+    @Input('helpKey') helpKey: string = '';
+
+    get helpText(): string {
+        return this.description || PAGE_HELP_TEXT[this.helpKey] || '';
+    }
+}

--- a/frontend/src/app/modules/common/guardian-page-header/page-help-text.ts
+++ b/frontend/src/app/modules/common/guardian-page-header/page-help-text.ts
@@ -1,0 +1,30 @@
+/**
+ * Help text shown under each main page title.
+ * Keys are referenced from templates via <guardian-page-header helpKey="...">.
+ */
+export const PAGE_HELP_TEXT: Readonly<Record<string, string>> = {
+    policies: 'Author and govern the policies in this workspace. Track what is in execution on Hedera, what is being prepared, and what has been imported from external Standard Registries.',
+    schemas: 'Schemas defined inside a specific policy. They describe the documents like projects, monitoring reports, and certificates that the policy receives, validates, and emits.',
+    'schema-rules': 'Validation rules attached to a policy schema. Use them to enforce conditions on incoming documents like required fields, allowed value ranges, and cross-field consistency before the policy accepts the data.',
+    'schema-templates': 'Standardized schema definitions shared across policies. Use them to enforce consistent data structures and field requirements without redefining them for each policy.',
+    artifacts: 'Static files attached to a policy, including calculation specs, policy documentation, and supporting media. Artifacts travel with the policy when published and stay versioned alongside it.',
+    tools: 'Reusable building blocks that policies can import. Each tool bundles its own blocks, schemas, and logic so you can ship a calculation, a verification, or a workflow once and use it across many policies.',
+    modules: 'Reusable groups of policy logic. A module bundles blocks, schemas, and configuration so policies can import the same logic instead of redefining it. Useful for shared validation steps, common workflows, or methodology stages.',
+    formulas: 'Reusable mathematical expressions referenced by policy logic and schemas. They cover emission factors, baseline calculations, scoring rules, and any other value derived from incoming data.',
+
+    tokens: 'Hedera-native tokens minted, burned, and managed by your policies. Each token has its own treasury, supply controls, and KYC settings; configure them here and link them to the policy steps that mint or transfer them.',
+    contracts: 'Smart contracts that wipe (burn) tokens from holder accounts. Use them to enforce supply controls; for example, retiring credits when they are consumed by a downstream offset claim, or removing invalid issuances.',
+    'relayer-accounts': 'Hedera operator accounts that broker transactions on behalf of users by paying network fees, signing transfers, and serving as the on-chain identity for relayer-driven flows. Update balances and review usage here.',
+
+    roles: 'Create and manage roles which bundle a set of permissions like issuing credentials, approving documents, and configuring policies.',
+    users: 'View users within the workspace and assign roles to grant or revoke permissions.',
+    'external-policies': 'Policies imported from another Standard Registry on the Hedera network. Approve a remote policy to make it available alongside the policies authored in this workspace.',
+    'service-status': 'Review the status of Guardian services.',
+    'worker-tasks': 'Long-running background jobs that the platform runs on your behalf, like publishing policies, importing schemas, and migrating data. Track progress, retry failed work, and clear out finished tasks here.',
+    logs: 'View the logs for visibility into Guardian services and activities. Exported logs may also be useful for troubleshooting purposes.',
+    branding: 'Update the look and feel of this workspace according to your preferences.',
+    settings: 'The Hedera and IPFS account and key details associated with this workspace.',
+
+    notifications: 'Notifications are collected here related to account activities.',
+    profile: 'Your account, security, Hedera identity, and identity documents for this workspace.',
+};

--- a/frontend/src/app/modules/contract-engine/configs/contract-config/contract-config.component.html
+++ b/frontend/src/app/modules/contract-engine/configs/contract-config/contract-config.component.html
@@ -12,7 +12,7 @@
 
   @if (isConfirmed && contracts) {
     <div class="guardian-page">
-      <div class="guardian-user-page-header">Retirement</div>
+      <guardian-page-header pageTitle="Contracts" helpKey="contracts"></guardian-page-header>
       <div class="actions actions--top">
         <div class="actions__tabs">
           <guardian-tabs-switch

--- a/frontend/src/app/modules/formulas/formulas/formulas.component.html
+++ b/frontend/src/app/modules/formulas/formulas/formulas.component.html
@@ -12,9 +12,7 @@
     </div>
   }
 
-  <div class="guardian-user-page-header">
-    <span>{{title}}</span>
-  </div>
+  <guardian-page-header [pageTitle]="title" helpKey="formulas"></guardian-page-header>
 
   <div class="actions-container">
     <div class="dropdown-block">

--- a/frontend/src/app/modules/policy-engine/external-policies/external-policies.component.html
+++ b/frontend/src/app/modules/policy-engine/external-policies/external-policies.component.html
@@ -12,9 +12,7 @@
     </div>
   }
 
-  <div class="guardian-user-page-header">
-    <span>{{title}}</span>
-  </div>
+  <guardian-page-header [pageTitle]="title" helpKey="external-policies"></guardian-page-header>
 
   <div class="actions-container">
     <div class="module-actions-buttons-container">

--- a/frontend/src/app/modules/policy-engine/external-policies/external-policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/external-policies/external-policies.component.ts
@@ -26,7 +26,7 @@ interface IColumn {
     standalone: false
 })
 export class ExternalPolicyComponent implements OnInit {
-    public title: string = 'Remote Policy Request';
+    public title: string = 'Remote Policy Requests';
 
     public loading: boolean = true;
     public isConfirmed: boolean = false;

--- a/frontend/src/app/modules/policy-engine/modules-list/modules-list.component.html
+++ b/frontend/src/app/modules/policy-engine/modules-list/modules-list.component.html
@@ -15,7 +15,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Modules</div>
+  <guardian-page-header pageTitle="Modules" helpKey="modules"></guardian-page-header>
 </ng-template>
 
 <ng-template #actionsContainer>

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.html
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.html
@@ -1,7 +1,5 @@
 <div class="guardian-page" [class.policies-min-width]="!user.POLICIES_POLICY_MANAGE">
-  <div class="guardian-user-page-header">
-    {{ user.POLICIES_POLICY_MANAGE ? "Manage Policies" : "List of Policies" }}
-  </div>
+  <guardian-page-header pageTitle="Policies" helpKey="policies"></guardian-page-header>
 
   @if (!isConfirmed) {
     <div class="not-exist">

--- a/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.html
+++ b/frontend/src/app/modules/policy-engine/tools-list/tools-list.component.html
@@ -1,6 +1,6 @@
 <div class="guardian-page">
 
-  <div class="guardian-user-page-header">Tools</div>
+  <guardian-page-header pageTitle="Tools" helpKey="tools"></guardian-page-header>
   @if (!isConfirmed) {
     <div class="not-exist">
       Before starting work you need to get DID <a [routerLink]="['/profile']">here</a>

--- a/frontend/src/app/modules/statistics/schema-rules/schema-rules/schema-rules.component.html
+++ b/frontend/src/app/modules/statistics/schema-rules/schema-rules/schema-rules.component.html
@@ -12,9 +12,7 @@
     </div>
   }
 
-  <div class="guardian-user-page-header">
-    <span>{{title}}</span>
-  </div>
+  <guardian-page-header [pageTitle]="title" helpKey="schema-rules"></guardian-page-header>
 
   <div class="actions-container">
     <div class="dropdown-block">

--- a/frontend/src/app/themes/guardian/page.scss
+++ b/frontend/src/app/themes/guardian/page.scss
@@ -77,7 +77,11 @@
         height: var(--guardian-page-header-height);
         padding: var(--guardian-page-header-padding);
         position: relative;
-        margin-bottom: var(--guardian-page-header-gap);
+        margin-bottom: var(--guardian-page-header-block-gap);
+    }
+
+    .guardian-user-page-header--with-help {
+        margin-bottom: 0;
     }
 
     .tabs-nav {

--- a/frontend/src/app/themes/guardian/variables.scss
+++ b/frontend/src/app/themes/guardian/variables.scss
@@ -27,13 +27,14 @@
     /* Page layout — canonical main-page skeleton; visual etalon = Tools page.
        Single source of truth for the page title font, outer padding, header band,
        and the toolbar-to-grid gap. Per-page alignment iterations target these. */
-    --guardian-page-padding: 56px 48px 48px 48px;
+    --guardian-page-padding: 28px 48px 48px 48px;
     --guardian-page-header-font-family: var(--font-family-poppins);
     --guardian-page-header-font-size: 32px;
     --guardian-page-header-font-weight: 600;
     --guardian-page-header-height: auto;
     --guardian-page-header-padding: 0px;
     --guardian-page-header-gap: 28px;
+    --guardian-page-header-block-gap: 16px;
     --guardian-page-tabs-gap: 28px;
     --guardian-page-toolbar-height: 56px;
     --guardian-page-toolbar-gap: 40px;

--- a/frontend/src/app/views/admin/logs-view/logs-view.component.html
+++ b/frontend/src/app/views/admin/logs-view/logs-view.component.html
@@ -14,7 +14,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Logs</div>
+  <guardian-page-header pageTitle="Logs" helpKey="logs"></guardian-page-header>
 </ng-template>
 
 <ng-template #actionsContainer>

--- a/frontend/src/app/views/admin/service-status/service-status.component.html
+++ b/frontend/src/app/views/admin/service-status/service-status.component.html
@@ -25,7 +25,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Services status</div>
+  <guardian-page-header pageTitle="Services Status" helpKey="service-status"></guardian-page-header>
 </ng-template>
 
 <ng-template #statusContainer>

--- a/frontend/src/app/views/admin/settings-view/settings-view.component.html
+++ b/frontend/src/app/views/admin/settings-view/settings-view.component.html
@@ -12,7 +12,7 @@
 <ng-container [ngTemplateOutlet]="actionsContainer"></ng-container>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Settings</div>
+  <guardian-page-header pageTitle="Settings" helpKey="settings"></guardian-page-header>
 </ng-template>
 
 <ng-template #container>

--- a/frontend/src/app/views/branding/branding.component.html
+++ b/frontend/src/app/views/branding/branding.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #header>
   <div class="branding-page-header">
-    <div class="guardian-user-page-header">Application Branding</div>
+    <guardian-page-header pageTitle="Application Branding" helpKey="branding"></guardian-page-header>
   </div>
 </ng-template>
 

--- a/frontend/src/app/views/branding/branding.component.scss
+++ b/frontend/src/app/views/branding/branding.component.scss
@@ -101,12 +101,13 @@
 
 .branding-page-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 24px;
-    margin-bottom: var(--guardian-page-header-gap);
+    margin-bottom: var(--guardian-page-header-block-gap);
 
-    .guardian-user-page-header {
+    .guardian-user-page-header,
+    guardian-page-header {
         margin-bottom: 0;
     }
 }

--- a/frontend/src/app/views/new-header/menu.model.ts
+++ b/frontend/src/app/views/new-header/menu.model.ts
@@ -62,11 +62,11 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
         active: false,
         childItems: [
             {
-                title: 'Manage Tokens',
+                title: 'Tokens',
                 routerLink: '/tokens'
             },
             {
-                title: 'Retirement Contracts',
+                title: 'Contracts',
                 routerLink: '/contracts'
             },
             {
@@ -83,7 +83,7 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
         section: 'Administration',
         childItems: [
             {
-                title: 'Manage Roles',
+                title: 'Roles',
                 routerLink: '/roles'
             },
             {
@@ -91,12 +91,12 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
                 routerLink: '/user-management'
             },
             {
-                title: 'Application Branding',
-                routerLink: '/branding'
+                title: 'Remote Policy Requests',
+                routerLink: '/external-policies'
             },
             {
-                title: 'Remote Policy Request',
-                routerLink: '/external-policies'
+                title: 'Services Status',
+                routerLink: '/admin/status'
             },
             {
                 title: 'Worker Tasks',
@@ -107,12 +107,12 @@ const NAVBAR_MENU_STANDARD_REGISTRY: NavbarMenuItem[] = [
                 routerLink: '/admin/logs'
             },
             {
-                title: 'Settings',
-                routerLink: '/admin/settings'
+                title: 'Application Branding',
+                routerLink: '/branding'
             },
             {
-                title: 'Status',
-                routerLink: '/admin/status'
+                title: 'Settings',
+                routerLink: '/admin/settings'
             },
         ],
     },
@@ -264,7 +264,7 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
                 user.TOKENS_TOKEN_MANAGE
             ) {
                 childItems.push({
-                    title: 'Manage Tokens',
+                    title: 'Tokens',
                     routerLink: '/tokens'
                 });
             }
@@ -283,7 +283,7 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
                 user.CONTRACTS_CONTRACT_MANAGE
             ) {
                 childItems.push({
-                    title: 'Retirement Contracts',
+                    title: 'Contracts',
                     routerLink: '/contracts'
                 });
             }
@@ -314,7 +314,7 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
             user.PERMISSIONS_ROLE_DELETE
         ) {
             childItems.push({
-                title: 'Manage Roles',
+                title: 'Roles',
                 routerLink: '/roles'
             });
         }
@@ -329,15 +329,9 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
             });
         }
 
-        if (user.BRANDING_CONFIG_UPDATE) {
-            childItems.push({
-                title: 'Application Branding',
-                routerLink: '/branding'
-            });
-        }
         if (user.POLICIES_EXTERNAL_POLICY_READ) {
             childItems.push({
-                title: 'Remote Policy Request',
+                title: 'Remote Policy Requests',
                 routerLink: '/external-policies'
             });
         }
@@ -351,6 +345,12 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
             childItems.push({
                 title: 'Logs',
                 routerLink: '/admin/logs'
+            });
+        }
+        if (user.BRANDING_CONFIG_UPDATE) {
+            childItems.push({
+                title: 'Application Branding',
+                routerLink: '/branding'
             });
         }
         if (user.SETTINGS_SETTINGS_READ) {

--- a/frontend/src/app/views/notifications/notifications.component.html
+++ b/frontend/src/app/views/notifications/notifications.component.html
@@ -11,7 +11,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Notifications</div>
+  <guardian-page-header pageTitle="Notifications" helpKey="notifications"></guardian-page-header>
 </ng-template>
 
 <ng-template #tableContainer>

--- a/frontend/src/app/views/relayer-accounts/relayer-accounts.component.html
+++ b/frontend/src/app/views/relayer-accounts/relayer-accounts.component.html
@@ -12,9 +12,7 @@
     </div>
   }
 
-  <div class="guardian-user-page-header">
-    <span>{{title}}</span>
-  </div>
+  <guardian-page-header [pageTitle]="title" helpKey="relayer-accounts"></guardian-page-header>
 
   <div class="actions-container">
     <div class="search-filter">

--- a/frontend/src/app/views/roles/roles-view.component.html
+++ b/frontend/src/app/views/roles/roles-view.component.html
@@ -6,7 +6,7 @@
 
 @if (!newRole) {
   <div class="guardian-page">
-    <div class="guardian-user-page-header">Roles</div>
+    <guardian-page-header pageTitle="Roles" helpKey="roles"></guardian-page-header>
     <div class="actions-container">
       <span class="p-input-icon-right">
         <i class="pi pi-search"></i>
@@ -118,7 +118,7 @@
         [iconPos]="'left'"
         [icon]="'pi pi-chevron-left'"
         class="button secondary height-40 margin-bottom-16"
-        label="Back to User Management"
+        label="Back to Roles"
         pButton
       type="button"></button>
     </div>

--- a/frontend/src/app/views/root-profile/root-profile.component.html
+++ b/frontend/src/app/views/root-profile/root-profile.component.html
@@ -25,7 +25,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Profile</div>
+  <guardian-page-header pageTitle="Profile" helpKey="profile"></guardian-page-header>
 </ng-template>
 
 <ng-template #userInfo>

--- a/frontend/src/app/views/schema-templates/schema-templates.component.html
+++ b/frontend/src/app/views/schema-templates/schema-templates.component.html
@@ -4,7 +4,7 @@
   </div>
 } @else {
   <div class="guardian-page">
-    <div class="guardian-user-page-header">Schema Templates</div>
+    <guardian-page-header pageTitle="Schema Templates" helpKey="schema-templates"></guardian-page-header>
 
     @if (!isConfirmed) {
       <div class="not-exist">

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -4,7 +4,7 @@
   </div>
 } @else {
 <div class="guardian-page">
-  <div class="guardian-user-page-header">Schemas</div>
+  <guardian-page-header pageTitle="Schemas" helpKey="schemas"></guardian-page-header>
 
   <div class="actions">
     <div class="tabs-nav">

--- a/frontend/src/app/views/token-config/token-config.component.html
+++ b/frontend/src/app/views/token-config/token-config.component.html
@@ -11,9 +11,7 @@
             <a [routerLink]="['/profile']">here</a>
         </div>
 
-        <div class="guardian-user-page-header">
-            <span>List of Tokens</span>
-        </div>
+        <guardian-page-header pageTitle="Tokens" helpKey="tokens"></guardian-page-header>
 
         <div *ngIf="!loading" class="actions-container">
             <div *ngIf="policies" class="dropdown-block">

--- a/frontend/src/app/views/user-management/user-management.component.html
+++ b/frontend/src/app/views/user-management/user-management.component.html
@@ -6,7 +6,7 @@
 
 <div class="guardian-page">
 
-  <div class="guardian-user-page-header">User Management</div>
+  <guardian-page-header pageTitle="User Management" helpKey="users"></guardian-page-header>
 
   <div class="actions-container">
     <span class="p-input-icon-right">

--- a/frontend/src/app/views/user-profile/user-profile.component.html
+++ b/frontend/src/app/views/user-profile/user-profile.component.html
@@ -12,7 +12,7 @@
 
     <ng-container *ngIf="isConfirmed; else elseTemplate">
         <div *ngIf="profile" class="profile">
-            <div class="guardian-user-page-header">Profile</div>
+            <guardian-page-header pageTitle="Profile" helpKey="profile"></guardian-page-header>
 
             <div class="tabs-nav">
                 <p-tabs [(value)]="tabIndex" (valueChange)="onChangeTab($event)" class="guardian-header-tabs">

--- a/frontend/src/app/views/worker-tasks/worker-tasks.component.html
+++ b/frontend/src/app/views/worker-tasks/worker-tasks.component.html
@@ -25,7 +25,7 @@
 </div>
 
 <ng-template #header>
-  <div class="guardian-user-page-header">Worker Tasks</div>
+  <guardian-page-header pageTitle="Worker Tasks" helpKey="worker-tasks"></guardian-page-header>
 </ng-template>
 
 <ng-template #tableContainer>


### PR DESCRIPTION
### Description

Closes #6538. Navigation labels and page titles no longer agree with each other or with the pages they open, and nothing on a page explains what it is for. This renames the inconsistent items, reorders the Administration group, and introduces a shared page header that carries a short description under the title.

- Rename menu items: Manage Tokens to Tokens, Retirement Contracts to Contracts, Manage Roles to Roles, Remote Policy Request to Remote Policy Requests, Status to Services Status
- Reorder the Administration group so Services Status follows Remote Policy Requests and Settings comes last
- Apply the same renames and ordering to the permission-filtered menu built for non Standard Registry users
- Rename page titles: Manage Policies to Policies, List of Tokens to Tokens, Retirement to Contracts, Services status to Services Status, Remote Policy Request to Remote Policy Requests
- Correct the New Role back button, which offered "Back to User Management" while returning to the Roles list
- Add a `guardian-page-header` component that renders the page title with optional help text underneath, and hold the copy for all twenty-two pages in a single `PAGE_HELP_TEXT` map keyed from the template
- Reduce the space around page titles: halve the page top padding and give the header block its own 16px gap token
