### PR TITLE
fix(interfaces): enforce a condition's cross-schema targets

### DIFF
--- a/interfaces/src/helpers/schema-helper.ts
+++ b/interfaces/src/helpers/schema-helper.ts
@@ -665,6 +665,22 @@ export class SchemaHelper {
             const thenFields = condition.thenFields || [];
             const elseFields = condition.elseFields || [];
 
+            /*
+             * thenTargets / elseTargets are the cross-schema half of a condition: a
+             * target lives at a path inside another sub-schema rather than being a field
+             * of the condition itself. buildDocument compiles them into nested
+             * properties/required (buildCrossRequired) and `false` (buildCrossForbidden),
+             * so they are enforced for a plain object instance, but nothing here checked
+             * them - which left them unverified wherever the compiled keyword cannot
+             * apply.
+             */
+            const thenTargets = (condition as any).thenTargets || [];
+            const elseTargets = (condition as any).elseTargets || [];
+            const targetPath = (t: any): string[] | null =>
+                (t?.fieldPath?.length > 1) ? t.fieldPath : null;
+            const targetName = (t: any): string =>
+                t?.field?.name || (t?.fieldPath ? t.fieldPath[t.fieldPath.length - 1] : '');
+
             if (!reachable) {
                 for (const field of [...thenFields, ...elseFields]) {
                     if (present(data[field.name])) {
@@ -673,13 +689,39 @@ export class SchemaHelper {
                         );
                     }
                 }
+                for (const target of [...thenTargets, ...elseTargets]) {
+                    const path = targetPath(target);
+                    if (path && present(resolve(path))) {
+                        errors.push(
+                            `Field "${targetName(target)}" is not allowed: the condition that reveals it is not applicable.`
+                        );
+                    }
+                }
                 continue;
             }
 
-            const active = evaluate(condition) ? thenFields : elseFields;
+            const matched = evaluate(condition);
+            const active = matched ? thenFields : elseFields;
             for (const field of active) {
                 if (field.required && !present(data[field.name])) {
                     errors.push(`Field "${field.name}" is required.`);
+                }
+            }
+
+            const activeTargets = matched ? thenTargets : elseTargets;
+            const inactiveTargets = matched ? elseTargets : thenTargets;
+            for (const target of activeTargets) {
+                const path = targetPath(target);
+                if (path && target?.field?.required && !present(resolve(path))) {
+                    errors.push(`Field "${targetName(target)}" is required.`);
+                }
+            }
+            for (const target of inactiveTargets) {
+                const path = targetPath(target);
+                if (path && present(resolve(path))) {
+                    errors.push(
+                        `Field "${targetName(target)}" is not allowed: the condition that reveals it is not applicable.`
+                    );
                 }
             }
         }

--- a/interfaces/tests/schema-condition-cross-targets.test.mjs
+++ b/interfaces/tests/schema-condition-cross-targets.test.mjs
@@ -1,0 +1,65 @@
+import { assert } from 'chai';
+import { SchemaHelper } from '../dist/helpers/schema-helper.js';
+
+const field = (name, required = false) => ({ name, required });
+
+/*
+ * A cross-schema condition: the trigger is a field of this schema, the target lives at
+ * a path inside another sub-schema. buildDocument compiles targets into nested
+ * properties/required and `false`, but validateConditionFields never read them.
+ */
+const condition = (fieldValue, targetRequired = true) => ([{
+    ifCondition: { field: field('kind'), fieldValue, fieldPath: ['kind'] },
+    thenFields: [],
+    elseFields: [],
+    thenTargets: [{ field: field('detail', targetRequired), fieldPath: ['sub', 'detail'] }],
+    elseTargets: [],
+}]);
+
+describe('@unit SchemaHelper.validateConditionFields cross-schema targets', () => {
+    it('requires the target when the condition matches', () => {
+        const errors = SchemaHelper.validateConditionFields(condition('full'), { kind: 'full', sub: {} });
+        assert.lengthOf(errors, 1);
+        assert.include(errors[0], 'detail');
+        assert.include(errors[0], 'required');
+    });
+
+    it('accepts the target when the condition matches and it is present', () => {
+        const errors = SchemaHelper.validateConditionFields(
+            condition('full'), { kind: 'full', sub: { detail: 'x' } }
+        );
+        assert.deepEqual(errors, []);
+    });
+
+    // the branch is inactive, so the target must not be carried at all
+    it('rejects a target smuggled in while the condition does not match', () => {
+        const errors = SchemaHelper.validateConditionFields(
+            condition('full'), { kind: 'partial', sub: { detail: 'smuggled' } }
+        );
+        assert.lengthOf(errors, 1);
+        assert.include(errors[0], 'not allowed');
+    });
+
+    it('accepts an absent target while the condition does not match', () => {
+        const errors = SchemaHelper.validateConditionFields(condition('full'), { kind: 'partial', sub: {} });
+        assert.deepEqual(errors, []);
+    });
+
+    it('leaves an optional target unenforced', () => {
+        const errors = SchemaHelper.validateConditionFields(
+            condition('full', false), { kind: 'full', sub: {} }
+        );
+        assert.deepEqual(errors, []);
+    });
+
+    it('ignores a target with no usable path', () => {
+        const conditions = [{
+            ifCondition: { field: field('kind'), fieldValue: 'full', fieldPath: ['kind'] },
+            thenFields: [],
+            elseFields: [],
+            thenTargets: [{ field: field('detail', true) }],
+            elseTargets: [],
+        }];
+        assert.deepEqual(SchemaHelper.validateConditionFields(conditions, { kind: 'full' }), []);
+    });
+});


### PR DESCRIPTION
Fixes #6742

## Fix

Validate `thenTargets` / `elseTargets` with the same semantics `buildDocument` compiles them to:

- on the **active** branch, a required target must be present (`buildCrossRequired`)
- the **inactive** branch's targets must be absent (`buildCrossForbidden`)
- optional targets are only ever hidden, never required
- a target with no usable `fieldPath` is ignored

Targets are resolved with the `resolve()` helper already in the function, so no new path logic is introduced.

## Tests

New `interfaces/tests/schema-condition-cross-targets.test.mjs`, 6 tests. On `develop` with the source change reverted, **2 fail**:

- a required target missing on the active branch
- a target smuggled in while its branch is inactive ← the one that matters

The other 4 pin what must not change: a satisfied target passes, an absent target on an inactive branch passes, optional targets stay unenforced, and a target with no path is ignored.

The 89 existing tests across `schema-condition-reachability`, `json-to-schema-conditions` and `schema-helper-conditions-serialize` still pass.

## Deliberately not included

The paired-repeatable case (`subA[i].type` → `subB[i].detail`) — correlating entry *i* across two arrays needs the schema's `arrayDependencies`, which this function does not receive. It would need a signature change, so it is described in #6742 rather than half-implemented here.