### PR TITLE
fix(guardian-service): drop the template snapshot when its policy is deleted

### DIFF
--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1629,19 +1629,9 @@ async function applySchemaTemplate(
 }
 
 /**
- * Drop a policy's template snapshot when the policy itself goes away.
- *
- * removeSchemaTemplateSnapshot was only ever called from this module's own
- * detach/update paths; the policy delete flows never called it. Deleting a draft
- * policy with a template applied therefore left the snapshot row behind forever,
- * along with its two GridFS payloads (configFileId / schemasFileId, removed by the
- * entity's @AfterDelete hook). One orphan per apply/delete cycle, accumulating
- * quietly.
- *
- * Best-effort by design: the caller is already deleting the policy, and failing
- * that because a snapshot could not be cleaned would be a worse outcome than the
- * orphan it is trying to avoid. Deliberately does not touch the schemas - they are
- * deleted with the policy.
+ * Drop a policy's template snapshot (and its GridFS payloads, via @AfterDelete)
+ * when the policy goes away. Best-effort: the caller is already deleting the
+ * policy, so a failed cleanup must not fail the delete.
  */
 export async function removePolicySchemaTemplateSnapshot(
     policy: Policy | null | undefined,

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -10,6 +10,7 @@ import {
     MessageType,
     NewNotifier,
     PinoLogger,
+    Policy,
     RunFunctionAsync,
     Schema,
     SchemaTemplateMessage,
@@ -1624,6 +1625,39 @@ async function applySchemaTemplate(
     } catch (error) {
         await DatabaseServer.removeSchemaTemplateSnapshot(snapshot);
         throw error;
+    }
+}
+
+/**
+ * Drop a policy's template snapshot when the policy itself goes away.
+ *
+ * removeSchemaTemplateSnapshot was only ever called from this module's own
+ * detach/update paths; the policy delete flows never called it. Deleting a draft
+ * policy with a template applied therefore left the snapshot row behind forever,
+ * along with its two GridFS payloads (configFileId / schemasFileId, removed by the
+ * entity's @AfterDelete hook). One orphan per apply/delete cycle, accumulating
+ * quietly.
+ *
+ * Best-effort by design: the caller is already deleting the policy, and failing
+ * that because a snapshot could not be cleaned would be a worse outcome than the
+ * orphan it is trying to avoid. Deliberately does not touch the schemas - they are
+ * deleted with the policy.
+ */
+export async function removePolicySchemaTemplateSnapshot(
+    policy: Policy | null | undefined,
+    logger?: PinoLogger
+): Promise<void> {
+    const snapshotId = (policy as any)?.schemaTemplate?.snapshotId;
+    if (!snapshotId) {
+        return;
+    }
+    try {
+        const snapshot = await DatabaseServer.getSchemaTemplateSnapshotById(snapshotId);
+        if (snapshot) {
+            await DatabaseServer.removeSchemaTemplateSnapshot(snapshot);
+        }
+    } catch (error) {
+        await logger?.error(error, ['GUARDIAN_SERVICE']);
     }
 }
 

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -941,8 +941,7 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
-        // the applied template's snapshot dies with the policy; without this the row
-        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        // must run before the policy row goes: snapshotId lives on it
         await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);
@@ -1038,8 +1037,7 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
-        // the applied template's snapshot dies with the policy; without this the row
-        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        // must run before the policy row goes: snapshotId lives on it
         await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);
@@ -1153,8 +1151,7 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
-        // the applied template's snapshot dies with the policy; without this the row
-        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        // must run before the policy row goes: snapshotId lives on it
         await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -79,6 +79,7 @@ import { AISuggestionsService } from '../helpers/ai-suggestions.js';
 import { publishFormula } from '../api/helpers/formulas-helpers.js';
 import { FilterObject } from '@mikro-orm/core';
 import { PolicyDataMigrator } from './helpers/policy-data-migrator.js';
+import { removePolicySchemaTemplateSnapshot } from '../api/schema-template.service.js';
 
 /**
  * Result of publishing
@@ -940,6 +941,9 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
+        // the applied template's snapshot dies with the policy; without this the row
+        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);
 
@@ -1034,6 +1038,9 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
+        // the applied template's snapshot dies with the policy; without this the row
+        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);
 
@@ -1146,6 +1153,9 @@ export class PolicyEngine extends NatsService {
         notifier.completeStep(STEP_DELETE_CREDENTIALS);
 
         notifier.startStep(STEP_DELETE_POLICY);
+        // the applied template's snapshot dies with the policy; without this the row
+        // and its two GridFS payloads are orphaned on every apply/delete cycle
+        await removePolicySchemaTemplateSnapshot(policyToDelete, logger);
         await DatabaseServer.deletePolicy(policyToDelete.id);
         notifier.completeStep(STEP_DELETE_POLICY);
 

--- a/guardian-service/tests/unit/policy-delete-snapshot-cleanup.test.mjs
+++ b/guardian-service/tests/unit/policy-delete-snapshot-cleanup.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Wiring test for the orphaned schema-template snapshot.
+ *
+ * removeSchemaTemplateSnapshot was only ever called from schema-template.service's
+ * own detach/update paths; none of the three policy delete flows in
+ * policy-engine.ts called it, so deleting a draft policy with a template applied
+ * left the snapshot row - and its two GridFS payloads - behind forever.
+ *
+ * The behaviour of the cleanup helper itself is covered in
+ * schema-template-handlers.test.mjs. What that cannot check is that *every* delete
+ * flow calls it, which is the part that regressed and the part a fourth delete
+ * flow would silently miss. Read at the source level for exactly that reason: the
+ * point is the call site, not the outcome of one of them.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('../../src/policy-engine/policy-engine.ts', import.meta.url)),
+    'utf8'
+);
+
+const countOf = (needle) => source.split(needle).length - 1;
+
+describe('policy delete flows clean up the schema template snapshot', () => {
+    it('imports the cleanup helper', () => {
+        assert.match(source, /import \{ removePolicySchemaTemplateSnapshot \}/);
+    });
+
+    it('calls it before every deletePolicy', () => {
+        const deletes = countOf('await DatabaseServer.deletePolicy(');
+        assert.ok(deletes >= 3, `expected the three delete flows, found ${deletes}`);
+        assert.equal(
+            countOf('await removePolicySchemaTemplateSnapshot('),
+            deletes,
+            'a delete flow that skips the cleanup orphans the snapshot and its GridFS payloads'
+        );
+    });
+
+    it('cleans up before the policy row goes, not after', () => {
+        // once the policy is gone its schemaTemplate.snapshotId goes with it, and the
+        // snapshot can no longer be found
+        for (const flow of source.split('await DatabaseServer.deletePolicy(').slice(0, -1)) {
+            const cleanup = flow.lastIndexOf('await removePolicySchemaTemplateSnapshot(');
+            assert.notEqual(cleanup, -1, 'a delete flow has no cleanup call before it');
+        }
+    });
+});

--- a/guardian-service/tests/unit/policy-delete-snapshot-cleanup.test.mjs
+++ b/guardian-service/tests/unit/policy-delete-snapshot-cleanup.test.mjs
@@ -3,18 +3,9 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Wiring test for the orphaned schema-template snapshot.
- *
- * removeSchemaTemplateSnapshot was only ever called from schema-template.service's
- * own detach/update paths; none of the three policy delete flows in
- * policy-engine.ts called it, so deleting a draft policy with a template applied
- * left the snapshot row - and its two GridFS payloads - behind forever.
- *
- * The behaviour of the cleanup helper itself is covered in
- * schema-template-handlers.test.mjs. What that cannot check is that *every* delete
- * flow calls it, which is the part that regressed and the part a fourth delete
- * flow would silently miss. Read at the source level for exactly that reason: the
- * point is the call site, not the outcome of one of them.
+ * Source-level on purpose: the helper's behaviour is covered in
+ * schema-template-handlers.test.mjs, but that cannot check that *every* delete flow
+ * calls it - which is what regressed, and what a fourth flow would silently miss.
  */
 const source = readFileSync(
     fileURLToPath(new URL('../../src/policy-engine/policy-engine.ts', import.meta.url)),
@@ -39,8 +30,6 @@ describe('policy delete flows clean up the schema template snapshot', () => {
     });
 
     it('cleans up before the policy row goes, not after', () => {
-        // once the policy is gone its schemaTemplate.snapshotId goes with it, and the
-        // snapshot can no longer be found
         for (const flow of source.split('await DatabaseServer.deletePolicy(').slice(0, -1)) {
             const cleanup = flow.lastIndexOf('await removePolicySchemaTemplateSnapshot(');
             assert.notEqual(cleanup, -1, 'a delete flow has no cleanup call before it');

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MessageAPI, ModuleStatus, PolicyStatus, SchemaCategory } from '@guardian/interfaces';
-import { schemaTemplatesAPI } from '../../dist/api/schema-template.service.js';
+import {
+    removePolicySchemaTemplateSnapshot,
+    schemaTemplatesAPI,
+} from '../../dist/api/schema-template.service.js';
 import {
     callHandler,
     DatabaseServer,
@@ -450,5 +453,69 @@ describe('APPLY_SCHEMA_TEMPLATE success path', () => {
         assert.equal(updatedPolicy.schemaTemplate.templateId, 'template-1');
         assert.equal(updatedPolicy.schemaTemplate.snapshotId, 'snap-1');
         assert.equal(updatedPolicy.schemaTemplate.templateStateHash, savedSnapshot.templateStateHash);
+    });
+});
+
+/*
+ * removeSchemaTemplateSnapshot was only ever called from this module's own
+ * detach/update paths; none of the three policy delete flows called it. Deleting a
+ * draft policy with a template applied left the snapshot row behind forever, along
+ * with its two GridFS payloads - one orphan per apply/delete cycle.
+ */
+describe('removePolicySchemaTemplateSnapshot', () => {
+    afterEach(() => restoreStubs());
+
+    const arrange = (snapshot) => {
+        const removed = [];
+        stub(DatabaseServer, 'getSchemaTemplateSnapshotById', async () => snapshot);
+        stub(DatabaseServer, 'removeSchemaTemplateSnapshot', async (value) => {
+            removed.push(value);
+        });
+        return removed;
+    };
+
+    it('removes the snapshot a deleted policy was bound to', async () => {
+        const snapshot = { id: 'snapshot-1' };
+        const removed = arrange(snapshot);
+
+        await removePolicySchemaTemplateSnapshot({
+            id: 'policy-1',
+            schemaTemplate: { templateId: 'template-1', snapshotId: 'snapshot-1' },
+        });
+
+        assert.deepEqual(removed, [snapshot]);
+    });
+
+    it('does nothing for a policy with no template applied', async () => {
+        const removed = arrange({ id: 'snapshot-1' });
+
+        await removePolicySchemaTemplateSnapshot({ id: 'policy-1' });
+        await removePolicySchemaTemplateSnapshot(null);
+
+        assert.deepEqual(removed, []);
+    });
+
+    it('does nothing when the snapshot is already gone', async () => {
+        const removed = arrange(null);
+
+        await removePolicySchemaTemplateSnapshot({
+            schemaTemplate: { snapshotId: 'snapshot-1' },
+        });
+
+        assert.deepEqual(removed, []);
+    });
+
+    it('never fails the delete it is cleaning up after', async () => {
+        stub(DatabaseServer, 'getSchemaTemplateSnapshotById', async () => {
+            throw new Error('database is down');
+        });
+        const logged = [];
+
+        await assert.doesNotReject(() => removePolicySchemaTemplateSnapshot(
+            { schemaTemplate: { snapshotId: 'snapshot-1' } },
+            { error: async (error) => { logged.push(error); } }
+        ));
+
+        assert.equal(logged.length, 1, 'the failure is logged rather than swallowed silently');
     });
 });


### PR DESCRIPTION
## Problem

`DatabaseServer.removeSchemaTemplateSnapshot` is called from `schema-template.service`'s own detach and update paths — and nowhere else. None of the three policy delete flows in `policy-engine.ts` (`deleteDemoPolicy`, `deletePolicy`, and the async variant) call it.

So deleting a draft policy that has a schema template applied leaves behind:

- the `SchemaTemplateSnapshot` row, referenced by a `policy.schemaTemplate.snapshotId` that no longer resolves to anything;
- its two GridFS payloads (`configFileId`, `schemasFileId`), which the entity's `@AfterDelete` hook would have removed had the row ever been deleted.

One orphan per apply/delete cycle, accumulating quietly — nothing surfaces it, and nothing ever collects it.

## Fix

A small helper in `schema-template.service.ts`, called by each of the three delete flows immediately before `DatabaseServer.deletePolicy` — before, because once the policy row is gone its `snapshotId` goes with it.

It is **best-effort by design**: the caller is already deleting the policy, and failing that operation because a snapshot could not be cleaned would be a worse outcome than the orphan it is trying to avoid. The error is logged rather than propagated.

It deliberately does not touch the schemas — those are deleted with the policy.

## Tests

`guardian-service/tests/unit/schema-template-handlers.test.mjs` — 4 cases for the helper: it removes the bound snapshot, does nothing for a policy with no template (or a null policy), does nothing when the snapshot is already gone, and never rejects when the database call fails while still logging it.

`guardian-service/tests/unit/policy-delete-snapshot-cleanup.test.mjs` — a wiring test asserting *every* `deletePolicy` call site is preceded by the cleanup. That is the part that regressed, and the part a fourth delete flow would silently miss; it reads the source for exactly that reason, in the same style as the existing `index-import-order.test.mjs`.

All fail against `develop`. guardian-service unit suite: 1796 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)