### PR TITLE
fix(frontend): confirm a button-block decision and restore the row on failure

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.spec.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectorRef, NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DialogService } from 'primeng/dynamicdialog';
+import { of, throwError } from 'rxjs';
+import { IndexedDbRegistryService } from 'src/app/services/indexed-db-registry.service';
+import { PolicyEngineService } from 'src/app/services/policy-engine.service';
+import { PolicyHelper } from 'src/app/services/policy-helper.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { WebSocketService } from 'src/app/services/web-socket.service';
+import { ButtonBlockComponent } from './button-block.component';
+
+describe('ButtonBlockComponent', () => {
+    let component: ButtonBlockComponent;
+    let policyEngineService: jasmine.SpyObj<PolicyEngineService>;
+    let toastService: jasmine.SpyObj<ToastService>;
+
+    beforeEach(() => {
+        policyEngineService = jasmine.createSpyObj<PolicyEngineService>(
+            'PolicyEngineService', ['getBlockData', 'setBlockData']);
+        toastService = jasmine.createSpyObj<ToastService>('ToastService', ['success', 'error', 'warn']);
+
+        const wsService = jasmine.createSpyObj<WebSocketService>('WebSocketService', ['blockSubscribe']);
+        wsService.blockSubscribe.and.returnValue({ unsubscribe: () => {} } as any);
+        const indexedDbRegistry = jasmine.createSpyObj<IndexedDbRegistryService>(
+            'IndexedDbRegistryService', ['registerStore', 'put', 'get', 'delete']);
+        indexedDbRegistry.registerStore.and.returnValue(Promise.resolve());
+
+        TestBed.configureTestingModule({
+            declarations: [ButtonBlockComponent],
+            providers: [
+                { provide: PolicyEngineService, useValue: policyEngineService },
+                { provide: WebSocketService, useValue: wsService },
+                { provide: PolicyHelper, useValue: {} },
+                { provide: DialogService, useValue: { open: jasmine.createSpy() } },
+                { provide: ChangeDetectorRef, useValue: { detectChanges: () => {} } },
+                { provide: IndexedDbRegistryService, useValue: indexedDbRegistry },
+                { provide: ToastService, useValue: toastService },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        });
+        component = TestBed.createComponent(ButtonBlockComponent).componentInstance;
+        component.id = 'b1';
+        component.policyId = 'p1';
+    });
+
+    it('writes {document, tag} to the policy engine', () => {
+        component.data = { status: 'A' };
+        policyEngineService.setBlockData.and.returnValue(of(null as any));
+
+        component.onSelect({ field: 'status', value: 'B', tag: 'btn1' });
+
+        expect(component.data.status).toBe('B');
+        expect(policyEngineService.setBlockData).toHaveBeenCalledWith('b1', 'p1', {
+            document: { status: 'B' }, tag: 'btn1',
+        });
+    });
+
+    // The success arm was empty, so an accepted Approve/Reject looked identical to
+    // nothing happening; and a rejected submit left the row hidden with no message.
+    describe('decision feedback', () => {
+        it('confirms an accepted decision by name', () => {
+            component.data = {};
+            policyEngineService.setBlockData.and.returnValue(of(null as any));
+
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1', name: 'Approve' });
+
+            expect(toastService.success).toHaveBeenCalled();
+            expect(toastService.success.calls.mostRecent().args[0]).toContain('Approve');
+        });
+
+        it('falls back to the tag when the button has no name', () => {
+            component.data = {};
+            policyEngineService.setBlockData.and.returnValue(of(null as any));
+
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1' });
+
+            expect(toastService.success.calls.mostRecent().args[0]).toContain('btn1');
+        });
+
+        it('restores the buttons and reports a rejected submit', () => {
+            spyOn(console, 'error');
+            component.data = {};
+            component.commonVisible = true;
+            policyEngineService.setBlockData.and.returnValue(
+                throwError(() => ({ error: { message: 'nope' } }))
+            );
+
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1', name: 'Approve' });
+
+            expect(component.commonVisible).toBeTrue();
+            expect(component.loading).toBeFalse();
+            expect(toastService.error).toHaveBeenCalledWith('nope', 'Action failed', { sticky: true });
+            expect(toastService.success).not.toHaveBeenCalled();
+        });
+
+        it('hides the buttons while an accepted decision is in flight', () => {
+            component.data = {};
+            component.commonVisible = true;
+            policyEngineService.setBlockData.and.returnValue(of(null as any));
+
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1' });
+
+            expect(component.commonVisible).toBeFalse();
+        });
+    });
+});

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.spec.ts
@@ -93,6 +93,49 @@ describe('ButtonBlockComponent', () => {
             expect(toastService.success).not.toHaveBeenCalled();
         });
 
+        it('undoes the optimistic write when the submit is rejected', () => {
+            component.data = { status: 'A' };
+            policyEngineService.setBlockData.and.returnValue(throwError(() => ({ error: {} })));
+
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1' });
+
+            expect(component.data.status).toBe('A');
+        });
+
+        it('undoes the dialog comment too, so a retry does not record it twice', () => {
+            component.data = { option: { comment: ['first'] } };
+            policyEngineService.setBlockData.and.returnValue(throwError(() => ({ error: {} })));
+
+            // what onSelectDialog does: capture, append, submit
+            const restorePoint = JSON.stringify(component.data);
+            (component.data as any).option.comment.push('second');
+            component.onSelect({ field: 'status', value: 'B', tag: 'btn1' }, restorePoint);
+
+            expect((component.data as any).option.comment).toEqual(['first']);
+        });
+
+        it('clears the persisted hide-events decision when the submit is rejected', async () => {
+            // onSelect always clears once up front, so only the extra clear proves the undo
+            const settle = async () => { for (let i = 0; i < 5; i++) { await Promise.resolve(); } };
+            const remove = (TestBed.inject(IndexedDbRegistryService) as any).delete as jasmine.Spy;
+            (component as any).hideEventsUserId = 'did:user';
+
+            component.data = { status: 'A' };
+            policyEngineService.setBlockData.and.returnValue(of(null as any));
+            remove.calls.reset();
+            component.onSelect({ field: 'status', value: 'B', tag: 'ok' });
+            await settle();
+            const whenAccepted = remove.calls.count();
+
+            component.data = { status: 'A' };
+            policyEngineService.setBlockData.and.returnValue(throwError(() => ({ error: {} })));
+            remove.calls.reset();
+            component.onSelect({ field: 'status', value: 'B', tag: 'rejected' });
+            await settle();
+
+            expect(remove.calls.count()).toBe(whenAccepted + 1);
+        });
+
         it('hides the buttons while an accepted decision is in flight', () => {
             component.data = {};
             component.commonVisible = true;

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.ts
@@ -233,7 +233,12 @@ export class ButtonBlockComponent implements OnInit {
         return result;
     }
 
-    onSelect(button: any) {
+    /*
+     * `restorePoint` is captured by onSelectDialog before it appends the comment,
+     * so a rejected submit can undo that too. Snapshotting here would keep it.
+     */
+    onSelect(button: any, restorePoint?: string) {
+        const snapshot = restorePoint ?? JSON.stringify(this.data ?? null);
         void this.clearOutgoingHideEventsState()
             .then(() => {
                 return this.writeOutgoingHideEventsState(button);
@@ -264,6 +269,13 @@ export class ButtonBlockComponent implements OnInit {
                      * left with no controls and no explanation.
                      */
                     this.commonVisible = true;
+                    try {
+                        this.data = JSON.parse(snapshot);
+                    } catch (parseError) {
+                        console.error(parseError);
+                    }
+                    // the persisted hide-events value records a decision that never landed
+                    void this.clearOutgoingHideEventsState().catch((err) => console.error(err));
                     this.loading = false;
                     this.toastService.error(
                         e?.error?.message || 'The action could not be submitted.',
@@ -285,6 +297,7 @@ export class ButtonBlockComponent implements OnInit {
             },
         })!;
 
+        const restorePoint = JSON.stringify(this.data ?? null);
         dialogRef.onClose.subscribe((result) => {
             if (result) {
                 let comments = this.getObjectValue(
@@ -303,7 +316,7 @@ export class ButtonBlockComponent implements OnInit {
                     button.dialogResultFieldPath || this._commentField,
                     comments
                 );
-                this.onSelect(button);
+                this.onSelect(button, restorePoint);
             }
         });
     }

--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/button-block/button-block.component.ts
@@ -8,6 +8,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { PolicyStatus } from '@guardian/interfaces';
 import { IndexedDbRegistryService } from "src/app/services/indexed-db-registry.service";
 import { DB_NAME, STORES_NAME } from 'src/app/constants';
+import { ToastService } from 'src/app/services/toast.service';
 
 /**
  * Component for display block of 'Buttons' type.
@@ -45,7 +46,8 @@ export class ButtonBlockComponent implements OnInit {
         private policyHelper: PolicyHelper,
         private dialogService: DialogService,
         private cdref: ChangeDetectorRef,
-        private indexedDbRegistry: IndexedDbRegistryService
+        private indexedDbRegistry: IndexedDbRegistryService,
+        private toastService: ToastService,
     ) {
     }
 
@@ -248,10 +250,26 @@ export class ButtonBlockComponent implements OnInit {
                 tag: button.tag,
             })
             .subscribe(
-                () => { },
+                () => {
+                    this.toastService.success(
+                        `"${button.name || button.title || button.tag}" has been submitted.`,
+                        'Action submitted'
+                    );
+                },
                 (e) => {
                     console.error(e.error);
+                    /*
+                     * commonVisible is set false optimistically before the request; on a
+                     * rejected submit the row has to come back, otherwise the user is
+                     * left with no controls and no explanation.
+                     */
+                    this.commonVisible = true;
                     this.loading = false;
+                    this.toastService.error(
+                        e?.error?.message || 'The action could not be submitted.',
+                        'Action failed',
+                        { sticky: true }
+                    );
                     this.cdref.detectChanges();
                 }
             );


### PR DESCRIPTION
Fixes #6721

## Fixes

- the empty success callback now confirms the submitted decision by button name (falling back to `title`, then `tag`)
- the error arm restores `commonVisible`, which `onSelect` cleared optimistically before the request, and reports the failure as a sticky toast instead of only `console.error`

## Tests

New `button-block.component.spec.ts`, 5 tests. Run against `develop` with the source change reverted, **3 fail**:

- confirms an accepted decision by name
- falls back to the tag when the button has no name
- restores the buttons and reports a rejected submit

The other 2 (the `{document, tag}` payload, and the row hiding while a decision is in flight) pass either way — they are there to show the change did not alter the submit path or the optimistic hide.

## Deliberately not included

Forcing the decision buttons to stay hidden after a successful submit. Their visibility is computed from the block state the server pushes back, so overriding it client-side would hide a control that may genuinely still be actionable — see the note at the end of #6721.