### PR TITLE
fix(frontend): put misplaced overlays, tooltips and empty states where they belong

### DIFF
--- a/frontend/src/app/components/credentials/credentials-panel/credentials-panel.component.html
+++ b/frontend/src/app/components/credentials/credentials-panel/credentials-panel.component.html
@@ -151,7 +151,18 @@
   </p-tabs>
 </div>
 
-<p-dialog header="Add Credential" [(visible)]="showDialog" [modal]="true" [style]="{width: '500px'}" [closable]="true">
+<!-- without appendTo the mask is created next to the dialog inside the page layout, so
+     it covers only that container and leaves an un-dimmed band below it -->
+<p-dialog
+    header="Add Credential"
+    [(visible)]="showDialog"
+    [modal]="true"
+    appendTo="body"
+    [draggable]="false"
+    [resizable]="false"
+    styleClass="guardian-dialog"
+    [style]="{width: '500px'}"
+    [closable]="true">
   <div class="dialog-body">
     <div class="guardian-input-container">
       <label class="form-label">Service</label>

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.scss
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.scss
@@ -103,14 +103,9 @@
     font-size: 20px;
 }
 
-.not-exist {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 20px;
-    color: darkgrey;
-}
+/* The .not-exist rule further down already centres the empty state with flex and
+   supersedes every declaration this block set; all it contributed was the absolute
+   positioning that lifted the empty state out of flow, on top of the toolbar. */
 
 .ml-8 {
     margin-left: 8px;
@@ -922,6 +917,8 @@
     align-items: center;
     row-gap: 8px;
     justify-content: center;
+    width: 100%;
+    padding: 64px 0;
 }
 
 .info-text {

--- a/frontend/src/app/modules/policy-engine/policies/policies.component.scss
+++ b/frontend/src/app/modules/policy-engine/policies/policies.component.scss
@@ -103,10 +103,6 @@
     font-size: 20px;
 }
 
-/* The .not-exist rule further down already centres the empty state with flex and
-   supersedes every declaration this block set; all it contributed was the absolute
-   positioning that lifted the empty state out of flow, on top of the toolbar. */
-
 .ml-8 {
     margin-left: 8px;
 }

--- a/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-viewer-config/document-viewer-config.component.html
+++ b/frontend/src/app/modules/policy-engine/policy-configuration/blocks/documents/document-viewer-config/document-viewer-config.component.html
@@ -49,7 +49,9 @@
           <span>{{ getFieldName(field, i) }}</span>
         </td>
         <td class="propRowCell not-editable-text">
-          <span>{{ field.name }}</span>
+          <!-- the cell clips the path, so without a tooltip the full value is unreadable -->
+          <span [pTooltip]="field.name" tooltipPosition="top" [tooltipOptions]="{showDelay: 300}"
+            tooltipStyleClass="guardian-tooltip">{{ field.name }}</span>
           <span class="remove-prop" [attr.readonly]="readonly" (click)="$event.stopPropagation(); removeField(i)">
             <i class="pi pi-trash"></i>
           </span>

--- a/frontend/src/app/views/relayer-accounts/relayer-accounts.component.scss
+++ b/frontend/src/app/views/relayer-accounts/relayer-accounts.component.scss
@@ -97,15 +97,31 @@
     min-width: 110px !important;
 }
 
+/*
+ * The icon was placed with a magic `top: 12px` against a wrapper that had no layout of
+ * its own, so it detached from the input whenever the rendered heights differed from the
+ * assumed 40px. Centre it on the input, make the wrapper an explicit flex box so it is
+ * unambiguously the offset parent, and reserve room so the text cannot run underneath.
+ */
 .search-filter {
     width: 400px;
     max-width: 400px;
     position: relative;
+    display: flex;
+    align-items: center;
+
+    .guardian-input {
+        width: 100%;
+        padding-right: 36px;
+    }
 
     .search-icon {
         position: absolute;
         right: 12px;
-        top: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        display: flex;
+        align-items: center;
         pointer-events: none;
     }
 }

--- a/frontend/src/app/views/schemas/schemas.component.html
+++ b/frontend/src/app/views/schemas/schemas.component.html
@@ -121,41 +121,45 @@
       </div>
       <div class="schema-actions-buttons-container">
         @if (canCreate) {
-          <p-button
-            (click)="onNewInEditor()"
-            class="toolbar-btn-primary"
-            [pTooltip]="'Create a Schema'"
-            tooltipPosition="bottom">
-            <svg-icon src="/assets/images/icons/add.svg" svgClass="color-white"></svg-icon>
-          </p-button>
+          <span class="toolbar-tooltip-anchor" pTooltip="Create a Schema"
+            tooltipStyleClass="guardian-tooltip" tooltipPosition="bottom">
+            <p-button
+              (click)="onNewInEditor()"
+              class="toolbar-btn-primary">
+              <svg-icon src="/assets/images/icons/add.svg" svgClass="color-white"></svg-icon>
+            </p-button>
+          </span>
         }
         @if (canImport) {
-          <p-button
-            (click)="downloadExcelExample()"
-            class="toolbar-btn-primary"
-            [pTooltip]="'Generate Excel Template'"
-            tooltipPosition="bottom">
-            <svg-icon src="/assets/images/icons/wizard.svg" svgClass="color-white"></svg-icon>
-          </p-button>
+          <span class="toolbar-tooltip-anchor" pTooltip="Generate Excel Template"
+            tooltipStyleClass="guardian-tooltip" tooltipPosition="bottom">
+            <p-button
+              (click)="downloadExcelExample()"
+              class="toolbar-btn-primary">
+              <svg-icon src="/assets/images/icons/wizard.svg" svgClass="color-white"></svg-icon>
+            </p-button>
+          </span>
         }
         @if (canImport) {
-          <p-button
-            (click)="onImportSchemas()"
-            class="toolbar-btn-primary"
-            [pTooltip]="'Import'"
-            tooltipPosition="bottom">
-            <svg-icon src="/assets/images/icons/import.svg" svgClass="color-white"></svg-icon>
-          </p-button>
+          <span class="toolbar-tooltip-anchor" pTooltip="Import"
+            tooltipStyleClass="guardian-tooltip" tooltipPosition="bottom">
+            <p-button
+              (click)="onImportSchemas()"
+              class="toolbar-btn-primary">
+              <svg-icon src="/assets/images/icons/import.svg" svgClass="color-white"></svg-icon>
+            </p-button>
+          </span>
         }
         @if (isPolicy || isModule || isTool) {
-          <p-button
-            (click)="onCompare()"
-            [pTooltip]="'Compare'"
-            class="toolbar-btn-secondary"
-            [outlined]=true
-            tooltipPosition="bottom">
-            <svg-icon src="/assets/images/icons/compare.svg" svgClass="primary-color"></svg-icon>
-          </p-button>
+          <span class="toolbar-tooltip-anchor" pTooltip="Compare"
+            tooltipStyleClass="guardian-tooltip" tooltipPosition="bottom">
+            <p-button
+              (click)="onCompare()"
+              class="toolbar-btn-secondary"
+              [outlined]=true>
+              <svg-icon src="/assets/images/icons/compare.svg" svgClass="primary-color"></svg-icon>
+            </p-button>
+          </span>
         }
       </div>
     </div>

--- a/frontend/src/app/views/schemas/schemas.component.scss
+++ b/frontend/src/app/views/schemas/schemas.component.scss
@@ -451,6 +451,11 @@ a {
     margin-left: auto;
 }
 
+/* tooltip anchor around each toolbar p-button - must not change the layout */
+.toolbar-tooltip-anchor {
+    display: inline-flex;
+}
+
 .toolbar-btn[readonly="true"] {
     background: #b5b5b5;
     cursor: not-allowed;


### PR DESCRIPTION
Fixes #6727

## Fixes

1. **Manage Schemas toolbar tooltips** — anchor each on an `inline-flex` wrapper around the `p-button` instead of on the component host, and add `tooltipStyleClass="guardian-tooltip"` to match the grid-row tooltips that render correctly.
2. **Field path in the documents block config** — add the tooltip the clipped cell needs, using the same pattern already used for the other labels in that component.
3. **Manage Policies empty state** — delete the obsolete first `.not-exist` rule. The later rule already centres it with flex and supersedes every other declaration; all the first contributed was the `position: absolute` that lifted it onto the toolbar. The remaining rule gets `width: 100%` and vertical padding so it flows below the toolbar.
4. **Relayer Accounts search icon** — centre it on the input (`top: 50%` + `translateY(-50%)`) instead of a magic `top: 12px`, make `.search-filter` an explicit flex box so it is unambiguously the offset parent, and reserve `padding-right` so the text cannot run under the icon.
5. **Add Credential dialog** — `appendTo="body"` so the mask spans the viewport, plus the `draggable`/`resizable`/`styleClass` flags the other dialogs use.

## Verification — please read

These are markup and CSS only, so there is nothing meaningful to unit-test; **I have not visually verified them in a browser**. Each change is justified by the mechanism described in #6727 rather than by a screenshot, and the toolbar-tooltip and search-icon fixes in particular would benefit from a reviewer confirming them visually.

I also could not use a full `ng build` as a check: `develop` currently fails to compile in my environment with 27 `TS7053`/`TS7006` errors, all in `frontend/src/app/views/first-steps-panel/first-steps-markdown.ts` (marked's token typings). That file is untouched by this PR and the failure reproduces without these changes.