### PR TITLE
fix(guardian-service): prove the Hedera key pair instead of probing for a balance

### DIFF
--- a/guardian-service/src/api/helpers/hedera-key-validator.ts
+++ b/guardian-service/src/api/helpers/hedera-key-validator.ts
@@ -1,0 +1,46 @@
+import { checkHederaKey, Workers } from '@guardian/common';
+import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
+import { WorkerTaskType } from '@guardian/interfaces';
+
+/**
+ * Prove that a private key controls an account.
+ *
+ * This used to be inferred from a GET_USER_BALANCE probe whose result was discarded:
+ * the pairing was assumed because that task built a signing client and did not throw.
+ * PrivateKey.fromString() beside it only proves the key parses.
+ *
+ * Deriving the public key from the supplied private key and comparing it with the
+ * account's on-chain public key proves the pair directly, and needs no signing, no fee
+ * and no mutation - the account is read over the keyless GET_ACCOUNT_INFO_REST task.
+ *
+ * @throws Error('Invalid Hedera account or key.')
+ */
+export async function validateHederaAccountKey(
+    hederaAccountId: string,
+    hederaAccountKey: string,
+    options?: { userId?: string; interception?: string }
+): Promise<void> {
+    try {
+        AccountId.fromString(hederaAccountId);
+        PrivateKey.fromString(hederaAccountKey);
+
+        const info = await new Workers().addNonRetryableTask({
+            type: WorkerTaskType.GET_ACCOUNT_INFO_REST,
+            data: {
+                hederaAccountId,
+                payload: { userId: options?.userId ?? null }
+            }
+        }, {
+            priority: 20,
+            userId: options?.userId ?? null,
+            interception: options?.interception ?? null
+        });
+
+        // the mirror node returns key as { _type, key }
+        if (!checkHederaKey(hederaAccountKey, info?.key?.key)) {
+            throw new Error('Key does not match the account');
+        }
+    } catch (error) {
+        throw new Error('Invalid Hedera account or key.');
+    }
+}

--- a/guardian-service/src/api/helpers/hedera-key-validator.ts
+++ b/guardian-service/src/api/helpers/hedera-key-validator.ts
@@ -2,29 +2,30 @@ import { checkHederaKey, Workers } from '@guardian/common';
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { WorkerTaskType } from '@guardian/interfaces';
 
+// key types the mirror node reports as one comparable public key
+const COMPARABLE_KEY_TYPES = ['ED25519', 'ECDSA_SECP256K1'];
+
 /**
  * Prove that a private key controls an account.
  *
- * This used to be inferred from a GET_USER_BALANCE probe whose result was discarded:
- * the pairing was assumed because that task built a signing client and did not throw.
- * PrivateKey.fromString() beside it only proves the key parses.
+ * The profile-setup "Check hedera key" step only parsed the key and probed for the
+ * account; the first real check came later at TopicHelper.create(). Comparing the
+ * derived public key with the account's on-chain one proves the pair directly, with
+ * no signing, fee or mutation.
  *
- * Deriving the public key from the supplied private key and comparing it with the
- * account's on-chain public key proves the pair directly, and needs no signing, no fee
- * and no mutation - the account is read over the keyless GET_ACCOUNT_INFO_REST task.
- *
- * @throws Error('Invalid Hedera account or key.')
+ * @throws Error('Invalid Hedera account or key.') with the underlying error as `cause`
  */
 export async function validateHederaAccountKey(
     hederaAccountId: string,
     hederaAccountKey: string,
     options?: { userId?: string; interception?: string }
 ): Promise<void> {
+    let info: any;
     try {
         AccountId.fromString(hederaAccountId);
         PrivateKey.fromString(hederaAccountKey);
 
-        const info = await new Workers().addNonRetryableTask({
+        info = await new Workers().addNonRetryableTask({
             type: WorkerTaskType.GET_ACCOUNT_INFO_REST,
             data: {
                 hederaAccountId,
@@ -35,12 +36,22 @@ export async function validateHederaAccountKey(
             userId: options?.userId ?? null,
             interception: options?.interception ?? null
         });
-
-        // the mirror node returns key as { _type, key }
-        if (!checkHederaKey(hederaAccountKey, info?.key?.key)) {
-            throw new Error('Key does not match the account');
-        }
     } catch (error) {
-        throw new Error('Invalid Hedera account or key.');
+        // keep the cause: a NATS timeout and a wrong key otherwise read identically
+        throw new Error('Invalid Hedera account or key.', { cause: error });
+    }
+
+    // a key-list account has no single key to compare against, and PublicKey.fromString
+    // throws on its ProtobufEncoded hex - defer it to the signing operations downstream
+    const keyType = info?.key?._type;
+    if (keyType && !COMPARABLE_KEY_TYPES.includes(keyType)) {
+        return;
+    }
+
+    // the mirror node returns key as { _type, key }
+    if (!checkHederaKey(hederaAccountKey, info?.key?.key)) {
+        throw new Error('Invalid Hedera account or key.', {
+            cause: new Error(`Key does not match account '${hederaAccountId}'`),
+        });
     }
 }

--- a/guardian-service/src/api/helpers/organization-helper.ts
+++ b/guardian-service/src/api/helpers/organization-helper.ts
@@ -29,6 +29,7 @@ import {
 } from '@guardian/common';
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { getGlobalTopic } from './profile-helper.js';
+import { validateHederaAccountKey } from './hedera-key-validator.js';
 
 /**
  * Lightweight shape used by guardian-service to round-trip Organization records over NATS.
@@ -205,25 +206,13 @@ export async function publishOrganization({
     // ------------------------
     notifier.startStep(STEP_RESOLVE_ACCOUNT);
     try {
-        const workers = new Workers();
-        AccountId.fromString(payload.hederaAccountId);
-        PrivateKey.fromString(payload.hederaAccountKey);
-        await workers.addNonRetryableTask({
-            type: WorkerTaskType.GET_USER_BALANCE,
-            data: {
-                hederaAccountId: payload.hederaAccountId,
-                hederaAccountKey: payload.hederaAccountKey
-            }
-        }, {
-            priority: 20,
-            attempts: 0,
-            registerCallback: true,
-            interception: owner.id,
-            userId: owner.id
+        await validateHederaAccountKey(payload.hederaAccountId, payload.hederaAccountKey, {
+            userId: owner.id,
+            interception: owner.id
         });
     } catch (error) {
         logger.error(error, ['GUARDIAN_SERVICE'], logId);
-        throw new Error('Invalid Hedera account or key.');
+        throw error;
     }
     notifier.completeStep(STEP_RESOLVE_ACCOUNT);
     // ------------------------

--- a/guardian-service/src/api/helpers/organization-helper.ts
+++ b/guardian-service/src/api/helpers/organization-helper.ts
@@ -27,7 +27,6 @@ import {
     Wallet,
     Workers,
 } from '@guardian/common';
-import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { getGlobalTopic } from './profile-helper.js';
 import { validateHederaAccountKey } from './hedera-key-validator.js';
 

--- a/guardian-service/src/api/helpers/profile-helper.ts
+++ b/guardian-service/src/api/helpers/profile-helper.ts
@@ -46,6 +46,7 @@ import {
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { serDefaultRole } from '../permission.service.js';
 import { publishSystemSchema } from '../../helpers/import-helpers/index.js';
+import { validateHederaAccountKey } from './hedera-key-validator.js';
 
 export interface IFireblocksConfig {
     fireBlocksVaultId: string;
@@ -365,23 +366,10 @@ export async function createUserProfile({
     // <-- Check hedera key
     // ------------------------
     notifier.startStep(STEP_RESOLVE_ACCOUNT);
-    try {
-        const workers = new Workers();
-        AccountId.fromString(hederaAccountId);
-        PrivateKey.fromString(hederaAccountKey);
-        await workers.addNonRetryableTask({
-            type: WorkerTaskType.GET_USER_BALANCE,
-            data: { hederaAccountId, hederaAccountKey }
-        }, {
-            priority: 20,
-            attempts: 0,
-            registerCallback: true,
-            interception: user.id.toString(),
-            userId: user.id.toString()
-        });
-    } catch (error) {
-        throw new Error(`Invalid Hedera account or key.`);
-    }
+    await validateHederaAccountKey(hederaAccountId, hederaAccountKey, {
+        userId: user.id.toString(),
+        interception: user.id.toString()
+    });
     notifier.completeStep(STEP_RESOLVE_ACCOUNT);
     // ------------------------
     // Check hedera key -->

--- a/guardian-service/src/api/profile.service.ts
+++ b/guardian-service/src/api/profile.service.ts
@@ -23,7 +23,7 @@ import {
 import { RestoreDataFromHedera } from '../helpers/restore-data-from-hedera.js';
 import { Controller, Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
-import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
+import { PrivateKey } from '@hiero-ledger/sdk';
 import { ICredentials, IFireblocksConfig, IOnboardingPayload, setupUserProfile, validateCommonDid } from './helpers/profile-helper.js';
 import { validateHederaAccountKey } from './helpers/hedera-key-validator.js';
 

--- a/guardian-service/src/api/profile.service.ts
+++ b/guardian-service/src/api/profile.service.ts
@@ -25,6 +25,7 @@ import { Controller, Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AccountId, PrivateKey } from '@hiero-ledger/sdk';
 import { ICredentials, IFireblocksConfig, IOnboardingPayload, setupUserProfile, validateCommonDid } from './helpers/profile-helper.js';
+import { validateHederaAccountKey } from './helpers/hedera-key-validator.js';
 
 @Controller()
 export class ProfileController {
@@ -316,21 +317,9 @@ export function profileAPI(logger: PinoLogger) {
 
                 const target = await new Users().getUser(username, user.id);
 
-                try {
-                    const workers = new Workers();
-                    AccountId.fromString(hederaAccountId);
-                    PrivateKey.fromString(hederaAccountKey);
-                    await workers.addNonRetryableTask({
-                        type: WorkerTaskType.GET_USER_BALANCE,
-                        data: { hederaAccountId, hederaAccountKey }
-                    }, {
-                        priority: 20,
-                        userId: target.id.toString(),
-                        interception: null
-                    });
-                } catch (error) {
-                    throw new Error(`Invalid Hedera account or key.`);
-                }
+                await validateHederaAccountKey(hederaAccountId, hederaAccountKey, {
+                    userId: target.id.toString()
+                });
 
                 const vcHelper = new VcHelper();
                 let oldDidDocument: CommonDidDocument;

--- a/guardian-service/tests/unit/hedera-key-validator.test.mjs
+++ b/guardian-service/tests/unit/hedera-key-validator.test.mjs
@@ -1,11 +1,7 @@
 import { assert } from 'chai';
 import esmock from 'esmock';
 
-/*
- * The key check used to be inferred from a GET_USER_BALANCE probe whose result was
- * discarded - it only held because the worker built a signing client. These cover the
- * direct check that replaces it.
- */
+// the old check was inferred from a GET_USER_BALANCE probe whose result was discarded
 async function load({ accountKey, mirrorKey, taskError } = {}) {
     const calls = [];
     const { validateHederaAccountKey } = await esmock(
@@ -101,5 +97,85 @@ describe('@unit validateHederaAccountKey', function () {
         }
         assert.isNotNull(failed, 'expected a rejection');
         assert.equal(failed.message, 'Invalid Hedera account or key.');
+    });
+
+    // the cases above stub checkHederaKey, so they would pass against a validator that
+    // never validates; these run the real one and stub only the mirror-node read
+    describe('with the real SDK and real checkHederaKey', () => {
+        async function loadReal(mirrorKeyObject) {
+            return await esmock(
+                '../../dist/api/helpers/hedera-key-validator.js',
+                {
+                    '@guardian/common': {
+                        Workers: class {
+                            async addNonRetryableTask() { return { key: mirrorKeyObject }; }
+                        },
+                        // checkHederaKey deliberately NOT stubbed - the real one runs
+                    },
+                },
+            );
+        }
+
+        it('accepts the key that actually controls the account', async () => {
+            const { PrivateKey } = await import('@hiero-ledger/sdk');
+            const key = PrivateKey.generateED25519();
+            const { validateHederaAccountKey } = await loadReal({
+                _type: 'ED25519', key: key.publicKey.toStringRaw(),
+            });
+            await validateHederaAccountKey('0.0.123', key.toStringDer());
+        });
+
+        it('rejects a key from a different account', async () => {
+            // both keys parse; only one controls the account
+            const { PrivateKey } = await import('@hiero-ledger/sdk');
+            const owner = PrivateKey.generateED25519();
+            const stranger = PrivateKey.generateED25519();
+            const { validateHederaAccountKey } = await loadReal({
+                _type: 'ED25519', key: owner.publicKey.toStringRaw(),
+            });
+            let failed = null;
+            try {
+                await validateHederaAccountKey('0.0.123', stranger.toStringDer());
+            } catch (error) {
+                failed = error;
+            }
+            assert.isNotNull(failed, 'a key from another account must not pass');
+            assert.equal(failed.message, 'Invalid Hedera account or key.');
+        });
+
+        it('accepts an ECDSA key pair too', async () => {
+            const { PrivateKey } = await import('@hiero-ledger/sdk');
+            const key = PrivateKey.generateECDSA();
+            const { validateHederaAccountKey } = await loadReal({
+                _type: 'ECDSA_SECP256K1', key: key.publicKey.toStringRaw(),
+            });
+            await validateHederaAccountKey('0.0.123', key.toStringDer());
+        });
+
+        it('does not reject a threshold / key-list account', async () => {
+            // ProtobufEncoded hex: PublicKey.fromString throws on it, so comparing
+            // would reject a 1-of-N account that signs perfectly well later
+            const { PrivateKey } = await import('@hiero-ledger/sdk');
+            const member = PrivateKey.generateED25519();
+            const { validateHederaAccountKey } = await loadReal({
+                _type: 'ProtobufEncoded', key: '32af00112233445566778899aabbccddeeff',
+            });
+            await validateHederaAccountKey('0.0.123', member.toStringDer());
+        });
+    });
+
+    it('keeps the underlying failure as the error cause', async () => {
+        // Without this a NATS timeout, a mirror 5xx and a genuinely wrong key all
+        // surface as one sentence, and only one of the three is the user's fault.
+        const taskError = new Error('mirror down');
+        const { validateHederaAccountKey } = await load({ taskError });
+        let failed = null;
+        try {
+            await validateHederaAccountKey('0.0.123', 'priv-of-pub-1');
+        } catch (error) {
+            failed = error;
+        }
+        assert.equal(failed.message, 'Invalid Hedera account or key.');
+        assert.equal(failed.cause, taskError, 'the original error must survive');
     });
 });

--- a/guardian-service/tests/unit/hedera-key-validator.test.mjs
+++ b/guardian-service/tests/unit/hedera-key-validator.test.mjs
@@ -1,0 +1,105 @@
+import { assert } from 'chai';
+import esmock from 'esmock';
+
+/*
+ * The key check used to be inferred from a GET_USER_BALANCE probe whose result was
+ * discarded - it only held because the worker built a signing client. These cover the
+ * direct check that replaces it.
+ */
+async function load({ accountKey, mirrorKey, taskError } = {}) {
+    const calls = [];
+    const { validateHederaAccountKey } = await esmock(
+        '../../dist/api/helpers/hedera-key-validator.js',
+        {
+            '@guardian/common': {
+                Workers: class {
+                    constructor() { calls.push({ ctor: true }); }
+                    async addNonRetryableTask(task, opts) {
+                        calls.push({ task, opts });
+                        if (taskError) { throw taskError; }
+                        return { key: { _type: 'ED25519', key: mirrorKey } };
+                    }
+                },
+                checkHederaKey: (priv, pub) => !!priv && !!pub && priv === `priv-of-${pub}`,
+            },
+            '@hiero-ledger/sdk': {
+                AccountId: { fromString: (v) => { if (!String(v).startsWith('0.0.')) { throw new Error('bad account'); } } },
+                PrivateKey: { fromString: (v) => { if (!v) { throw new Error('bad key'); } } },
+            },
+            '@guardian/interfaces': {
+                WorkerTaskType: { GET_ACCOUNT_INFO_REST: 'get-account-info-rest' },
+            },
+        }
+    );
+    return { validateHederaAccountKey, calls };
+}
+
+describe('@unit validateHederaAccountKey', function () {
+    // the first esmock load compiles the module graph and takes several seconds
+    this.timeout(30000);
+
+    it('accepts a key that matches the account s on-chain public key', async () => {
+        const { validateHederaAccountKey } = await load({ mirrorKey: 'pub-1' });
+        await validateHederaAccountKey('0.0.123', 'priv-of-pub-1');
+    });
+
+    // this is the case the balance probe could not see once it went keyless
+    it('rejects a well-formed key that does not control the account', async () => {
+        const { validateHederaAccountKey } = await load({ mirrorKey: 'pub-1' });
+        let failed = null;
+        try {
+            await validateHederaAccountKey('0.0.123', 'priv-of-pub-other');
+        } catch (error) {
+            failed = error;
+        }
+        assert.isNotNull(failed, 'expected a rejection');
+        assert.equal(failed.message, 'Invalid Hedera account or key.');
+    });
+
+    it('reads the account over the keyless REST task', async () => {
+        const { validateHederaAccountKey, calls } = await load({ mirrorKey: 'pub-1' });
+        await validateHederaAccountKey('0.0.123', 'priv-of-pub-1', { userId: 'u-1' });
+
+        const task = calls.find((c) => c.task)?.task;
+        assert.equal(task.type, 'get-account-info-rest');
+        assert.equal(task.data.hederaAccountId, '0.0.123');
+        // the key must never be sent to the worker
+        assert.isUndefined(task.data.hederaAccountKey);
+    });
+
+    it('rejects a malformed account id', async () => {
+        const { validateHederaAccountKey } = await load({ mirrorKey: 'pub-1' });
+        let failed = null;
+        try {
+            await validateHederaAccountKey('nonsense', 'priv-of-pub-1');
+        } catch (error) {
+            failed = error;
+        }
+        assert.isNotNull(failed, 'expected a rejection');
+        assert.equal(failed.message, 'Invalid Hedera account or key.');
+    });
+
+    it('rejects when the account cannot be read', async () => {
+        const { validateHederaAccountKey } = await load({ taskError: new Error('mirror down') });
+        let failed = null;
+        try {
+            await validateHederaAccountKey('0.0.123', 'priv-of-pub-1');
+        } catch (error) {
+            failed = error;
+        }
+        assert.isNotNull(failed, 'expected a rejection');
+        assert.equal(failed.message, 'Invalid Hedera account or key.');
+    });
+
+    it('rejects when the account has no key on chain', async () => {
+        const { validateHederaAccountKey } = await load({ mirrorKey: undefined });
+        let failed = null;
+        try {
+            await validateHederaAccountKey('0.0.123', 'priv-of-pub-1');
+        } catch (error) {
+            failed = error;
+        }
+        assert.isNotNull(failed, 'expected a rejection');
+        assert.equal(failed.message, 'Invalid Hedera account or key.');
+    });
+});

--- a/worker-service/src/api/helpers/hedera-sdk-helper.ts
+++ b/worker-service/src/api/helpers/hedera-sdk-helper.ts
@@ -2436,18 +2436,32 @@ export class HederaSDKHelper {
             }
         }
 
-        const res = await axios.get(
-            `${Environment.HEDERA_ACCOUNT_API}/${accountId}`,
-            { responseType: 'json' }
-        );
-        if (!res || !res.data) {
-            throw new Error(`Invalid account '${accountId}'`);
+        // a not-yet-ingested account 404s like a nonexistent one, and
+        // ONBOARD_USER_ASYNC validates moments after creating - same retry as balance()
+        for (let attempt = 1; ; attempt++) {
+            try {
+                const res = await axios.get(
+                    `${Environment.HEDERA_ACCOUNT_API}/${accountId}`,
+                    { responseType: 'json' }
+                );
+                if (res && res.data) {
+                    return {
+                        account: res.data.account,
+                        balance: res.data.balance?.balance,
+                        key: res.data.key,
+                    };
+                }
+            } catch (error) {
+                // only a 404 is worth waiting on; auth/5xx/network will not resolve
+                if (error?.response?.status !== 404) {
+                    throw error;
+                }
+            }
+            if (attempt >= HederaSDKHelper.MIRROR_NODE_INDEXING_ATTEMPTS) {
+                throw new Error(`Invalid account '${accountId}'`);
+            }
+            await delay(HederaSDKHelper.MIRROR_NODE_INDEXING_DELAY);
         }
-        return {
-            account: res.data.account,
-            balance: res.data.balance?.balance,
-            key: res.data.key,
-        };
     }
 
     /**


### PR DESCRIPTION
Fixes #6750

## Fix

New `validateHederaAccountKey` helper: read the account's on-chain public key over the keyless `GET_ACCOUNT_INFO_REST` task, derive the public key from the supplied private key, and compare with the existing `checkHederaKey` from `common`. It throws the same `Invalid Hedera account or key.` the probe threw, so callers are unchanged.

All three probe sites now use it:

- `guardian-service/src/api/helpers/profile-helper.ts:372`
- `guardian-service/src/api/helpers/organization-helper.ts:211`
- `guardian-service/src/api/profile.service.ts:322`

This proves the pair directly rather than inferring it from a signing client being constructed, and needs no signing, no fee and no mutation.

It also unblocks #73b17e259: once these checks no longer depend on `GET_USER_BALANCE` building a client, consolidating onto a single keyless REST balance task is safe.

## Left alone

The second probe in `profile-helper.ts:649` already sends `data: { hederaAccountId }` with no key — it is an account-exists check, not a key check, so it is out of scope here.

## Tests

New `guardian-service/tests/unit/hedera-key-validator.test.mjs`, 6 tests, all passing:

- accepts a key matching the account's on-chain public key
- **rejects a well-formed key that does not control the account** ← the case the probe cannot see once it goes keyless
- sends the account id over `GET_ACCOUNT_INFO_REST` and asserts the key is **never** sent to the worker
- rejects a malformed account id
- rejects when the account cannot be read
- rejects when the account has no key on chain

To be straight about verification: these cover a helper that does not exist on `develop`, so "fails without the fix" is not meaningful for them in the usual way. The behaviour they pin is the wrong-key rejection, which today only works as a side effect of client construction and stops working with 73b17e259. `guardian-service` builds clean, and there are no existing tests over these paths to regress.