### PR TITLE
fix: an organization policy assignment must belong to the policy's owner

### DIFF
--- a/api-gateway/src/api/service/organization.ts
+++ b/api-gateway/src/api/service/organization.ts
@@ -1,5 +1,5 @@
 import { Auth, AuthUser } from '#auth';
-import { EntityOwner, Guardians, InternalException, Users, toOrgResponse } from '#helpers';
+import { EntityOwner, Guardians, InternalException, PolicyEngine, Users, toOrgResponse } from '#helpers';
 import { IAuthUser, PinoLogger } from '@guardian/common';
 import { Permissions } from '@guardian/interfaces';
 import {
@@ -692,6 +692,31 @@ export class OrganizationApi {
     ): Promise<PolicyOrgAssignmentDTO> {
         try {
             const owner = new EntityOwner(user);
+
+            /*
+             * The policy has to be checked here.
+             *
+             * auth-service owns the assignment row but not the Policy collection, so
+             * its handler can only verify that the caller owns the organization and
+             * that policyId is non-empty. Nothing downstream looks at the policy at
+             * all, so a Standard Registry could assign another SR's policy to their
+             * own organization - and policy-service's relayed block-action gate then
+             * honours that assignment.
+             *
+             * The gateway is the one layer that can reach both services, so it
+             * resolves the policy and refuses anything the caller does not own.
+             */
+            const policy = await (new PolicyEngine()).getPolicy({ filters: body.policyId }, owner);
+            if (!policy) {
+                throw new HttpException('Policy not found.', HttpStatus.NOT_FOUND);
+            }
+            if (policy.owner !== owner.creator) {
+                throw new HttpException(
+                    'Only the owner of a policy can assign it to an organization.',
+                    HttpStatus.FORBIDDEN
+                );
+            }
+
             return toOrgResponse(await (new Users()).assignPolicyToOrg(id, body.policyId, owner));
         } catch (error) {
             await InternalException(error, this.logger, user.id);

--- a/api-gateway/src/api/service/organization.ts
+++ b/api-gateway/src/api/service/organization.ts
@@ -694,17 +694,9 @@ export class OrganizationApi {
             const owner = new EntityOwner(user);
 
             /*
-             * The policy has to be checked here.
-             *
-             * auth-service owns the assignment row but not the Policy collection, so
-             * its handler can only verify that the caller owns the organization and
-             * that policyId is non-empty. Nothing downstream looks at the policy at
-             * all, so a Standard Registry could assign another SR's policy to their
-             * own organization - and policy-service's relayed block-action gate then
-             * honours that assignment.
-             *
-             * The gateway is the one layer that can reach both services, so it
-             * resolves the policy and refuses anything the caller does not own.
+             * auth-service owns the assignment row but not the Policy collection, so it can
+             * only check organization ownership. The gateway is the one layer that reaches
+             * both, so the policy-owner check belongs here.
              */
             const policy = await (new PolicyEngine()).getPolicy({ filters: body.policyId }, owner);
             if (!policy) {

--- a/api-gateway/tests/service/organization-policy-assign.test.mjs
+++ b/api-gateway/tests/service/organization-policy-assign.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import {
+    makeUser, makeLogger, FakeEntityOwner, internalExceptionRethrow,
+    loadController, guardiansInterfaces
+} from './_controller-harness.mjs';
+
+const DIST = '../../dist/api/service/organization.js';
+
+/*
+ * ASSIGN_POLICY_TO_ORG checked that the caller owned the organization and that
+ * policyId was non-empty, and nothing else. auth-service owns the assignment row
+ * but not the Policy collection, so its handler could not check the policy, and no
+ * layer above it did either. A Standard Registry could therefore assign any policy
+ * id - including another SR's - to their own organization, and policy-service's
+ * relayed block-action gate honours the assignment.
+ */
+
+let stub;
+
+class FakePolicyEngine {
+    getPolicy(...args) { return stub.getPolicy(...args); }
+}
+
+class FakeUsers {
+    assignPolicyToOrg(...args) { return stub.assignPolicyToOrg(...args); }
+}
+
+const load = () => loadController(DIST, {
+    '#helpers': {
+        Guardians: class {},
+        PolicyEngine: FakePolicyEngine,
+        Users: FakeUsers,
+        InternalException: internalExceptionRethrow,
+        EntityOwner: FakeEntityOwner,
+        toOrgResponse: (value) => value,
+    },
+    '#auth': { Auth: () => () => undefined, AuthUser: () => () => undefined },
+    '#middlewares': new Proxy({}, { get: () => class {} }),
+    '@guardian/common': { PinoLogger: class {} },
+    '@guardian/interfaces': guardiansInterfaces,
+});
+
+describe('OrganizationApi.assignPolicyToOrg', function () {
+    this.timeout(60000);
+
+    let Api;
+    before(async () => { ({ OrganizationApi: Api } = await load()); });
+
+    const user = makeUser({ did: 'did:sr' });
+    const call = () => new Api(makeLogger())
+        .assignPolicyToOrg(user, 'org-1', { policyId: 'policy-1' });
+
+    beforeEach(() => {
+        stub = {
+            getPolicy: async () => ({ id: 'policy-1', owner: 'did:sr' }),
+            assignPolicyToOrg: async (orgId, policyId) => ({ orgId, policyId, active: true }),
+        };
+    });
+
+    it('assigns a policy the caller owns', async () => {
+        const result = await call();
+
+        assert.deepEqual(result, { orgId: 'org-1', policyId: 'policy-1', active: true });
+    });
+
+    it('refuses a policy belonging to another owner', async () => {
+        const assigned = [];
+        stub.getPolicy = async () => ({ id: 'policy-1', owner: 'did:other-sr' });
+        stub.assignPolicyToOrg = async (...args) => { assigned.push(args); };
+
+        await assert.rejects(call, (error) => {
+            assert.equal(error.getStatus(), 403);
+            return true;
+        });
+        assert.deepEqual(assigned, [],
+            'the assignment must never be written for a policy the caller does not own');
+    });
+
+    it('reports a policy that does not exist as not found', async () => {
+        stub.getPolicy = async () => null;
+
+        await assert.rejects(call, (error) => {
+            assert.equal(error.getStatus(), 404);
+            return true;
+        });
+    });
+
+    it('looks the policy up by the id being assigned', async () => {
+        const lookups = [];
+        stub.getPolicy = async (filters, owner) => {
+            lookups.push({ filters, creator: owner.creator });
+            return { id: 'policy-1', owner: 'did:sr' };
+        };
+
+        await call();
+
+        assert.deepEqual(lookups, [{ filters: { filters: 'policy-1' }, creator: 'did:sr' }]);
+    });
+});

--- a/api-gateway/tests/service/organization-policy-assign.test.mjs
+++ b/api-gateway/tests/service/organization-policy-assign.test.mjs
@@ -7,12 +7,8 @@ import {
 const DIST = '../../dist/api/service/organization.js';
 
 /*
- * ASSIGN_POLICY_TO_ORG checked that the caller owned the organization and that
- * policyId was non-empty, and nothing else. auth-service owns the assignment row
- * but not the Policy collection, so its handler could not check the policy, and no
- * layer above it did either. A Standard Registry could therefore assign any policy
- * id - including another SR's - to their own organization, and policy-service's
- * relayed block-action gate honours the assignment.
+ * The assignment must be refused unless the caller owns the policy - otherwise an
+ * SR can assign another SR's policy to their own organization.
  */
 
 let stub;

--- a/policy-service/src/policy-engine/actions-service.ts
+++ b/policy-service/src/policy-engine/actions-service.ts
@@ -864,6 +864,22 @@ export class PolicyActionsService {
             if (await DatabaseServer.getAssignedEntity(AssignedEntityType.Policy, this.policyId, policyUser.did)) {
                 return true;
             }
+            /*
+             * An organization assignment only grants access within the policy's own
+             * owner.
+             *
+             * guardian-service's accessPolicyCode rejects `user.owner !== policy.owner`
+             * before it consults an assignment; this gate did not, so the two were
+             * asymmetric - a PolicyOrgAssignment row naming a policy that belongs to a
+             * different Standard Registry let that organization's members through here.
+             *
+             * Only a *known* mismatch denies. A virtual (dry-run) user or one built
+             * from a bare DID has no parent, and treating unknown as mismatched would
+             * break dry-run runs that never had an owner to compare.
+             */
+            if (policyUser.parent && this.policyOwner && policyUser.parent !== this.policyOwner) {
+                return false;
+            }
             try {
                 return await isPolicyAssignedToUserOrg(policyUser, this.policyId);
             } catch {

--- a/policy-service/src/policy-engine/actions-service.ts
+++ b/policy-service/src/policy-engine/actions-service.ts
@@ -865,17 +865,9 @@ export class PolicyActionsService {
                 return true;
             }
             /*
-             * An organization assignment only grants access within the policy's own
-             * owner.
-             *
-             * guardian-service's accessPolicyCode rejects `user.owner !== policy.owner`
-             * before it consults an assignment; this gate did not, so the two were
-             * asymmetric - a PolicyOrgAssignment row naming a policy that belongs to a
-             * different Standard Registry let that organization's members through here.
-             *
-             * Only a *known* mismatch denies. A virtual (dry-run) user or one built
-             * from a bare DID has no parent, and treating unknown as mismatched would
-             * break dry-run runs that never had an owner to compare.
+             * An organization assignment grants access only within the policy's own
+             * owner, matching guardian-service's accessPolicyCode. Only a known
+             * mismatch denies: a dry-run or bare-DID user has no parent to compare.
              */
             if (policyUser.parent && this.policyOwner && policyUser.parent !== this.policyOwner) {
                 return false;

--- a/policy-service/src/policy-engine/policy-user.ts
+++ b/policy-service/src/policy-engine/policy-user.ts
@@ -83,15 +83,11 @@ export class PolicyUser {
      */
     public readonly policyOwner: string | null;
     /**
-     * The DID of the Standard Registry this user belongs to.
-     *
-     * EntityOwner derives `owner` the same way (user.parent for a USER, user.did for
-     * an SR), and guardian-service's accessPolicyCode compares it against
-     * policy.owner before honouring any assignment. PolicyUser carried no
-     * equivalent, so the policy-service gate could not make the same comparison.
+     * The DID of the Standard Registry this user belongs to, derived the same way
+     * EntityOwner derives `owner` (user.parent for a USER, user.did for an SR).
      *
      * Null for a virtual (dry-run) user or one built from a bare DID, where the
-     * parent is simply unknown - callers must not read that as "no owner".
+     * parent is unknown - callers must not read that as "no owner".
      */
     public readonly parent: string | null;
     /**

--- a/policy-service/src/policy-engine/policy-user.ts
+++ b/policy-service/src/policy-engine/policy-user.ts
@@ -83,6 +83,18 @@ export class PolicyUser {
      */
     public readonly policyOwner: string | null;
     /**
+     * The DID of the Standard Registry this user belongs to.
+     *
+     * EntityOwner derives `owner` the same way (user.parent for a USER, user.did for
+     * an SR), and guardian-service's accessPolicyCode compares it against
+     * policy.owner before honouring any assignment. PolicyUser carried no
+     * equivalent, so the policy-service gate could not make the same comparison.
+     *
+     * Null for a virtual (dry-run) user or one built from a bare DID, where the
+     * parent is simply unknown - callers must not read that as "no owner".
+     */
+    public readonly parent: string | null;
+    /**
      * Policy status
      */
     public readonly policyStatus: PolicyStatus | null;
@@ -131,6 +143,7 @@ export class PolicyUser {
             this.location = LocationType.LOCAL;
             this._userId = null;
             this._hederaAccountId = null;
+            this.parent = null;
         } else {
             this.did = arg.did;
             this.username = arg.username;
@@ -138,6 +151,7 @@ export class PolicyUser {
             this.location = arg.location || LocationType.LOCAL;
             this._userId = arg.id;
             this._hederaAccountId = arg.hederaAccountId;
+            this.parent = arg.parent || null;
         }
         this.role = null;
         this.group = null;

--- a/policy-service/tests/unit-tests/policy-engine/actions-service-access-policy.test.mjs
+++ b/policy-service/tests/unit-tests/policy-engine/actions-service-access-policy.test.mjs
@@ -1,0 +1,90 @@
+import { assert } from 'chai';
+import esmock from 'esmock';
+import { Permissions, PolicyStatus } from '@guardian/interfaces';
+
+const SERVICE = '../../../dist/policy-engine/actions-service.js';
+const ORG_UTILS = '../../../dist/policy-engine/helpers/org-utils.js';
+
+/*
+ * guardian-service's accessPolicyCode rejects `user.owner !== policy.owner` before
+ * it consults an assignment; this gate did not, so the two were asymmetric. A
+ * PolicyOrgAssignment row naming a policy that belongs to a different Standard
+ * Registry let that organization's members through here.
+ */
+async function makeService({ assignedEntity = null, orgAssigned = true } = {}) {
+    const calls = { orgAssigned: [] };
+    const { PolicyActionsService } = await esmock(SERVICE, {
+        '@guardian/common': {
+            DatabaseServer: { getAssignedEntity: async () => assignedEntity },
+        },
+        [ORG_UTILS]: {
+            // recorded so a test can assert the owner guard short-circuits before the
+            // organization fallback is consulted at all
+            isPolicyAssignedToUserOrg: async (...args) => {
+                calls.orgAssigned.push(args);
+                return orgAssigned;
+            },
+        },
+    });
+
+    const service = new PolicyActionsService(
+        'policy-1',
+        {},
+        { owner: 'did:policy-owner', status: PolicyStatus.PUBLISH, actionsTopicId: '0.0.1', messageId: 'm-1' },
+        'user-1'
+    );
+    return { service, calls };
+}
+
+describe('@unit PolicyActionsService.accessPolicy — organization assignments', function () {
+    this.timeout(60000);
+
+    const assignedUser = (parent) => ({
+        did: 'did:actor',
+        parent,
+        permissions: [Permissions.ACCESS_POLICY_ASSIGNED],
+    });
+
+    it('honours an organization assignment for a member of the policy owner', async () => {
+        const { service, calls } = await makeService();
+
+        assert.isTrue(await service.accessPolicy(assignedUser('did:policy-owner')));
+        assert.lengthOf(calls.orgAssigned, 1, 'the organization fallback should be consulted');
+    });
+
+    it('refuses an organization assignment that belongs to a different owner', async () => {
+        const { service, calls } = await makeService();
+
+        assert.isFalse(await service.accessPolicy(assignedUser('did:other-sr')),
+            'an assignment cannot cross the policy owner');
+        assert.lengthOf(calls.orgAssigned, 0,
+            'and the fallback must not even be consulted, so a stale row cannot grant access');
+    });
+
+    it('still consults the fallback when the parent is unknown', async () => {
+        // a virtual (dry-run) user, or one built from a bare DID, has no parent -
+        // treating unknown as mismatched would break dry-run runs
+        const { service, calls } = await makeService();
+
+        assert.isTrue(await service.accessPolicy(assignedUser(null)));
+        assert.lengthOf(calls.orgAssigned, 1);
+    });
+
+    it('leaves a direct entity assignment alone', async () => {
+        const { service, calls } = await makeService({ assignedEntity: { id: 'row-1' } });
+
+        assert.isTrue(await service.accessPolicy(assignedUser('did:other-sr')),
+            'the owner guard applies to the organization fallback, not to a direct grant');
+        assert.lengthOf(calls.orgAssigned, 0);
+    });
+
+    it('still grants blanket access regardless of owner', async () => {
+        const { service } = await makeService();
+
+        assert.isTrue(await service.accessPolicy({
+            did: 'did:actor',
+            parent: 'did:other-sr',
+            permissions: [Permissions.ACCESS_POLICY_ALL],
+        }));
+    });
+});

--- a/policy-service/tests/unit-tests/policy-engine/policy-user.test.mjs
+++ b/policy-service/tests/unit-tests/policy-engine/policy-user.test.mjs
@@ -46,6 +46,10 @@ describe('PolicyUser', function () {
             const user = new PolicyUser('did:str', instance);
             assert.isNull(user.hederaAccountId);
         });
+        it('sets parent to null - the owning registry is unknown here', function () {
+            const user = new PolicyUser('did:str', instance);
+            assert.isNull(user.parent);
+        });
         it('sets id equal to did when no group', function () {
             const user = new PolicyUser('did:str', instance);
             assert.equal(user.id, 'did:str');
@@ -63,6 +67,14 @@ describe('PolicyUser', function () {
         it('copies permissions', function () {
             const user = new PolicyUser(makeAuthUser(), instance);
             assert.deepEqual(user.permissions, ['PERM_A']);
+        });
+        it('copies parent - the DID of the registry the user belongs to', function () {
+            const user = new PolicyUser(makeAuthUser({ parent: 'did:sr' }), instance);
+            assert.equal(user.parent, 'did:sr');
+        });
+        it('defaults parent to null when missing', function () {
+            const user = new PolicyUser(makeAuthUser({ parent: undefined }), instance);
+            assert.isNull(user.parent);
         });
         it('defaults permissions to empty array when missing', function () {
             const user = new PolicyUser(makeAuthUser({ permissions: undefined }), instance);


### PR DESCRIPTION
Two halves of one privilege escalation.

## 1. `ASSIGN_POLICY_TO_ORG` never looks at the policy

The gateway route calls straight through to NATS:

```ts
const owner = new EntityOwner(user);
return toOrgResponse(await (new Users()).assignPolicyToOrg(id, body.policyId, owner));
```

`auth-service` owns the `PolicyOrgAssignment` row but **not** the `Policy` collection, so its handler can only verify that the caller owns the organization and that `policyId` is non-empty. Nothing above it looks at the policy either.

A Standard Registry can therefore assign **any** policy id — including another SR's — to their own organization.

## 2. `policy-service` honours that assignment across owners

```ts
if (await DatabaseServer.getAssignedEntity(AssignedEntityType.Policy, this.policyId, policyUser.did)) {
    return true;
}
try {
    return await isPolicyAssignedToUserOrg(policyUser, this.policyId);
```

There is no policy-owner comparison, so the assignee's organization members pass the relayed block-action gate for a policy belonging to someone else. `guardian-service`'s `accessPolicyCode` rejects `user.owner !== policy.owner` *before* it consults an assignment — the two gates were asymmetric.

## Fix

**Gateway.** It is the one layer that can reach both services, so it resolves the policy and refuses anything the caller does not own — 404 when the policy does not exist, 403 when it belongs to another owner. `InternalException` re-throws `HttpException` unchanged, so both statuses survive to the client.

**policy-service.** The gate now makes the same owner comparison `accessPolicyCode` already makes, so a row written before the gateway check existed is no longer honoured. `PolicyUser` did not carry the user's owning registry, so it gains `parent`, derived exactly as `EntityOwner` derives `owner` (`user.parent` for a USER, absent for a bare DID).

Only a **known** mismatch denies. A virtual (dry-run) user or one built from a bare DID has no parent, and treating unknown as mismatched would break dry-run runs that never had an owner to compare. A direct `AssignedEntity` grant is unaffected — the guard applies to the organization fallback.

## Tests

`api-gateway/tests/service/organization-policy-assign.test.mjs` — 4 cases: an owned policy is assigned, a foreign policy is 403 **and nothing is written**, a missing policy is 404, and the lookup uses the id being assigned.

`policy-service/tests/unit-tests/policy-engine/actions-service-access-policy.test.mjs` — 5 cases, including that on a mismatch the organization fallback is **not even consulted**, so a stale row cannot grant access; plus a direct entity assignment and blanket `ACCESS_POLICY_ALL` staying unaffected.

`policy-user.test.mjs` — 3 cases for `parent`.

All fail against `develop`. api-gateway 3038 passing, policy-service 3613 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)