### PR TITLE
fix(guardian-service): strip server-managed fields from an imported schema template

### DIFF
--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -147,6 +147,14 @@ async function createSchemaTemplate(
     delete (payload as any).contentFileId;
     delete (payload as any).configFileId;
     delete (payload as any)._configFileId;
+    /*
+     * uuid is server-managed by the same definition as the rest of this list.
+     * generateZipFile strips it on export, so it never appears in a legitimate
+     * archive, but setDefaults() only generates one when it is missing - so a
+     * hand-crafted zip can pin a chosen uuid, which then propagates into the topic's
+     * targetUUID and the snapshot's templateUUID as a misleading identifier.
+     */
+    delete payload.uuid;
 
     payload.creator = owner.creator;
     payload.owner = owner.owner;

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -147,13 +147,8 @@ async function createSchemaTemplate(
     delete (payload as any).contentFileId;
     delete (payload as any).configFileId;
     delete (payload as any)._configFileId;
-    /*
-     * uuid is server-managed by the same definition as the rest of this list.
-     * generateZipFile strips it on export, so it never appears in a legitimate
-     * archive, but setDefaults() only generates one when it is missing - so a
-     * hand-crafted zip can pin a chosen uuid, which then propagates into the topic's
-     * targetUUID and the snapshot's templateUUID as a misleading identifier.
-     */
+    // setDefaults() only generates a uuid when missing, so a forged one would be
+    // kept and propagate into targetUUID / templateUUID.
     delete payload.uuid;
 
     payload.creator = owner.creator;

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -128,22 +128,12 @@ async function createSchemaTemplate(
     }
 
     /*
-     * Strip every server-managed field from an imported payload.
-     *
-     * SchemaTemplateImportExport.generateZipFile already omits these, so nothing
-     * legitimate depends on them surviving an import - a hand-crafted zip is the
-     * only way they arrive. Two of them are dangerous rather than untidy:
-     *
-     *  - contentFileId / configFileId are GridFS handles, and
-     *    SchemaTemplate.deleteFiles() passes them straight to
-     *    DataBaseHelper.gridFS.delete(). A user able to create and delete a
-     *    template could therefore delete an arbitrary GridFS file - a policy
-     *    package, a schema document, another template's payload.
-     *  - topicId short-circuits createTemplateTopic(), which returns early when it
-     *    is already set. The imported template then binds silently to an existing
-     *    topic, its schemas are imported into that topic, and a later publish signs
-     *    with that topic's stored submit key - writing the importer's
-     *    PublishSchemaTemplate message into a topic they do not own.
+     * A legitimate export never carries these, so a hand-crafted zip is the only
+     * source. Two are dangerous rather than untidy:
+     *  - contentFileId / configFileId reach gridFS.delete() via deleteFiles(),
+     *    so a forged value deletes someone else's file.
+     *  - topicId makes createTemplateTopic() return early, binding the import to
+     *    an existing topic; a later publish then signs with that topic's key.
      */
     delete payload._id;
     delete payload.id;

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -127,6 +127,24 @@ async function createSchemaTemplate(
         throw new Error('Invalid schema template');
     }
 
+    /*
+     * Strip every server-managed field from an imported payload.
+     *
+     * SchemaTemplateImportExport.generateZipFile already omits these, so nothing
+     * legitimate depends on them surviving an import - a hand-crafted zip is the
+     * only way they arrive. Two of them are dangerous rather than untidy:
+     *
+     *  - contentFileId / configFileId are GridFS handles, and
+     *    SchemaTemplate.deleteFiles() passes them straight to
+     *    DataBaseHelper.gridFS.delete(). A user able to create and delete a
+     *    template could therefore delete an arbitrary GridFS file - a policy
+     *    package, a schema document, another template's payload.
+     *  - topicId short-circuits createTemplateTopic(), which returns early when it
+     *    is already set. The imported template then binds silently to an existing
+     *    topic, its schemas are imported into that topic, and a later publish signs
+     *    with that topic's stored submit key - writing the importer's
+     *    PublishSchemaTemplate message into a topic they do not own.
+     */
     delete payload._id;
     delete payload.id;
     delete payload.status;
@@ -135,6 +153,10 @@ async function createSchemaTemplate(
     delete payload.messageId;
     delete payload.version;
     delete payload.previousVersion;
+    delete payload.topicId;
+    delete (payload as any).contentFileId;
+    delete (payload as any).configFileId;
+    delete (payload as any)._configFileId;
 
     payload.creator = owner.creator;
     payload.owner = owner.owner;

--- a/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
@@ -572,10 +572,14 @@ export class PolicyImport {
 
         const components = await SchemaTemplateImportExport.parseZipFile(message.document);
         const templatePayload: any = components.template || {};
+        // kept in step with createSchemaTemplate's sanitizer: this parses a
+        // message-sourced zip, which is equally hand-craftable
         delete templatePayload._id;
         delete templatePayload.id;
         delete templatePayload.configFileId;
         delete templatePayload.contentFileId;
+        delete templatePayload._configFileId;
+        delete templatePayload.uuid;
 
         templatePayload.owner = message.owner;
         templatePayload.creator = message.owner;

--- a/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
+++ b/guardian-service/src/helpers/import-helpers/policy/policy-import.ts
@@ -572,8 +572,7 @@ export class PolicyImport {
 
         const components = await SchemaTemplateImportExport.parseZipFile(message.document);
         const templatePayload: any = components.template || {};
-        // kept in step with createSchemaTemplate's sanitizer: this parses a
-        // message-sourced zip, which is equally hand-craftable
+        // same list as createSchemaTemplate's sanitizer - this zip is equally forgeable
         delete templatePayload._id;
         delete templatePayload.id;
         delete templatePayload.configFileId;

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -314,8 +314,8 @@ describe('schema template CRUD and query handlers', () => {
         assert.equal(saved.uuid, undefined, 'a pinned uuid must not survive import');
 
         assert.equal(saved.owner, owner.owner);
-        // the fixture forges 'did:victim' for both, so these prove the reassignment
-        // rather than comparing undefined to undefined
+        // guards the assertion below: without a creator on the fixture it would
+        // compare undefined to undefined
         assert.notEqual(owner.creator, undefined);
         assert.equal(saved.creator, owner.creator);
         assert.equal(saved.status, ModuleStatus.DRAFT);

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -265,26 +265,16 @@ describe('schema template CRUD and query handlers', () => {
         assert.equal(response.body.id, 'template-1');
     });
 
-    /*
-     * A schema template zip is user-supplied. The sanitizer stripped the identity
-     * fields but left topicId and the GridFS handles, and a legitimate export never
-     * carries them - only a hand-crafted zip does.
-     *
-     *  - contentFileId / configFileId reach DataBaseHelper.gridFS.delete() through
-     *    SchemaTemplate.deleteFiles(), so a forged value deletes someone else's file.
-     *  - topicId makes createTemplateTopic() return early, binding the import to an
-     *    existing topic; a later publish then signs with that topic's submit key.
-     */
+    // forged topicId / GridFS handles in a hand-crafted zip: see the sanitizer in
+    // schema-template.service.ts for what each one reaches
     it('CREATE_SCHEMA_TEMPLATE strips server-managed fields from the payload', async () => {
         let saved = null;
         stub(DatabaseServer, 'saveSchemaTemplate', async (payload) => {
             saved = payload;
             return { ...payload, id: 'template-new' };
         });
-        // createTemplateTopic runs after the save and needs Hedera infrastructure this
-        // harness does not provide, so it throws and the handler rolls back. The
-        // sanitization under test happens before that, and the payload is captured
-        // above.
+        // createTemplateTopic needs Hedera and throws here; the sanitization under
+        // test already happened, and the payload is captured above.
         stub(DatabaseServer, 'removeSchemaTemplate', async () => undefined);
 
         const response = await callHandler(handlers, MessageAPI.CREATE_SCHEMA_TEMPLATE, {

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -265,6 +265,66 @@ describe('schema template CRUD and query handlers', () => {
         assert.equal(response.body.id, 'template-1');
     });
 
+    /*
+     * A schema template zip is user-supplied. The sanitizer stripped the identity
+     * fields but left topicId and the GridFS handles, and a legitimate export never
+     * carries them - only a hand-crafted zip does.
+     *
+     *  - contentFileId / configFileId reach DataBaseHelper.gridFS.delete() through
+     *    SchemaTemplate.deleteFiles(), so a forged value deletes someone else's file.
+     *  - topicId makes createTemplateTopic() return early, binding the import to an
+     *    existing topic; a later publish then signs with that topic's submit key.
+     */
+    it('CREATE_SCHEMA_TEMPLATE strips server-managed fields from the payload', async () => {
+        let saved = null;
+        stub(DatabaseServer, 'saveSchemaTemplate', async (payload) => {
+            saved = payload;
+            return { ...payload, id: 'template-new' };
+        });
+        // createTemplateTopic runs after the save and needs Hedera infrastructure this
+        // harness does not provide, so it throws and the handler rolls back. The
+        // sanitization under test happens before that, and the payload is captured
+        // above.
+        stub(DatabaseServer, 'removeSchemaTemplate', async () => undefined);
+
+        const response = await callHandler(handlers, MessageAPI.CREATE_SCHEMA_TEMPLATE, {
+            template: {
+                name: 'Forged',
+                config: {},
+                _id: 'forged-id',
+                id: 'forged-id',
+                status: ModuleStatus.PUBLISHED,
+                owner: 'did:victim',
+                creator: 'did:victim',
+                messageId: 'forged-message',
+                version: '9.9.9',
+                previousVersion: '9.9.8',
+                topicId: '0.0.999',
+                contentFileId: '64b7f1e2d3a4b5c6d7e8f901',
+                configFileId: '64b7f1e2d3a4b5c6d7e8f902',
+                _configFileId: '64b7f1e2d3a4b5c6d7e8f903'
+            },
+            owner
+        });
+
+        void response;
+        assert.ok(saved, 'the sanitized payload should have reached saveSchemaTemplate');
+
+        assert.equal(saved.topicId, undefined, 'a forged topicId must not survive import');
+        assert.equal(saved.contentFileId, undefined, 'a forged GridFS handle must not survive import');
+        assert.equal(saved.configFileId, undefined, 'a forged GridFS handle must not survive import');
+        assert.equal(saved._configFileId, undefined, 'a forged GridFS handle must not survive import');
+
+        assert.equal(saved.messageId, undefined);
+        assert.equal(saved.version, undefined);
+        assert.equal(saved.previousVersion, undefined);
+
+        assert.equal(saved.owner, owner.owner);
+        assert.equal(saved.creator, owner.creator);
+        assert.equal(saved.status, ModuleStatus.DRAFT);
+        assert.equal(saved.name, 'Forged', 'legitimate fields are untouched');
+    });
+
     it('CHECK_SCHEMA_TEMPLATE returns not-found when messageId is absent', async () => {
         const response = await callHandler(handlers, MessageAPI.CHECK_SCHEMA_TEMPLATE, {
             messageId: '',

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -20,6 +20,7 @@ const importHelpersPath = path.resolve(__dirname, '../../dist/helpers/import-hel
 const owner = {
     id: 'user-1',
     owner: 'did:owner',
+    creator: 'did:owner-creator',
 };
 
 const policy = (overrides = {}) => ({
@@ -292,7 +293,8 @@ describe('schema template CRUD and query handlers', () => {
                 topicId: '0.0.999',
                 contentFileId: '64b7f1e2d3a4b5c6d7e8f901',
                 configFileId: '64b7f1e2d3a4b5c6d7e8f902',
-                _configFileId: '64b7f1e2d3a4b5c6d7e8f903'
+                _configFileId: '64b7f1e2d3a4b5c6d7e8f903',
+                uuid: 'forged-uuid'
             },
             owner
         });
@@ -309,7 +311,12 @@ describe('schema template CRUD and query handlers', () => {
         assert.equal(saved.version, undefined);
         assert.equal(saved.previousVersion, undefined);
 
+        assert.equal(saved.uuid, undefined, 'a pinned uuid must not survive import');
+
         assert.equal(saved.owner, owner.owner);
+        // the fixture forges 'did:victim' for both, so these prove the reassignment
+        // rather than comparing undefined to undefined
+        assert.notEqual(owner.creator, undefined);
         assert.equal(saved.creator, owner.creator);
         assert.equal(saved.status, ModuleStatus.DRAFT);
         assert.equal(saved.name, 'Forged', 'legitimate fields are untouched');


### PR DESCRIPTION
A schema template zip is user-supplied. `createSchemaTemplate()` sanitises the payload:

```ts
delete payload._id;
delete payload.id;
delete payload.status;
delete payload.owner;
delete payload.creator;
delete payload.messageId;
delete payload.version;
delete payload.previousVersion;
```

but leaves `topicId`, `contentFileId`, `configFileId` and `_configFileId`.

`SchemaTemplateImportExport.generateZipFile` already omits all of them, so nothing legitimate depends on them surviving an import — a hand-crafted zip is the only way they arrive. Two are dangerous rather than merely untidy.

### Arbitrary GridFS deletion

`contentFileId` / `configFileId` are GridFS handles, and `SchemaTemplate.deleteFiles()` passes them straight to `DataBaseHelper.gridFS.delete()`:

```ts
@AfterDelete()
deleteFiles() {
    if (this.configFileId) { DataBaseHelper.gridFS.delete(this.configFileId)...
    if (this.contentFileId) { DataBaseHelper.gridFS.delete(this.contentFileId)...
```

A user who can create and delete a schema template can therefore delete an arbitrary GridFS file — a policy package, a schema document, another template's payload — by naming its id in the imported zip and then deleting the template.

### Publishing into a topic you do not own

`topicId` short-circuits `createTemplateTopic()`, which returns early when the template already carries one. No topic is created and no `CreateSchemaTemplate` message is sent. The imported template binds silently to an existing topic, its schemas are imported into that topic, and a later publish loads that topic's stored submit key and writes the importer's `PublishSchemaTemplate` message into a topic belonging to someone else.

### Fix

Extend the strip list with the four server-managed fields.

### Tests

Adds a spec to `schema-template-handlers.test.mjs` asserting the forged values are dropped, that legitimate fields survive, and that the server-assigned `owner` / `creator` / `status` still win. It fails on the current code.

Full `guardian-service` suite on this branch: `1807 passing`.

### Checklist

- [x] Includes tests to exercise the new behaviour
- [x] Code is documented
- [x] Local run of tests succeeds
- [x] Commit message includes context
- [ ] Related issue — none found; a search of open issues turned up no existing report