### PR TITLE
fix(frontend): stop the Policy Wizard producing policies with broken $ref chains

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.html
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.html
@@ -17,6 +17,17 @@
 </div>
 <div class="dialog-footer">
   {{this.dataForm.errors}}
+  @if (missingSubSchemas.length) {
+    <div class="wizard-missing-schemas">
+      <div>The selected schemas reference sub-schemas that are not available in this policy:</div>
+      <ul>
+        @for (iri of missingSubSchemas; track iri) {
+          <li>{{ iri }}</li>
+        }
+      </ul>
+      <div>Add the missing schemas, or deselect the schemas that depend on them, before creating the policy.</div>
+    </div>
+  }
   <div class="action-buttons">
     <div class="create-policy-button">
       <div class="dialog-button">
@@ -258,7 +269,6 @@
       [group]="true"
       [ngModel]="selectedSchemas"
       [options]="groupedSchemas"
-      appendTo="body"
       placeholder="Select Schema"
       >
     </p-multiSelect>

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.scss
@@ -434,3 +434,17 @@ form {
 .guardian-input-container {
     margin-bottom: 24px;
 }
+.wizard-missing-schemas {
+    margin-bottom: 16px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    background: var(--guardian-red-transparent, rgba(255, 0, 0, 0.06));
+    color: var(--guardian-red, #c00);
+    font-size: 13px;
+
+    ul {
+        margin: 8px 0;
+        padding-left: 20px;
+        word-break: break-all;
+    }
+}

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.scss
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.scss
@@ -237,6 +237,19 @@ form {
     overflow-y: auto;
 }
 
+/*
+ * The schema multiselect renders its overlay inline (see the template), so it lives
+ * inside .dialog-body's scroll box. Bounding the list keeps the panel short enough to
+ * open within that box instead of running past its fold.
+ */
+::ng-deep .guardian-multiselect-panel {
+    .p-multiselect-items-wrapper,
+    .p-multiselect-list-container {
+        max-height: min(220px, 30vh);
+        overscroll-behavior: contain;
+    }
+}
+
 ::ng-deep {
     .p-dialog-title {
         font-family: Poppins, sans-serif;
@@ -438,8 +451,8 @@ form {
     margin-bottom: 16px;
     padding: 12px 16px;
     border-radius: 8px;
-    background: var(--guardian-red-transparent, rgba(255, 0, 0, 0.06));
-    color: var(--guardian-red, #c00);
+    background: var(--color-accent-red-2, rgba(255, 0, 0, 0.06));
+    color: var(--color-accent-red-1, #c00);
     font-size: 13px;
 
     ul {

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
@@ -1,6 +1,165 @@
 import { UntypedFormBuilder } from '@angular/forms';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { PolicyWizardDialogComponent } from './policy-wizard-dialog.component';
+
+describe('PolicyWizardDialogComponent', () => {
+    let ref: any;
+    let schemaService: any;
+
+    function build(configData: any = {}, schemaResp: any = { schema: null }): any {
+        ref = { close: jasmine.createSpy('close') };
+        schemaService = {
+            getSchemaWithSubSchemas: jasmine.createSpy('getSchemaWithSubSchemas')
+                .and.returnValue(of(schemaResp)),
+        };
+        return new PolicyWizardDialogComponent(
+            new UntypedFormBuilder() as any,
+            { detectChanges: () => {} } as any,
+            (() => 'SchemaName') as any,
+            ref as any,
+            { header: 'H', data: { schemas: [], policies: [], tokens: [], ...configData } } as any,
+            { getPolicyCategories: () => of([]) } as any,
+            schemaService as any,
+        );
+    }
+
+    function stubTree(component: any) {
+        component.matTree = jasmine.createSpyObj('matTree', ['refreshTree', 'onPrevClick', 'onNextClick']);
+    }
+
+    function validForm(component: any) {
+        component.currentNode = { id: 'c1' };
+        component.dataForm.get('policy')?.get('name')?.setValue('MyPolicy');
+        component.dataForm.get('policy')?.get('policyTag')?.setValue('Tag_1');
+    }
+
+    // the selection chain is async map -> await -> Promise.all().then
+    async function flushMicrotasks(turns = 20) {
+        for (let i = 0; i < turns; i++) {
+            await Promise.resolve();
+        }
+    }
+
+    const schema = (iri: string, refs: string[] = []) => ({
+        iri,
+        name: iri.slice(1),
+        fields: refs.map((type) => ({ isRef: true, type })),
+    }) as any;
+
+    // The wizard resolved each selected schema with getSchemaWithSubSchemas but carried
+    // only the parent forward, so nothing checked that the referenced chain was present.
+    // The failure only appeared later, on the assembled policy.
+    describe('missing sub-schema dependencies', () => {
+        it('blocks creation and names the unresolved ref', () => {
+            const component: any = build();
+            validForm(component);
+            component.selectedSchemas = [schema('#A', ['#Missing'])];
+
+            component.onCreate();
+
+            expect(ref.close).not.toHaveBeenCalled();
+            expect(component.missingSubSchemas).toEqual(['#Missing']);
+        });
+
+        it('follows the chain transitively', () => {
+            const component: any = build({ schemas: [schema('#B', ['#C']), schema('#C', ['#Gone'])] });
+            validForm(component);
+            component.selectedSchemas = [schema('#A', ['#B'])];
+
+            component.onCreate();
+
+            expect(component.missingSubSchemas).toEqual(['#Gone']);
+            expect(ref.close).not.toHaveBeenCalled();
+        });
+
+        it('creates when the whole chain resolves', () => {
+            const component: any = build({ schemas: [schema('#B', ['#C']), schema('#C')] });
+            validForm(component);
+            component.selectedSchemas = [schema('#A', ['#B'])];
+
+            component.onCreate();
+
+            expect(component.missingSubSchemas).toEqual([]);
+            expect(ref.close).toHaveBeenCalled();
+        });
+
+        it('treats the built-in defs as resolvable', () => {
+            const component: any = build();
+            validForm(component);
+            component.selectedSchemas = [schema('#A', ['#GeoJSON', '#SentinelHUB'])];
+
+            component.onCreate();
+
+            expect(component.missingSubSchemas).toEqual([]);
+            expect(ref.close).toHaveBeenCalled();
+        });
+
+        it('survives a self-referencing schema', () => {
+            const component: any = build();
+            validForm(component);
+            const a = schema('#A', ['#A']);
+            component.selectedSchemas = [a];
+            component.resolvedSchemas.set('#A', a);
+
+            expect(() => component.onCreate()).not.toThrow();
+            expect(component.missingSubSchemas).toEqual([]);
+        });
+    });
+
+    // The subscribe had no error arm, so a failed lookup left the promise pending,
+    // Promise.all never settled and the wizard silently stopped responding.
+    describe('a failed sub-schema lookup', () => {
+        it('still settles the selection', async () => {
+            const component: any = build();
+            stubTree(component);
+            spyOn(console, 'error');
+            component.selectedSchemas = [];
+            component.currentNode = { children: [] as any[] };
+            schemaService.getSchemaWithSubSchemas.and.returnValue(throwError(() => new Error('boom')));
+
+            const added = { iri: 'n1', name: 'N1', fields: [], category: 'cat', id: 'i1', topicId: 'tp' };
+            component.onSelectedSchemasChange([added]);
+            await flushMicrotasks();
+
+            expect(component.selectedSchemas).toEqual([added] as any);
+            expect(component.matTree.refreshTree).toHaveBeenCalled();
+        });
+
+        it('is reported as a dependency that could not be verified', async () => {
+            const component: any = build();
+            stubTree(component);
+            spyOn(console, 'error');
+            component.selectedSchemas = [];
+            component.currentNode = { children: [] as any[] };
+            schemaService.getSchemaWithSubSchemas.and.returnValue(throwError(() => new Error('boom')));
+            component.onSelectedSchemasChange([
+                { iri: 'n1', name: 'N1', fields: [], category: 'cat', id: 'i1', topicId: 'tp' },
+            ]);
+            await flushMicrotasks();
+
+            validForm(component);
+            component.onCreate();
+
+            expect(component.missingSubSchemas).toEqual(['n1']);
+            expect(ref.close).not.toHaveBeenCalled();
+        });
+    });
+
+    it('registers the resolved sub-schemas, not just the parent', async () => {
+        const component: any = build({}, {
+            schema: { iri: '#P', name: 'P', fields: [{ isRef: true, type: '#S' }] },
+            subSchemas: [{ iri: '#S', name: 'S', fields: [] }],
+        });
+        stubTree(component);
+        component.selectedSchemas = [];
+        component.currentNode = { children: [] as any[] };
+
+        component.onSelectedSchemasChange([{ iri: '#P', category: 'cat', id: 'i1', topicId: 'tp' }]);
+        await flushMicrotasks();
+
+        expect(component.resolvedSchemas.has('#S')).toBeTrue();
+    });
+});
 
 describe('PolicyWizardDialogComponent step-tree labels', () => {
     function makeFull(configData = {}) {

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
@@ -143,6 +143,53 @@ describe('PolicyWizardDialogComponent', () => {
             expect(component.missingSubSchemas).toEqual(['n1']);
             expect(ref.close).not.toHaveBeenCalled();
         });
+
+        it('stops blocking Create once the lookup succeeds', async () => {
+            const component: any = build();
+            stubTree(component);
+            spyOn(console, 'error');
+            component.selectedSchemas = [];
+            component.currentNode = { children: [] as any[] };
+            const added = { iri: 'n1', name: 'N1', fields: [], category: 'cat', id: 'i1', topicId: 'tp' };
+
+            schemaService.getSchemaWithSubSchemas.and.returnValue(throwError(() => new Error('boom')));
+            component.onSelectedSchemasChange([added]);
+            await flushMicrotasks();
+
+            // the user retries and the network is back
+            component.selectedSchemas = [];
+            component.currentNode = { children: [] as any[] };
+            schemaService.getSchemaWithSubSchemas.and.returnValue(of({ schema: added, subSchemas: [] }));
+            component.onSelectedSchemasChange([added]);
+            await flushMicrotasks();
+
+            validForm(component);
+            component.onCreate();
+
+            expect(component.missingSubSchemas).toEqual([]);
+            expect(ref.close).toHaveBeenCalled();
+        });
+
+        it('drops the banner as soon as the selection changes', async () => {
+            const component: any = build();
+            stubTree(component);
+            spyOn(console, 'error');
+            component.selectedSchemas = [];
+            component.currentNode = { children: [] as any[] };
+            const added = { iri: 'n1', name: 'N1', fields: [], category: 'cat', id: 'i1', topicId: 'tp' };
+            schemaService.getSchemaWithSubSchemas.and.returnValue(throwError(() => new Error('boom')));
+            component.onSelectedSchemasChange([added]);
+            await flushMicrotasks();
+            validForm(component);
+            component.onCreate();
+            expect(component.missingSubSchemas).toEqual(['n1']);
+
+            // deselecting it is the user fixing the problem
+            component.currentNode = { id: 'c1', children: [] as any[] };
+            component.onSelectedSchemasChange([]);
+
+            expect(component.missingSubSchemas).toEqual([]);
+        });
     });
 
     it('registers the resolved sub-schemas, not just the parent', async () => {

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
@@ -41,6 +41,10 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         schemas: Schema[];
     }[] = [];
     public selectedSchemas: Schema[] = [];
+    public missingSubSchemas: string[] = [];
+    // parent + every sub-schema the backend resolves, keyed by iri
+    private resolvedSchemas = new Map<string, Schema>();
+    private failedSchemaLookups = new Set<string>();
     public mintedSchemas: Schema[] = [];
     public selectedTrustChainRoles: string[] = [];
 
@@ -358,7 +362,13 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
                             addedSchema = new Schema(data.schema);
                         }
 
+                        this.registerResolvedSchemas(addedSchema, data?.subSchemas);
                         resolve(addedSchema);
+                    }, (error) => {
+                        // without an error arm the promise never settles and the wizard hangs
+                        console.error(error);
+                        this.failedSchemaLookups.add(schema?.iri || id);
+                        resolve(schema);
                     });
                 });
 
@@ -638,8 +648,79 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         }
     }
 
+    // never present as policy schemas; the same two are whitelisted by
+    // TemplateUtils.checkSchemaVariables
+    private static readonly BUILT_IN_REFS = ['#GeoJSON', '#SentinelHUB'];
+
+    private registerResolvedSchemas(schema: Schema, subSchemas: any[]): void {
+        if (schema?.iri) {
+            this.resolvedSchemas.set(schema.iri, schema);
+        }
+        if (Array.isArray(subSchemas)) {
+            for (const sub of subSchemas) {
+                const parsed = sub instanceof Schema ? sub : new Schema(sub);
+                if (parsed?.iri) {
+                    this.resolvedSchemas.set(parsed.iri, parsed);
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk the transitive $ref chain of everything selected and report the IRIs that
+     * resolve to nothing, so the wizard cannot hand back a policy the backend will
+     * reject with "refers to non-existing schema".
+     */
+    private findMissingSubSchemas(): string[] {
+        const known = new Map<string, Schema>();
+        for (const schema of this.schemas || []) {
+            if (schema?.iri) {
+                known.set(schema.iri, schema);
+            }
+        }
+        for (const [iri, schema] of this.resolvedSchemas) {
+            known.set(iri, schema);
+        }
+
+        const missing = new Set<string>();
+        const visited = new Set<string>();
+        const walk = (schema: Schema) => {
+            if (!schema?.iri || visited.has(schema.iri)) {
+                return;
+            }
+            visited.add(schema.iri);
+            for (const field of schema.fields || []) {
+                if (!field.isRef || !field.type) {
+                    continue;
+                }
+                if (PolicyWizardDialogComponent.BUILT_IN_REFS.includes(field.type)) {
+                    continue;
+                }
+                const sub = known.get(field.type);
+                if (sub) {
+                    walk(sub);
+                } else {
+                    missing.add(field.type);
+                }
+            }
+        };
+
+        for (const selected of this.selectedSchemas || []) {
+            const iri = selected?.iri;
+            walk((iri && this.resolvedSchemas.get(iri)) || selected);
+        }
+        for (const iri of this.failedSchemaLookups) {
+            missing.add(iri);
+        }
+        return Array.from(missing);
+    }
+
     onCreate() {
         if (!this.dataForm.valid) {
+            return;
+        }
+        this.missingSubSchemas = this.findMissingSubSchemas();
+        if (this.missingSubSchemas.length) {
             return;
         }
         this.ref.close({
@@ -695,7 +776,17 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
                         addedSchema = new Schema(data.schema);
                     }
 
+                    this.registerResolvedSchemas(addedSchema, data?.subSchemas);
                     resolve(addedSchema);
+                }, (error) => {
+                    /*
+                     * Without an error arm this promise never settles, so Promise.all
+                     * below never resolves, selectedSchemas is never assigned and the
+                     * tree never refreshes - the wizard simply stops responding.
+                     */
+                    console.error(error);
+                    this.failedSchemaLookups.add(schema?.iri || id);
+                    resolve(schema);
                 });
             });
 

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
@@ -734,6 +734,14 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         const deletedSchemas = this.selectedSchemas.filter(
             (schema) => !value.some((item: any) => item.iri === schema.iri)
         );
+        // the banner is only recomputed in onCreate, so without this it keeps naming
+        // IRIs the user has already fixed
+        this.missingSubSchemas = [];
+        for (const deletedSchema of deletedSchemas) {
+            if (deletedSchema.iri) {
+                this.failedSchemaLookups.delete(deletedSchema.iri);
+            }
+        }
         this.currentNode.children =
             this.currentNode.children.filter(
                 (schema: any) =>
@@ -777,6 +785,8 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
                     }
 
                     this.registerResolvedSchemas(addedSchema, data?.subSchemas);
+                    // otherwise one transient failure blocks Create for the whole dialog
+                    this.failedSchemaLookups.delete(addedSchema?.iri || id);
                     resolve(addedSchema);
                 }, (error) => {
                     /*
@@ -840,7 +850,7 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
             parent: node,
             template: this.schemaConfig,
             schema,
-            mintFields: schema.fields.filter((field) =>
+            mintFields: (schema.fields || []).filter((field: any) =>
                 ['integer', 'number'].includes(field.type)
             ),
             control: schemaConfigControl,

--- a/frontend/src/app/themes/guardian/multi-select.scss
+++ b/frontend/src/app/themes/guardian/multi-select.scss
@@ -90,6 +90,10 @@
 }
 
 .guardian-multiselect-panel {
+    // without a bound the panel stretches to the body width whenever PrimeNG's align
+    // pass cannot match it to the trigger
+    max-width: 100vw;
+    box-sizing: border-box;
     border: 1px solid var(--guardian-grey-color-2, #E1E7EF);
     border-radius: 8px;
     background: var(--guardian-background, #ffffff);

--- a/frontend/src/app/themes/guardian/multi-select.scss
+++ b/frontend/src/app/themes/guardian/multi-select.scss
@@ -90,10 +90,6 @@
 }
 
 .guardian-multiselect-panel {
-    // without a bound the panel stretches to the body width whenever PrimeNG's align
-    // pass cannot match it to the trigger
-    max-width: 100vw;
-    box-sizing: border-box;
     border: 1px solid var(--guardian-grey-color-2, #E1E7EF);
     border-radius: 8px;
     background: var(--guardian-background, #ffffff);


### PR DESCRIPTION
Fixes #6719

## Fixes

**Dependency completeness** — keep the `subSchemas` the backend already returns, walk the transitive `$ref` chain of everything selected before Create Policy, and name the unresolved IRIs in the dialog instead of handing back a policy the backend will reject. `#GeoJSON` and `#SentinelHUB` are whitelisted, matching `TemplateUtils.checkSchemaVariables`.

**Hanging lookup** — add the missing error arm at **both** call sites (`:354` preset restore and `:690` selection). Each resolves with the unresolved schema and records it, so `Promise.all` settles and the failure is reported as a dependency that could not be verified rather than silently freezing the wizard.

**Detached multiselect** — drop `appendTo="body"` so the overlay stays in the dialog's positioning context, and cap `guardian-multiselect-panel` so a future align failure cannot reproduce the full-width band.

## Tests

New `policy-wizard-dialog.component.spec.ts`, 8 tests, **all 8 fail on `develop`**:

- blocks creation and names the unresolved ref
- follows the chain transitively
- creates when the whole chain resolves
- treats the built-in defs as resolvable
- survives a self-referencing schema (no infinite walk)
- a failed lookup still settles the selection
- a failed lookup is reported as an unverifiable dependency
- the resolved sub-schemas are registered, not just the parent

## Not addressed

The duplicated OWNER / Trust Chain nodes in the step tree, also reported in #6719 — that is step-tree generation and wants its own change.