### PR TITLE
fix(auth-service): make GET_ORGANIZATIONS pageable and escape the name filter

### DIFF
--- a/auth-service/src/api/organization-service.ts
+++ b/auth-service/src/api/organization-service.ts
@@ -145,6 +145,14 @@ function redactWalletToken(organization: Organization): Organization {
 }
 
 /**
+ * User input reaches a $regex below. Unescaped, `?name=[` is an invalid expression
+ * and Mongo answers with a 500 instead of a result set.
+ */
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Standard pagination shape borrowed from RoleService.GET_ROLES.
  */
 function buildPaging(pageIndex: any, pageSize: any): any {
@@ -233,8 +241,8 @@ export class OrganizationService extends NatsService {
          * List organizations owned by the caller, plus — if the caller is an active member whose
          * role carries MEMBER_MANAGE — the single organization they administer (their discovery
          * path for that organizationId). Deduped and name-filtered like the owned query; the
-         * admin case adds at most one row, so it is only appended on the first page to avoid it
-         * reappearing on every subsequent page.
+         * admin case adds at most one row, and it is folded into the query rather than appended
+         * to a page, so the count and the paging stay exact.
          */
         this.getMessages(AuthEvents.GET_ORGANIZATIONS,
             async (msg: {
@@ -254,36 +262,56 @@ export class OrganizationService extends NatsService {
                     const entityRepository = new DatabaseServer();
 
                     const otherOptions = buildPaging(pageIndex, pageSize);
-                    const options: any = { owner: creator };
+
+                    /*
+                     * The administered organization is part of the query, not an extra
+                     * row appended to the first page.
+                     *
+                     * Appending it only when offset is 0, and incrementing the count
+                     * only there, meant a delegated admin who owns no organizations
+                     * reported count 1 on page 0 and count 0 on page 1 - a total that
+                     * moves between pages breaks any paging client - and page 0 carried
+                     * pageSize + 1 items. The dedup also inspected page-0 items only, so
+                     * an owner who is additionally enrolled with MEMBER_MANAGE and owns
+                     * more than pageSize organizations received the same row twice, with
+                     * the count double-counting it.
+                     *
+                     * Folding it into the filter makes the count and the paging exact,
+                     * and a document cannot match a query twice, so the dedup is
+                     * inherent.
+                     */
+                    const adminMember = await entityRepository.findOne(OrganizationMember, {
+                        did: creator,
+                        active: true
+                    });
+                    const adminRole = adminMember?.orgRoleId
+                        ? await entityRepository.findOne(OrgRole, { id: adminMember.orgRoleId })
+                        : null;
+                    const administeredOrgId = roleCarriesMemberManage(adminRole)
+                        ? adminMember?.organizationId
+                        : null;
+
+                    const scope: any[] = [{ owner: creator }];
+                    if (administeredOrgId) {
+                        scope.push({ id: administeredOrgId });
+                    }
+                    const options: any = scope.length > 1 ? { $or: scope } : scope[0];
                     if (filters?.name) {
-                        options.name = { $regex: '.*' + filters.name + '.*' };
+                        // Escaped, and case-insensitive as the API documents. Applied to
+                        // one query now, so the owned and administered rows can no longer
+                        // filter by different rules - the admin branch used String.includes
+                        // while the owned query used a regex.
+                        options.name = { $regex: '.*' + escapeRegex(filters.name) + '.*', $options: 'i' };
                     }
 
                     const [items, count] = await entityRepository.findAndCount(Organization, options, otherOptions);
-                    let resultItems = items;
-                    let resultCount = count;
 
-                    if (!otherOptions.offset) {
-                        const adminMember = await entityRepository.findOne(OrganizationMember, {
-                            did: creator,
-                            active: true
-                        });
-                        const adminRole = adminMember?.orgRoleId
-                            ? await entityRepository.findOne(OrgRole, { id: adminMember.orgRoleId })
-                            : null;
-                        if (roleCarriesMemberManage(adminRole)) {
-                            const adminOrg = await entityRepository.findOne(Organization, {
-                                id: adminMember.organizationId
-                            });
-                            const matchesName = !filters?.name || (adminOrg?.name ?? '').includes(filters.name);
-                            if (adminOrg && matchesName && !resultItems.some((item) => item.id === adminOrg.id)) {
-                                resultItems = [...resultItems, redactWalletToken(adminOrg)];
-                                resultCount += 1;
-                            }
-                        }
-                    }
+                    // The wallet token belongs to the owner: a row reachable only through
+                    // the administered-organization branch is still redacted.
+                    const resultItems = items.map((item) =>
+                        item.owner === creator ? item : redactWalletToken(item));
 
-                    return new MessageResponse({ items: resultItems, count: resultCount });
+                    return new MessageResponse({ items: resultItems, count });
                 } catch (error) {
                     await logger.error(error, ['AUTH_SERVICE'], userId);
                     return new MessageError(error);

--- a/auth-service/src/api/organization-service.ts
+++ b/auth-service/src/api/organization-service.ts
@@ -264,21 +264,10 @@ export class OrganizationService extends NatsService {
                     const otherOptions = buildPaging(pageIndex, pageSize);
 
                     /*
-                     * The administered organization is part of the query, not an extra
-                     * row appended to the first page.
-                     *
-                     * Appending it only when offset is 0, and incrementing the count
-                     * only there, meant a delegated admin who owns no organizations
-                     * reported count 1 on page 0 and count 0 on page 1 - a total that
-                     * moves between pages breaks any paging client - and page 0 carried
-                     * pageSize + 1 items. The dedup also inspected page-0 items only, so
-                     * an owner who is additionally enrolled with MEMBER_MANAGE and owns
-                     * more than pageSize organizations received the same row twice, with
-                     * the count double-counting it.
-                     *
-                     * Folding it into the filter makes the count and the paging exact,
-                     * and a document cannot match a query twice, so the dedup is
-                     * inherent.
+                     * Fold the administered organization into the query instead of appending it to
+                     * page 0: appending there moved the total between pages, overfilled page 0, and
+                     * deduped against page-0 items only. A document cannot match twice, so folding
+                     * it in makes the count exact and the dedup inherent.
                      */
                     const adminMember = await entityRepository.findOne(OrganizationMember, {
                         did: creator,

--- a/auth-service/tests/organization-service-list.test.mjs
+++ b/auth-service/tests/organization-service-list.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { loadService, capturedHandlers } from './_handler-harness.mjs';
+
+/*
+ * GET_ORGANIZATIONS used to run the owned-organizations query and then append the
+ * caller's administered organization to the result, but only when offset was 0.
+ * That made three things wrong:
+ *
+ *  - the total count changed between pages (1 on page 0, 0 on page 1) and page 0
+ *    carried pageSize + 1 items, so no paging client could add up;
+ *  - the dedup compared against page-0 items only, so an owner additionally
+ *    enrolled with MEMBER_MANAGE saw the same organization twice once they owned
+ *    more than pageSize of them;
+ *  - the name filter was applied as a regex to the owned query and as
+ *    String.includes to the appended row - different case sensitivity, and an
+ *    unescaped regex, so `?name=[` reached Mongo as an invalid expression.
+ *
+ * Folding the administered organization into the query fixes all three.
+ */
+
+const MEMBER_MANAGE = 'MEMBER_MANAGE';
+
+/**
+ * Records the filter/options GET_ORGANIZATIONS builds, and answers the incidental
+ * lookups (member row, role row) from the fixture.
+ */
+function makeRepository({ organizations = [], member = null, role = null }) {
+    const calls = { findAndCount: [] };
+    class Repository {
+        async findAndCount(_entity, filter, options) {
+            calls.findAndCount.push({ filter, options });
+            const offset = options?.offset || 0;
+            const limit = options?.limit ?? organizations.length;
+            return [organizations.slice(offset, offset + limit), organizations.length];
+        }
+        async findOne(entity, filter) {
+            const name = entity?.name || String(entity);
+            if (name.includes('OrganizationMember')) {
+                return member;
+            }
+            if (name.includes('OrgRole')) {
+                return role;
+            }
+            if (name.includes('Organization')) {
+                return organizations.find((organization) => organization.id === filter?.id) || null;
+            }
+            return null;
+        }
+        async find() { return []; }
+        async count() { return 0; }
+        create(_entity, data) { return data; }
+        async save(_entity, data) { return data; }
+        async update() { return null; }
+        async remove() { }
+        async aggregate() { return []; }
+    }
+    return { Repository, calls };
+}
+
+async function listOrganizations(fixture, msg) {
+    const { Repository, calls } = makeRepository(fixture);
+    const start = capturedHandlers.length;
+    const { OrganizationService } = await loadService(
+        '../dist/api/organization-service.js',
+        {
+            '@guardian/common': { DatabaseServer: Repository },
+            '@guardian/interfaces': { OrgRolePermission: { MEMBER_MANAGE } },
+        }
+    );
+    const logger = { async error() { }, async info() { }, async warn() { }, async debug() { } };
+    new OrganizationService().registerListeners(logger);
+    const handler = capturedHandlers
+        .slice(start)
+        .find(({ event }) => String(event).endsWith('GET_ORGANIZATIONS'));
+    assert.ok(handler, 'GET_ORGANIZATIONS handler is registered');
+
+    const response = await handler.cb({ owner: { creator: 'did:sr' }, userId: 'u-1', ...msg });
+    assert.ok(!response?.error, `handler returned an error: ${response?.error}`);
+    return { body: response.body, calls };
+}
+
+const owned = (id, extra = {}) => ({
+    id, name: `Org ${id}`, owner: 'did:sr', walletToken: `wallet-${id}`, ...extra
+});
+
+describe('@unit organization-service GET_ORGANIZATIONS', function () {
+    // each case loads the dist module under esmock; the first load is well over
+    // mocha's 2s default on a cold cache
+    this.timeout(30000);
+    afterEach(() => { capturedHandlers.length = 0; });
+
+    describe('the administered organization', () => {
+        const administered = {
+            organizations: [owned('own-1'), { ...owned('admin-1'), owner: 'did:other-sr' }],
+            member: { did: 'did:sr', active: true, orgRoleId: 'role-1', organizationId: 'admin-1' },
+            role: { id: 'role-1', permissions: [MEMBER_MANAGE] },
+        };
+
+        it('is part of the query, not appended to the first page', async () => {
+            const { calls } = await listOrganizations(administered, { pageIndex: 0, pageSize: 10 });
+
+            const { filter } = calls.findAndCount[0];
+            assert.ok(Array.isArray(filter.$or), 'the filter should be an $or over owner and administered id');
+            assert.deepEqual(filter.$or, [{ owner: 'did:sr' }, { id: 'admin-1' }]);
+        });
+
+        it('reports the same count on every page', async () => {
+            const first = await listOrganizations(administered, { pageIndex: 0, pageSize: 1 });
+            const second = await listOrganizations(administered, { pageIndex: 1, pageSize: 1 });
+
+            assert.equal(first.body.count, second.body.count,
+                'a total that changes between pages cannot be paged through');
+            assert.equal(first.body.count, 2);
+        });
+
+        it('never returns more items than the requested page size', async () => {
+            const { body } = await listOrganizations(administered, { pageIndex: 0, pageSize: 1 });
+
+            assert.equal(body.items.length, 1);
+        });
+
+        it('appears once when the caller both owns it and administers it', async () => {
+            const both = {
+                organizations: [owned('own-1'), owned('own-2'), owned('own-3')],
+                member: { did: 'did:sr', active: true, orgRoleId: 'role-1', organizationId: 'own-1' },
+                role: { id: 'role-1', permissions: [MEMBER_MANAGE] },
+            };
+
+            const { body } = await listOrganizations(both, { pageIndex: 0, pageSize: 2 });
+            const ids = body.items.map((item) => item.id);
+
+            assert.equal(new Set(ids).size, ids.length, `duplicate row in ${JSON.stringify(ids)}`);
+            assert.equal(body.count, 3, 'the count must not double-count an owned organization');
+        });
+
+        it('is not included when the member role lacks MEMBER_MANAGE', async () => {
+            const { calls } = await listOrganizations({
+                ...administered,
+                role: { id: 'role-1', permissions: ['POLICY_VIEW'] },
+            }, {});
+
+            const { filter } = calls.findAndCount[0];
+            assert.equal(filter.$or, undefined);
+            assert.equal(filter.owner, 'did:sr');
+        });
+
+        it('keeps the wallet token hidden on rows the caller does not own', async () => {
+            const { body } = await listOrganizations(administered, {});
+
+            const administeredRow = body.items.find((item) => item.id === 'admin-1');
+            const ownedRow = body.items.find((item) => item.id === 'own-1');
+            assert.equal(administeredRow.walletToken, undefined,
+                'a delegated admin must not receive the vault credential locator');
+            assert.equal(ownedRow.walletToken, 'wallet-own-1', 'the owner still sees their own');
+        });
+    });
+
+    describe('the name filter', () => {
+        const fixture = { organizations: [owned('own-1')], member: null, role: null };
+
+        it('is applied once, case-insensitively', async () => {
+            const { calls } = await listOrganizations(fixture, { filters: { name: 'acme' } });
+
+            assert.deepEqual(calls.findAndCount[0].filter.name, {
+                $regex: '.*acme.*',
+                $options: 'i',
+            });
+        });
+
+        it('escapes regex metacharacters instead of passing them to Mongo', async () => {
+            const { calls } = await listOrganizations(fixture, { filters: { name: 'a[b(c' } });
+
+            const { $regex } = calls.findAndCount[0].filter.name;
+            assert.equal($regex, '.*a\\[b\\(c.*');
+            assert.doesNotThrow(() => new RegExp($regex),
+                'an unescapable expression reaches Mongo as a 500');
+        });
+
+        it('applies to the administered organization by the same rule', async () => {
+            const { calls } = await listOrganizations({
+                organizations: [owned('own-1')],
+                member: { did: 'did:sr', active: true, orgRoleId: 'role-1', organizationId: 'admin-1' },
+                role: { id: 'role-1', permissions: [MEMBER_MANAGE] },
+            }, { filters: { name: 'acme' } });
+
+            const { filter } = calls.findAndCount[0];
+            assert.ok(filter.$or, 'both branches are in one query');
+            assert.ok(filter.name, 'so one name predicate covers both');
+        });
+    });
+});


### PR DESCRIPTION
## Problem

`AuthEvents.GET_ORGANIZATIONS` runs the owned-organizations query, then **appends** the caller's administered organization (an active member whose role carries `MEMBER_MANAGE`) to the result — but only when `offset` is 0.

That produces three distinct defects:

1. **The total is not stable across pages.** A delegated admin who owns no organizations gets `count: 1` on page 0 and `count: 0` on page 1. Page 0 also carries `pageSize + 1` items. No paging client can reconcile that.
2. **The dedup is page-local.** It checks `resultItems` — the current page only. An owner who is *additionally* enrolled with `MEMBER_MANAGE` and owns more than `pageSize` organizations receives the same row twice, and `count` double-counts it.
3. **The two branches filter by different rules.** The owned query uses `{ $regex: '.*' + name + '.*' }` (case-sensitive); the appended row uses `String.includes`. Same query parameter, two behaviours.

Separately, `filters.name` is user input interpolated straight into a `$regex`. `?name=[` is an invalid expression and Mongo answers with a 500 instead of a result set.

## Fix

Fold the administered organization into the query as an `$or` term rather than appending it afterwards:

```ts
const scope: any[] = [{ owner: creator }];
if (administeredOrgId) {
    scope.push({ id: administeredOrgId });
}
const options: any = scope.length > 1 ? { $or: scope } : scope[0];
```

`count` and the page slice then come from `findAndCount` directly, so both are exact on every page. A document cannot match a single query twice, so the dedup is inherent rather than something the handler has to get right.

The name filter is escaped and applied once, case-insensitively, to the whole query — so both branches now agree by construction.

Redaction is preserved but keyed on ownership rather than on which branch produced the row: any organization the caller does not own comes back without its `walletToken`, whichever `$or` term matched it. That is at least as strict as before.

## Tests

New: `auth-service/tests/organization-service-list.test.mjs` (9 cases, using the existing `_handler-harness.mjs`). **7 of the 9 fail against `develop`**, covering each defect:

- the administered org is in the query, not appended to page 0
- the count is identical on page 0 and page 1
- a page never exceeds `pageSize`
- no duplicate row when the caller owns *and* administers the same organization
- nothing added when the role lacks `MEMBER_MANAGE`
- `walletToken` withheld on non-owned rows, kept on owned rows
- the name regex is escaped and case-insensitive

Full `auth-service` suite: 258 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)