### PR TITLE
fix(frontend): clear "Unsaved changes" when an edit is reverted

### DIFF
--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -60,6 +60,7 @@ describe('SchemasConfigurationComponent', () => {
         component.schemasPage = 0;
         component.schemaSearch = '';
         component.dirtySchemaIds = new Set<string>(state.dirtyIds || []);
+        component.savedSignatures = new Map<string, string>();
         component.newSchemaKeys = new Set<string>(state.newKeys || []);
 
         component.router = { url: state.url || '/schema-configuration', navigate: () => Promise.resolve(true) };
@@ -189,6 +190,126 @@ describe('SchemasConfigurationComponent', () => {
             component.onExport();
 
             expect(component.toasts[0].detail).toBe('Unknown error');
+        });
+    });
+
+    // Dirty tracking was add-only: markDirty() added the schema id and nothing ever
+    // removed it, so once touched a schema stayed dirty until saved even if the user
+    // undid the change.
+    describe('reverting an edit clears the dirty flag', () => {
+
+        function withBaseline() {
+            const field = makeField({ name: 'f1', title: 'Original' });
+            const schema: any = makeSchema({ id: 'a', fields: [field] });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.snapshotSchema(schema);
+            return { component, schema, field };
+        }
+
+        it('marks dirty on edit and clean again on revert', () => {
+            const { component, field } = withBaseline();
+
+            field.title = 'Changed';
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            field.title = 'Original';
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeFalse();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('notices an added and then removed field', () => {
+            const { component, schema } = withBaseline();
+
+            schema.fields.push(makeField({ name: 'f2' }));
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            schema.fields.pop();
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('notices an added and then removed condition', () => {
+            const { component, schema } = withBaseline();
+
+            schema.conditions.push({
+                ifCondition: { field: { name: 'f1' }, fieldValue: 'x' },
+                thenFields: [makeField({ name: 'then_1' })],
+                elseFields: [],
+            });
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            schema.conditions.pop();
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('stays dirty when only part of the edit is reverted', () => {
+            const { component, schema, field } = withBaseline();
+
+            field.title = 'Changed';
+            schema.fields.push(makeField({ name: 'f2' }));
+            component.markDirty();
+
+            field.title = 'Original';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+        });
+
+        // A false clean would hide Save all and silently discard the user's work, so
+        // anything the signature cannot model has to leave the schema dirty.
+        it('stays dirty when there is no saved baseline', () => {
+            const field = makeField({ name: 'f1' });
+            const schema: any = makeSchema({ id: 'a', fields: [field] });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+        });
+
+        it('stays dirty when the field tree is cyclic', () => {
+            const field = makeField({ name: 'f1' });
+            const schema: any = makeSchema({ id: 'a', fields: [field] });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.snapshotSchema(schema);
+
+            field.fields = [field];
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('a')).toBeTrue();
+        });
+
+        it('a never-saved schema is always dirty', () => {
+            const schema: any = makeSchema({ uuid: 'u-new' });
+            schema.id = undefined;
+            schema._id = undefined;
+            const component = createComponent({
+                schemas: [schema], selectedSchema: schema, newKeys: ['new:u-new'],
+            });
+
+            component.markDirty();
+            expect(component.dirtySchemaIds.has('new:u-new')).toBeTrue();
+        });
+
+        it('a successful save becomes the new baseline', () => {
+            const { component, field } = withBaseline();
+
+            field.title = 'Changed';
+            component.markDirty();
+            component.saveAll();
+            expect(component.hasUnsavedChanges).toBeFalse();
+
+            field.title = 'Original';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
         });
     });
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -386,12 +386,217 @@ describe('SchemasConfigurationComponent', () => {
             expect(Array.from(component.dirtySchemaIds).sort()).toEqual(['a', 'b']);
         });
 
-        it('returns early and touches nothing when there are no dirty keys', () => {
+        it('returns early and touches nothing when there is nothing to prune', () => {
             const component = createComponent({ schemas: [], dirtyIds: [] });
 
             component.pruneDirtySchemaIds();
 
             expect(component.dirtySchemaIds.size).toBe(0);
+            expect(component.savedSignatures.size).toBe(0);
+        });
+
+        it('drops the saved baseline of a schema that is gone from the list', () => {
+            const a = makeSchema({ id: 'a' });
+            const component = createComponent({ schemas: [a] });
+            component.snapshotSchema(a);
+            component.snapshotSchema(makeSchema({ id: 'gone' }));
+            expect(component.savedSignatures.size).toBe(2);
+
+            component.pruneDirtySchemaIds();
+
+            expect(Array.from(component.savedSignatures.keys())).toEqual(['a']);
+        });
+
+        it('keeps the baseline of the open schema even when the list does not contain it', () => {
+            const open = makeSchema({ id: 'open' });
+            const component = createComponent({ schemas: [], selectedSchema: open });
+            component.snapshotSchema(open);
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.savedSignatures.has('open')).toBeTrue();
+        });
+
+        it('still prunes baselines when no key is dirty', () => {
+            // The guard used to key off dirtySchemaIds alone, so a baseline could
+            // outlive every dirty mark and never be reached.
+            const component = createComponent({ schemas: [], dirtyIds: [] });
+            component.snapshotSchema(makeSchema({ id: 'gone' }));
+            expect(component.savedSignatures.size).toBe(1);
+
+            component.pruneDirtySchemaIds();
+
+            expect(component.savedSignatures.size).toBe(0);
+        });
+    });
+
+    describe('the signature covers everything the editor can change', () => {
+
+        function withBaseline(schema: any) {
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.snapshotSchema(schema);
+            return component;
+        }
+
+        // Each of these is editable in the UI but was absent from the old allow-list,
+        // so an edit touching only it hashed to the same signature and was discarded.
+        [
+            ['hidden', true],
+            ['isUpdatable', true],
+            ['textBold', true],
+            ['textColor', '#ff0000'],
+            ['default', 'a default'],
+            ['suggest', 'a suggestion'],
+            ['examples', ['an example']],
+        ].forEach(([prop, value]: any) => {
+            it(`notices a change to ${prop}`, () => {
+                const field = makeField({ name: 'f1' });
+                const schema = makeSchema({ id: 'a', fields: [field] });
+                const component = withBaseline(schema);
+
+                const before = field[prop];
+                field[prop] = value;
+                component.markDirty();
+                expect(component.hasUnsavedChanges).toBeTrue();
+
+                field[prop] = before;
+                component.markDirty();
+                expect(component.hasUnsavedChanges).toBeFalse();
+            });
+        });
+
+        it('notices an edit to a predicate inside an AND condition', () => {
+            // ifCondition is { AND: [...] } here, so it has no .field / .fieldValue of
+            // its own - reading those two returned undefined for every predicate.
+            const target = makeField({ name: 'target' });
+            const schema = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            schema.conditions = [{
+                ifCondition: { AND: [{ field: { name: 'f1' }, fieldValue: 'yes' }] },
+                thenFields: [target],
+                elseFields: [],
+            }];
+            const component = withBaseline(schema);
+
+            schema.conditions[0].ifCondition.AND[0].fieldValue = 'no';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            schema.conditions[0].ifCondition.AND[0].fieldValue = 'yes';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('notices a predicate added to an OR condition', () => {
+            const schema = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            schema.conditions = [{
+                ifCondition: { OR: [{ field: { name: 'f1' }, fieldValue: 'yes' }] },
+                thenFields: [],
+                elseFields: [],
+            }];
+            const component = withBaseline(schema);
+
+            schema.conditions[0].ifCondition.OR.push({ field: { name: 'f2' }, fieldValue: 'x' });
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            schema.conditions[0].ifCondition.OR.pop();
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('notices an edit to a then-field of a condition', () => {
+            const target = makeField({ name: 'target', title: 'Original' });
+            const schema = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            schema.conditions = [{
+                ifCondition: { field: { name: 'f1' }, fieldValue: 'yes' },
+                thenFields: [target],
+                elseFields: [],
+            }];
+            const component = withBaseline(schema);
+
+            target.title = 'Changed';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            target.title = 'Original';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('notices an array dependency being added and removed', () => {
+            const schema = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            schema.arrayDependencies = [];
+            const component = withBaseline(schema);
+
+            schema.arrayDependencies.push({ field: ['a'], on: ['b'], kind: 'array' });
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            schema.arrayDependencies.pop();
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('signs a tree that reaches the same sub-schema object twice', () => {
+            // Two ref fields pointing at one sub-schema IRI share their field objects.
+            // A single set for the whole traversal calls the second visit a cycle, so
+            // the signature came back null and the schema stayed dirty forever.
+            const shared = makeField({ name: 'shared', title: 'Original' });
+            const left = makeField({ name: 'left', isRef: true, fields: [shared] });
+            const right = makeField({ name: 'right', isRef: true, fields: [shared] });
+            const schema = makeSchema({ id: 'a', fields: [left, right] });
+            const component = withBaseline(schema);
+
+            expect(component.savedSignatures.get('a')).toBeDefined();
+
+            shared.title = 'Changed';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
+
+            shared.title = 'Original';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeFalse();
+        });
+
+        it('treats a property cleared back to undefined as absent', () => {
+            // JSON.stringify drops undefined-valued keys, so the two states save
+            // identically; the signature has to agree or the flag can never clear.
+            const bare = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            const withUndefined = makeSchema({ id: 'a', fields: [makeField({ name: 'f1' })] });
+            withUndefined.fields[0].hidden = undefined;
+            const component = createComponent({ schemas: [bare] });
+
+            expect(component.schemaSignature(withUndefined)).toBe(component.schemaSignature(bare));
+        });
+
+        it('still refuses to sign a genuine cycle', () => {
+            const field = makeField({ name: 'f1' });
+            field.fields = [field];
+            const schema = makeSchema({ id: 'a', fields: [field] });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+
+            expect(component.schemaSignature(schema)).toBeNull();
+        });
+
+        it('signs a deeply nested field tree', () => {
+            // The walk descends every object and array level, so a field one level
+            // deeper costs two of the depth budget. A realistic tree must still sign:
+            // a throw means "cannot prove clean", which latches Unsaved changes.
+            const root = makeField({ name: 'level_0' });
+            let cursor = root;
+            for (let i = 1; i <= 8; i++) {
+                const child = makeField({ name: `level_${i}` });
+                cursor.fields = [child];
+                cursor = child;
+            }
+            const schema = makeSchema({ id: 'a', fields: [root] });
+            const component = withBaseline(schema);
+
+            expect(component.savedSignatures.get('a')).toBeDefined();
+
+            cursor.title = 'Changed';
+            component.markDirty();
+            expect(component.hasUnsavedChanges).toBeTrue();
         });
     });
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -1115,64 +1115,106 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         return schemaConfig.fields[fieldKey];
     }
 
+    /*
+     * Counts every object and array level, not just field nesting. A field one level
+     * deeper costs two (its parent's `fields` array, then the field object), so this is
+     * double the ~12 levels of field nesting actually intended. Scalars return before
+     * the check and cost nothing. Too low is not harmless: the throw means "cannot
+     * prove clean", so a legitimately deep schema would latch "Unsaved changes" forever
+     * - the exact failure this fix exists to remove.
+     */
+    private static readonly SIGNATURE_MAX_DEPTH = 24;
+
+    /* Recomputed by the editor rather than edited by the user; everything else is hashed. */
+    private static readonly SIGNATURE_IGNORED_KEYS = new Set([
+        'errors', 'path', 'fullPath', 'parent', 'controlKey', '_id',
+    ]);
+
     /**
      * A stable signature of everything the editor can change.
+     *
+     * This walks the schema generically instead of hashing a hand-picked list of
+     * properties. An allow-list fails in the dangerous direction: any editable
+     * property nobody remembered to add is invisible to the check, the dirty flag
+     * clears, `saveAll()` early-returns on `!hasUnsavedChanges`, and the edit is lost
+     * on navigation with no toast and no guard dialog. Ignoring only what is provably
+     * derived inverts that - an unrecognised property makes the schema look dirty,
+     * which merely costs a redundant save.
+     *
+     * It also removes two whole classes of blind spot for free: a condition built with
+     * AND/OR has no `ifCondition.field`, so every predicate edit used to hash to the
+     * same null; and `then`/`else` targets are now reached like anything else.
      *
      * Returns null on anything it cannot model (cycle, depth blow-out, throw). Callers
      * treat null as "cannot prove clean" and leave the schema dirty: a false clean would
      * hide Save all and silently discard the user's work, which is far worse than the
      * stale "Unsaved changes" this fixes.
      */
-    private static readonly SIGNATURE_MAX_DEPTH = 12;
-
     private schemaSignature(schema: Schema | null | undefined): string | null {
         if (!schema) {
             return null;
         }
         try {
-            const seen = new WeakSet<object>();
-            const field = (f: any, depth: number): any => {
-                if (!f || typeof f !== 'object') {
-                    return f ?? null;
+            /*
+             * Path-local rather than one set for the whole traversal. A global set
+             * rejects any object reached twice, not just cycles - and two ref fields
+             * pointing at the same sub-schema IRI share their field objects, so the
+             * signature would return null and leave that schema permanently dirty.
+             */
+            const ancestors = new Set<object>();
+            const walk = (value: any, depth: number): any => {
+                if (value === undefined || typeof value === 'function') {
+                    return null;
                 }
-                if (depth > SchemasConfigurationComponent.SIGNATURE_MAX_DEPTH || seen.has(f)) {
+                if (value === null || typeof value !== 'object') {
+                    return value;
+                }
+                if (depth > SchemasConfigurationComponent.SIGNATURE_MAX_DEPTH || ancestors.has(value)) {
                     throw new Error('unbounded');
                 }
-                seen.add(f);
-                return [
-                    f.name, f.title, f.description, f.type, f.format, f.pattern, f.unit,
-                    f.unitSystem, f.property, f.customType, f.enumName, f.comment,
-                    f.textSize, f.expression, f.remoteLink, f.templateFieldId,
-                    !!f.required, !!f.isArray, !!f.isRef, !!f.readOnly, !!f.autocalculate,
-                    f.enum ?? null,
-                    f.availableOptions ?? null,
-                    f.dependency ?? null,
-                    (f.fields ?? []).map((sub: any) => field(sub, depth + 1)),
-                    (f.conditions ?? []).map((c: any) => condition(c, depth + 1)),
-                ];
-            };
-            const condition = (c: any, depth: number): any => {
-                if (!c || typeof c !== 'object') {
-                    return c ?? null;
+                ancestors.add(value);
+                try {
+                    if (Array.isArray(value)) {
+                        return value.map((item) => walk(item, depth + 1));
+                    }
+                    const out: any = {};
+                    for (const key of Object.keys(value).sort()) {
+                        if (SchemasConfigurationComponent.SIGNATURE_IGNORED_KEYS.has(key)) {
+                            continue;
+                        }
+                        const item = value[key];
+                        /*
+                         * JSON.stringify drops undefined- and function-valued keys, so the
+                         * saved schema cannot tell those from absent ones. Clearing a
+                         * property back to unset has to read as clean, or it leaves a
+                         * dirty flag nothing can ever clear.
+                         */
+                        if (item === undefined || typeof item === 'function') {
+                            continue;
+                        }
+                        out[key] = walk(item, depth + 1);
+                    }
+                    return out;
+                } finally {
+                    ancestors.delete(value);
                 }
-                if (depth > SchemasConfigurationComponent.SIGNATURE_MAX_DEPTH || seen.has(c)) {
-                    throw new Error('unbounded');
-                }
-                seen.add(c);
-                return [
-                    c.ifCondition?.field?.name ?? null,
-                    c.ifCondition?.fieldValue ?? null,
-                    (c.thenFields ?? []).map((f: any) => field(f, depth + 1)),
-                    (c.elseFields ?? []).map((f: any) => field(f, depth + 1)),
-                ];
             };
-            return JSON.stringify([
-                schema.name ?? null,
-                schema.description ?? null,
-                schema.entity ?? null,
-                (schema.fields ?? []).map((f: any) => field(f, 0)),
-                (schema.conditions ?? []).map((c: any) => condition(c, 0)),
-            ]);
+            /*
+             * The walk is generic, but it can only reach what this root names, so the
+             * root is the one remaining allow-list and needs the same scrutiny.
+             * `arrayDependencies` is user-editable (addArrayDependency /
+             * removeArrayDependency, both of which call markDirty) and is persisted on
+             * the model, so editing only an array dependency used to recompute a
+             * signature identical to the baseline and lose the edit.
+             */
+            return JSON.stringify(walk({
+                name: schema.name ?? null,
+                description: schema.description ?? null,
+                entity: schema.entity ?? null,
+                fields: schema.fields ?? [],
+                conditions: schema.conditions ?? [],
+                arrayDependencies: schema.arrayDependencies ?? [],
+            }, 0));
         } catch {
             return null;
         }
@@ -3353,8 +3395,21 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         }
     }
 
+    /**
+     * Drop dirty marks and saved baselines for schemas that have left the list.
+     *
+     * `dirtySchemaIds` and `savedSignatures` are a matched pair - one records that a
+     * schema changed, the other what it looked like when saved - so they are pruned
+     * together. `savedSignatures` used to only ever grow, holding a full serialised
+     * field tree per schema for as long as the page lived.
+     *
+     * Dropping a baseline can only fail safe: `reconcileDirty` treats a missing
+     * baseline as "cannot prove clean" and leaves the schema dirty, and any schema
+     * still reachable is re-snapshotted by the next list load.
+     */
     private pruneDirtySchemaIds(): void {
-        if (!this.dirtySchemaIds.size) { return; }
+        // Both maps gate entry here - a signature can outlive the last dirty mark.
+        if (!this.dirtySchemaIds.size && !this.savedSignatures.size) { return; }
         const liveKeys = new Set<string>();
         for (const schema of this.schemas) {
             const id = schema.id || (schema as any)._id;
@@ -3370,6 +3425,11 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             if (!liveKeys.has(dirtyId)) {
                 this.dirtySchemaIds.delete(dirtyId);
                 this.newSchemaKeys.delete(dirtyId);
+            }
+        }
+        for (const key of Array.from(this.savedSignatures.keys())) {
+            if (!liveKeys.has(key)) {
+                this.savedSignatures.delete(key);
             }
         }
     }

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -119,6 +119,8 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
     public get currentDrilledSchemaIri(): string { return this.drillStack[this.drillStack.length - 1]?.schemaIri || ''; }
 
     private dirtySchemaIds = new Set<string>();
+    // last-saved signature per schema, so a reverted edit can clear the dirty flag
+    private savedSignatures = new Map<string, string>();
     public isSaving: boolean = false;
     private _subSchemasByIri = new Map<string, Schema>();
     public newArrayDependencyField: string | null = null;
@@ -615,7 +617,11 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             this.resetArrayDependencyEditor();
             this.schemaLoading = false;
             const schemaId = schema.id || (schema as any)._id;
-            if (schemaId) { this.dirtySchemaIds.delete(schemaId); }
+            if (schemaId) {
+                this.dirtySchemaIds.delete(schemaId);
+                // freshly loaded from the server, so this is the saved baseline
+                this.snapshotSchema(schema, schemaId);
+            }
             if (!this.topic && schema.topicId) {
                 this.topic = schema.topicId;
             }
@@ -1109,6 +1115,100 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         return schemaConfig.fields[fieldKey];
     }
 
+    /**
+     * A stable signature of everything the editor can change.
+     *
+     * Returns null on anything it cannot model (cycle, depth blow-out, throw). Callers
+     * treat null as "cannot prove clean" and leave the schema dirty: a false clean would
+     * hide Save all and silently discard the user's work, which is far worse than the
+     * stale "Unsaved changes" this fixes.
+     */
+    private static readonly SIGNATURE_MAX_DEPTH = 12;
+
+    private schemaSignature(schema: Schema | null | undefined): string | null {
+        if (!schema) {
+            return null;
+        }
+        try {
+            const seen = new WeakSet<object>();
+            const field = (f: any, depth: number): any => {
+                if (!f || typeof f !== 'object') {
+                    return f ?? null;
+                }
+                if (depth > SchemasConfigurationComponent.SIGNATURE_MAX_DEPTH || seen.has(f)) {
+                    throw new Error('unbounded');
+                }
+                seen.add(f);
+                return [
+                    f.name, f.title, f.description, f.type, f.format, f.pattern, f.unit,
+                    f.unitSystem, f.property, f.customType, f.enumName, f.comment,
+                    f.textSize, f.expression, f.remoteLink, f.templateFieldId,
+                    !!f.required, !!f.isArray, !!f.isRef, !!f.readOnly, !!f.autocalculate,
+                    f.enum ?? null,
+                    f.availableOptions ?? null,
+                    f.dependency ?? null,
+                    (f.fields ?? []).map((sub: any) => field(sub, depth + 1)),
+                    (f.conditions ?? []).map((c: any) => condition(c, depth + 1)),
+                ];
+            };
+            const condition = (c: any, depth: number): any => {
+                if (!c || typeof c !== 'object') {
+                    return c ?? null;
+                }
+                if (depth > SchemasConfigurationComponent.SIGNATURE_MAX_DEPTH || seen.has(c)) {
+                    throw new Error('unbounded');
+                }
+                seen.add(c);
+                return [
+                    c.ifCondition?.field?.name ?? null,
+                    c.ifCondition?.fieldValue ?? null,
+                    (c.thenFields ?? []).map((f: any) => field(f, depth + 1)),
+                    (c.elseFields ?? []).map((f: any) => field(f, depth + 1)),
+                ];
+            };
+            return JSON.stringify([
+                schema.name ?? null,
+                schema.description ?? null,
+                schema.entity ?? null,
+                (schema.fields ?? []).map((f: any) => field(f, 0)),
+                (schema.conditions ?? []).map((c: any) => condition(c, 0)),
+            ]);
+        } catch {
+            return null;
+        }
+    }
+
+    private snapshotSchema(schema: Schema | null | undefined, key?: string): void {
+        const id = key || schema?.id || (schema as any)?._id;
+        if (!id) {
+            return;
+        }
+        const signature = this.schemaSignature(schema);
+        if (signature === null) {
+            this.savedSignatures.delete(id);
+        } else {
+            this.savedSignatures.set(id, signature);
+        }
+    }
+
+    /**
+     * Drop the dirty mark when the schema matches what was last saved. An unknown
+     * signature or a missing baseline leaves it dirty.
+     */
+    private reconcileDirty(key: string, schema: Schema | null | undefined): void {
+        const baseline = this.savedSignatures.get(key);
+        if (baseline === undefined) {
+            this.dirtySchemaIds.add(key);
+            return;
+        }
+        const current = this.schemaSignature(schema);
+        if (current !== null && current === baseline) {
+            this.dirtySchemaIds.delete(key);
+        } else {
+            this.dirtySchemaIds.add(key);
+        }
+    }
+
     public markDirty(): void {
         if (this.isTemplateReadonly) {
             return;
@@ -1123,15 +1223,16 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
             const subId = subSchema?.id || (subSchema as any)?._id;
             const subUuid = (subSchema as any)?.uuid;
             if (subId) {
-                this.dirtySchemaIds.add(subId);
+                this.reconcileDirty(subId, subSchema);
             } else if (subUuid) {
+                // a schema that has never been saved has no baseline: always dirty
                 this.dirtySchemaIds.add(`new:${subUuid}`);
             }
             return;
         }
         const rootId = this.selectedSchema?.id || (this.selectedSchema as any)?._id;
         if (rootId) {
-            this.dirtySchemaIds.add(rootId);
+            this.reconcileDirty(rootId, this.selectedSchema);
         } else if (this.selectedSchema?.uuid) {
             this.dirtySchemaIds.add(`new:${this.selectedSchema.uuid}`);
         }
@@ -1257,6 +1358,8 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                     this.isSaving = false;
                     this.dirtySchemaIds.clear();
                     this.newSchemaKeys.clear();
+                    // what was just saved becomes the new baseline
+                    allSchemas.forEach(schema => this.snapshotSchema(schema));
                 },
                 error: (error) => { this.isSaving = false; this.reportError('Save all', error); }
             });
@@ -3334,6 +3437,9 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                         this.schemasLoading = false;
                     }
                     this.schemasFetched = true;
+                    // server copies are the saved baseline; a locally edited
+                    // selectedSchema still differs from its signature and stays dirty
+                    items.forEach(schema => this.snapshotSchema(schema));
                     this.loadAppliedSchemaTemplate();
                     if (this.selectedSchema) { this.upsertInSidebar(this.selectedSchema); }
                     this.pruneDirtySchemaIds();


### PR DESCRIPTION
Fixes #6723

## Fix

Keep a signature of the last-saved state per schema — taken when a schema loads (single load and list load) and again after a successful save — and have `markDirty()` drop the id when the current state matches it.

The signature covers what the editor can actually change: the schema's name/description/entity, and the full field tree including nested `fields` and `conditions`.

## The failure mode this avoids

The signature deliberately **fails toward dirty**. A cycle, a depth blow-out, or anything else it cannot model returns `null`, and callers treat `null` as "cannot prove clean" and leave the schema dirty.

A false clean would hide Save all and silently discard the user's work — far worse than the stale indicator being fixed. Schemas that have never been saved have no baseline and are always dirty.

## Tests

8 new tests in the existing `schemas-configuration.component.spec.ts`. Run against `develop` with the source change reverted, **6 fail**:

- marks dirty on edit and clean again on revert
- notices an added and then removed field
- notices an added and then removed condition
- stays dirty when only part of the edit is reverted
- stays dirty when the field tree is cyclic
- a successful save becomes the new baseline

The 2 that pass either way pin the fail-toward-dirty behaviour (no baseline, and never-saved schemas) — they must keep passing, which is the point of including them.

`39 passing` on this branch.