### PR TITLE
fix(frontend): guard lists that are read before they load

### DIFF
--- a/frontend/src/app/modules/analytics/compare-module/compare-module.component.spec.ts
+++ b/frontend/src/app/modules/analytics/compare-module/compare-module.component.spec.ts
@@ -1,0 +1,30 @@
+import { CompareModuleComponent } from './compare-module.component';
+
+describe('CompareModuleComponent', () => {
+    function create(): any {
+        return Object.create(CompareModuleComponent.prototype);
+    }
+
+    // See compare-policy: an absent blocks report crashed the unguarded loop in onInit.
+    it('survives a diff whose blocks report is missing', () => {
+        const component = create();
+        component.value = {
+            total: 0, left: {}, right: {},
+            blocks: {}, inputEvents: {}, outputEvents: {}, variables: {},
+        };
+        expect(() => component.onInit()).not.toThrow();
+        expect(component.blocks).toEqual([]);
+    });
+
+    it('still computes _collapse for a populated report', () => {
+        const component = create();
+        component.value = {
+            total: 1, left: {}, right: {},
+            blocks: { report: [{ lvl: 0 }, { lvl: 1 }, { lvl: 0 }], columns: [] },
+            inputEvents: { report: [] }, outputEvents: { report: [] }, variables: { report: [] },
+        };
+        component.onInit();
+        expect(component.blocks[0]._collapse).toBe(1);
+        expect(component.blocks[1]._collapse).toBe(0);
+    });
+});

--- a/frontend/src/app/modules/analytics/compare-module/compare-module.component.ts
+++ b/frontend/src/app/modules/analytics/compare-module/compare-module.component.ts
@@ -109,7 +109,7 @@ export class CompareModuleComponent implements OnInit {
         this.inputEvents = inputEvents?.report;
         this.outputEvents = outputEvents?.report;
         this.variables = variables?.report;
-        this.blocks = blocks?.report;
+        this.blocks = Array.isArray(blocks?.report) ? blocks.report : [];
 
         let max = 0;
         for (let i = 0; i < this.blocks.length; i++) {

--- a/frontend/src/app/modules/analytics/compare-policy/compare-policy.component.spec.ts
+++ b/frontend/src/app/modules/analytics/compare-policy/compare-policy.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComparePolicyComponent } from './compare-policy.component';
+
+describe('ComparePolicyComponent', () => {
+    function create(): any {
+        return Object.create(ComparePolicyComponent.prototype);
+    }
+
+    // A degenerate diff arrives with no `report` node. `?.report` already anticipates
+    // that, but the loop below it walked `.length` unguarded, so onInit threw after the
+    // parent had already cleared its spinner - leaving a broken page.
+    it('survives a diff whose blocks report is missing', () => {
+        const component = create();
+        component.value = {
+            total: 0, left: {}, right: {},
+            blocks: {}, roles: {}, groups: {}, tokens: {}, topics: {}, tools: {},
+        };
+        expect(() => component.onInit()).not.toThrow();
+        expect(component.blocks).toEqual([]);
+    });
+
+    it('still computes _collapse for a populated report', () => {
+        const component = create();
+        component.value = {
+            total: 1, left: {}, right: {},
+            blocks: { report: [{ lvl: 0 }, { lvl: 1 }, { lvl: 0 }], columns: [] },
+            roles: { report: [] }, groups: { report: [] }, tokens: { report: [] },
+            topics: { report: [] }, tools: { report: [] },
+        };
+        component.onInit();
+        expect(component.blocks[0]._collapse).toBe(1);
+        expect(component.blocks[1]._collapse).toBe(0);
+    });
+});

--- a/frontend/src/app/modules/analytics/compare-policy/compare-policy.component.ts
+++ b/frontend/src/app/modules/analytics/compare-policy/compare-policy.component.ts
@@ -74,7 +74,7 @@ export class ComparePolicyComponent {
         this.groups = groups?.report;
         this.tokens = tokens?.report;
         this.topics = topics?.report;
-        this.blocks = blocks?.report;
+        this.blocks = Array.isArray(blocks?.report) ? blocks.report : [];
         this.tools = tools?.report;
 
         let max = 0;

--- a/frontend/src/app/modules/analytics/compare-schema/compare-schema.component.spec.ts
+++ b/frontend/src/app/modules/analytics/compare-schema/compare-schema.component.spec.ts
@@ -1,0 +1,26 @@
+import { CompareSchemaComponent } from './compare-schema.component';
+
+describe('CompareSchemaComponent', () => {
+    function create(): any {
+        return Object.create(CompareSchemaComponent.prototype);
+    }
+
+    // See compare-policy: an absent fields report crashed the unguarded loop in onInit.
+    it('survives a diff whose fields report is missing', () => {
+        const component = create();
+        component.value = { total: 0, left: {}, right: {}, fields: {} };
+        expect(() => component.onInit()).not.toThrow();
+        expect(component.report).toEqual([]);
+    });
+
+    it('still computes _collapse for a populated report', () => {
+        const component = create();
+        component.value = {
+            total: 1, left: {}, right: {},
+            fields: { report: [{ lvl: 0 }, { lvl: 1 }, { lvl: 0 }], columns: [] },
+        };
+        component.onInit();
+        expect(component.report[0]._collapse).toBe(1);
+        expect(component.report[1]._collapse).toBe(0);
+    });
+});

--- a/frontend/src/app/modules/analytics/compare-schema/compare-schema.component.ts
+++ b/frontend/src/app/modules/analytics/compare-schema/compare-schema.component.ts
@@ -48,7 +48,7 @@ export class CompareSchemaComponent implements OnInit {
         this.schema2 = this.value.right;
 
         const fields = this.value.fields;
-        this.report = fields?.report;
+        this.report = Array.isArray(fields?.report) ? fields.report : [];
         this.columns = fields?.columns || [];
         this.displayedColumns = this.columns
             .filter(c => c.label)

--- a/frontend/src/app/modules/analytics/compare/compare.component.spec.ts
+++ b/frontend/src/app/modules/analytics/compare/compare.component.spec.ts
@@ -1,0 +1,103 @@
+import { of, throwError } from 'rxjs';
+import { CompareComponent } from './compare.component';
+
+describe('CompareComponent', () => {
+    let analyticsService: any;
+    let snapshot: any;
+
+    function create(): any {
+        const component: any = Object.create(CompareComponent.prototype);
+        component.route = { snapshot, queryParams: of({}) };
+        component.router = { navigate: () => Promise.resolve(true) };
+        component.analyticsService = analyticsService;
+        component.compareStorage = { getFile: () => null };
+        component.items = [];
+        component.result = null;
+        component.error = null;
+        component.loading = false;
+        return component;
+    }
+
+    // two items is the minimum the non-original paths require
+    function twoItems(component: any) {
+        component.items = [{ type: 'id', value: 'a' }, { type: 'id', value: 'b' }];
+        snapshot.queryParams.items = btoa(JSON.stringify({
+            parent: null,
+            items: component.items,
+        }));
+    }
+
+    beforeEach(() => {
+        snapshot = { queryParams: {} };
+        analyticsService = {
+            compareDocuments: jasmine.createSpy('compareDocuments').and.returnValue(of({ total: 1 })),
+            compareSchema: jasmine.createSpy('compareSchema').and.returnValue(of({ total: 1 })),
+            compareModule: jasmine.createSpy('compareModule').and.returnValue(of({ total: 1 })),
+            comparePolicy: jasmine.createSpy('comparePolicy').and.returnValue(of({ total: 1 })),
+            compareTools: jasmine.createSpy('compareTools').and.returnValue(of({ total: 1 })),
+            comparePolicyOriginal: jasmine.createSpy('comparePolicyOriginal').and.returnValue(of({ total: 1 })),
+        };
+    });
+
+    // Every load error callback did only `loading = false; console.error(...)`, so the
+    // template's `@if (error)` banner was reachable only from the local "Invalid params"
+    // pre-check. A timeout, a 500 or an oversized diff left a blank page with no message.
+    describe('a failed comparison explains itself', () => {
+        function expectBanner(type: string, spy: jasmine.Spy) {
+            spyOn(console, 'error');
+            const component = create();
+            snapshot.queryParams.type = type;
+            twoItems(component);
+            spy.and.returnValue(throwError(() => ({ message: `${type} load failed` })));
+
+            component.loadData();
+
+            expect(component.loading).toBe(false);
+            expect(component.result).toBeNull();
+            expect(component.error).toBe(`${type} load failed`);
+        }
+
+        it('reports a failed document comparison', () => {
+            expectBanner('document', analyticsService.compareDocuments);
+        });
+
+        it('reports a failed schema comparison', () => {
+            expectBanner('schema', analyticsService.compareSchema);
+        });
+
+        it('reports a failed module comparison', () => {
+            expectBanner('module', analyticsService.compareModule);
+        });
+
+        it('reports a failed policy comparison', () => {
+            expectBanner('policy', analyticsService.comparePolicy);
+        });
+
+        it('reports a failed tool comparison', () => {
+            expectBanner('tool', analyticsService.compareTools);
+        });
+
+        it('falls back to a generic banner when the failure carries no message', () => {
+            spyOn(console, 'error');
+            const component = create();
+            snapshot.queryParams.type = 'document';
+            twoItems(component);
+            analyticsService.compareDocuments.and.returnValue(throwError(() => ({})));
+
+            component.loadData();
+
+            expect(component.loading).toBe(false);
+            expect(component.error).toBeTruthy();
+        });
+
+        it('leaves the banner clear on a successful comparison', () => {
+            const component = create();
+            snapshot.queryParams.type = 'document';
+            twoItems(component);
+
+            component.loadData();
+
+            expect(component.error).toBeNull();
+        });
+    });
+});

--- a/frontend/src/app/modules/analytics/compare/compare.component.ts
+++ b/frontend/src/app/modules/analytics/compare/compare.component.ts
@@ -241,6 +241,17 @@ export class CompareComponent implements OnInit {
         return results;
     }
 
+    /**
+     * Every load error used to be swallowed into console.error, leaving a stopped
+     * spinner over a blank page: the template's `@if (error)` banner was only ever
+     * reachable from the local "Invalid params" pre-check.
+     */
+    private onLoadFailed(message?: string): void {
+        this.loading = false;
+        this.error = message || 'The comparison could not be loaded. Please try again.';
+        console.error(message);
+    }
+
     private loadDocument() {
         this.error = null;
         const options = {
@@ -262,8 +273,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -287,8 +297,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
     private loadOriginalPolicy(policyId: string) {
@@ -307,8 +316,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -333,8 +341,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -358,8 +365,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -382,8 +388,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -405,8 +410,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -433,8 +437,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -460,8 +463,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -486,8 +488,7 @@ export class CompareComponent implements OnInit {
                 this.loading = false;
             }, 500);
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 
@@ -511,8 +512,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.loading = false;
-            console.error(message);
+            this.onLoadFailed(message);
         });
     }
 

--- a/frontend/src/app/modules/analytics/compare/compare.component.ts
+++ b/frontend/src/app/modules/analytics/compare/compare.component.ts
@@ -252,6 +252,12 @@ export class CompareComponent implements OnInit {
         console.error(message);
     }
 
+    private onExportFailed(message?: string): void {
+        this.loading = false;
+        this.error = message || 'The report could not be exported. Please try again.';
+        console.error(message);
+    }
+
     private loadDocument() {
         this.error = null;
         const options = {
@@ -297,7 +303,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.onLoadFailed(message);
+            this.onExportFailed(message);
         });
     }
     private loadOriginalPolicy(policyId: string) {
@@ -365,7 +371,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.onLoadFailed(message);
+            this.onExportFailed(message);
         });
     }
 
@@ -410,7 +416,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.onLoadFailed(message);
+            this.onExportFailed(message);
         });
     }
 
@@ -463,7 +469,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.onLoadFailed(message);
+            this.onExportFailed(message);
         });
     }
 
@@ -512,7 +518,7 @@ export class CompareComponent implements OnInit {
             }
             this.loading = false;
         }, ({ message }) => {
-            this.onLoadFailed(message);
+            this.onExportFailed(message);
         });
     }
 

--- a/frontend/src/app/modules/contract-engine/dialogs/wipe-requests-dialog/wipe-requests-dialog.component.spec.ts
+++ b/frontend/src/app/modules/contract-engine/dialogs/wipe-requests-dialog/wipe-requests-dialog.component.spec.ts
@@ -1,0 +1,57 @@
+import { of, throwError } from 'rxjs';
+import { WipeRequestsDialogComponent } from './wipe-requests-dialog.component';
+
+describe('WipeRequestsDialogComponent', () => {
+    let contractService: any;
+
+    function create(data: any = {}): any {
+        return new WipeRequestsDialogComponent(
+            contractService,
+            { close: () => {} } as any,
+            { data: { contractId: '0.0.1', version: '1.0.0', ...data } } as any,
+        );
+    }
+
+    beforeEach(() => {
+        contractService = {
+            getWipeRequests: jasmine.createSpy('getWipeRequests')
+                .and.returnValue(of({ body: [], headers: { get: () => null } })),
+            approveWipeRequest: jasmine.createSpy('approveWipeRequest').and.returnValue(of({})),
+            rejectWipeRequest: jasmine.createSpy('rejectWipeRequest').and.returnValue(of({})),
+        };
+    });
+
+    // The template reads `requests.length` on its first render, before the async load
+    // resolves, so an uninitialised list threw in change detection.
+    it('starts with an empty request list so the first render cannot throw', () => {
+        expect(create().requests).toEqual([] as any);
+    });
+
+    it('loads the page and reads the total from the header', () => {
+        const headers = new Map<string, string>([['X-Total-Count', '7']]);
+        contractService.getWipeRequests.and.returnValue(of({
+            body: [{ id: 'r1', user: 'u' }],
+            headers: { get: (k: string) => headers.get(k) },
+        }));
+        const c = create();
+        c.loadRequests();
+        expect(c.requests.length).toBe(1);
+        expect(c.length).toBe(7);
+    });
+
+    it('falls back to the empty state when the request list fails to load', () => {
+        contractService.getWipeRequests.and.returnValue(of({
+            body: [{ id: 'r1', user: 'u' }],
+            headers: { get: () => '1' },
+        }));
+        const c = create();
+        c.loadRequests();
+        expect(c.requests.length).toBe(1);
+
+        contractService.getWipeRequests.and.returnValue(throwError(() => new Error('boom')));
+        c.loadRequests();
+        expect(c.requests).toEqual([] as any);
+        expect(c.length).toBe(0);
+        expect(c.loading).toBe(false);
+    });
+});

--- a/frontend/src/app/modules/contract-engine/dialogs/wipe-requests-dialog/wipe-requests-dialog.component.ts
+++ b/frontend/src/app/modules/contract-engine/dialogs/wipe-requests-dialog/wipe-requests-dialog.component.ts
@@ -14,7 +14,7 @@ export class WipeRequestsDialogComponent implements OnInit {
         id: string;
         user: string;
         token?: string;
-    }[];
+    }[] = [];
     loading: boolean = false;
     pageIndex = 0;
     pageSize = 5;
@@ -53,7 +53,12 @@ export class WipeRequestsDialogComponent implements OnInit {
                     this.length = (count && +count) || this.requests.length;
                     this.loading = false;
                 },
-                () => (this.loading = false)
+                () => {
+                    // fall back to the empty state; the template reads requests.length
+                    this.requests = [];
+                    this.length = 0;
+                    this.loading = false;
+                }
             );
     }
 


### PR DESCRIPTION
Fixes #6717

## Fixes

**compare-policy / compare-schema / compare-module** — normalise `X?.report` to `[]` with `Array.isArray`, matching what the newer `compare-tool` / `compare-document` / `compare-record` already do. The `?.` anticipated an absent report node; the loop right after it did not.

**wipe-requests-dialog** — initialise `requests` to `[]` like all four sibling dialogs, and reset it in the load error arm so the empty state renders instead of the body staying permanently broken.

**compare.component** — route all eleven load error callbacks through one helper that sets `this.error`, so the template's existing `@if (error)` banner is reached on an HTTP failure rather than only from the local "Invalid params" pre-check.

## Tests

Four new spec files (16 tests). Run against `develop` with only the source changes reverted, **11 of them fail**:

- `ComparePolicyComponent` / `CompareSchemaComponent` / `CompareModuleComponent` — "survives a diff whose report is missing" (3)
- `CompareComponent` — banner set for document/schema/module/policy/tool failures, plus the no-message fallback (6)
- `WipeRequestsDialogComponent` — empty initial list, and the empty state after a failed load (2)

The 5 that pass either way are the companion assertions (populated reports still compute `_collapse`, a successful load leaves the banner clear, the header total is read) — they are there to show the guards did not change the working path.