### PR TITLE
chore: skip CI for docs-only changes

### DIFF
--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   buildAndTest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Guardian CI
 on:
   workflow_dispatch:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    paths-ignore:
+      - 'docs/**'
 jobs:
   buildAndTest:
     name: Build and Test (Manual - Main)


### PR DESCRIPTION
### Description
- Prevents the `main` CI and `api-after-commit` workflows from running on documentation-only updates under `docs/`.
- The `main` workflow now executes for `dependabot/**` branches as well, ensuring these updates don't break anything.