### PR TITLE
fix(frontend): sort related policies by version when seeding previousVersion

### DIFF
--- a/frontend/src/app/modules/policy-engine/policies/policies.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.spec.ts
@@ -1,0 +1,59 @@
+import { PoliciesComponent } from './policies.component';
+
+describe('PoliciesComponent', () => {
+    let component: PoliciesComponent;
+    let dialogService: any;
+
+    beforeEach(() => {
+        dialogService = {
+            open: jasmine.createSpy('open').and.returnValue({
+                onClose: { pipe: () => ({ subscribe: jasmine.createSpy('subscribe') }) },
+            }),
+        };
+        const indexedDb = { registerStore: jasmine.createSpy('registerStore') };
+
+        component = new PoliciesComponent(
+            {} as any, {} as any, {} as any, {} as any, {} as any,
+            { queryParams: { subscribe: jasmine.createSpy('subscribe') } } as any,
+            dialogService as any,
+            {} as any, {} as any, {} as any, {} as any, {} as any, {} as any, {} as any,
+            new Map<string, any>(),
+            {} as any,
+            indexedDb as any
+        );
+    });
+
+    describe('setVersion previousVersion seeding', () => {
+        it('seeds previousVersion from the highest related version', () => {
+            component.policies = [
+                { id: 'p1', uuid: 'u1', version: '1.0.0' },
+                { id: 'p2', uuid: 'u1', version: '2.0.0' },
+                { id: 'p3', uuid: 'u1', version: '1.5.0' },
+                { id: 'p4', uuid: 'other', version: '9.0.0' },
+            ] as any;
+
+            (component as any).setVersion({ id: 'p1', uuid: 'u1' });
+
+            expect(component.policies![0].previousVersion).toBe('2.0.0');
+        });
+
+        it('orders by version rather than by list position', () => {
+            component.policies = [
+                { id: 'p1', uuid: 'u1', version: '10.0.0' },
+                { id: 'p2', uuid: 'u1', version: '9.0.0' },
+            ] as any;
+
+            (component as any).setVersion({ id: 'p1', uuid: 'u1' });
+
+            expect(component.policies![0].previousVersion).toBe('10.0.0');
+        });
+
+        it('leaves previousVersion empty when nothing shares the uuid', () => {
+            component.policies = [{ id: 'p1', uuid: 'u1', version: '' }] as any;
+
+            (component as any).setVersion({ id: 'p1', uuid: 'u1' });
+
+            expect(component.policies![0].previousVersion).toBe('');
+        });
+    });
+});

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.ts
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.ts
@@ -1049,7 +1049,7 @@ export class PoliciesComponent implements OnInit {
             policy.uuid === element.uuid && policy.version !== ''
         ) || [];
         const lastVersion = relatedPolicies
-            .sort((a, b) => ModelHelper.versionCompare(a.toString(), b.toString()))
+            .sort((a, b) => ModelHelper.versionCompare(a.version, b.version))
             .pop();
         selectedPolicy.previousVersion = lastVersion?.version || '';
         const dialogRef = this.dialogService.open(PublishPolicyDialog, {

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -4,6 +4,6 @@
     "outDir": "./out-tsc/spec",
     "types": ["jasmine", "node"]
   },
-  "files": ["src/test.ts"],
+  "files": ["src/test.ts", "src/prototypes/date-prototype.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
`PoliciesComponent.setVersion()` picks the previous version with

```ts
const lastVersion = relatedPolicies
    .sort((a, b) => ModelHelper.versionCompare(a.toString(), b.toString()))
    .pop();
selectedPolicy.previousVersion = lastVersion?.version || "";
```

Both operands are **policy objects**, so each stringifies to `"[object Object]"` and the comparison result is identical for every pair. The resulting order has nothing to do with the versions, so `.pop()` can return any of the related policies — and the Publish Policy dialog is seeded with an arbitrary `previousVersion` rather than the latest one.

### Fix

Compare `a.version` / `b.version`, which restores the intended "highest version wins" ordering that `.pop()` assumes.

### Tests

Adds `policies.component.spec.ts` covering `setVersion`. On the current code the "highest related version" case fails — given versions `1.0.0`, `2.0.0`, `1.5.0` it seeds `1.0.0` instead of `2.0.0`. The two-element case happens to pass by accident, which is itself the symptom: the ordering is incidental rather than version-driven.

- before: `1 FAILED, 2 SUCCESS`
- after: `3 SUCCESS`

Full frontend suite on this branch: `239 SUCCESS`, no failures.

### Note on `tsconfig.spec.json`

One extra line is included:

```json
"files": ["src/test.ts", "src/prototypes/date-prototype.ts"],
```

`src/prototypes/date-prototype.ts` declares the global `Date.prototype.addDays` augmentation and is imported only from `app.module.ts`, so it is absent from the spec compilation unit. Without it, any spec that transitively reaches `DiscontinuePolicy` — which includes anything importing `PoliciesComponent` — fails to compile with `TS2339: Property "addDays" does not exist on type "Date"`. This is what currently blocks component-level specs in this area, so the line is needed for the test above to build. Happy to split it into its own PR if you would prefer.

### Checklist

- [x] Includes tests to exercise the new behaviour
- [x] Code is documented (rationale in the commit message)
- [x] Local run of tests succeeds
- [x] Commit message includes context
- [ ] Related issue — none found; a search of open issues turned up no existing report