### PR TITLE
fix: stop dropping schema import errors

### DIFF
--- a/common/src/xlsx/models/xlsx-result.ts
+++ b/common/src/xlsx/models/xlsx-result.ts
@@ -224,7 +224,9 @@ export class XlsxResult {
                 const schemaCache = this._schemaCache.find(c => c.iri === schema.iri);
                 for (const field of schema.fields) {
                     if (field.isRef) {
-                        if (field.type === '#GeoJSON') {
+                        // both are pre-seeded as validated ref types by the schema import,
+                        // so neither has a link entry
+                        if (field.type === '#GeoJSON' || field.type === '#SentinelHUB') {
                             continue;
                         }
                         const link = this._linkCache.get(field.type);
@@ -236,6 +238,9 @@ export class XlsxResult {
                                 worksheet: schemaCache?.worksheet,
                                 row: field.order
                             }, field);
+                            // without this, link.worksheet below throws and the outer
+                            // catch replaces every collected error with one generic message
+                            continue;
                         }
 
                         let subSchemaCache: ISchemaCache;

--- a/common/src/xlsx/models/xlsx-result.ts
+++ b/common/src/xlsx/models/xlsx-result.ts
@@ -238,8 +238,8 @@ export class XlsxResult {
                                 worksheet: schemaCache?.worksheet,
                                 row: field.order
                             }, field);
-                            // without this, link.worksheet below throws and the outer
-                            // catch replaces every collected error with one generic message
+                            // clear the dangling ref so it is not persisted into the schema
+                            field.type = null;
                             continue;
                         }
 

--- a/common/tests/unit-tests/xlsx-result/xlsx-result-unknown-type.test.mjs
+++ b/common/tests/unit-tests/xlsx-result/xlsx-result-unknown-type.test.mjs
@@ -1,0 +1,73 @@
+import { assert } from 'chai';
+import { XlsxResult } from '../../../dist/xlsx/models/xlsx-result.js';
+import { Workbook } from '../../../dist/xlsx/models/workbook.js';
+
+function ws(name) {
+    return new Workbook().createWorksheet(name);
+}
+
+/*
+ * A schema stand-in that satisfies everything updateSchemas() touches, so any throw is
+ * the bug under test rather than an artefact of the fixture. A real throw lands in the
+ * outer catch and collapses every collected error into one generic
+ * "Failed to update schemas." - which is exactly the regression being pinned.
+ */
+function fakeSchema(name, iri, fields) {
+    const schema = {
+        name,
+        iri,
+        fields,
+        updateDocument() { },
+        updateRefs() { },
+    };
+    return {
+        schema,
+        worksheet: { name },
+        updateExpressions() { },
+    };
+}
+
+describe('@unit XlsxResult.updateSchemas unknown ref types', () => {
+    it('reports the unknown type without collapsing the other errors', () => {
+        const r = new XlsxResult();
+        const sheet = ws('S1');
+        const field = { isRef: true, type: 'link_missing', order: 4 };
+        r.addSchema(sheet, fakeSchema('S1', '#S1', [field]));
+        r.updateSchemas();
+
+        const errors = r.toJson().errors;
+        assert.isTrue(
+            errors.some((e) => /Unknown field type/.test(e.text)),
+            'the precise per-field error must survive'
+        );
+        assert.isFalse(
+            errors.some((e) => /Failed to update schemas/.test(e.text)),
+            'the null deref used to abandon the run and replace every error'
+        );
+        assert.deepEqual(field.errors?.map((e) => e.text), ['Unknown field type.']);
+    });
+
+    it('keeps collecting errors from schemas after the bad one', () => {
+        const r = new XlsxResult();
+        r.addSchema(ws('Bad'), fakeSchema('Bad', '#Bad', [{ isRef: true, type: 'link_missing', order: 1 }]));
+
+        // a resolvable link whose target is absent from the cache - a different,
+        // later error that the crash used to swallow
+        const linkId = r.addLink('Nowhere');
+        r.addSchema(ws('Next'), fakeSchema('Next', '#Next', [{ isRef: true, type: linkId, order: 2 }]));
+
+        const texts = r.updateSchemas() ?? r.toJson().errors.map((e) => e.text);
+        assert.include(texts.join('|'), 'Unknown field type.');
+        assert.include(texts.join('|'), 'Sub-schema named "Nowhere" not found.');
+    });
+
+    it('treats #SentinelHUB as a known ref type, like #GeoJSON', () => {
+        const r = new XlsxResult();
+        r.addSchema(ws('Geo'), fakeSchema('Geo', '#Geo', [
+            { isRef: true, type: '#GeoJSON', order: 1 },
+            { isRef: true, type: '#SentinelHUB', order: 2 },
+        ]));
+        r.updateSchemas();
+        assert.deepEqual(r.toJson().errors, []);
+    });
+});

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -461,6 +461,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             case TaskAction.DELETE_SCHEMAS:
             case TaskAction.IMPORT_SCHEMA_FILE:
             case TaskAction.IMPORT_SCHEMA_MESSAGE:
+                this.reportSchemaImportErrors(result);
                 if (this.last) {
                     const schemaId = typeof result === 'string' && result ? result : null;
                     const lastWithSchema = schemaId
@@ -603,6 +604,27 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             }
         });
         this.applyChanges();
+    }
+
+    /**
+     * ImportSchemaResult.errors is {type,uuid,name,error} and nothing downstream renders
+     * it, so flatten it into one sticky toast naming each schema that failed.
+     */
+    private reportSchemaImportErrors(result: any): void {
+        const errors = result?.errors;
+        if (!Array.isArray(errors) || !errors.length) {
+            return;
+        }
+        const text = errors
+            .map((e: any) => (e?.name ? `${e.name}: ${e.error}` : e?.error))
+            .filter((line: any) => !!line)
+            .join('\n');
+        const msg = text || 'Some schemas could not be imported.';
+        this.toastService.warn(
+            msg,
+            errors.length === 1 ? '1 schema was not imported' : `${errors.length} schemas were not imported`,
+            { sticky: true, logMessage: msg }
+        );
     }
 
     private redirect(urlString: string, replaceUrl: boolean = false) {


### PR DESCRIPTION
Fixes #6715

## Problem

**common** — `updateSchemas()` pushes an "Unknown field type" error for an unresolvable ref and then dereferences the same `undefined` link (`link.worksheet`). The `TypeError` is caught by the surrounding `catch`, which replaces every error collected so far with one generic `Failed to update schemas.` and abandons the run. One bad cell discards all the precise diagnostics.

`#SentinelHUB` is also pre-seeded as a validated ref type by the schema import (alongside `#GeoJSON`), so it has no link entry — it was reported as an unknown type and then triggered that crash.

**frontend** — the import returns `ImportSchemaResult.errors`, but the `IMPORT_SCHEMA_FILE` / `IMPORT_SCHEMA_MESSAGE` resolver navigates away without reading it, so a bundle that fails def validation completes silently.

## Fix

- add the missing `continue` after the unknown-type `addError`, and skip `#SentinelHUB` alongside `#GeoJSON`
- surface `result.errors` at task completion as one sticky toast naming each schema that failed

Reported by toast rather than through `SchemaViewDialog`: that dialog counts `type === 'error' | 'warning'` and renders `.text`, which does not match `ImportSchemaError`'s `{type,uuid,name,error}` and would render blank rows.

## Tests

New `common/tests/unit-tests/xlsx-result/xlsx-result-unknown-type.test.mjs`:

- the unknown-type error survives and is **not** replaced by the generic message
- errors from schemas processed after the bad one are still collected
- `#SentinelHUB` is treated as known, like `#GeoJSON`

All three fail on `develop`; the first reports `TypeError: Cannot read properties of undefined (reading 'worksheet')`, which is the bug. `17 passing` for the xlsx-result suite on this branch.

The fixtures stub everything `updateSchemas()` touches, so a throw is the defect under test rather than an artefact of the fixture.