### PR TITLE
fix(frontend): name the wizard's role steps for what they configure

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.spec.ts
@@ -1,0 +1,73 @@
+import { UntypedFormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { PolicyWizardDialogComponent } from './policy-wizard-dialog.component';
+
+describe('PolicyWizardDialogComponent step-tree labels', () => {
+    function makeFull(configData = {}) {
+        const fb = new UntypedFormBuilder();
+        const ref = { close: jasmine.createSpy('close') };
+        const cmp = new PolicyWizardDialogComponent(
+            fb as any,
+            { detectChanges: () => {} } as any,
+            (() => 'SchemaName') as any,
+            ref as any,
+            { header: 'H', data: { schemas: [], policies: [], tokens: [], ...configData } } as any,
+            { getPolicyCategories: () => of([]) } as any,
+            { getSchemaWithSubSchemas: () => of({ schema: null }) } as any,
+        );
+        return { cmp, fb, ref };
+    }
+
+    // The schema-role node and the trust-chain-role node were both named
+    // "<role> configuration", so the same label appeared under Policy Schemas and again
+    // under Trust Chain. The step walk has no wrap-around, but two identically named
+    // stops read as one the user keeps coming back to.
+    describe('step-tree labels distinguish where a role is configured', () => {
+        function addSchemaRole(cmp: any, fb: any, node: any) {
+            cmp.onSchemaRoleConfigChange(
+                'OWNER',
+                [],
+                fb.array([]),
+                fb.control([]),
+                fb.control(false),
+                fb.control(''),
+                node,
+            );
+            return node;
+        }
+
+        it('names a schema role node after the schema it configures', () => {
+            const { cmp, fb } = makeFull({ schemas: [], policies: [], tokens: [] });
+            const node = addSchemaRole(cmp, fb, {
+                id: '3.1', icon: 'description', children: [] as any[],
+                schema: { name: 'Project Description' },
+            });
+            expect(node.children[0].name).toBe('OWNER in Project Description');
+        });
+
+        it('names a trust-chain role node after the trust chain', () => {
+            const { cmp } = makeFull({ schemas: [], policies: [], tokens: [] });
+            const node: any = { id: '4', icon: 'link', children: [] as any[] };
+            (cmp as any).onSelectedTrustChainRoleChange('OWNER', node);
+            expect(node.children[0].name).toBe('OWNER trust chain');
+        });
+
+        it('gives the same role different labels in the two sections', () => {
+            const { cmp, fb } = makeFull({ schemas: [], policies: [], tokens: [] });
+            const schemas = addSchemaRole(cmp, fb, {
+                id: '3.1', icon: 'description', children: [] as any[],
+                schema: { name: 'Project Description' },
+            });
+            const trustChain: any = { id: '4', icon: 'link', children: [] as any[] };
+            (cmp as any).onSelectedTrustChainRoleChange('OWNER', trustChain);
+
+            expect(schemas.children[0].name).not.toBe(trustChain.children[0].name);
+        });
+
+        it('falls back to the plain label when the parent carries no schema', () => {
+            const { cmp, fb } = makeFull({ schemas: [], policies: [], tokens: [] });
+            const node = addSchemaRole(cmp, fb, { id: '3.1', icon: 'description', children: [] as any[] });
+            expect(node.children[0].name).toBe('OWNER configuration');
+        });
+    });
+});

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
@@ -521,7 +521,14 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         const newNode: any = {
             id: `${node.id}.${node.children.length + 1}`,
             icon: node.icon,
-            name: `${role} configuration`,
+            /*
+             * This and the trust-chain role node were both called "<role>
+             * configuration", so the same label appeared under Policy Schemas and again
+             * under Trust Chain. The step walk is a plain depth-first pass with no
+             * wrap-around, but two identically named stops read as one the user keeps
+             * returning to, which is why the flow felt like a loop with no end.
+             */
+            name: node.schema?.name ? `${role} in ${node.schema.name}` : `${role} configuration`,
             parent: node,
             template: this.schemaRoleConfig,
             fields,
@@ -798,7 +805,7 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         const newNode = {
             id: `${node.id}.${node.children.length + 1}`,
             icon: node.icon,
-            name: `${trustChainRole} configuration`,
+            name: `${trustChainRole} trust chain`,
             children: [],
             parent: node,
             template: this.trustChainRoleConfig,

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-wizard-dialog/policy-wizard-dialog.component.ts
@@ -521,13 +521,7 @@ export class PolicyWizardDialogComponent implements OnInit, AfterViewInit {
         const newNode: any = {
             id: `${node.id}.${node.children.length + 1}`,
             icon: node.icon,
-            /*
-             * This and the trust-chain role node were both called "<role>
-             * configuration", so the same label appeared under Policy Schemas and again
-             * under Trust Chain. The step walk is a plain depth-first pass with no
-             * wrap-around, but two identically named stops read as one the user keeps
-             * returning to, which is why the flow felt like a loop with no end.
-             */
+            // Name the step after its schema so it is distinct from the trust-chain role node.
             name: node.schema?.name ? `${role} in ${node.schema.name}` : `${role} configuration`,
             parent: node,
             template: this.schemaRoleConfig,


### PR DESCRIPTION
Fixes #6746

## Fix

Name each role step for what it configures:

- schema role → `OWNER in Project Description` (the schema its parent node carries)
- trust-chain role → `OWNER trust chain`

A schema role node falls back to the previous `<role> configuration` if its parent carries no schema, so nothing breaks if a node is built outside the normal path.

The step walk is untouched — `getNextNode()` already terminates correctly, so there is no navigation bug to fix here (see #6746).

## Tests

New `policy-wizard-dialog.component.spec.ts`, 4 tests. On `develop` with the source change reverted, **3 fail**:

- names a schema role node after the schema it configures
- names a trust-chain role node after the trust chain
- gives the same role different labels in the two sections

The fourth pins the fallback and passes either way by design.