### PR TITLE
fix(frontend): remove two controls the user cannot use

### DIFF
--- a/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.html
+++ b/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.html
@@ -29,12 +29,19 @@
 
 <div class="dialog-footer">
   <div class="action-buttons">
-    <div class="copy-button">
-      <button (click)="handleCopyToClipboard(schema.messageId)" [disabled]="!schema.messageId"
-        class="button secondary"
-        label="Copy message identifier"
-        pButton
-      ></button>
+    <!-- a draft has no Hedera message identifier, so this used to render permanently
+         greyed out with no explanation -->
+    @if (schema?.messageId) {
+      <div class="copy-button">
+        <button (click)="handleCopyToClipboard(schema.messageId)"
+          class="button secondary"
+          label="Copy message identifier"
+          pButton
+        ></button>
+      </div>
+    }
+    <div>
+      <button (click)="onClose()" class="button secondary" label="Cancel" pButton style="margin-right: 15px"></button>
     </div>
     <div>
       <button (click)="saveToFile()" class="button" label="Save to file" pButton style="margin-right: 15px"></button>

--- a/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.html
+++ b/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.html
@@ -29,8 +29,7 @@
 
 <div class="dialog-footer">
   <div class="action-buttons">
-    <!-- a draft has no Hedera message identifier, so this used to render permanently
-         greyed out with no explanation -->
+    <!-- only a published schema has a Hedera message identifier -->
     @if (schema?.messageId) {
       <div class="copy-button">
         <button (click)="handleCopyToClipboard(schema.messageId)"

--- a/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.spec.ts
@@ -29,8 +29,7 @@ describe('ExportSchemaDialog', () => {
             .find((button) => button.getAttribute('label') === label);
     }
 
-    // A draft is not published and so has no Hedera message identifier: the button used
-    // to render permanently greyed out with no explanation of why.
+    // Drafts have no Hedera message identifier since they are not yet published
     it('hides Copy message identifier on a draft', () => {
         expect(buttonByLabel(render({ name: 'S' }), 'Copy message identifier')).toBeUndefined();
     });
@@ -39,8 +38,7 @@ describe('ExportSchemaDialog', () => {
         expect(buttonByLabel(render({ name: 'S', messageId: '1.2.3' }), 'Copy message identifier')).toBeDefined();
     });
 
-    // onClose() existed but was never wired to anything, so the dialog closed only
-    // programmatically after a successful save.
+    // Users can close the dialog with Cancel instead of only through a successful save.
     it('offers a Cancel control that closes the dialog', () => {
         const fixture = render({ name: 'S' });
         const cancel = buttonByLabel(fixture, 'Cancel');

--- a/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/export-schema-dialog/export-schema-dialog.component.spec.ts
@@ -1,0 +1,59 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SchemaService } from 'src/app/services/schema.service';
+import { ExportSchemaDialog } from './export-schema-dialog.component';
+
+describe('ExportSchemaDialog', () => {
+    let ref: jasmine.SpyObj<DynamicDialogRef>;
+
+    function render(schema: any): ComponentFixture<ExportSchemaDialog> {
+        ref = jasmine.createSpyObj<DynamicDialogRef>('DynamicDialogRef', ['close']);
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            declarations: [ExportSchemaDialog],
+            providers: [
+                { provide: DynamicDialogRef, useValue: ref },
+                { provide: DynamicDialogConfig, useValue: { data: { schema } } },
+                { provide: SchemaService, useValue: {} },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        });
+        const fixture = TestBed.createComponent(ExportSchemaDialog);
+        fixture.detectChanges();
+        return fixture;
+    }
+
+    function buttonByLabel(fixture: ComponentFixture<ExportSchemaDialog>, label: string): HTMLButtonElement | undefined {
+        return Array.from(fixture.nativeElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>)
+            .find((button) => button.getAttribute('label') === label);
+    }
+
+    // A draft is not published and so has no Hedera message identifier: the button used
+    // to render permanently greyed out with no explanation of why.
+    it('hides Copy message identifier on a draft', () => {
+        expect(buttonByLabel(render({ name: 'S' }), 'Copy message identifier')).toBeUndefined();
+    });
+
+    it('offers Copy message identifier once the schema is published', () => {
+        expect(buttonByLabel(render({ name: 'S', messageId: '1.2.3' }), 'Copy message identifier')).toBeDefined();
+    });
+
+    // onClose() existed but was never wired to anything, so the dialog closed only
+    // programmatically after a successful save.
+    it('offers a Cancel control that closes the dialog', () => {
+        const fixture = render({ name: 'S' });
+        const cancel = buttonByLabel(fixture, 'Cancel');
+
+        expect(cancel).toBeDefined();
+        cancel!.click();
+
+        expect(ref.close).toHaveBeenCalledWith(false);
+    });
+
+    it('still offers both save actions', () => {
+        const fixture = render({ name: 'S' });
+        expect(buttonByLabel(fixture, 'Save to file')).toBeDefined();
+        expect(buttonByLabel(fixture, 'Save to Excel')).toBeDefined();
+    });
+});

--- a/frontend/src/app/views/new-header/menu.model.spec.ts
+++ b/frontend/src/app/views/new-header/menu.model.spec.ts
@@ -1,0 +1,40 @@
+import { getMenuItems, NavbarMenuItem } from './menu.model';
+
+describe('getMenuItems', () => {
+    const user = (flags: Record<string, boolean> = {}) => flags as any;
+    const titles = (menu: NavbarMenuItem[]) => menu.map((m) => m.title);
+    const childTitles = (item: NavbarMenuItem) => (item.childItems || []).map((c) => c.title);
+
+    // /schema-templates requires TEMPLATES_TEMPLATE_READ, so gating the nav item on
+    // schema-read showed it to roles that PermissionsGuard then bounced to
+    // "Access Restricted" - a dead link.
+    describe('Schema Templates is gated on the permission its route requires', () => {
+        it('is hidden from a schema reader who cannot read templates', () => {
+            const menu = getMenuItems(user({ SCHEMAS_SCHEMA_READ: true }));
+            expect(childTitles(menu[0])).not.toContain('Schema Templates');
+        });
+
+        it('is hidden from a system-schema reader who cannot read templates', () => {
+            const menu = getMenuItems(user({ SCHEMAS_SYSTEM_SCHEMA_READ: true }));
+            expect(childTitles(menu[0])).not.toContain('Schema Templates');
+        });
+
+        it('opens the Manage section for a template reader alone', () => {
+            const menu = getMenuItems(user({ TEMPLATES_TEMPLATE_READ: true }));
+            expect(titles(menu)).toEqual(['Manage']);
+            expect(childTitles(menu[0])).toEqual(['Schema Templates']);
+        });
+
+        it('appears alongside the schema entry when both are held', () => {
+            const menu = getMenuItems(user({
+                SCHEMAS_SCHEMA_READ: true,
+                TEMPLATES_TEMPLATE_READ: true,
+            }));
+            expect(childTitles(menu[0])).toEqual(['Schemas', 'Schema Templates']);
+        });
+    });
+
+    it('still builds nothing for a user with no permissions', () => {
+        expect(getMenuItems(user())).toEqual([]);
+    });
+});

--- a/frontend/src/app/views/new-header/menu.model.ts
+++ b/frontend/src/app/views/new-header/menu.model.ts
@@ -145,7 +145,11 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
         user.POLICIES_POLICY_READ ||
         user.POLICIES_POLICY_EXECUTE ||
         user.POLICIES_POLICY_MANAGE ||
-        user.TOOLS_TOOL_READ
+        user.TOOLS_TOOL_READ ||
+        // without this a template-only role opens no Manage section at all, so gating
+        // the item below on TEMPLATES_TEMPLATE_READ would hide it from the very users
+        // who can use it
+        user.TEMPLATES_TEMPLATE_READ
     ) {
         const childItems: any = [];
         const canReadPolicies = user.POLICIES_POLICY_READ ||
@@ -189,10 +193,8 @@ function customMenu(user: UserPermissions): NavbarMenuItem[] {
                 routerLink: '/schema-rules'
             });
         }
-        if (
-            user.SCHEMAS_SCHEMA_READ ||
-            user.SCHEMAS_SYSTEM_SCHEMA_READ
-        ) {
+        // gated on the permission the ROUTE requires, not on schema-read
+        if (user.TEMPLATES_TEMPLATE_READ) {
             childItems.push({
                 title: 'Schema Templates',
                 routerLink: '/schema-templates'


### PR DESCRIPTION
Fixes #6725

## Fixes

**Schema Templates nav item** — gate it on `TEMPLATES_TEMPLATE_READ`, the permission `/schema-templates` actually requires, and add that permission to the condition that opens the **Manage** section. Both halves are needed: without the second, the new gate would hide the item from the roles that can use it.

**Export Schema dialog** — show "Copy message identifier" only for a schema that has one, instead of rendering it permanently disabled on every draft; and wire the existing `onClose()` to a Cancel button so the dialog can be dismissed without saving.

## Tests

Two new spec files, 9 tests. Run against `develop` with the source changes reverted, **5 fail**:

- Schema Templates hidden from a schema reader (1)
- Schema Templates hidden from a system-schema reader (2)
- Manage opens for a template reader alone (3)
- Copy hidden on a draft (4)
- Cancel present and closing the dialog (5)

The 4 that pass either way are the companions — Copy still offered on a published schema, both save actions still present, the item still shown when both permissions are held, and an empty menu for a user with no permissions.