### PR TITLE
fix(frontend): say which operation started, and show a failed search once

### DIFF
--- a/frontend/src/app/components/notification/notification.component.spec.ts
+++ b/frontend/src/app/components/notification/notification.component.spec.ts
@@ -1,0 +1,54 @@
+import { NotificationComponent } from './notification.component';
+
+describe('NotificationComponent', () => {
+    let toastService: any;
+
+    function create(): any {
+        toastService = jasmine.createSpyObj('ToastService', ['info', 'success', 'warn', 'error']);
+        return new NotificationComponent(
+            {} as any,
+            {} as any,
+            toastService as any,
+            {} as any,
+        );
+    }
+
+    // Every async task sends the same "Operation started" constant, so the toast looked
+    // like a generic success and never said which operation had begun.
+    describe('toastProgress', () => {
+        it('replaces the generic constant with the action', () => {
+            const component = create();
+
+            component.toastProgress({ message: 'Operation started', action: 'Migrate data' });
+
+            const [detail, summary] = toastService.info.calls.mostRecent().args;
+            expect(detail).toContain('Migrate data');
+            expect(detail).not.toBe('Operation started');
+            expect(summary).toBe('Migrate data');
+        });
+
+        it('handles a progress notification with no message at all', () => {
+            const component = create();
+
+            component.toastProgress({ action: 'Publish policy' });
+
+            expect(toastService.info.calls.mostRecent().args[0]).toContain('Publish policy');
+        });
+
+        it('passes a specific message through untouched', () => {
+            const component = create();
+
+            component.toastProgress({ message: 'Step 2 of 8', action: 'Import' });
+
+            expect(toastService.info).toHaveBeenCalledWith('Step 2 of 8', 'Import');
+        });
+
+        it('falls back to a heading when there is no action', () => {
+            const component = create();
+
+            component.toastProgress({ message: 'Operation started' });
+
+            expect(toastService.info).toHaveBeenCalledWith('Operation started', 'In progress');
+        });
+    });
+});

--- a/frontend/src/app/components/notification/notification.component.ts
+++ b/frontend/src/app/components/notification/notification.component.ts
@@ -88,8 +88,21 @@ export class NotificationComponent implements OnInit {
         }
     }
 
+    /**
+     * The backend sends the same constant for every async task, so the toast read like a
+     * generic success and never said what had actually begun. A message that is not the
+     * constant is passed through untouched.
+     */
+    private static readonly GENERIC_PROGRESS_MESSAGE = 'Operation started';
+
     toastProgress(notification: any) {
-        this.toastService.info(notification.message, notification.action);
+        const action = notification?.action;
+        const message = notification?.message;
+        const isGeneric = !message || message === NotificationComponent.GENERIC_PROGRESS_MESSAGE;
+        const detail = isGeneric && action
+            ? `${action} is running. You will be notified when it finishes.`
+            : message;
+        this.toastService.info(detail, action || 'In progress');
     }
 
     countUnreadNotification() {

--- a/frontend/src/app/modules/policy-engine/dialogs/search-external-policy-dialog/search-external-policy-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/search-external-policy-dialog/search-external-policy-dialog.component.ts
@@ -45,7 +45,8 @@ export class SearchExternalPolicyDialog {
             }, (e) => {
                 this.loading = false;
                 this.step = 0;
-                this.error = e?.error?.message;
+                // a gateway HTML 502 or a reset carries no JSON message
+                this.error = e?.error?.message || 'Import failed. Please try again.';
             });
     }
 
@@ -67,7 +68,7 @@ export class SearchExternalPolicyDialog {
             }, (e) => {
                 this.loading = false;
                 this.step = 0;
-                this.error = e?.error?.message;
+                this.error = e?.error?.message || 'Search failed. Please try again.';
             });
     }
 

--- a/frontend/src/app/services/external-policy.service.spec.ts
+++ b/frontend/src/app/services/external-policy.service.spec.ts
@@ -1,0 +1,52 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { SILENT_HTTP_ERRORS } from '../constants';
+import { API_BASE_URL } from './api';
+import { ExternalPoliciesService } from './external-policy.service';
+
+const URL = `${API_BASE_URL}/external-policies`;
+
+describe('ExternalPoliciesService', () => {
+    let service: ExternalPoliciesService;
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [ExternalPoliciesService],
+        });
+        service = TestBed.inject(ExternalPoliciesService);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => httpMock.verify());
+
+    it('preview posts the messageId', () => {
+        service.preview('msg-1').subscribe();
+        const req = httpMock.expectOne(`${URL}/preview`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({ messageId: 'msg-1' });
+        req.flush({});
+    });
+
+    // The Search Policy dialog renders these failures inline; without the flag the global
+    // interceptor toasts the identical message a second time.
+    it('marks preview and import as handled inline', () => {
+        service.preview('msg-1').subscribe();
+        const preview = httpMock.expectOne(`${URL}/preview`);
+        expect(preview.request.context.get(SILENT_HTTP_ERRORS)).toBeTrue();
+        preview.flush({});
+
+        service.import('msg-1').subscribe();
+        const imported = httpMock.expectOne(`${URL}/import`);
+        expect(imported.request.context.get(SILENT_HTTP_ERRORS)).toBeTrue();
+        imported.flush({});
+    });
+
+    it('leaves other external-policy calls on the global toast', () => {
+        service.approve('msg-1').subscribe();
+        const req = httpMock.expectOne(`${URL}/msg-1/approve`);
+        expect(req.request.context.get(SILENT_HTTP_ERRORS)).toBeFalse();
+        req.flush({});
+    });
+});

--- a/frontend/src/app/services/external-policy.service.ts
+++ b/frontend/src/app/services/external-policy.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { API_BASE_URL } from './api';
+import { SILENT_HTTP_ERRORS } from '../constants';
 
 /**
  * Services for working from labels and separate blocks.
@@ -48,12 +49,20 @@ export class ExternalPoliciesService {
         return this.http.get<any>(`${this.url}`, { observe: 'response', params });
     }
 
+    /**
+     * The Search Policy dialog renders these failures inline, so the global interceptor
+     * toast is a second copy of the same message.
+     */
+    private silent(): HttpContext {
+        return new HttpContext().set(SILENT_HTTP_ERRORS, true);
+    }
+
     public preview(messageId: string): Observable<any> {
-        return this.http.post<any>(`${this.url}/preview`, { messageId });
+        return this.http.post<any>(`${this.url}/preview`, { messageId }, { context: this.silent() });
     }
 
     public import(messageId: string): Observable<any> {
-        return this.http.post<any>(`${this.url}/import`, { messageId });
+        return this.http.post<any>(`${this.url}/import`, { messageId }, { context: this.silent() });
     }
 
     public approve(messageId: string): Observable<any> {


### PR DESCRIPTION
Fixes #6729

## Fixes

**Progress toast** — when the message is the generic `'Operation started'` constant (or absent), name the action and phrase it as in-progress. A backend message that is *not* the constant is passed through untouched, so anything more specific a task sends still wins. The toast stays info-styled: it is progress, not success.

Done on the frontend rather than by changing the backend constant, so it applies to every existing task action without touching `notification-events.ts`.

**Duplicated search error** — put `preview` and `import` behind the existing `SILENT_HTTP_ERRORS` context flag, the same mechanism `branding.service` and `auth.service` already use for requests they handle themselves. The dialog keeps its inline message; the global interceptor stops adding a second copy. Every other `external-policy` call keeps the global toast.

## Tests

Two new spec files, 7 tests. Run against `develop` with the source changes reverted, **4 fail**:

- replaces the generic constant with the action
- handles a progress notification with no message at all
- falls back to a heading when there is no action
- marks preview and import as handled inline

The 3 that pass either way pin what must **not** change: a specific backend message is passed through untouched, `preview` still posts the `messageId`, and other external-policy calls still reach the global toast.