### PR TITLE
fix(guardian-service): make schema-template apply and update recoverable

### DIFF
--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1462,7 +1462,9 @@ async function updateAppliedSchemaTemplate(
      */
     const originalSchemas = new Map<string, Schema>();
     const createdSchemas: Schema[] = [];
+    const pendingRemovals: Schema[] = [];
     let nextSnapshot: Awaited<ReturnType<typeof saveApplySnapshot>> | null = null;
+    let result: Policy;
     const rollback = async (): Promise<void> => {
         if (nextSnapshot) {
             try {
@@ -1541,7 +1543,9 @@ async function updateAppliedSchemaTemplate(
         );
         const action = conflict ? resolutions.get(conflict.id) : null;
         if (action === SchemaTemplateUpdateResolutionAction.REMOVE_FROM_POLICY) {
-            await removePolicySchema(policySchema, owner);
+            // deleted only past the commit: rollback() restores originalSchemas and
+            // drops createdSchemas, and a hard-deleted row is in neither
+            pendingRemovals.push(policySchema);
         } else {
             // another in-place edit; capture before detaching the markers
             if (!originalSchemas.has(policySchema.id)) {
@@ -1582,18 +1586,24 @@ async function updateAppliedSchemaTemplate(
         updatedAt: appliedAt,
         schemaMap
     };
-    const result = await DatabaseServer.updatePolicy(context.policy);
+    result = await DatabaseServer.updatePolicy(context.policy);
     // the old snapshot only goes once the new binding is committed, so a failure
     // above still leaves the policy describable by its old snapshot
     nextSnapshot = null;
-    await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
-    return result;
     } catch (error) {
         // undo the copies and restore the edited rows, then surface the original
         // failure. Previously only the new snapshot was removed.
         await rollback();
         throw error;
     }
+
+    // Past the commit point. rollback() must not run from here: the binding already
+    // names the new snapshot, so restoring the old schema rows would contradict it.
+    for (const policySchema of pendingRemovals) {
+        await removePolicySchema(policySchema, owner);
+    }
+    await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
+    return result;
 }
 
 /**

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -50,6 +50,7 @@ import {
     TopicType
 } from '@guardian/interfaces';
 import { ApiResponse } from './helpers/api-response.js';
+import { withPolicyTemplateLock } from '../helpers/policy-template-lock.js';
 import { createSchemaAndArtifacts, deleteSchema, SchemaImportExportHelper, updateSchemaDefs } from '../helpers/import-helpers/index.js';
 
 async function createTemplateTopic(
@@ -1436,6 +1437,7 @@ async function updateAppliedSchemaTemplate(
     templateId: string,
     policyId: string,
     owner: IOwner,
+    logger: PinoLogger,
     options?: ISchemaTemplateUpdateOptions
 ): Promise<any> {
     const context = await loadSchemaTemplateUpdateContext(templateId, policyId, owner, true);
@@ -1452,10 +1454,57 @@ async function updateAppliedSchemaTemplate(
         templateSchemaById.set(schema.templateSchemaId, schema);
     }
 
+    /*
+     * The policy's schemas are rewritten in place, so the only way to undo is to
+     * have kept what they looked like first.
+     *
+     * The loop below edits existing policy schemas and persists each one before the
+     * new snapshot is saved and the binding swapped. A failure part-way used to
+     * leave some schemas on the new template version while policy.schemaTemplate
+     * still pointed at the old snapshot and state hash - and the catch removed only
+     * the new snapshot, never the schema edits. Preview then diffed against a
+     * snapshot that no longer described reality.
+     *
+     * Copies created during an update are undone by deletion, like APPLY; edits are
+     * undone by restoring the captured document. Both are best-effort, and the
+     * original error is what surfaces.
+     */
+    const originalSchemas = new Map<string, Schema>();
+    const createdSchemas: Schema[] = [];
+    let nextSnapshot: Awaited<ReturnType<typeof saveApplySnapshot>> | null = null;
+    const rollback = async (): Promise<void> => {
+        if (nextSnapshot) {
+            try {
+                await DatabaseServer.removeSchemaTemplateSnapshot(nextSnapshot);
+            } catch (error) {
+                await logger?.error?.(error, ['GUARDIAN_SERVICE'], owner?.id);
+            }
+        }
+        for (const created of createdSchemas.reverse()) {
+            try {
+                await removePolicySchema(created, owner);
+            } catch (error) {
+                await logger?.error?.(error, ['GUARDIAN_SERVICE'], owner?.id);
+            }
+        }
+        for (const original of originalSchemas.values()) {
+            try {
+                await DatabaseServer.updateSchema(original.id, original);
+            } catch (error) {
+                await logger?.error?.(error, ['GUARDIAN_SERVICE'], owner?.id);
+            }
+        }
+    };
+
+    try {
     for (const [templateSchemaId, source] of templateSchemaById.entries()) {
         const target = context.policySchemaByTemplateId.get(templateSchemaId);
         if (target) {
             const targetSourceIri = source.iri;
+            // snapshot the row before it is edited, so the edit is undoable
+            if (!originalSchemas.has(target.id)) {
+                originalSchemas.set(target.id, cloneJson(target));
+            }
             preparePolicySchemaUpdate(
                 target,
                 source,
@@ -1483,6 +1532,7 @@ async function updateAppliedSchemaTemplate(
         if (sourceIri && copied.iri) {
             iriMap.set(sourceIri, copied.iri);
         }
+        createdSchemas.push(copied);
         changedSchemas.push(copied);
     }
 
@@ -1502,6 +1552,10 @@ async function updateAppliedSchemaTemplate(
         if (action === SchemaTemplateUpdateResolutionAction.REMOVE_FROM_POLICY) {
             await removePolicySchema(policySchema, owner);
         } else {
+            // another in-place edit; capture before detaching the markers
+            if (!originalSchemas.has(policySchema.id)) {
+                originalSchemas.set(policySchema.id, cloneJson(policySchema));
+            }
             policySchema.templateId = '';
             policySchema.templateSchemaId = '';
             SchemaHelper.removeTemplateFieldIds(policySchema.document);
@@ -1516,13 +1570,14 @@ async function updateAppliedSchemaTemplate(
     );
 
     const appliedAt = new Date().toISOString();
-    const snapshot = await saveApplySnapshot(
+    nextSnapshot = await saveApplySnapshot(
         context.template,
         context.policy,
         context.templateSchemas,
         schemaMap,
         appliedAt
     );
+    const snapshot = nextSnapshot;
 
     context.policy.schemaTemplate = {
         templateId: context.template.id,
@@ -1536,12 +1591,16 @@ async function updateAppliedSchemaTemplate(
         updatedAt: appliedAt,
         schemaMap
     };
-    try {
-        const result = await DatabaseServer.updatePolicy(context.policy);
-        await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
-        return result;
+    const result = await DatabaseServer.updatePolicy(context.policy);
+    // the old snapshot only goes once the new binding is committed, so a failure
+    // above still leaves the policy describable by its old snapshot
+    nextSnapshot = null;
+    await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
+    return result;
     } catch (error) {
-        await DatabaseServer.removeSchemaTemplateSnapshot(snapshot);
+        // undo the copies and restore the edited rows, then surface the original
+        // failure. Previously only the new snapshot was removed.
+        await rollback();
         throw error;
     }
 }
@@ -1623,7 +1682,8 @@ async function updateCopiedSchemaRefs(
 async function applySchemaTemplate(
     templateId: string,
     policyId: string,
-    owner: IOwner
+    owner: IOwner,
+    logger: PinoLogger
 ): Promise<any> {
     const template = await DatabaseServer.getSchemaTemplateById(templateId);
     if (!template || (template.status !== ModuleStatus.PUBLISHED && template.owner !== owner.owner)) {
@@ -1664,48 +1724,83 @@ async function applySchemaTemplate(
     const iriMap = new Map<string, string>();
     const copiedSchemas: Schema[] = [];
 
-    for (const schema of templateSchemas as Schema[]) {
-        const sourceIri = schema.iri;
-        const copy = preparePolicySchemaCopy(schema, policy.topicId, template.id);
-        const copied = await createSchemaAndArtifacts(
-            SchemaCategory.POLICY,
-            copy,
-            owner,
-            NewNotifier.empty()
-        );
-        schemaMap[schema.templateSchemaId] = copied.id;
-        if (sourceIri && copied.iri) {
-            iriMap.set(sourceIri, copied.iri);
+    /*
+     * Everything from here on is undone if any step fails.
+     *
+     * The copies are persisted one at a time, so a throw part-way through used to
+     * leave schemas 1..N-1 sitting in the policy topic carrying templateId and
+     * templateSchemaId, with no snapshot and no binding. Nothing cleaned them up -
+     * and because the binding is written last, hasSchemaTemplateBinding() still
+     * reported false, so a retry sailed past the guard and copied the whole set
+     * again. Every failed attempt added another duplicate.
+     *
+     * Undo is exact here: these are rows this call created, and their ids are known.
+     * It is best-effort - a compensating delete can itself fail, and the original
+     * error is the one worth surfacing.
+     */
+    let snapshot: Awaited<ReturnType<typeof saveApplySnapshot>> | null = null;
+    const rollback = async (): Promise<void> => {
+        if (snapshot) {
+            try {
+                await DatabaseServer.removeSchemaTemplateSnapshot(snapshot);
+            } catch (error) {
+                await logger?.error?.(error, ['GUARDIAN_SERVICE'], owner?.id);
+            }
         }
-        copiedSchemas.push(copied);
-    }
-
-    await updateCopiedSchemaRefs(copiedSchemas, iriMap);
-
-    const appliedAt = new Date().toISOString();
-    const snapshot = await saveApplySnapshot(
-        template,
-        policy,
-        templateSchemas as Schema[],
-        schemaMap,
-        appliedAt
-    );
-
-    policy.schemaTemplate = {
-        templateId: template.id,
-        templateName: template.name,
-        templateVersion: template.version,
-        templateStatus: template.status,
-        templateMessageId: template.messageId,
-        templateStateHash: snapshot.templateStateHash,
-        snapshotId: snapshot.id,
-        appliedAt,
-        schemaMap
+        for (const copied of copiedSchemas.reverse()) {
+            try {
+                await removePolicySchema(copied, owner);
+            } catch (error) {
+                await logger?.error?.(error, ['GUARDIAN_SERVICE'], owner?.id);
+            }
+        }
     };
+
     try {
+        for (const schema of templateSchemas as Schema[]) {
+            const sourceIri = schema.iri;
+            const copy = preparePolicySchemaCopy(schema, policy.topicId, template.id);
+            const copied = await createSchemaAndArtifacts(
+                SchemaCategory.POLICY,
+                copy,
+                owner,
+                NewNotifier.empty()
+            );
+            schemaMap[schema.templateSchemaId] = copied.id;
+            if (sourceIri && copied.iri) {
+                iriMap.set(sourceIri, copied.iri);
+            }
+            copiedSchemas.push(copied);
+        }
+
+        await updateCopiedSchemaRefs(copiedSchemas, iriMap);
+
+        const appliedAt = new Date().toISOString();
+        snapshot = await saveApplySnapshot(
+            template,
+            policy,
+            templateSchemas as Schema[],
+            schemaMap,
+            appliedAt
+        );
+
+        policy.schemaTemplate = {
+            templateId: template.id,
+            templateName: template.name,
+            templateVersion: template.version,
+            templateStatus: template.status,
+            templateMessageId: template.messageId,
+            templateStateHash: snapshot.templateStateHash,
+            snapshotId: snapshot.id,
+            appliedAt,
+            schemaMap
+        };
         return await DatabaseServer.updatePolicy(policy);
     } catch (error) {
-        await DatabaseServer.removeSchemaTemplateSnapshot(snapshot);
+        // undo the copies and the snapshot, then surface the original failure.
+        // Previously only a failing updatePolicy was compensated, and only by
+        // removing the snapshot.
+        await rollback();
         throw error;
     }
 }
@@ -2319,7 +2414,10 @@ export async function schemaTemplatesAPI(logger: PinoLogger): Promise<void> {
         }) => {
             try {
                 const { templateId, policyId, owner } = msg;
-                const result = await applySchemaTemplate(templateId, policyId, owner);
+                // one template operation per policy at a time. The binding is written
+                // last, so it cannot guard the window being raced.
+                const result = await withPolicyTemplateLock(policyId, () =>
+                    applySchemaTemplate(templateId, policyId, owner, logger));
                 return new MessageResponse(result);
             } catch (error) {
                 await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
@@ -2352,7 +2450,10 @@ export async function schemaTemplatesAPI(logger: PinoLogger): Promise<void> {
         }) => {
             try {
                 const { templateId, policyId, owner, options } = msg;
-                const result = await updateAppliedSchemaTemplate(templateId, policyId, owner, options);
+                // shares the lock with APPLY: both rewrite the same policy's schemas
+                // and binding.
+                const result = await withPolicyTemplateLock(policyId, () =>
+                    updateAppliedSchemaTemplate(templateId, policyId, owner, logger, options));
                 return new MessageResponse(result);
             } catch (error) {
                 await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1597,15 +1597,6 @@ async function updateAppliedSchemaTemplate(
         throw error;
     }
 
-    /*
-     * Past the commit point. rollback() must not run from here: the binding already
-     * names the new snapshot, so restoring the old schema rows would contradict it.
-     *
-     * Neither cleanup may throw either. updatePolicy has committed and the binding is
-     * live, so letting a failure propagate would reach the API handler and report the
-     * update as failed when it succeeded. Both are logged and swallowed; what they
-     * leave behind is a stale row, not a broken binding.
-     */
     for (const policySchema of pendingRemovals) {
         try {
             await removePolicySchema(policySchema, owner);

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1455,19 +1455,10 @@ async function updateAppliedSchemaTemplate(
     }
 
     /*
-     * The policy's schemas are rewritten in place, so the only way to undo is to
-     * have kept what they looked like first.
-     *
-     * The loop below edits existing policy schemas and persists each one before the
-     * new snapshot is saved and the binding swapped. A failure part-way used to
-     * leave some schemas on the new template version while policy.schemaTemplate
-     * still pointed at the old snapshot and state hash - and the catch removed only
-     * the new snapshot, never the schema edits. Preview then diffed against a
-     * snapshot that no longer described reality.
-     *
-     * Copies created during an update are undone by deletion, like APPLY; edits are
-     * undone by restoring the captured document. Both are best-effort, and the
-     * original error is what surfaces.
+     * The loop below edits existing policy schemas in place and persists each one
+     * before the binding is swapped, so the only way to undo is to have captured the
+     * originals first. Copies are undone by deletion, edits by restore; both
+     * best-effort, and the original error is what surfaces.
      */
     const originalSchemas = new Map<string, Schema>();
     const createdSchemas: Schema[] = [];
@@ -1725,18 +1716,11 @@ async function applySchemaTemplate(
     const copiedSchemas: Schema[] = [];
 
     /*
-     * Everything from here on is undone if any step fails.
-     *
-     * The copies are persisted one at a time, so a throw part-way through used to
-     * leave schemas 1..N-1 sitting in the policy topic carrying templateId and
-     * templateSchemaId, with no snapshot and no binding. Nothing cleaned them up -
-     * and because the binding is written last, hasSchemaTemplateBinding() still
-     * reported false, so a retry sailed past the guard and copied the whole set
-     * again. Every failed attempt added another duplicate.
-     *
-     * Undo is exact here: these are rows this call created, and their ids are known.
-     * It is best-effort - a compensating delete can itself fail, and the original
-     * error is the one worth surfacing.
+     * Undone if any step fails. The copies persist one at a time, so a throw
+     * part-way used to leave schemas carrying template markers with no binding - and
+     * since the binding is written last, hasSchemaTemplateBinding() still reported
+     * false, so a retry copied the whole set again. Best-effort; the original error
+     * is the one worth surfacing.
      */
     let snapshot: Awaited<ReturnType<typeof saveApplySnapshot>> | null = null;
     const rollback = async (): Promise<void> => {

--- a/guardian-service/src/api/schema-template.service.ts
+++ b/guardian-service/src/api/schema-template.service.ts
@@ -1597,12 +1597,33 @@ async function updateAppliedSchemaTemplate(
         throw error;
     }
 
-    // Past the commit point. rollback() must not run from here: the binding already
-    // names the new snapshot, so restoring the old schema rows would contradict it.
+    /*
+     * Past the commit point. rollback() must not run from here: the binding already
+     * names the new snapshot, so restoring the old schema rows would contradict it.
+     *
+     * Neither cleanup may throw either. updatePolicy has committed and the binding is
+     * live, so letting a failure propagate would reach the API handler and report the
+     * update as failed when it succeeded. Both are logged and swallowed; what they
+     * leave behind is a stale row, not a broken binding.
+     */
     for (const policySchema of pendingRemovals) {
-        await removePolicySchema(policySchema, owner);
+        try {
+            await removePolicySchema(policySchema, owner);
+        } catch (error) {
+            await logger.error(
+                `Schema template update committed, but removing policy schema ${policySchema?.id} failed: ${error?.message}`,
+                ['GUARDIAN_SERVICE']
+            );
+        }
     }
-    await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
+    try {
+        await DatabaseServer.removeSchemaTemplateSnapshot(previousSnapshot);
+    } catch (error) {
+        await logger.error(
+            `Schema template update committed, but removing the superseded snapshot failed: ${error?.message}`,
+            ['GUARDIAN_SERVICE']
+        );
+    }
     return result;
 }
 

--- a/guardian-service/src/helpers/policy-template-lock.ts
+++ b/guardian-service/src/helpers/policy-template-lock.ts
@@ -1,0 +1,116 @@
+import { DataBaseHelper } from '@guardian/common';
+import { Db } from 'mongodb';
+import { hostname } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Advisory lock for schema-template operations on a single policy.
+ *
+ * APPLY and UPDATE both read the policy, copy or rewrite its schemas, save a
+ * snapshot and only then write the binding. Two overlapping runs for the same
+ * policy therefore both pass the "already applied" check, both do the work, and
+ * both call updatePolicy: last writer wins, the loser's snapshot is orphaned and
+ * its schema copies are left as duplicates. The binding cannot serve as the guard
+ * because it is written last, which is precisely the window being raced.
+ *
+ * Modelled on withMigrationLock (common/src/helpers/migration-lock.ts), which
+ * already runs in production: a Mongo compare-and-set with a lease, so a holder
+ * that dies without releasing frees the lock after TTL_MS rather than wedging the
+ * policy forever.
+ *
+ * Unlike the migration lock this one does NOT wait. These run behind a request or
+ * a push task, and queueing a second APPLY would only mean it starts, discovers
+ * the binding the first one just wrote, and fails anyway - after a long silence.
+ * Failing immediately says something true and actionable instead.
+ */
+
+const LOCK_COLLECTION = '_policy_template_lock';
+
+// A generous ceiling for a large apply; a crashed holder frees the policy after this.
+const TTL_MS = 120_000;
+// Renew well inside the lease while the work is still running.
+const HEARTBEAT_MS = 30_000;
+
+export class PolicyTemplateLockedError extends Error {
+    constructor(policyId: string) {
+        super(
+            `Another schema template operation is already running for policy "${policyId}". ` +
+            `Wait for it to finish and try again.`
+        );
+    }
+}
+
+/**
+ * Run `fn` while holding the lock for `policyId`. Throws PolicyTemplateLockedError
+ * immediately if another run holds it, and always releases - including on failure.
+ */
+export async function withPolicyTemplateLock<T>(
+    policyId: string,
+    fn: () => Promise<T>
+): Promise<T> {
+    /*
+     * Optional *calls*, not just optional property access: `em?.getDriver()` still
+     * throws when getDriver is absent, and a lock helper must never be the reason a
+     * template operation fails. If there is no connection to coordinate through we
+     * run unlocked - the pre-existing behaviour, not a regression.
+     */
+    let db: Db | undefined;
+    try {
+        db = (DataBaseHelper as any).orm?.em?.getDriver?.()?.getConnection?.()?.getDb?.();
+    } catch {
+        db = undefined;
+    }
+    if (!db) {
+        return await fn();
+    }
+
+    const col = db.collection(LOCK_COLLECTION);
+    const token = `${hostname()}-${process.pid}-${randomUUID()}`;
+
+    const acquired = await col.findOneAndUpdate(
+        {
+            _id: policyId as any,
+            $or: [{ holder: null }, { expiresAt: { $lt: new Date() } }],
+        },
+        {
+            $set: {
+                holder: token,
+                acquiredAt: new Date(),
+                expiresAt: new Date(Date.now() + TTL_MS),
+            },
+        },
+        { upsert: true, returnDocument: 'after' }
+    ).catch((error: any) => {
+        // 11000: another run inserted the document first, i.e. it holds the lock.
+        if (error?.code === 11000) {
+            return null;
+        }
+        throw error;
+    });
+
+    if (!acquired) {
+        throw new PolicyTemplateLockedError(policyId);
+    }
+
+    // Keep the lease fresh for a long-running apply. unref() so a pending renewal
+    // can never hold the process open by itself.
+    const heartbeat = setInterval(() => {
+        col.updateOne(
+            { _id: policyId as any, holder: token },
+            { $set: { expiresAt: new Date(Date.now() + TTL_MS) } }
+        ).catch(() => undefined);
+    }, HEARTBEAT_MS);
+    heartbeat.unref?.();
+
+    try {
+        return await fn();
+    } finally {
+        clearInterval(heartbeat);
+        // Only ever release our own hold: if the lease expired and someone else took
+        // over, the holder check stops us from freeing their lock.
+        await col.updateOne(
+            { _id: policyId as any, holder: token },
+            { $set: { holder: null, expiresAt: new Date(0) } }
+        ).catch(() => undefined);
+    }
+}

--- a/guardian-service/src/helpers/policy-template-lock.ts
+++ b/guardian-service/src/helpers/policy-template-lock.ts
@@ -4,24 +4,12 @@ import { hostname } from 'node:os';
 import { randomUUID } from 'node:crypto';
 
 /**
- * Advisory lock for schema-template operations on a single policy.
+ * Advisory lock for schema-template operations on one policy.
  *
- * APPLY and UPDATE both read the policy, copy or rewrite its schemas, save a
- * snapshot and only then write the binding. Two overlapping runs for the same
- * policy therefore both pass the "already applied" check, both do the work, and
- * both call updatePolicy: last writer wins, the loser's snapshot is orphaned and
- * its schema copies are left as duplicates. The binding cannot serve as the guard
- * because it is written last, which is precisely the window being raced.
- *
- * Modelled on withMigrationLock (common/src/helpers/migration-lock.ts), which
- * already runs in production: a Mongo compare-and-set with a lease, so a holder
- * that dies without releasing frees the lock after TTL_MS rather than wedging the
- * policy forever.
- *
- * Unlike the migration lock this one does NOT wait. These run behind a request or
- * a push task, and queueing a second APPLY would only mean it starts, discovers
- * the binding the first one just wrote, and fails anyway - after a long silence.
- * Failing immediately says something true and actionable instead.
+ * APPLY and UPDATE write the binding last, so it cannot guard the window being
+ * raced: two overlapping runs both pass the "already applied" check, both do the
+ * work, and last writer wins - orphaning the loser's snapshot and leaving its
+ * schema copies as duplicates. Modelled on withMigrationLock.
  */
 
 const LOCK_COLLECTION = '_policy_template_lock';

--- a/guardian-service/tests/unit/policy-template-lock.test.mjs
+++ b/guardian-service/tests/unit/policy-template-lock.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import esmock from 'esmock';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const lockPath = path.resolve(__dirname, '../../dist/helpers/policy-template-lock.js');
+
+/**
+ * A Mongo collection stand-in recording what the lock does with it.
+ *
+ * `findOneAndUpdate` answers according to whether the document is currently held,
+ * which is what the compare-and-set filter means in practice.
+ */
+function makeDb() {
+    const held = new Map();
+    const calls = { findOneAndUpdate: [], updateOne: [] };
+    const collection = {
+        async findOneAndUpdate(filter, update, options) {
+            calls.findOneAndUpdate.push({ filter, update, options });
+            const id = filter._id;
+            const current = held.get(id);
+            const free = !current || (current.expiresAt && current.expiresAt < new Date());
+            if (!free) {
+                // the real driver raises E11000 here on the upsert
+                const error = new Error('E11000 duplicate key');
+                error.code = 11000;
+                throw error;
+            }
+            const doc = { _id: id, ...update.$set };
+            held.set(id, doc);
+            return doc;
+        },
+        async updateOne(filter, update) {
+            calls.updateOne.push({ filter, update });
+            const current = held.get(filter._id);
+            if (current && current.holder === filter.holder) {
+                Object.assign(current, update.$set);
+            }
+            return { modifiedCount: 1 };
+        },
+    };
+    return {
+        calls,
+        held,
+        db: { collection: () => collection },
+    };
+}
+
+const load = (db) => esmock(lockPath, {
+    '@guardian/common': {
+        DataBaseHelper: {
+            orm: { em: { getDriver: () => ({ getConnection: () => ({ getDb: () => db }) }) } },
+        },
+    },
+});
+
+describe('withPolicyTemplateLock', function () {
+    // the first esmock load of the dist module is well over mocha's 2s default
+    this.timeout(30000);
+
+    it('runs the operation and releases the lock afterwards', async () => {
+        const { db, calls, held } = makeDb();
+        const { withPolicyTemplateLock } = await load(db);
+
+        const result = await withPolicyTemplateLock('policy-1', async () => 'done');
+
+        assert.equal(result, 'done');
+        assert.equal(calls.findOneAndUpdate.length, 1);
+        assert.equal(held.get('policy-1').holder, null, 'the lock must not stay held');
+    });
+
+    it('refuses a second operation on the same policy instead of racing it', async () => {
+        const { db } = makeDb();
+        const { withPolicyTemplateLock, PolicyTemplateLockedError } = await load(db);
+
+        let release;
+        const first = withPolicyTemplateLock('policy-1', () => new Promise((resolve) => {
+            release = resolve;
+        }));
+        // first is in flight and holds the lock
+        await assert.rejects(
+            () => withPolicyTemplateLock('policy-1', async () => 'second'),
+            (error) => {
+                assert.ok(error instanceof PolicyTemplateLockedError);
+                assert.match(error.message, /policy-1/);
+                return true;
+            },
+            'the binding is written last, so it cannot guard this window'
+        );
+
+        release('first');
+        assert.equal(await first, 'first');
+    });
+
+    it('does not block a different policy', async () => {
+        const { db } = makeDb();
+        const { withPolicyTemplateLock } = await load(db);
+
+        let release;
+        const first = withPolicyTemplateLock('policy-1', () => new Promise((r) => { release = r; }));
+        const second = await withPolicyTemplateLock('policy-2', async () => 'ok');
+
+        assert.equal(second, 'ok');
+        release('first');
+        await first;
+    });
+
+    it('releases the lock when the operation throws', async () => {
+        const { db, held } = makeDb();
+        const { withPolicyTemplateLock } = await load(db);
+
+        await assert.rejects(
+            () => withPolicyTemplateLock('policy-1', async () => { throw new Error('apply failed'); }),
+            /apply failed/
+        );
+
+        assert.equal(held.get('policy-1').holder, null);
+        // and the policy is usable again
+        assert.equal(await withPolicyTemplateLock('policy-1', async () => 'retry'), 'retry');
+    });
+
+    it('takes over a lease whose holder died', async () => {
+        const { db, held } = makeDb();
+        const { withPolicyTemplateLock } = await load(db);
+
+        held.set('policy-1', {
+            _id: 'policy-1',
+            holder: 'a-process-that-is-gone',
+            expiresAt: new Date(Date.now() - 1000),
+        });
+
+        assert.equal(
+            await withPolicyTemplateLock('policy-1', async () => 'taken over'),
+            'taken over',
+            'a crashed holder must not wedge the policy forever'
+        );
+    });
+
+    it('runs unlocked rather than failing when there is no connection', async () => {
+        const { withPolicyTemplateLock } = await esmock(lockPath, {
+            '@guardian/common': { DataBaseHelper: { orm: undefined } },
+        });
+
+        assert.equal(await withPolicyTemplateLock('policy-1', async () => 'ran'), 'ran');
+    });
+});

--- a/guardian-service/tests/unit/schema-template-handlers.test.mjs
+++ b/guardian-service/tests/unit/schema-template-handlers.test.mjs
@@ -19,6 +19,10 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const importHelpersPath = path.resolve(__dirname, '../../dist/helpers/import-helpers/index.js');
+// The lock has its own suite (policy-template-lock.test.mjs). Stubbed here so these
+// cases do not pay for esmock re-importing @guardian/common through it.
+const lockPath = path.resolve(__dirname, '../../dist/helpers/policy-template-lock.js');
+const passThroughLock = { withPolicyTemplateLock: (_policyId, fn) => fn() };
 
 const owner = {
     id: 'user-1',
@@ -883,5 +887,269 @@ describe('PUBLISH_SCHEMA_TEMPLATE content file', () => {
         });
 
         assert.deepEqual(gridFsDeletes, []);
+    });
+});
+
+
+/*
+ * APPLY persists the schema copies one at a time, so a throw part-way used to
+ * leave schemas 1..N-1 in the policy topic carrying templateId and
+ * templateSchemaId, with no snapshot and no binding. Nothing cleaned them up, and
+ * because the binding is written last hasSchemaTemplateBinding() still reported
+ * false - so a retry sailed past the guard and copied the whole set again. Every
+ * failed attempt added another duplicate.
+ */
+describe('APPLY_SCHEMA_TEMPLATE rollback', () => {
+    const templateSchema = (id) => ({
+        id,
+        templateSchemaId: `tpl-${id}`,
+        iri: `#${id}&1.0.0`,
+        uuid: id,
+        name: id,
+        topicId: '0.0.20',
+        category: SchemaCategory.TEMPLATE,
+        document: { $id: `#${id}&1.0.0`, type: 'object', properties: {} },
+    });
+
+    const arrange = async ({ failOn }) => {
+        const created = [];
+        const removedSchemas = [];
+        const removedSnapshots = [];
+        let snapshotSaved = null;
+
+        const fakeDb = {
+            getSchemaTemplateById: async () => ({
+                id: 'template-1',
+                name: 'Template',
+                owner: owner.owner,
+                status: ModuleStatus.PUBLISHED,
+                topicId: '0.0.20',
+                config: { schemas: {} },
+            }),
+            getPolicyById: async () => policy({ schemaTemplate: null }),
+            getSchemas: async () => [templateSchema('a'), templateSchema('b')],
+            updateSchema: async () => null,
+            saveSchemaTemplateSnapshot: async (value) => {
+                snapshotSaved = { ...value, id: 'snap-1' };
+                if (failOn === 'snapshot') {
+                    throw new Error('snapshot write failed');
+                }
+                return snapshotSaved;
+            },
+            removeSchemaTemplateSnapshot: async (value) => { removedSnapshots.push(value); },
+            updatePolicy: async () => {
+                if (failOn === 'policy') {
+                    throw new Error('policy write failed');
+                }
+                return {};
+            },
+        };
+
+        const { handlers } = await loadAPI(
+            '../dist/api/schema-template.service.js',
+            'schemaTemplatesAPI',
+            {
+                '@guardian/common': {
+                    DatabaseServer: fakeDb,
+                    NewNotifier: Object.assign(() => {}, { empty: () => ({}) }),
+                },
+                [lockPath]: passThroughLock,
+                [importHelpersPath]: {
+                    createSchemaAndArtifacts: async (_category, copy) => {
+                        if (failOn === 'copy' && created.length === 1) {
+                            throw new Error('copy failed');
+                        }
+                        const copied = { ...copy, id: `copy-${created.length + 1}` };
+                        created.push(copied);
+                        return copied;
+                    },
+                    deleteSchema: async (id) => { removedSchemas.push(id); },
+                    SchemaImportExportHelper: class {},
+                    updateSchemaDefs: async () => {}
+                }
+            }
+        );
+
+        const response = await handlers[MessageAPI.APPLY_SCHEMA_TEMPLATE]({
+            templateId: 'template-1',
+            policyId: 'policy-1',
+            owner
+        });
+        return { response, created, removedSchemas, removedSnapshots, snapshotSaved };
+    };
+
+    it('deletes the copies it already made when a later copy fails', async () => {
+        const { response, created, removedSchemas } = await arrange({ failOn: 'copy' });
+
+        assert.equal(ok(response), false);
+        assert.match(response.error, /copy failed/, 'the original failure is what surfaces');
+        assert.deepEqual(removedSchemas, created.map((schema) => schema.id),
+            'a partial apply must not leave orphan copies for the retry to duplicate');
+    });
+
+    it('deletes the copies when the snapshot cannot be written', async () => {
+        const { response, created, removedSchemas } = await arrange({ failOn: 'snapshot' });
+
+        assert.equal(ok(response), false);
+        assert.equal(removedSchemas.length, created.length);
+    });
+
+    it('deletes the copies and the snapshot when the binding cannot be written', async () => {
+        const { response, created, removedSchemas, removedSnapshots } =
+            await arrange({ failOn: 'policy' });
+
+        assert.equal(ok(response), false);
+        assert.equal(removedSchemas.length, created.length,
+            'previously only the snapshot was removed, and the copies were left behind');
+        assert.equal(removedSnapshots.length, 1);
+    });
+
+    it('removes nothing when the apply succeeds', async () => {
+        const { response, removedSchemas, removedSnapshots } = await arrange({ failOn: null });
+
+        assert.equal(ok(response), true);
+        assert.deepEqual(removedSchemas, []);
+        assert.deepEqual(removedSnapshots, []);
+    });
+});
+
+/*
+ * UPDATE rewrites the policy's schemas in place and persists each one before the
+ * new snapshot is saved and the binding swapped. A failure part-way used to leave
+ * some schemas on the new template version while policy.schemaTemplate still
+ * pointed at the old snapshot and state hash - and the catch removed only the new
+ * snapshot, never the schema edits. Preview then diffed against a snapshot that no
+ * longer described reality.
+ */
+describe('UPDATE_APPLIED_SCHEMA_TEMPLATE rollback', () => {
+    // the template gained a field the policy copy does not have yet: that is the
+    // in-place edit UPDATE performs, and the thing a rollback has to undo
+    const document = (properties) => ({
+        $id: '#a&1.0.0',
+        title: 'A',
+        type: 'object',
+        properties,
+        required: [],
+    });
+
+    const arrange = async ({ failOnPolicy }) => {
+        const writes = [];
+        const removedSnapshots = [];
+        const templateSchema = {
+            id: 'ts-a',
+            templateSchemaId: 'tpl-a',
+            iri: '#a&1.0.0',
+            uuid: 'a',
+            version: '1.0.0',
+            name: 'A',
+            topicId: '0.0.20',
+            category: SchemaCategory.TEMPLATE,
+            document: document({ fromTemplate: { type: 'string', title: 'From template' } }),
+        };
+        const policySchema = {
+            id: 'ps-1',
+            templateId: 'template-1',
+            templateSchemaId: 'tpl-a',
+            iri: '#a&1.0.0',
+            uuid: 'a',
+            version: '1.0.0',
+            name: 'A',
+            topicId: '0.0.10',
+            category: SchemaCategory.POLICY,
+            document: document({}),
+        };
+
+        const fakeDb = {
+            getSchemaTemplateById: async () => ({
+                id: 'template-1',
+                name: 'Template',
+                owner: owner.owner,
+                status: ModuleStatus.PUBLISHED,
+                topicId: '0.0.20',
+                config: { schemas: {} },
+            }),
+            getPolicyById: async () => policy({
+                schemaTemplate: {
+                    templateId: 'template-1',
+                    snapshotId: 'snap-0',
+                    appliedAt: '2026-01-01T00:00:00.000Z',
+                    schemaMap: { 'tpl-a': 'ps-1' },
+                },
+            }),
+            getSchemaTemplateSnapshotById: async () => ({
+                id: 'snap-0',
+                config: { schemas: {} },
+                schemas: { schemas: { 'tpl-a': { templateSchemaId: 'tpl-a', name: 'A (old)', fields: [], conditions: [] } } },
+            }),
+            getSchemas: async (filter) => (
+                filter?.category === SchemaCategory.TEMPLATE ? [templateSchema] : [policySchema]
+            ),
+            updateSchema: async (id, value) => {
+                writes.push({ id, fields: Object.keys(value?.document?.properties || {}) });
+                return value;
+            },
+            saveSchemaTemplateSnapshot: async (value) => ({ ...value, id: 'snap-1' }),
+            removeSchemaTemplateSnapshot: async (value) => { removedSnapshots.push(value?.id); },
+            updatePolicy: async (value) => {
+                if (failOnPolicy) {
+                    throw new Error('policy write failed');
+                }
+                return value;
+            },
+        };
+
+        const { handlers } = await loadAPI(
+            '../dist/api/schema-template.service.js',
+            'schemaTemplatesAPI',
+            {
+                '@guardian/common': {
+                    DatabaseServer: fakeDb,
+                    NewNotifier: Object.assign(() => {}, { empty: () => ({}) }),
+                },
+                [lockPath]: passThroughLock,
+                [importHelpersPath]: {
+                    createSchemaAndArtifacts: async (_category, copy) => ({ ...copy, id: 'copy-1' }),
+                    deleteSchema: async () => {},
+                    SchemaImportExportHelper: class {},
+                    updateSchemaDefs: async () => {}
+                }
+            }
+        );
+
+        const response = await handlers[MessageAPI.UPDATE_APPLIED_SCHEMA_TEMPLATE]({
+            templateId: 'template-1',
+            policyId: 'policy-1',
+            owner
+        });
+        return { response, writes, removedSnapshots };
+    };
+
+    it('restores the edited schema when the binding cannot be written', async () => {
+        const { response, writes } = await arrange({ failOnPolicy: true });
+
+        assert.equal(ok(response), false);
+        assert.match(response.error, /policy write failed/);
+
+        const edits = writes.filter((write) => write.id === 'ps-1');
+        assert.ok(
+            edits.some((edit) => edit.fields.includes('fromTemplate')),
+            `the update should have edited the policy schema first, saw ${JSON.stringify(writes)}`
+        );
+        assert.deepEqual(edits.at(-1).fields, [],
+            'an in-place edit cannot be undone by deletion; the captured document must be written back');
+    });
+
+    it('removes the new snapshot, not the old one, on failure', async () => {
+        const { removedSnapshots } = await arrange({ failOnPolicy: true });
+
+        assert.deepEqual(removedSnapshots, ['snap-1'],
+            'the policy must stay describable by the snapshot its binding still points at');
+    });
+
+    it('removes the old snapshot once the new binding is committed', async () => {
+        const { response, removedSnapshots } = await arrange({ failOnPolicy: false });
+
+        assert.equal(ok(response), true, response.error);
+        assert.deepEqual(removedSnapshots, ['snap-0']);
     });
 });


### PR DESCRIPTION
Three related defects in `applySchemaTemplate` / `updateAppliedSchemaTemplate`.

## 1. APPLY has no rollback

The schema copies are persisted one at a time:

```ts
for (const schema of templateSchemas as Schema[]) {
    const copied = await createSchemaAndArtifacts(SchemaCategory.POLICY, copy, owner, NewNotifier.empty());
    copiedSchemas.push(copied);
}
```

A throw part-way through leaves schemas 1..N-1 sitting in the policy topic carrying `templateId` and `templateSchemaId`, with no snapshot and no binding. Nothing cleans them up — and because the binding is written **last**, `hasSchemaTemplateBinding()` still reports false, so a retry sails past the guard and copies the whole set again. **Every failed attempt adds another duplicate.**

The only existing compensation covered a failing `updatePolicy`, and only by removing the snapshot.

Undo is exact here: these are rows the call created and their ids are known.

## 2. UPDATE mutates before it commits

Policy schemas are rewritten **in place** and persisted before the new snapshot is saved and the binding swapped. A mid-loop failure leaves some schemas on the new template version while `policy.schemaTemplate` still points at the old snapshot and state hash — and the catch removes only the new snapshot, never the schema edits. Preview then diffs against a snapshot that no longer describes reality.

In-place edits cannot be undone by deletion, so each document is captured before it is touched and restored on failure; copies created during an update are deleted like APPLY's. The old snapshot is now removed only *after* the new binding is committed, so a failure above still leaves the policy describable by the snapshot its binding points at.

## 3. Neither has a concurrency guard

Two overlapping runs for one policy both pass the "already applied" check, both do the work, and both call `updatePolicy`: last writer wins, the loser's snapshot is orphaned and its copies are left as duplicates. The binding cannot be the guard, because it is written last — that window is precisely what is being raced.

`withPolicyTemplateLock` is modelled on `withMigrationLock` (`common/src/helpers/migration-lock.ts`), which already runs in production: a Mongo compare-and-set with a lease, so a holder that dies frees the policy after the TTL rather than wedging it forever.

Unlike the migration lock it does **not** wait. These run behind a request or a push task, and queueing a second APPLY would only mean it starts, discovers the binding the first one just wrote, and fails anyway — after a long silence. Failing immediately says something true and actionable instead. If there is no connection to coordinate through it runs unlocked, which is the pre-existing behaviour rather than a new failure mode.

All compensation is best-effort: a compensating write can itself fail, and the original error is the one worth surfacing.

## Tests

- `guardian-service/tests/unit/policy-template-lock.test.mjs` — 6 cases: acquire and release, refusal of a concurrent run on the same policy, no blocking across different policies, release when the operation throws, takeover of an expired lease, and the no-connection fallback.
- `guardian-service/tests/unit/schema-template-handlers.test.mjs` — 7 cases: APPLY deletes its copies when a later copy / the snapshot / the binding write fails and removes nothing on success; UPDATE restores the edited document, removes the new snapshot rather than the old one on failure, and removes the old one only once the binding is committed.

Reverting each rollback fails its own cases. The existing APPLY suite stubs the lock module so esmock does not re-import `@guardian/common` through it (that alone cost ~4s per case).

guardian-service unit suite: 1802 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)