### PR TITLE
fix(policy-service): match source filter values as stored, not only as coerced

### DIFF
--- a/policy-service/src/policy-engine/blocks/document-validator-block.ts
+++ b/policy-service/src/policy-engine/blocks/document-validator-block.ts
@@ -118,34 +118,63 @@ export class DocumentValidatorBlock {
             filter.assignedToGroup = { $eq: user.group };
         }
 
+        /*
+         * The DB filter has to match the value as STORED, not only as coerced.
+         *
+         * coerceValue turns '100' into the number 100 and '2024-06-01' into epoch
+         * milliseconds, but VC JSON stores those fields as strings and Mongo comparisons
+         * are type-bracketed. So `gte '2024-01-01'` compared a number against strings and
+         * matched nothing - fail-closed, valid sources never found - while $ne against
+         * string-stored values matched nothing to exclude and left the excluded documents
+         * as candidates: fail-open. The in-memory condition phase coerces both sides,
+         * which is what makes the DB phase's one-sided coercion a mismatch.
+         *
+         * Where coercion actually changes the value, both representations are offered.
+         */
+        const alternatives = (rawValue: any, coerced: any): any[] =>
+            (rawValue === coerced || rawValue === undefined || rawValue === null)
+                ? [coerced]
+                : [coerced, rawValue];
+        const rangeFilters: any[] = [];
+
         for (const f of (sourceValidation.filters || [])) {
             const raw = f.typeValue === 'variable'
                 ? PolicyUtils.getObjectValue(document, f.value)
                 : f.value;
             const value = this.coerceValue(raw);
+            const both = alternatives(raw, value);
 
             switch (f.type) {
-                case 'not_equal': filter[f.field] = { $ne: value }; break;
-                case 'in': {
-                    const arr = f.typeValue === 'variable'
-                        ? (Array.isArray(raw) ? raw.map((e: any) => this.coerceValue(e)) : [value])
-                        : String(f.value).split(',').map((v: string) => this.coerceValue(v.trim()));
-                    filter[f.field] = { $in: arr };
-                    break;
-                }
+                case 'not_equal': filter[f.field] = { $nin: both }; break;
+                case 'in':
                 case 'not_in': {
-                    const arr = f.typeValue === 'variable'
-                        ? (Array.isArray(raw) ? raw.map((e: any) => this.coerceValue(e)) : [value])
-                        : String(f.value).split(',').map((v: string) => this.coerceValue(v.trim()));
-                    filter[f.field] = { $nin: arr };
+                    const source: any[] = f.typeValue === 'variable'
+                        ? (Array.isArray(raw) ? raw : [raw])
+                        : String(f.value).split(',').map((v: string) => v.trim());
+                    const arr = source.flatMap((e: any) => alternatives(e, this.coerceValue(e)));
+                    filter[f.field] = f.type === 'in' ? { $in: arr } : { $nin: arr };
                     break;
                 }
-                case 'gt':        filter[f.field] = { $gt: value }; break;
-                case 'gte':       filter[f.field] = { $gte: value }; break;
-                case 'lt':        filter[f.field] = { $lt: value }; break;
-                case 'lte':       filter[f.field] = { $lte: value }; break;
-                default:          filter[f.field] = { $eq: value }; break;
+                case 'gt':
+                case 'gte':
+                case 'lt':
+                case 'lte': {
+                    const op = `$${f.type}`;
+                    if (both.length === 1) {
+                        filter[f.field] = { [op]: both[0] };
+                    } else {
+                        // type bracketing means one predicate cannot span both, so the
+                        // document qualifies if it compares true as EITHER type
+                        rangeFilters.push({ $or: both.map((v) => ({ [f.field]: { [op]: v } })) });
+                    }
+                    break;
+                }
+                default:          filter[f.field] = { $in: both }; break;
             }
+        }
+
+        if (rangeFilters.length) {
+            filter.$and = rangeFilters;
         }
 
         return filter;

--- a/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
@@ -51,4 +51,30 @@ describe('documentValidatorBlock source filter coercion', () => {
             assert.deepEqual(filter.f, { $in: [1, '1', 2, '2'] });
         });
     });
+
+    describe('values resolved from the document', () => {
+        it('widens a variable-resolved range value', () => {
+            const document = { currentAmount: '100' };
+            const filter = block().buildSourceFilter(
+                { filters: [{ field: 'amount', type: 'gte', value: 'currentAmount', typeValue: 'variable' }] },
+                ref, document, {}
+            );
+
+            const [{ $or }] = filter.$and;
+            assert.deepEqual($or, [
+                { amount: { $gte: 100 } },
+                { amount: { $gte: '100' } }
+            ]);
+        });
+
+        it('widens every element of a variable-resolved in list', () => {
+            const document = { allowed: ['1', '2'] };
+            const filter = block().buildSourceFilter(
+                { filters: [{ field: 'f', type: 'in', value: 'allowed', typeValue: 'variable' }] },
+                ref, document, {}
+            );
+
+            assert.deepEqual(filter.f, { $in: [1, '1', 2, '2'] });
+        });
+    });
 });

--- a/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
@@ -1,0 +1,54 @@
+import { assert } from 'chai';
+import { DocumentValidatorBlock } from '../../../dist/policy-engine/blocks/document-validator-block.js';
+
+const block = () => Object.create(DocumentValidatorBlock.prototype);
+const ref = { policyId: 'policy-1' };
+
+describe('documentValidatorBlock source filter coercion', () => {
+    describe('type coercion against string-stored values', () => {
+        const filterFor = (type, value) => block().buildSourceFilter(
+            { filters: [{ field: 'document.credentialSubject.0.date', type, value, typeValue: 'value' }] },
+            ref, {}, {}
+        );
+
+        it('offers both representations for equality', () => {
+            const filter = filterFor('equal', '100');
+
+            // '100' coerces to the number 100; VC JSON stores the string, and Mongo
+            // comparisons are type-bracketed, so one representation alone misses
+            assert.deepEqual(filter['document.credentialSubject.0.date'], { $in: [100, '100'] });
+        });
+
+        it('excludes both representations for not_equal', () => {
+            const filter = filterFor('not_equal', '100');
+
+            assert.deepEqual(filter['document.credentialSubject.0.date'], { $nin: [100, '100'] });
+        });
+
+        it('compares a date range as either type', () => {
+            const filter = filterFor('gte', '2024-01-01');
+
+            // a single $gte would compare epoch-ms against strings and match nothing
+            assert.isArray(filter.$and);
+            const or = filter.$and[0].$or;
+            assert.lengthOf(or, 2);
+            assert.equal(or[1]['document.credentialSubject.0.date'].$gte, '2024-01-01');
+        });
+
+        it('keeps a single predicate when coercion changes nothing', () => {
+            const filter = filterFor('gte', 'abc');
+
+            assert.isUndefined(filter.$and);
+            assert.deepEqual(filter['document.credentialSubject.0.date'], { $gte: 'abc' });
+        });
+
+        it('widens every element of an in list', () => {
+            const filter = block().buildSourceFilter(
+                { filters: [{ field: 'f', type: 'in', value: '1, 2', typeValue: 'value' }] },
+                ref, {}, {}
+            );
+
+            assert.deepEqual(filter.f, { $in: [1, '1', 2, '2'] });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #6744

## Fix

Where `coerceValue` actually changes the value, offer both representations:

- equality and `in` → `$in` over both; `not_equal` and `not_in` → `$nin` over both
- range operators cannot express both in one field predicate (type bracketing), so they go through `$and` / `$or` and qualify a document that compares true as **either** type
- where coercion changes nothing, the single predicate is kept unchanged

## Tests

New `policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs`, 5 tests. On `develop` with the source change reverted, **4 fail**:

- both representations offered for equality
- both excluded for `not_equal` (the fail-open direction)
- a date range compared as either type (the fail-closed direction)
- every element of an `in` list widened

The fifth pins what must not change: when coercion changes nothing, a single predicate is still emitted and no `$and` is added.

All 17 tests across the block's existing suites pass.

## Related

Same audit as #6740 (group fail-open) and #6714 (`in`/`not_in` ordering). This is the last of the four findings that reproduces upstream; the fourth was a missing custom Fail Message, which is a feature rather than a fix.