### PR TITLE
fix: keep required custom fields, strip $defs markers, stabilize policy hash

### DIFF
--- a/common/src/import-export/policy.ts
+++ b/common/src/import-export/policy.ts
@@ -635,14 +635,10 @@ export class PolicyImportExport {
         PolicyImportExport.removeField(components, 'systemSchemas');
         delete components.schemaTemplateSnapshot;
         /*
-         * The template binding is environment-specific, so it cannot take part in the
-         * hash. schemaTemplateSnapshot was already dropped, but policy.schemaTemplate
-         * carries a snapshotId, schemaMap ObjectIds and appliedAt/updatedAt timestamps,
-         * all assigned per environment. Exporting and re-importing an identical
-         * template-bound policy therefore produced a different hash every time, so
-         * hash-based same-policy detection reported a difference for every
-         * template-bound policy. The per-schema markers below are environment-specific
-         * for the same reason.
+         * Environment-specific, so it cannot take part in the hash: snapshotId,
+         * schemaMap ObjectIds and the timestamps are assigned per environment, so an
+         * identical policy hashed differently in each one. Same for the per-schema
+         * markers below.
          */
         delete (components.policy as any).schemaTemplate;
 

--- a/common/src/import-export/policy.ts
+++ b/common/src/import-export/policy.ts
@@ -634,6 +634,17 @@ export class PolicyImportExport {
         PolicyImportExport.removeField(components, 'guardianVersion');
         PolicyImportExport.removeField(components, 'systemSchemas');
         delete components.schemaTemplateSnapshot;
+        /*
+         * The template binding is environment-specific, so it cannot take part in the
+         * hash. schemaTemplateSnapshot was already dropped, but policy.schemaTemplate
+         * carries a snapshotId, schemaMap ObjectIds and appliedAt/updatedAt timestamps,
+         * all assigned per environment. Exporting and re-importing an identical
+         * template-bound policy therefore produced a different hash every time, so
+         * hash-based same-policy detection reported a difference for every
+         * template-bound policy. The per-schema markers below are environment-specific
+         * for the same reason.
+         */
+        delete (components.policy as any).schemaTemplate;
 
         components.schemas.sort((schemaA, schemaB) => schemaA.name > schemaB.name ? -1 : 1);
 
@@ -648,6 +659,9 @@ export class PolicyImportExport {
             delete schema.creator;
             delete schema.owner;
             delete schema.codeVersion;
+            // see the note on policy.schemaTemplate above
+            delete (schema as any).templateId;
+            delete (schema as any).templateSchemaId;
         });
 
         components.tokens.forEach(token => {

--- a/common/tests/unit-tests/policy-hash-schema-template.test.mjs
+++ b/common/tests/unit-tests/policy-hash-schema-template.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { PolicyImportExport } from '../../dist/import-export/policy.js';
+
+/*
+ * the schema-template binding is environment-specific and must not reach
+ * the policy hash.
+ *
+ * cleanBeforeHash already dropped components.schemaTemplateSnapshot, but
+ * policy.schemaTemplate carries a snapshotId, schemaMap ObjectIds and
+ * appliedAt/updatedAt, and every schema carries templateId. All of them differ
+ * between environments, so exporting a template-bound policy and re-importing it
+ * produced a different hash every time — hash-based same-policy detection then
+ * reported a difference for every template-bound policy.
+ */
+
+const baseComponents = () => ({
+    policy: {
+        id: 'p-1',
+        name: 'Test Policy',
+        uuid: 'uuid-1',
+        policyTag: 'Tag_1',
+        topicId: '0.0.1',
+        version: '1.0.0',
+        config: { blockType: 'interfaceContainerBlock', children: [] },
+    },
+    schemas: [
+        { name: 'Alpha', uuid: 's-uuid-1', iri: '#Alpha', document: { $id: '#Alpha' } },
+    ],
+    tokens: [],
+    tools: [],
+    artifacts: [],
+    // preparePolicyComponents maps over each of these unconditionally
+    systemSchemas: [],
+    tags: [],
+    tests: [],
+    formulas: [],
+});
+
+const withBinding = (components, overrides = {}) => {
+    const copy = structuredClone(components);
+    copy.policy.schemaTemplate = {
+        templateId: 'tpl-1',
+        snapshotId: 'snap-A',
+        schemaMap: { '#Alpha': '64b7f1e2d3a4b5c6d7e8f901' },
+        appliedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+    };
+    copy.schemas[0].templateId = 'tpl-1';
+    copy.schemas[0].templateSchemaId = 'tsid-1';
+    return copy;
+};
+
+describe('getPolicyHash — schema template binding', () => {
+    it('is unchanged by the presence of a template binding', () => {
+        const unbound = PolicyImportExport.getPolicyHash(baseComponents());
+        const bound = PolicyImportExport.getPolicyHash(withBinding(baseComponents()));
+
+        assert.equal(bound, unbound,
+            'a template-bound policy must hash the same as the identical unbound one');
+    });
+
+    it('is stable across environments that assigned different snapshot ids', () => {
+        // the same policy applied in two environments: different snapshotId, different
+        // schemaMap ObjectIds, different timestamps — same policy.
+        const envA = PolicyImportExport.getPolicyHash(withBinding(baseComponents()));
+        const envB = PolicyImportExport.getPolicyHash(withBinding(baseComponents(), {
+            snapshotId: 'snap-B',
+            schemaMap: { '#Alpha': '75c8f2e3d4b5c6d7e8f90123' },
+            appliedAt: '2026-06-30T12:00:00.000Z',
+            updatedAt: '2026-07-01T09:30:00.000Z',
+        }));
+
+        assert.equal(envA, envB,
+            'export/re-import of the same policy must not change the hash');
+    });
+
+    it('still distinguishes policies that genuinely differ', () => {
+        const one = PolicyImportExport.getPolicyHash(withBinding(baseComponents()));
+
+        const other = baseComponents();
+        other.schemas[0].document = { $id: '#Alpha', properties: { extra: { type: 'string' } } };
+
+        assert.notEqual(PolicyImportExport.getPolicyHash(withBinding(other)), one,
+            'ignoring the binding must not make different policies hash alike');
+    });
+});

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1006,35 +1006,35 @@ function findSchemaProperty(document: any, path: string[]): any {
     return current;
 }
 
-function ensureSchemaPropertyParent(document: any, path: string[]): any {
+/**
+ * Walk to the object that owns `path`'s last segment.
+ *
+ * `create` distinguishes the two callers: the target document is being built, so it
+ * wants the `properties` containers filled in on the way down; the source document is
+ * only being read, and creating nodes there would mutate the very thing being copied
+ * from.
+ */
+function schemaPropertyParent(document: any, path: string[], create: boolean): any {
     let current = document;
     for (const key of path.slice(0, -1)) {
         const parent = current?.type === 'array' ? current.items : current;
-        parent.properties = parent.properties || {};
-        current = parent.properties[key];
+        if (create) {
+            parent.properties = parent.properties || {};
+        }
+        current = parent?.properties?.[key];
         if (!current) {
             return null;
         }
     }
     const target = current?.type === 'array' ? current.items : current;
-    target.properties = target.properties || {};
+    if (create && target) {
+        target.properties = target.properties || {};
+    }
     return target;
 }
 
-/**
- * Locate the object that owns `path`'s last segment, without creating anything.
- * Used to read the source document's `required` list for a preserved field.
- */
-function findSchemaPropertyParent(document: any, path: string[]): any {
-    let current = document;
-    for (const key of path.slice(0, -1)) {
-        const target = current?.type === 'array' ? current.items : current;
-        current = target?.properties?.[key];
-        if (!current) {
-            return null;
-        }
-    }
-    return current?.type === 'array' ? current.items : current;
+function ensureSchemaPropertyParent(document: any, path: string[]): any {
+    return schemaPropertyParent(document, path, true);
 }
 
 export function mergeCustomFieldsIntoDocument(
@@ -1064,7 +1064,15 @@ export function mergeCustomFieldsIntoDocument(
          * as optional, and VCs missing it started validating. `required` lives on the
          * parent, not on the property, so it has to be copied separately.
          */
-        const sourceParent = findSchemaPropertyParent(sourceDocument, path);
+        /*
+         * Read the source document's own `required` list rather than the parsed
+         * field.required flag: parseField sets `required || !!conditionRequired`, so a
+         * field required only by a condition branch reports true there while the
+         * document's required array correctly omits it. Copying that flag across would
+         * promote a branch-scoped requirement into an unconditional one - the thing the
+         * $comment marking in this same change exists to avoid.
+         */
+        const sourceParent = schemaPropertyParent(sourceDocument, path, false);
         if (Array.isArray(sourceParent?.required) && sourceParent.required.includes(fieldName)) {
             parent.required = Array.isArray(parent.required) ? parent.required : [];
             if (!parent.required.includes(fieldName)) {

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1056,21 +1056,11 @@ export function mergeCustomFieldsIntoDocument(
         parent.properties[fieldName] = cloneJson(property);
 
         /*
-         * Carry the required flag across with the field.
-         *
-         * The target document is a fresh clone of the template, so its `required`
-         * list is the template's. Re-inserting the preserved field into `properties`
-         * alone left it optional: a required custom field survived a template update
-         * as optional, and VCs missing it started validating. `required` lives on the
-         * parent, not on the property, so it has to be copied separately.
-         */
-        /*
-         * Read the source document's own `required` list rather than the parsed
-         * field.required flag: parseField sets `required || !!conditionRequired`, so a
-         * field required only by a condition branch reports true there while the
-         * document's required array correctly omits it. Copying that flag across would
-         * promote a branch-scoped requirement into an unconditional one - the thing the
-         * $comment marking in this same change exists to avoid.
+         * `required` lives on the parent, so it is copied separately or the preserved
+         * field comes back optional. Read it from the source document, not from
+         * field.required: parseField sets `required || !!conditionRequired`
+         * (interfaces schema-helper.ts:321), which would promote a branch-scoped
+         * requirement into an unconditional one.
          */
         const sourceParent = schemaPropertyParent(sourceDocument, path, false);
         if (Array.isArray(sourceParent?.required) && sourceParent.required.includes(fieldName)) {

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1021,7 +1021,23 @@ function ensureSchemaPropertyParent(document: any, path: string[]): any {
     return target;
 }
 
-function mergeCustomFieldsIntoDocument(
+/**
+ * Locate the object that owns `path`'s last segment, without creating anything.
+ * Used to read the source document's `required` list for a preserved field.
+ */
+function findSchemaPropertyParent(document: any, path: string[]): any {
+    let current = document;
+    for (const key of path.slice(0, -1)) {
+        const target = current?.type === 'array' ? current.items : current;
+        current = target?.properties?.[key];
+        if (!current) {
+            return null;
+        }
+    }
+    return current?.type === 'array' ? current.items : current;
+}
+
+export function mergeCustomFieldsIntoDocument(
     targetDocument: any,
     sourceDocument: any,
     fields: any[]
@@ -1038,6 +1054,23 @@ function mergeCustomFieldsIntoDocument(
             continue;
         }
         parent.properties[fieldName] = cloneJson(property);
+
+        /*
+         * Carry the required flag across with the field.
+         *
+         * The target document is a fresh clone of the template, so its `required`
+         * list is the template's. Re-inserting the preserved field into `properties`
+         * alone left it optional: a required custom field survived a template update
+         * as optional, and VCs missing it started validating. `required` lives on the
+         * parent, not on the property, so it has to be copied separately.
+         */
+        const sourceParent = findSchemaPropertyParent(sourceDocument, path);
+        if (Array.isArray(sourceParent?.required) && sourceParent.required.includes(fieldName)) {
+            parent.required = Array.isArray(parent.required) ? parent.required : [];
+            if (!parent.required.includes(fieldName)) {
+                parent.required.push(fieldName);
+            }
+        }
     }
 }
 

--- a/guardian-service/tests/unit/schema-template-update-helpers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-update-helpers.test.mjs
@@ -3,6 +3,7 @@ import {
     buildFieldChangeDetails,
     buildTemplateSchemasSnapshot,
     createTemplateStateHash,
+    mergeCustomFieldsIntoDocument,
     normalizeFieldForDiff,
 } from '../../dist/api/schema-template.service.js';
 import { SchemaHelper } from '../../../interfaces/dist/helpers/schema-helper.js';
@@ -220,5 +221,92 @@ describe('schema template update diff helpers', () => {
             { label: 'Order', before: '0', after: '1' },
             { label: 'Required', before: 'No', after: 'Yes' }
         ]);
+    });
+});
+
+/*
+ * Preserved custom fields silently lost their required flag.
+ *
+ * preparePolicySchemaUpdate replaces target.document with a fresh clone of the
+ * template document, so the `required` list becomes the template's, and then asks
+ * mergeCustomFieldsIntoDocument to put the SR's own fields back. It re-inserted
+ * them into `properties` only - and `required` lives on the parent, not on the
+ * property - so a required custom field survived a template update as optional
+ * and VCs missing it started validating.
+ */
+describe('mergeCustomFieldsIntoDocument — required flag', () => {
+    const sourceDocument = () => ({
+        $id: '#Policy',
+        properties: {
+            keep: { type: 'string', title: 'Keep' },
+            optionalCustom: { type: 'string', title: 'Optional' },
+            nested: {
+                type: 'object',
+                properties: {
+                    innerCustom: { type: 'string', title: 'Inner' },
+                },
+                required: ['innerCustom'],
+            },
+        },
+        required: ['keep'],
+    });
+
+    // the fresh template clone: no trace of the custom fields
+    const templateDocument = () => ({
+        $id: '#Policy',
+        properties: {
+            fromTemplate: { type: 'string' },
+            nested: { type: 'object', properties: {}, required: [] },
+        },
+        required: ['fromTemplate'],
+    });
+
+    it('re-adds a preserved required field to the parent required list', () => {
+        const source = sourceDocument();
+        source.required.push('optionalCustom');
+        const target = templateDocument();
+
+        mergeCustomFieldsIntoDocument(target, source, [{ path: 'optionalCustom' }]);
+
+        assert.ok(target.properties.optionalCustom, 'the field is restored');
+        assert.ok(target.required.includes('optionalCustom'),
+            'a required custom field must stay required across a template update');
+        assert.ok(target.required.includes('fromTemplate'),
+            'the template requirements are untouched');
+    });
+
+    it('leaves an optional preserved field optional', () => {
+        const target = templateDocument();
+
+        mergeCustomFieldsIntoDocument(target, sourceDocument(), [{ path: 'optionalCustom' }]);
+
+        assert.ok(target.properties.optionalCustom);
+        assert.equal(target.required.includes('optionalCustom'), false,
+            'an optional field must not become required');
+    });
+
+    it('carries the required flag for a nested field to its own parent', () => {
+        const target = templateDocument();
+
+        mergeCustomFieldsIntoDocument(target, sourceDocument(), [{ path: 'nested.innerCustom' }]);
+
+        assert.ok(target.properties.nested.properties.innerCustom);
+        assert.ok(target.properties.nested.required.includes('innerCustom'),
+            'required is tracked on the owning object, not the root');
+        assert.equal(target.required.includes('innerCustom'), false,
+            'and must not leak to the root required list');
+    });
+
+    it('does not duplicate an entry that is already required', () => {
+        const source = sourceDocument();
+        source.required.push('optionalCustom');
+        const target = templateDocument();
+        target.required.push('optionalCustom');
+        target.properties.other = { type: 'string' };
+
+        mergeCustomFieldsIntoDocument(target, source, [{ path: 'optionalCustom' }]);
+
+        const occurrences = target.required.filter((name) => name === 'optionalCustom').length;
+        assert.equal(occurrences, 1);
     });
 });

--- a/guardian-service/tests/unit/schema-template-update-helpers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-update-helpers.test.mjs
@@ -310,3 +310,51 @@ describe('mergeCustomFieldsIntoDocument — required flag', () => {
         assert.equal(occurrences, 1);
     });
 });
+
+/*
+ * The required flag is read from the source DOCUMENT, not from the parsed field.
+ *
+ * SchemaHelper.parseField sets `required || !!conditionRequired`, so a field that is
+ * required only by a condition branch reports required === true on the parsed object
+ * while the document's own `required` array correctly omits it. Copying the parsed
+ * flag across would promote a branch-scoped requirement into an unconditional one -
+ * exactly what the $comment marking in this change exists to prevent, since JSON
+ * Schema cannot tell "answered differently" from "never asked".
+ */
+describe('mergeCustomFieldsIntoDocument - condition-required fields', () => {
+    it('does not promote a branch-required field to unconditionally required', () => {
+        const source = {
+            $id: '#Policy',
+            properties: {
+                branchOnly: {
+                    type: 'string',
+                    title: 'Branch only',
+                    // marked required by a condition branch, not by the schema
+                    $comment: JSON.stringify({ term: 'branchOnly', conditionRequired: true }),
+                },
+            },
+            required: [],
+        };
+        const target = { $id: '#Policy', properties: {}, required: [] };
+
+        mergeCustomFieldsIntoDocument(target, source, [{ path: 'branchOnly' }]);
+
+        assert.ok(target.properties.branchOnly, 'the field is still preserved');
+        assert.equal(target.required.includes('branchOnly'), false,
+            'a condition branch requirement must not become an unconditional one');
+    });
+
+    it('still carries a genuinely required field across', () => {
+        const source = {
+            $id: '#Policy',
+            properties: { always: { type: 'string', title: 'Always' } },
+            required: ['always'],
+        };
+        const target = { $id: '#Policy', properties: {}, required: [] };
+
+        mergeCustomFieldsIntoDocument(target, source, [{ path: 'always' }]);
+
+        assert.equal(target.required.includes('always'), true);
+    });
+});
+

--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -145,9 +145,27 @@ export class SchemaHelper {
      * @param document
      */
     public static removeTemplateFieldIds(document: any): void {
-        SchemaHelper.walkDocumentProperties(document, (property) => {
-            delete property.templateFieldId;
-        });
+        const strip = (node: any) => {
+            SchemaHelper.walkDocumentProperties(node, (property) => {
+                delete property.templateFieldId;
+            });
+            /*
+             * walkDocumentProperties only follows `properties`, so embedded sub-schema
+             * definitions under `$defs` kept their markers after a detach. That left the
+             * document inconsistent with the cleaned sub-schema rows, and the markers
+             * leaked into subsequently published documents.
+             *
+             * Only removal walks $defs; ensureTemplateFieldIds is deliberately left
+             * alone, so this cannot start minting ids in places that never had them.
+             */
+            const defs = node?.$defs;
+            if (defs && typeof defs === 'object') {
+                for (const def of Object.values<any>(defs)) {
+                    strip(def);
+                }
+            }
+        };
+        strip(document);
     }
 
     /**

--- a/interfaces/tests/schema-helper-template-field-ids.test.mjs
+++ b/interfaces/tests/schema-helper-template-field-ids.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { SchemaHelper } from '../dist/helpers/schema-helper.js';
+
+/*
+ * removeTemplateFieldIds used walkDocumentProperties, which only follows
+ * `properties`. Embedded sub-schema definitions under `$defs` kept their
+ * templateFieldId markers after a detach — inconsistent with the cleaned
+ * sub-schema rows, and leaking into subsequently published documents.
+ */
+
+const documentWithDefs = () => ({
+    $id: '#Root',
+    properties: {
+        plain: { type: 'string', templateFieldId: 'f-plain' },
+        nested: {
+            type: 'object',
+            templateFieldId: 'f-nested',
+            properties: {
+                inner: { type: 'string', templateFieldId: 'f-inner' },
+            },
+        },
+        list: {
+            type: 'array',
+            templateFieldId: 'f-list',
+            items: {
+                type: 'object',
+                properties: {
+                    item: { type: 'string', templateFieldId: 'f-item' },
+                },
+            },
+        },
+    },
+    $defs: {
+        '#Sub': {
+            $id: '#Sub',
+            properties: {
+                subField: { type: 'string', templateFieldId: 'f-sub' },
+                subNested: {
+                    type: 'object',
+                    properties: {
+                        deep: { type: 'string', templateFieldId: 'f-deep' },
+                    },
+                },
+            },
+        },
+    },
+});
+
+const collectMarkers = (node, found = []) => {
+    if (!node || typeof node !== 'object') {
+        return found;
+    }
+    if (Object.prototype.hasOwnProperty.call(node, 'templateFieldId')) {
+        found.push(node.templateFieldId);
+    }
+    for (const value of Object.values(node)) {
+        collectMarkers(value, found);
+    }
+    return found;
+};
+
+describe('SchemaHelper.removeTemplateFieldIds', () => {
+    it('finds every marker in the fixture before removal', () => {
+        // guards the test itself: if the fixture stops carrying markers the
+        // assertions below would pass vacuously
+        assert.deepEqual(
+            collectMarkers(documentWithDefs()).sort(),
+            ['f-deep', 'f-inner', 'f-item', 'f-list', 'f-nested', 'f-plain', 'f-sub']
+        );
+    });
+
+    it('removes markers from $defs as well as properties', () => {
+        const document = documentWithDefs();
+
+        SchemaHelper.removeTemplateFieldIds(document);
+
+        assert.deepEqual(collectMarkers(document), [],
+            'no templateFieldId may survive anywhere in the document');
+    });
+
+    it('leaves the rest of the document intact', () => {
+        const document = documentWithDefs();
+
+        SchemaHelper.removeTemplateFieldIds(document);
+
+        assert.equal(document.$defs['#Sub'].properties.subField.type, 'string');
+        assert.equal(document.$defs['#Sub'].properties.subNested.properties.deep.type, 'string');
+        assert.equal(document.properties.list.items.properties.item.type, 'string');
+        assert.equal(document.$id, '#Root');
+    });
+
+    it('is safe on a document with no $defs and on empty input', () => {
+        const plain = { properties: { a: { type: 'string', templateFieldId: 'x' } } };
+        SchemaHelper.removeTemplateFieldIds(plain);
+        assert.deepEqual(collectMarkers(plain), []);
+
+        assert.doesNotThrow(() => SchemaHelper.removeTemplateFieldIds(undefined));
+        assert.doesNotThrow(() => SchemaHelper.removeTemplateFieldIds({}));
+    });
+});


### PR DESCRIPTION
Three small, independent schema-template defects. Each has its own test, and reverting each fix individually fails only its own tests.

## 1. A preserved custom field loses its `required` flag

`preparePolicySchemaUpdate` replaces the target document with a fresh clone of the template — so the `required` list becomes *the template's* — and then calls `mergeCustomFieldsIntoDocument` to put the caller's own fields back. That re-inserted them into `properties` only:

```ts
parent.properties[fieldName] = cloneJson(property);
```

`required` lives on the parent, not on the property, so a **required** custom field survived a template update as **optional**, and VCs missing it started validating. The flag is now carried across with the field, onto the field's own parent rather than the root (nested fields land in the right list).

## 2. Detach leaves `templateFieldId` markers inside `$defs`

`SchemaHelper.removeTemplateFieldIds` walks via `walkDocumentProperties`, which only follows `properties`. Embedded sub-schema definitions under `$defs` kept their markers after a detach — inconsistent with the cleaned sub-schema rows, and leaking into subsequently published documents.

Only *removal* walks `$defs`. `ensureTemplateFieldIds` is deliberately left alone, so this cannot start minting ids in places that never had them.

## 3. The template binding destabilizes the policy hash

`cleanBeforeHash` already drops `components.schemaTemplateSnapshot`, but it left:

- `policy.schemaTemplate` — carries `snapshotId`, `schemaMap` ObjectIds, `appliedAt` / `updatedAt`
- each schema's `templateId` and `templateSchemaId` — assigned per environment by `ensureTemplateSchemaReferences`

All of those differ between environments, so exporting and re-importing an *identical* template-bound policy produced a different hash every time — hash-based same-policy detection reported a difference for every template-bound policy.

## Notes

`mergeCustomFieldsIntoDocument` is exported for its test, matching how `normalizeFieldForDiff` and `buildFieldChangeDetails` are already exported from that module.

## Tests

- `interfaces/tests/schema-helper-template-field-ids.test.mjs` (4) — including a case that asserts the fixture actually carries markers, so the others cannot pass vacuously
- `common/tests/unit-tests/policy-hash-schema-template.test.mjs` (3) — hash unchanged by a binding, stable across environments with different snapshot ids, and still distinguishing policies that genuinely differ
- `guardian-service/tests/unit/schema-template-update-helpers.test.mjs` (4) — required restored, optional left optional, nested tracked on its own parent, no duplicate entry

Suites: interfaces 2543 passing, common 3342 passing, guardian-service unit 1793 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)