### PR TITLE
fix(frontend): surface backend failures in the schema editor

### DIFF
--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.spec.ts
@@ -64,6 +64,12 @@ describe('SchemasConfigurationComponent', () => {
 
         component.router = { url: state.url || '/schema-configuration', navigate: () => Promise.resolve(true) };
         component.route = {};
+        component.toasts = [];
+        component.toastService = {
+            error: (detail: string, action?: string) => { component.toasts.push({ detail, action }); },
+            success: () => {},
+            warn: () => {},
+        };
         component.schemaService = {
             update: (s: any) => { component.updated.push(s); return of([]); },
             create: (_c: any, s: any) => { component.created.push(s); return of([]); },
@@ -130,6 +136,59 @@ describe('SchemasConfigurationComponent', () => {
 
             expect(component.dirtySchemaIds.has('sub')).toBeFalse();
             expect(component.hasUnsavedChanges).toBeFalse();
+        });
+    });
+
+    // Every error path in this component was a silent no-op: the button stayed enabled,
+    // the click fired, and a failed backend call produced no toast, dialog or message -
+    // indistinguishable from a dead button.
+    describe('backend failures are surfaced', () => {
+        it('reports a failed export instead of never opening the dialog', () => {
+            const schema: any = makeSchema({ id: 'a' });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.schemaService.exportInMessage = () => throwError(() => ({ error: { message: 'nope' } }));
+            component.dialogService = { open: () => ({ onClose: of(null) }) };
+
+            component.onExport();
+
+            expect(component.toasts.length).toBe(1);
+            expect(component.toasts[0].detail).toBe('nope');
+            expect(component.toasts[0].action).toBe('Export');
+        });
+
+        it('reports a failed deletion preview instead of doing nothing', () => {
+            const schema: any = makeSchema({ id: 'a' });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.schemaService.getSchemaDeletionPreview = () => throwError(() => ({ error: { message: 'blocked' } }));
+            component.dialogService = { open: () => ({ onClose: of(null) }) };
+
+            component.onDeleteSchema(schema);
+
+            expect(component.toasts.length).toBe(1);
+            expect(component.toasts[0].detail).toBe('blocked');
+        });
+
+        it('reports a rejected save and clears the saving flag', () => {
+            const schema: any = makeSchema({ id: 'a', fields: [makeField()] });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema, dirtyIds: ['a'] });
+            component.schemaService.update = () => throwError(() => ({ error: { message: 'rejected' } }));
+
+            component.saveAll();
+
+            expect(component.isSaving).toBeFalse();
+            expect(component.toasts.length).toBe(1);
+            expect(component.toasts[0].action).toBe('Save all');
+        });
+
+        it('falls back to a generic detail when the error carries no message', () => {
+            const schema: any = makeSchema({ id: 'a' });
+            const component = createComponent({ schemas: [schema], selectedSchema: schema });
+            component.schemaService.exportInMessage = () => throwError(() => ({}));
+            component.dialogService = { open: () => ({ onClose: of(null) }) };
+
+            component.onExport();
+
+            expect(component.toasts[0].detail).toBe('Unknown error');
         });
     });
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -17,6 +17,7 @@ import { ExportPolicyDialog } from 'src/app/modules/policy-engine/dialogs/export
 import { PublishSchemaTemplateDialog } from 'src/app/modules/policy-engine/dialogs/publish-schema-template-dialog/publish-schema-template-dialog.component';
 import { FieldTypeUI, FIELD_TYPES_UI } from 'src/app/modules/schema-engine/field-type-ui';
 import { SchemaTemplatesService } from 'src/app/services/schema-templates.service';
+import { ToastService } from 'src/app/services/toast.service';
 
 export interface DrillEntry {
     fieldLabel: string;
@@ -534,7 +535,17 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         private _elRef: ElementRef,
         private _zone: NgZone,
         private _cdr: ChangeDetectorRef,
+        private toastService: ToastService,
     ) {}
+
+    /**
+     * Surface a backend failure. Every error path in this component used to be a silent
+     * no-op, which makes a failed operation indistinguishable from a dead button.
+     */
+    private reportError(action: string, error: any): void {
+        const detail = error?.error?.message || error?.message || 'Unknown error';
+        this.toastService.error(detail, action, { sticky: true });
+    }
 
     public ngOnInit(): void {
         this.restoreCanvasTab();
@@ -1219,13 +1230,13 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                                 queryParams: { last: btoa(returnUrl) },
                             });
                         },
-                        error: () => { this.isSaving = false; },
+                        error: (error) => { this.isSaving = false; this.reportError('Save all', error); },
                     });
             };
             if (createObs.length) {
                 forkJoin(createObs).pipe(takeUntil(this.destroy$)).subscribe({
                     next: triggerNewVersion,
-                    error: () => { this.isSaving = false; },
+                    error: (error) => { this.isSaving = false; this.reportError('Save all', error); },
                 });
             } else {
                 triggerNewVersion();
@@ -1247,7 +1258,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                     this.dirtySchemaIds.clear();
                     this.newSchemaKeys.clear();
                 },
-                error: () => { this.isSaving = false; }
+                error: (error) => { this.isSaving = false; this.reportError('Save all', error); }
             });
     }
 
@@ -3459,10 +3470,10 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                                 void this.router.navigate(['task', result.taskId], {
                                     queryParams: { last: btoa(returnUrl) },
                                 });
-                            });
+                            }, (error) => this.reportError('Delete schema', error));
                     }
                 });
-            });
+            }, (error) => this.reportError('Delete schema', error));
     }
 
     // Build $defs the same way as the old editor (SchemaHelper.findRefs + uniqueRefs),
@@ -3579,7 +3590,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                     styleClass: 'custom-dialog',
                     data: { schema },
                 });
-            });
+            }, (error) => this.reportError('Export', error));
     }
 
     public onExportTemplate(): void {
@@ -3597,7 +3608,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
                         schemaTemplate
                     },
                 });
-            });
+            }, (error) => this.reportError('Export', error));
     }
 
     public onSidebarScroll(event: Event): void {


### PR DESCRIPTION
Fixes #6748

## Fix

Inject `ToastService` and route every swallowed error through one helper:

- `onExport` / `onExportTemplate` — add the missing error callback
- the schema deletion preview — add an error arm, and one on the delete call it opens
- `saveAll`'s three terminal error handlers — report as well as reset `isSaving`

The helper falls back to a generic detail when the error carries no message. `dirtySchemaIds` is still deliberately not cleared on failure — the changes really are unsaved — but now the user is told why.

## Tests

4 new tests in the existing `schemas-configuration.component.spec.ts`. On `develop` with `reportError` neutralised, **all 4 fail**:

- a failed export is reported instead of never opening the dialog
- a failed deletion preview is reported instead of doing nothing
- a rejected save is reported and clears the saving flag
- a message-less error falls back to a generic detail

The 31 existing tests still pass (35 total on this branch).

## Related

The same ticket in our tracker also noted that the Save gate validates fields but not conditions, so a half-configured condition passes the client check and the server rejects the PUT. That is a separate change and not included here.