### PR TITLE
fix(policy-service): a scalar is not in the empty set

### DIFF
--- a/policy-service/src/policy-engine/helpers/utils.ts
+++ b/policy-service/src/policy-engine/helpers/utils.ts
@@ -517,12 +517,9 @@ export class PolicyUtils {
         const leftIsArray = Array.isArray(left);
         const rightIsArray = Array.isArray(right);
 
-        // Empty array vs scalar — no elements to validate, fail-closed. [] vs [] passes.
-        if (leftIsArray && left.length === 0 && !rightIsArray) { return false; }
-        if (rightIsArray && right.length === 0 && !leftIsArray) { return false; }
-
-        // in/not_in must come before the pairwise branch; otherwise equal-length arrays
-        // get positional comparison instead of membership.
+        // in/not_in must come before the pairwise branch (otherwise equal-length arrays
+        // get positional comparison instead of membership) and before the empty-array
+        // guard, which is inverted for not_in: a scalar is trivially not in the empty set.
         if (type === 'in' || type === 'not_in') {
             if (leftIsArray) {
                 if (left.length === 0) { return false; }
@@ -536,6 +533,10 @@ export class PolicyUtils {
             }
             return PolicyUtils.compareScalarPair(left, type, right);
         }
+
+        // Empty array vs scalar — no elements to validate, fail-closed. [] vs [] passes.
+        if (leftIsArray && left.length === 0 && !rightIsArray) { return false; }
+        if (rightIsArray && right.length === 0 && !leftIsArray) { return false; }
 
         if (leftIsArray && rightIsArray) {
             if (left.length !== right.length) { return false; }

--- a/policy-service/tests/unit-tests/helpers/check-document-field.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/check-document-field.test.mjs
@@ -230,6 +230,24 @@ describe('PolicyUtils.evaluateFieldCondition', () => {
         assert.equal(PolicyUtils.evaluateFieldCondition('D', 'not_in', ['A', 'B', 'C']), true);
     });
 
+    it('not_in: a scalar is not in the empty set', () => {
+        assert.equal(PolicyUtils.evaluateFieldCondition('D', 'not_in', []), true);
+    });
+
+    it('in: a scalar is never in the empty set', () => {
+        assert.equal(PolicyUtils.evaluateFieldCondition('D', 'in', []), false);
+    });
+
+    it('in/not_in: an empty left side still fails closed', () => {
+        assert.equal(PolicyUtils.evaluateFieldCondition([], 'not_in', ['A']), false);
+        assert.equal(PolicyUtils.evaluateFieldCondition([], 'in', ['A']), false);
+    });
+
+    it('the empty-array guard still applies to the comparison operators', () => {
+        assert.equal(PolicyUtils.evaluateFieldCondition('A', 'equal', []), false);
+        assert.equal(PolicyUtils.evaluateFieldCondition('5', 'gte', []), false);
+    });
+
     it('in: array left — every element must be in right', () => {
         assert.equal(PolicyUtils.evaluateFieldCondition(['A', 'B'], 'in', ['A', 'B', 'C']), true);
     });


### PR DESCRIPTION
Fixes #6713

## Problem

`evaluateFieldCondition` ran its empty-array guard before dispatching `in` / `not_in`. The guard fails closed, which is right for a comparison with nothing to compare and right for `in` — nothing is a member of the empty set — but inverted for `not_in`, where a scalar is trivially *not* in it.

So whenever a source list resolved to empty, a `not_in` condition rejected a document it should have accepted.

## Fix

Dispatch `in` / `not_in` above the guard. Every other operator, and the empty-**left** case for `in`/`not_in`, keeps failing closed exactly as before.

## Tests

Added to `policy-service/tests/unit-tests/helpers/check-document-field.test.mjs`:

- `not_in` against an empty set passes (this is the regression — it fails on `develop` with `false !== true`)
- `in` against an empty set still fails
- an empty **left** side still fails closed for both `in` and `not_in`
- the guard still applies to `equal` / `gte`

`71 passing` on this branch; on `develop` with the source change reverted the new `not_in` case fails, confirming the test is not vacuous.