### PR TITLE
fix: 6629 save all does nothing after several schema edits

### DIFF
--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -169,6 +169,72 @@ describe('SchemasConfigurationComponent', () => {
         });
     });
 
+    describe('a failed sidebar list load', () => {
+
+        function failingComponent(state: any = {}): any {
+            const component = createComponent(state);
+            component.schemaService.getSchemasByPage = () => throwError(() => new Error('boom'));
+            return component;
+        }
+
+        it('drops the dirty key of a schema that was only in the list', () => {
+            const a = makeSchema({ id: 'a' });
+            const component = failingComponent({ schemas: [a], dirtyIds: ['a'] });
+
+            component.loadSchemas('topic-1');
+
+            expect(component.schemas).toEqual([]);
+            expect(component.dirtySchemaIds.size).toBe(0);
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('keeps the open schema key, and saveAll still sends it', () => {
+            const a = makeSchema({ id: 'a', fields: [makeField()] });
+            const component = failingComponent({ schemas: [a], selectedSchema: a, dirtyIds: ['a'] });
+
+            component.loadSchemas('topic-1');
+
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+            component.saveAll();
+            expect(component.updated.length).toBe(1);
+        });
+
+        it('keeps a new-schema key for the open unsaved schema', () => {
+            const fresh = makeSchema({ uuid: 'u-new', fields: [makeField()] });
+            fresh.id = undefined;
+            fresh._id = undefined;
+            const component = failingComponent({
+                schemas: [fresh], selectedSchema: fresh,
+                dirtyIds: ['new:u-new'], newKeys: ['new:u-new'],
+            });
+
+            component.loadSchemas('topic-1');
+
+            expect(component.dirtySchemaIds.has('new:u-new')).toBeTrue();
+            expect(component.newSchemaKeys.has('new:u-new')).toBeTrue();
+        });
+
+        it('leaves the list and the dirty keys alone when an append fails', () => {
+            const a = makeSchema({ id: 'a' });
+            const b = makeSchema({ id: 'b' });
+            const component = failingComponent({ schemas: [a, b], dirtyIds: ['a', 'b'] });
+
+            component.loadSchemas('topic-1', true);
+
+            expect(component.schemas.length).toBe(2);
+            expect(component.dirtySchemaIds.size).toBe(2);
+            expect(component.schemasLoadingMore).toBeFalse();
+        });
+
+        it('clears the loading flag on a failed full load', () => {
+            const component = failingComponent({ schemas: [], dirtyIds: [] });
+
+            component.loadSchemas('topic-1');
+
+            expect(component.schemasLoading).toBeFalse();
+        });
+    });
+
     describe('save invariant: after any list change, an enabled Save all always sends something', () => {
 
         function saveButtonEnabled(component: any): boolean {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -87,6 +87,52 @@ describe('SchemasConfigurationComponent', () => {
         return component;
     }
 
+    describe('a drill edit followed by a sidebar search', () => {
+
+        it('keeps the sub-schema key when the search returns it, and saveAll sends the drill edits', () => {
+            const root: any = makeSchema({ id: 'root', iri: '#root', fields: [makeField()] });
+            const sub: any = makeSchema({ id: 'sub', iri: '#sub', fields: [makeField({ name: 'f_sub' })] });
+            const component = createComponent({ schemas: [root, sub], selectedSchema: root });
+            component.drillStack = [{ fieldLabel: 'Sub', fields: sub.fields, schemaIri: '#sub' }];
+
+            component.markDirty();
+            expect(Array.from(component.dirtySchemaIds)).toEqual(['sub']);
+
+            const fresh: any = makeSchema({ id: 'sub', iri: '#sub', fields: [makeField({ name: 'f_sub' })] });
+            component.schemaService.getSchemasByPage = () => of({
+                body: [fresh], headers: { get: () => '1' },
+            });
+
+            component.schemas = [];
+            component.loadSchemas('topic-1');
+
+            expect(component.dirtySchemaIds.has('sub')).toBeTrue();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            component.saveAll();
+            expect(component.updated.length).toBe(1);
+            expect(component.updated[0].fields).toBe(component.drillCurrentFields);
+        });
+
+        it('drops the sub-schema key when the search does not return it', () => {
+            const root: any = makeSchema({ id: 'root', iri: '#root', fields: [makeField()] });
+            const sub: any = makeSchema({ id: 'sub', iri: '#sub', fields: [makeField({ name: 'f_sub' })] });
+            const component = createComponent({ schemas: [root, sub], selectedSchema: root });
+            component.drillStack = [{ fieldLabel: 'Sub', fields: sub.fields, schemaIri: '#sub' }];
+
+            component.markDirty();
+            component.schemaService.getSchemasByPage = () => of({
+                body: [], headers: { get: () => '0' },
+            });
+
+            component.schemas = [];
+            component.loadSchemas('topic-1');
+
+            expect(component.dirtySchemaIds.has('sub')).toBeFalse();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+    });
+
     describe('pruneDirtySchemaIds', () => {
 
         it('keeps a dirty key whose schema is still in the reloaded list', () => {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -235,6 +235,80 @@ describe('SchemasConfigurationComponent', () => {
         });
     });
 
+    describe('saveAll resolving a new unsaved schema', () => {
+
+        function newSchemaComponent(state: any): any {
+            const fresh = makeSchema({ uuid: 'u-new', fields: [makeField()] });
+            fresh.id = undefined;
+            fresh._id = undefined;
+            const component = createComponent({
+                schemas: state.inList ? [fresh] : [],
+                selectedSchema: state.open ? fresh : null,
+                dirtyIds: ['new:u-new'],
+                newKeys: ['new:u-new'],
+            });
+            return component;
+        }
+
+        it('creates it from the open schema when the list is empty', () => {
+            const component = newSchemaComponent({ open: true, inList: false });
+
+            component.saveAll();
+
+            expect(component.created.length).toBe(1);
+            expect(component.created[0].uuid).toBe('u-new');
+        });
+
+        it('still creates it from the list when it is not the open schema', () => {
+            const component = newSchemaComponent({ open: false, inList: true });
+
+            component.saveAll();
+
+            expect(component.created.length).toBe(1);
+        });
+
+        it('sends nothing when it is in neither place', () => {
+            const component = newSchemaComponent({ open: false, inList: false });
+
+            component.saveAll();
+
+            expect(component.created.length).toBe(0);
+            expect(component.updated.length).toBe(0);
+        });
+
+        it('creates and updates in the same run when both are dirty', () => {
+            const saved = makeSchema({ id: 'a', fields: [makeField()] });
+            const fresh = makeSchema({ uuid: 'u-new', fields: [makeField()] });
+            fresh.id = undefined;
+            fresh._id = undefined;
+            const component = createComponent({
+                schemas: [saved],
+                selectedSchema: fresh,
+                dirtyIds: ['a', 'new:u-new'],
+                newKeys: ['new:u-new'],
+            });
+
+            component.saveAll();
+
+            expect(component.created.length).toBe(1);
+            expect(component.updated.length).toBe(1);
+        });
+
+        it('does not confuse the open saved schema with a new-schema key', () => {
+            const saved = makeSchema({ id: 'a', uuid: 'u-new', fields: [makeField()] });
+            const component = createComponent({
+                schemas: [saved],
+                selectedSchema: saved,
+                dirtyIds: ['a'],
+            });
+
+            component.saveAll();
+
+            expect(component.created.length).toBe(0);
+            expect(component.updated.length).toBe(1);
+        });
+    });
+
     describe('save invariant: after any list change, an enabled Save all always sends something', () => {
 
         function saveButtonEnabled(component: any): boolean {
@@ -303,7 +377,6 @@ describe('SchemasConfigurationComponent', () => {
             },
             {
                 name: 'new unsaved schema, open, list emptied by a search',
-                pending: 'iteration-03',
                 build: () => {
                     const fresh = makeSchema({ uuid: 'u-new', fields: [validField()] });
                     fresh.id = undefined;

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -1,0 +1,304 @@
+import { of, Subject, throwError } from 'rxjs';
+import { SchemasConfigurationComponent } from './schemas-configuration.component';
+
+describe('SchemasConfigurationComponent', () => {
+
+    function makeSchema(overrides: any = {}): any {
+        const schema: any = {
+            id: overrides.id,
+            _id: overrides.id,
+            uuid: overrides.uuid || `uuid-${overrides.id || 'x'}`,
+            iri: overrides.iri || `#${overrides.id || 'x'}`,
+            name: overrides.name || 'Schema',
+            status: overrides.status || 'DRAFT',
+            entity: overrides.entity || '',
+            topicId: 'topic-1',
+            conditions: [],
+            fields: overrides.fields || [],
+            document: overrides.document || { $defs: {} },
+            update: () => {},
+        };
+        return schema;
+    }
+
+    function makeField(overrides: any = {}): any {
+        return {
+            name: overrides.name || 'field_1',
+            title: overrides.title || 'Field',
+            description: overrides.description || 'A field',
+            type: 'string',
+            enum: undefined,
+            dependency: undefined,
+            ...overrides,
+        };
+    }
+
+    function createComponent(state: any = {}): any {
+        const component: any = Object.create(SchemasConfigurationComponent.prototype);
+
+        component.created = [];
+        component.updated = [];
+        component.templateSaves = [];
+
+        component.destroy$ = new Subject<void>();
+        component.type = state.type || '';
+        component.topic = 'topic-1';
+        component.templateId = '';
+        component.schemas = state.schemas || [];
+        component.selectedSchema = state.selectedSchema ?? null;
+        component.selectedField = null;
+        component.schemaTemplate = state.schemaTemplate ?? null;
+        component.templateConfigDirty = !!state.templateConfigDirty;
+        component.templateConfigSaving = false;
+        component.isSaving = !!state.isSaving;
+        component.drillStack = [];
+        component.schemaEditVersion = 0;
+        component.schemasLoading = false;
+        component.schemasLoadingMore = false;
+        component.schemasFetched = false;
+        component.schemasTotal = 0;
+        component.schemasPage = 0;
+        component.schemaSearch = '';
+        component.dirtySchemaIds = new Set<string>(state.dirtyIds || []);
+        component.newSchemaKeys = new Set<string>(state.newKeys || []);
+
+        component.router = { url: state.url || '/schema-configuration', navigate: () => Promise.resolve(true) };
+        component.route = {};
+        component.schemaService = {
+            update: (s: any) => { component.updated.push(s); return of([]); },
+            create: (_c: any, s: any) => { component.created.push(s); return of([]); },
+            updateSystemSchema: (s: any) => { component.updated.push(s); return of([]); },
+            getSchemasByPage: () => of({ body: [], headers: { get: () => '0' } }),
+        };
+        component.tagsService = { updateSchema: (s: any) => { component.updated.push(s); return of([]); } };
+        component.schemaTemplatesService = {
+            update: (_id: string, body: any) => { component.templateSaves.push(body); return of({}); },
+        };
+        component.projectComparisonService = { getProperties: () => of([]) };
+        component._cancelLoadSchemas$ = new Subject<void>();
+        component._subSchemasByIri = new Map();
+
+        component._buildRefs = () => ({});
+        component.loadAppliedSchemaTemplate = () => {};
+        component.rebuildPreview = () => {};
+        component.loadParentSchemas = () => {};
+        component.getCategory = () => 'POLICY';
+
+        return component;
+    }
+
+    describe('pruneDirtySchemaIds', () => {
+
+        it('keeps a dirty key whose schema is still in the reloaded list', () => {
+            const a = makeSchema({ id: 'a' });
+            const component = createComponent({ schemas: [a], dirtyIds: ['a'] });
+
+            component.pruneDirtySchemaIds();
+
+            expect(Array.from(component.dirtySchemaIds)).toEqual(['a']);
+            expect(component.hasUnsavedChanges).toBeTrue();
+        });
+
+        it('drops a dirty key whose schema is gone from the reloaded list', () => {
+            const b = makeSchema({ id: 'b' });
+            const component = createComponent({ schemas: [b], dirtyIds: ['a'] });
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.dirtySchemaIds.size).toBe(0);
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('keeps the open schema key even when the reloaded list does not contain it', () => {
+            const a = makeSchema({ id: 'a' });
+            const b = makeSchema({ id: 'b' });
+            const component = createComponent({ schemas: [b], selectedSchema: a, dirtyIds: ['a'] });
+
+            component.pruneDirtySchemaIds();
+
+            expect(Array.from(component.dirtySchemaIds)).toEqual(['a']);
+        });
+
+        it('keeps a new-schema key for the open unsaved schema, with its newSchemaKeys entry', () => {
+            const fresh = makeSchema({ id: undefined, uuid: 'u-new' });
+            fresh.id = undefined;
+            fresh._id = undefined;
+            const component = createComponent({
+                schemas: [],
+                selectedSchema: fresh,
+                dirtyIds: ['new:u-new'],
+                newKeys: ['new:u-new'],
+            });
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.dirtySchemaIds.has('new:u-new')).toBeTrue();
+            expect(component.newSchemaKeys.has('new:u-new')).toBeTrue();
+        });
+
+        it('drops a new-schema key that is in neither the list nor the open slot', () => {
+            const component = createComponent({
+                schemas: [],
+                selectedSchema: null,
+                dirtyIds: ['new:u-gone'],
+                newKeys: ['new:u-gone'],
+            });
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.dirtySchemaIds.size).toBe(0);
+            expect(component.newSchemaKeys.size).toBe(0);
+        });
+
+        it('removes nothing when every dirty key is still reachable', () => {
+            const a = makeSchema({ id: 'a' });
+            const b = makeSchema({ id: 'b' });
+            const component = createComponent({ schemas: [a, b], dirtyIds: ['a', 'b'] });
+
+            component.pruneDirtySchemaIds();
+
+            expect(Array.from(component.dirtySchemaIds).sort()).toEqual(['a', 'b']);
+        });
+
+        it('returns early and touches nothing when there are no dirty keys', () => {
+            const component = createComponent({ schemas: [], dirtyIds: [] });
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.dirtySchemaIds.size).toBe(0);
+        });
+    });
+
+    describe('save invariant: after any list change, an enabled Save all always sends something', () => {
+
+        function saveButtonEnabled(component: any): boolean {
+            return !(component.isTemplateReadonly
+                || !component.hasUnsavedChanges
+                || component.isSaving
+                || (!component.isTemplateConfigMode && component.currentSchemaErrorCount > 0));
+        }
+
+        function sentCount(component: any): number {
+            return component.created.length + component.updated.length + component.templateSaves.length;
+        }
+
+        const validField = () => makeField({ name: 'field_1', title: 'Field', description: 'A field' });
+        const brokenField = () => makeField({ name: '', title: '', description: '' });
+
+        const states: { name: string; build: () => any; pending?: string }[] = [
+            {
+                name: 'nothing dirty',
+                build: () => createComponent({ schemas: [makeSchema({ id: 'a' })] }),
+            },
+            {
+                name: 'dirty schema is the open one',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [validField()] });
+                    return createComponent({ schemas: [a], selectedSchema: a, dirtyIds: ['a'] });
+                },
+            },
+            {
+                name: 'dirty schema is in the list but not open',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [validField()] });
+                    const b = makeSchema({ id: 'b', fields: [validField()] });
+                    return createComponent({ schemas: [a, b], selectedSchema: b, dirtyIds: ['a'] });
+                },
+            },
+            {
+                name: 'dirty schema is neither open nor in the list',
+                build: () => {
+                    const b = makeSchema({ id: 'b', fields: [validField()] });
+                    return createComponent({ schemas: [b], selectedSchema: b, dirtyIds: ['a'] });
+                },
+            },
+            {
+                name: 'one dirty schema resolvable, one not',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [validField()] });
+                    return createComponent({ schemas: [a], selectedSchema: a, dirtyIds: ['a', 'gone'] });
+                },
+            },
+            {
+                name: 'empty list, nothing open',
+                build: () => createComponent({ schemas: [], selectedSchema: null, dirtyIds: ['a'] }),
+            },
+            {
+                name: 'new unsaved schema, open, present in the list',
+                build: () => {
+                    const fresh = makeSchema({ uuid: 'u-new', fields: [validField()] });
+                    fresh.id = undefined;
+                    fresh._id = undefined;
+                    return createComponent({
+                        schemas: [fresh], selectedSchema: fresh,
+                        dirtyIds: ['new:u-new'], newKeys: ['new:u-new'],
+                    });
+                },
+            },
+            {
+                name: 'new unsaved schema, open, list emptied by a search',
+                pending: 'iteration-03',
+                build: () => {
+                    const fresh = makeSchema({ uuid: 'u-new', fields: [validField()] });
+                    fresh.id = undefined;
+                    fresh._id = undefined;
+                    return createComponent({
+                        schemas: [], selectedSchema: fresh,
+                        dirtyIds: ['new:u-new'], newKeys: ['new:u-new'],
+                    });
+                },
+            },
+            {
+                name: 'save already in flight',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [validField()] });
+                    return createComponent({ schemas: [a], selectedSchema: a, dirtyIds: ['a'], isSaving: true });
+                },
+            },
+            {
+                name: 'dirty schema has an invalid field',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [brokenField()] });
+                    return createComponent({ schemas: [a], selectedSchema: a, dirtyIds: ['a'] });
+                },
+            },
+            {
+                name: 'published template, read only',
+                build: () => {
+                    const a = makeSchema({ id: 'a', fields: [validField()] });
+                    return createComponent({
+                        schemas: [a], selectedSchema: a, dirtyIds: ['a'],
+                        type: 'template', schemaTemplate: { id: 't1', status: 'PUBLISHED' },
+                    });
+                },
+            },
+            {
+                name: 'template configuration route, template marked dirty',
+                build: () => createComponent({
+                    url: '/schema-template-configuration',
+                    schemaTemplate: { id: 't1', status: 'DRAFT', config: {} },
+                    templateConfigDirty: true,
+                }),
+            },
+        ];
+
+        states.forEach((state) => {
+            const title = `${state.name}: if the button is enabled, a click sends at least one request`;
+            const runner = state.pending ? xit : it;
+            runner(title, () => {
+                const component = state.build();
+                component.pruneDirtySchemaIds();
+
+                if (!saveButtonEnabled(component)) {
+                    component.saveAll();
+                    expect(sentCount(component)).toBe(0);
+                    return;
+                }
+
+                component.saveAll();
+                expect(sentCount(component))
+                    .toBeGreaterThan(0, `enabled button sent nothing for state: ${state.name}`);
+            });
+        });
+    });
+});

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -3333,6 +3333,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                         this.schemas = [];
                         this.schemasLoading = false;
                     }
+                    this.pruneDirtySchemaIds();
                 }
             });
     }

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -670,6 +670,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             this.schemaSearch = search;
             this.schemasPage = 0;
             this.schemas = [];
+            this.pruneDirtySchemaIds();
             this.loadSchemas(this.topic);
         });
     }
@@ -3237,6 +3238,27 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         }
     }
 
+    private pruneDirtySchemaIds(): void {
+        if (!this.dirtySchemaIds.size) { return; }
+        const liveKeys = new Set<string>();
+        for (const schema of this.schemas) {
+            const id = schema.id || (schema as any)._id;
+            if (id) { liveKeys.add(id); }
+            const uuid = (schema as any).uuid;
+            if (uuid) { liveKeys.add(`new:${uuid}`); }
+        }
+        const selectedId = this.selectedSchema?.id || (this.selectedSchema as any)?._id;
+        if (selectedId) { liveKeys.add(selectedId); }
+        const selectedUuid = (this.selectedSchema as any)?.uuid;
+        if (selectedUuid) { liveKeys.add(`new:${selectedUuid}`); }
+        for (const dirtyId of Array.from(this.dirtySchemaIds)) {
+            if (!liveKeys.has(dirtyId)) {
+                this.dirtySchemaIds.delete(dirtyId);
+                this.newSchemaKeys.delete(dirtyId);
+            }
+        }
+    }
+
     private loadSchemas(topicId: string, append: boolean = false): void {
         if (append) {
             this.schemasLoadingMore = true;
@@ -3302,6 +3324,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                     this.schemasFetched = true;
                     this.loadAppliedSchemaTemplate();
                     if (this.selectedSchema) { this.upsertInSidebar(this.selectedSchema); }
+                    this.pruneDirtySchemaIds();
                 },
                 error: () => {
                     if (append) {

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -1144,7 +1144,9 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         for (const dirtyId of this.dirtySchemaIds) {
             if (this.newSchemaKeys.has(dirtyId)) {
                 const uuid = dirtyId.slice(4);
-                const s = this.schemas.find(s => s.uuid === uuid);
+                const s = this.selectedSchema && (this.selectedSchema as any).uuid === uuid
+                    ? this.selectedSchema
+                    : this.schemas.find(s => s.uuid === uuid);
                 if (s) { toCreate.push(s); }
             } else if (selId && dirtyId === selId && this.selectedSchema) {
                 toSave.push(this.selectedSchema);

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -670,7 +670,6 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             this.schemaSearch = search;
             this.schemasPage = 0;
             this.schemas = [];
-            this.pruneDirtySchemaIds();
             this.loadSchemas(this.topic);
         });
     }


### PR DESCRIPTION
**Description**:

In the schema editor, `Save all` could look usable and do nothing when clicked:no save, no error, and no request leaving the browser. The reporter could not reproduce it on demand, so her exact run was never established; what is fixed here is a defect producing that same symptom, reproduced and then confirmed gone by hand.

Unsaved changes are tracked as a set of schema ids, while the schemas themselves live in the sidebar list that `loadSchemas` rebuilds from the server. The ids outlived the objects they pointed at, so the button stayed enabled while
`saveAll` had nothing left to resolve and returned without sending anything. Add `pruneDirtySchemaIds`, called wherever that list changes — after a successful load, after a failed one, and when a search empties it — keeping only ids still
in the list plus the schema open on screen. `saveAll` also resolves a never-saved schema from the open editor, not only from the list it can never return from.

No message was added and no validation rule changed.

Fixes #6629

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
