### PR TITLE
fix: apply auth test stubs to transitive imports

### DIFF
--- a/auth-service/tests/_handler-harness.mjs
+++ b/auth-service/tests/_handler-harness.mjs
@@ -175,12 +175,15 @@ function mergeMocks(overrides) {
 /**
  * Load a dist module under esmock with the default @guardian/common +
  * @guardian/interfaces stubs. Returns the loaded namespace object.
+ *
+ * Stubs go in as esmock global definitions: the second argument only rewrites
+ * the target's own imports, so a transitive one (`#utils`) would pull in the
+ * real @guardian/common.
  */
 export async function loadService(distPath, overrides = {}, globals = undefined) {
-    if (globals) {
-        return await esmock(distPath, mergeMocks(overrides), globals);
-    }
-    return await esmock(distPath, mergeMocks(overrides));
+    const mocks = mergeMocks(overrides);
+    const globalMocks = globals ? { ...mocks, ...globals } : mocks;
+    return await esmock(distPath, mocks, globalMocks);
 }
 
 export { mergeMocks };


### PR DESCRIPTION
### Description

The auth-service handler test harness stubbed `@guardian/common` only for the module under test, so a service reaching it through a transitive import loaded the real `Wallet` and `OldSecretManager`, which then retried NATS calls during the test run.

- Pass the harness stub map as esmock global definitions so it applies across the whole import graph
- Merge caller-supplied globals on top of the defaults instead of replacing them
