### PR TITLE
fix(policy-service): honour the configured start date in timerBlock

### DIFF
--- a/policy-service/src/policy-engine/blocks/timer-block.ts
+++ b/policy-service/src/policy-engine/blocks/timer-block.ts
@@ -118,7 +118,7 @@ export class TimerBlock {
     private startCron(ref: AnyBlockType) {
         try {
             let sd = moment(ref.options.startDate).utc();
-            if (sd.isValid()) {
+            if (!sd.isValid()) {
                 sd = moment().utc();
             }
 

--- a/policy-service/tests/unit-tests/blocks/runtime-timer-block.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/runtime-timer-block.test.mjs
@@ -139,3 +139,38 @@ describe('TimerBlock runtime — tickCron', () => {
         assert.deepEqual(timer.state, []);
     });
 });
+
+describe('TimerBlock runtime — startCron start date', () => {
+    const runStartCron = (options) => {
+        const block = mk();
+        const { ref, calls } = makeRef({ options });
+        try {
+            withRef(ref, calls, () => basePrototype.startCron.call(block, ref));
+        } finally {
+            if (block.job) {
+                block.job.stop();
+            }
+        }
+        const line = calls.logs.find((l) => l.startsWith('start scheduler:'));
+        return line?.slice('start scheduler: '.length).split(',')[0];
+    };
+
+    // A start date 30 minutes from now can never share a minute with "now",
+    // so the assertion cannot pass by coincidence.
+    const startDate = new Date(Date.now() + 30 * 60 * 1000);
+
+    it('builds an hourly mask from the configured start date', () => {
+        const mask = runStartCron({ period: 'hourly', startDate: startDate.toISOString() });
+        assert.equal(mask, `${startDate.getUTCMinutes()} * * * *`);
+    });
+
+    it('builds a daily mask from the configured start date', () => {
+        const mask = runStartCron({ period: 'daily', startDate: startDate.toISOString() });
+        assert.equal(mask, `${startDate.getUTCMinutes()} ${startDate.getUTCHours()} * * *`);
+    });
+
+    it('falls back to the current time when the start date is unusable', () => {
+        const mask = runStartCron({ period: 'hourly', startDate: new Date('nope') });
+        assert.match(mask, /^\d{1,2} \* \* \* \*$/, 'mask must not contain NaN');
+    });
+});


### PR DESCRIPTION
Fixes #6766

### What

The start-date validity check in `TimerBlock.startCron` is inverted:

```ts
let sd = moment(ref.options.startDate).utc();
if (sd.isValid()) {
    sd = moment().utc();
}
```

A **valid** start date is discarded and replaced with the current time, so every yearly / monthly / weekly / daily / hourly mask is built from whenever the policy last started rather than from the configured value — and shifts again after each restart. An **unparseable** start date takes the other branch and stays invalid, so `minute()`/`hour()` yield `NaN`, the mask becomes `NaN * * * *`, and `CronJob` rejects it as `start scheduler fail`.

`period: 'custom'` is unaffected, since it uses `periodMask` directly.

### How

One character: fall back to the current time only when the start date cannot be parsed.

```ts
if (!sd.isValid()) {
    sd = moment().utc();
}
```

### Behaviour change

Policies that already set a `startDate` will start firing at the configured time instead of at policy-start time. That is the documented intent of the option, but it is visible to anyone who has unknowingly been relying on the current behaviour — worth a release note.

### Tests

Three cases added to `policy-service/tests/unit-tests/blocks/runtime-timer-block.test.mjs`, reading the mask back from the `start scheduler:` log line:

- an hourly mask is built from the configured start date
- a daily mask is built from the configured start date (minute *and* hour)
- an unusable start date falls back to the current time and never produces `NaN` in the mask

The start date is derived as "now + 30 minutes" so it can never coincidentally share a minute with the current time.

**All 3 fail on `develop`**; the 11 pre-existing tests in that file continue to pass. `tests/unit-tests/blocks/` is green at 1372 passing with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
