### PR TITLE
fix(frontend): give Schema Templates the shared paginator

### DIFF
--- a/frontend/src/app/views/schema-templates/schema-templates.component.html
+++ b/frontend/src/app/views/schema-templates/schema-templates.component.html
@@ -271,7 +271,6 @@
               [pageIndex]="pageIndex"
               [pageSize]="pageSize"
               [length]="total"
-              [options]="[10, 25, 50, 100, 500]"
               (page)="onPage($event)"
             ></app-paginator>
           </div>

--- a/frontend/src/app/views/schema-templates/schema-templates.component.html
+++ b/frontend/src/app/views/schema-templates/schema-templates.component.html
@@ -86,11 +86,6 @@
         <div class="guardian-grid-container">
           <p-table
             [value]="templates"
-            [paginator]="true"
-            [rows]="pageSize"
-            [totalRecords]="total"
-            [lazy]="true"
-            (onPage)="onPage($event)"
             class="guardian-grid-table"
             [scrollable]="true">
             <ng-template pTemplate="header">
@@ -270,6 +265,16 @@
               </tr>
             </ng-template>
           </p-table>
+          <div class="guardian-grid-paginator">
+            <app-paginator
+              class="guardian-grid-paginator"
+              [pageIndex]="pageIndex"
+              [pageSize]="pageSize"
+              [length]="total"
+              [options]="[10, 25, 50, 100, 500]"
+              (page)="onPage($event)"
+            ></app-paginator>
+          </div>
         </div>
       } @else {
         <div class="schema-template-empty">

--- a/frontend/src/app/views/schema-templates/schema-templates.component.spec.ts
+++ b/frontend/src/app/views/schema-templates/schema-templates.component.spec.ts
@@ -1,0 +1,38 @@
+import { SchemaTemplatesComponent } from './schema-templates.component';
+
+describe('SchemaTemplatesComponent', () => {
+    function create(state: any = {}): any {
+        const component: any = Object.create(SchemaTemplatesComponent.prototype);
+        component.templates = state.templates || [];
+        component.total = state.total ?? 0;
+        component.pageIndex = state.pageIndex ?? 0;
+        component.pageSize = state.pageSize ?? 25;
+        component.loads = 0;
+        component.loadTemplates = () => { component.loads++; };
+        return component;
+    }
+
+    // The grid used the p-table pager, which emits {first, rows} and offers no
+    // rows-per-page control. app-paginator emits {pageIndex, pageSize} instead.
+    describe('onPage', () => {
+        it('moves to the requested page', () => {
+            const component = create();
+
+            component.onPage({ pageIndex: 3, pageSize: 25 });
+
+            expect(component.pageIndex).toBe(3);
+            expect(component.pageSize).toBe(25);
+            expect(component.loads).toBe(1);
+        });
+
+        it('returns to the first page when the page size changes', () => {
+            const component = create({ pageIndex: 4 });
+
+            component.onPage({ pageIndex: 4, pageSize: 100 });
+
+            expect(component.pageIndex).toBe(0);
+            expect(component.pageSize).toBe(100);
+            expect(component.loads).toBe(1);
+        });
+    });
+});

--- a/frontend/src/app/views/schema-templates/schema-templates.component.ts
+++ b/frontend/src/app/views/schema-templates/schema-templates.component.ts
@@ -27,7 +27,7 @@ export class SchemaTemplatesComponent implements OnInit, OnDestroy {
     public templates: SchemaTemplateGridItem[] = [];
     public total: number = 0;
     public pageIndex: number = 0;
-    public pageSize: number = 20;
+    public pageSize: number = 25;
     public user: UserPermissions = new UserPermissions();
     public isConfirmed: boolean = false;
     public textSearch: string = '';
@@ -338,9 +338,19 @@ export class SchemaTemplatesComponent implements OnInit, OnDestroy {
         });
     }
 
+    /**
+     * app-paginator emits {pageIndex, pageSize}; the p-table pager this replaced emitted
+     * {first, rows}. Changing the page size resets to the first page, matching the
+     * Schemas grid.
+     */
     public onPage(event: any): void {
-        this.pageIndex = Math.floor((event.first || 0) / (event.rows || this.pageSize));
-        this.pageSize = event.rows || this.pageSize;
+        if (this.pageSize !== event.pageSize) {
+            this.pageIndex = 0;
+            this.pageSize = event.pageSize;
+        } else {
+            this.pageIndex = event.pageIndex;
+            this.pageSize = event.pageSize;
+        }
         this.loadTemplates();
     }
 


### PR DESCRIPTION
Fixes #6731

## Fix

Replace `p-table`'s built-in pager with the shared `app-paginator`, using the standard 10/25/50/100/500 options, so the grid gets a rows-per-page control and matches every other grid in the app.

`onPage` now reads `{pageIndex, pageSize}` instead of PrimeNG's `{first, rows}`, and resets to the first page when the size changes — the same behaviour as the Schemas grid.

The default `pageSize` moves 20 → 25 so it is one of the offered options; otherwise `app-paginator.ngOnChanges` appends 20 to its own list and the selector shows a value no other grid offers.

## Tests

New spec covering the payload change: moving page, and the reset-to-first-page on a size change. Both fail on `develop`, where `onPage` reads `event.first` / `event.rows` and leaves `pageIndex` at 0 / `pageSize` unchanged for this payload.