### PR TITLE
fix(policy-service): stop publishing empty policy backup diffs

### DIFF
--- a/policy-service/src/policy-engine/db-restore/db-backup.ts
+++ b/policy-service/src/policy-engine/db-restore/db-backup.ts
@@ -91,6 +91,26 @@ export class PolicyBackup {
         }
     }
 
+    /**
+     * Check whether a diff carries no changes at all.
+     *
+     * Only an incremental 'diff' can be meaningfully empty: a full backup is
+     * always worth publishing, and key documents are produced by a separate
+     * path. A diff is empty when every collection it carries has no actions.
+     */
+    public static isEmptyDiff(diff: IPolicyCollectionDiff): boolean {
+        if (!diff || diff.type !== 'diff') {
+            return false;
+        }
+        const collections = Object.values(diff) as any[];
+        for (const collection of collections) {
+            if (collection && Array.isArray(collection.actions) && collection.actions.length > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public async create(full = false): Promise<{ backup: IPolicyCollectionDiff, diff: IPolicyCollectionDiff }> {
         if (this.lastDiff.file && !full) {
             return await this._createDiff(this.lastDiff.file);

--- a/policy-service/src/policy-engine/restore-service.ts
+++ b/policy-service/src/policy-engine/restore-service.ts
@@ -141,6 +141,12 @@ export class PolicyBackupService {
     private async task() {
         try {
             const { backup, diff } = await this.controller.create(false);
+            if (PolicyBackup.isEmptyDiff(diff)) {
+                //Nothing changed since the last backup. Publishing would spend an
+                //IPFS upload and a Hedera transaction to record that nothing
+                //happened, and the stored backup is still current, so skip both.
+                return;
+            }
             await this.sendDiff(diff);
             await this.controller.save(backup);
         } catch (error) {

--- a/policy-service/tests/unit-tests/policy-engine/policy-backup-empty-diff.test.mjs
+++ b/policy-service/tests/unit-tests/policy-engine/policy-backup-empty-diff.test.mjs
@@ -1,0 +1,88 @@
+import { assert } from 'chai';
+import { PolicyBackup } from '../../../dist/policy-engine/db-restore/index.js';
+import { PolicyBackupService } from '../../../dist/policy-engine/restore-service.js';
+
+const collection = (actions = []) => ({ hash: 'h', fullHash: 'fh', actions });
+
+const diffWith = (overrides = {}) => ({
+    uuid: 'diff-uuid',
+    type: 'diff',
+    index: 7,
+    lastUpdate: new Date('2020-01-01T00:00:00.000Z'),
+    vcCollection: collection(),
+    vpCollection: collection(),
+    didCollection: collection(),
+    stateCollection: collection(),
+    ...overrides,
+});
+
+describe('PolicyBackup.isEmptyDiff', () => {
+    it('reports an incremental diff with no actions as empty', () => {
+        assert.isTrue(PolicyBackup.isEmptyDiff(diffWith()));
+    });
+
+    it('reports a diff carrying an action as not empty', () => {
+        const diff = diffWith({
+            stateCollection: collection([{ type: 'update', id: 'b1', data: {} }]),
+        });
+        assert.isFalse(PolicyBackup.isEmptyDiff(diff));
+    });
+
+    it('detects an action in any collection, not just the first', () => {
+        const diff = diffWith({
+            policyCommentCollection: collection([{ type: 'create', id: 'c1', data: {} }]),
+        });
+        assert.isFalse(PolicyBackup.isEmptyDiff(diff));
+    });
+
+    it('treats a diff with metadata only as empty', () => {
+        assert.isTrue(PolicyBackup.isEmptyDiff({
+            uuid: 'u', type: 'diff', index: 1, lastUpdate: new Date(),
+        }));
+    });
+
+    it('never reports a full backup as empty', () => {
+        const backup = diffWith({ type: 'backup', index: 0 });
+        assert.isFalse(PolicyBackup.isEmptyDiff(backup));
+    });
+
+    it('never reports a keys document as empty', () => {
+        assert.isFalse(PolicyBackup.isEmptyDiff({
+            uuid: 'u', type: 'keys', index: 3, discussionsKeys: collection(),
+        }));
+    });
+
+    it('is safe on a missing diff', () => {
+        assert.isFalse(PolicyBackup.isEmptyDiff(null));
+        assert.isFalse(PolicyBackup.isEmptyDiff(undefined));
+    });
+});
+
+describe('PolicyBackupService.task — publishing an empty diff', () => {
+    const makeService = (diff) => {
+        const svc = Object.create(PolicyBackupService.prototype);
+        const calls = { sent: 0, saved: 0 };
+        svc.controller = {
+            async create() { return { backup: { uuid: 'b', type: 'backup', index: 8 }, diff }; },
+            async save() { calls.saved++; },
+        };
+        svc.sendDiff = async () => { calls.sent++; };
+        return { svc, calls };
+    };
+
+    it('does not publish or store anything when the diff is empty', async () => {
+        const { svc, calls } = makeService(diffWith());
+        await PolicyBackupService.prototype.task.call(svc);
+        assert.equal(calls.sent, 0, 'sendDiff must not be called for an empty diff');
+        assert.equal(calls.saved, 0, 'the backup must not be rewritten for an empty diff');
+    });
+
+    it('publishes and stores when the diff carries a change', async () => {
+        const { svc, calls } = makeService(diffWith({
+            vcCollection: collection([{ type: 'create', id: 'vc1', data: {} }]),
+        }));
+        await PolicyBackupService.prototype.task.call(svc);
+        assert.equal(calls.sent, 1);
+        assert.equal(calls.saved, 1);
+    });
+});


### PR DESCRIPTION
Fixes #6765

### What

`PolicyBackupService.task()` publishes whatever `create(false)` returns, with no check for an empty diff. A published policy carrying a `timerBlock` arms the backup timer on every tick (`timerBlock.tickCron` calls `ref.backup()` unconditionally), so an idle policy with a one-minute timer emits 1,440 diffs a day in which every collection reports `SIZE: 0`.

Each one costs an IPFS upload, a Hedera `TopicMessageSubmitTransaction`, and a rewrite of the stored backup file — to record that nothing changed.

### How

Adds `PolicyBackup.isEmptyDiff()`, which reports an incremental diff as empty when no collection carries any actions, and skips both the publish and the backup rewrite in `task()` when it returns true.

Deliberate constraints:

- **Only `type: 'diff'` can be skipped.** A full backup is always worth publishing and key documents come from a separate path, so both return `false`.
- **The check iterates the diff's own values** rather than a hard-coded collection list, so a collection added later is covered without touching this code.
- **The stored backup is also left alone.** When nothing changed, the recomputed backup is equivalent to the stored one, so rewriting it is pure churn. Leaving it means the next diff is computed against the same baseline, which is correct.
- **Skipping does not break restore.** `PolicyRestore._restoreDiff` assigns `oldDiff.index = diff.index` and applies actions; it never requires contiguous diff indexes. An empty diff applies zero actions, so a consumer that never receives it ends in exactly the same state.

### Tests

`policy-service/tests/unit-tests/policy-engine/policy-backup-empty-diff.test.mjs` — 9 tests covering the predicate (empty, action in the first collection, action in a later collection, metadata-only, full backup, keys document, missing input) and the wiring in `task()` (empty diff publishes and stores nothing; a diff carrying a change still does both).

**8 of the 9 fail on `develop`.** The one that passes is "publishes and stores when the diff carries a change", which guards against over-suppression.

Full suites run green with the change: 755 passing in `tests/unit-tests/policy-engine/`, 1372 passing in `tests/unit-tests/blocks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
