### PR TITLE
docs: Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,4 +895,4 @@ For any questions, please reach out to the Hashgraph team at:
 
 ## License
 
-MIT License. See the [LICENSE](LICENSE) file for details.
+Apache 2.0. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
* typo: MIT should say —> Apache 2.0

Story: fixes #6764