### PR TITLE
fix(frontend): fire the teardown subject these two dialogs never fired

### DIFF
--- a/frontend/src/app/modules/policy-engine/dialogs/policy-parameters-dialog/policy-parameters-dialog.component.spec.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-parameters-dialog/policy-parameters-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { Subject, takeUntil } from 'rxjs';
+import { PolicyParametersDialog } from './policy-parameters-dialog.component';
+
+describe('PolicyParametersDialog', () => {
+    function build(): any {
+        return new PolicyParametersDialog(
+            {} as any,
+            { data: { policyId: 'p1' } } as any,
+            {} as any,
+            {} as any,
+        );
+    }
+
+    // takeUntil(this._destroy$) guarded the ngOnInit subscription, but nothing ever
+    // fired the subject, so every open leaked it.
+    it('stops its guarded subscriptions on destroy', () => {
+        const component = build();
+        const source = new Subject<number>();
+        const seen: number[] = [];
+        source.pipe(takeUntil(component._destroy$)).subscribe((value) => seen.push(value));
+
+        source.next(1);
+        component.ngOnDestroy();
+        source.next(2);
+
+        expect(seen).toEqual([1]);
+    });
+
+    it('completes the subject rather than leaving it open', () => {
+        const component = build();
+
+        component.ngOnDestroy();
+
+        // a completed subject completes any later subscriber at once
+        let completed = false;
+        component._destroy$.subscribe({ complete: () => { completed = true; } });
+        expect(completed).toBeTrue();
+    });
+});

--- a/frontend/src/app/modules/policy-engine/dialogs/policy-parameters-dialog/policy-parameters-dialog.component.ts
+++ b/frontend/src/app/modules/policy-engine/dialogs/policy-parameters-dialog/policy-parameters-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { AbstractControl, FormArray, FormControl, FormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { PolicyEditableFieldDTO, UserPermissions } from '@guardian/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -23,7 +23,7 @@ interface PolicyParameterItem {
     styleUrls: ['./policy-parameters-dialog.component.scss'],
     standalone: false
 })
-export class PolicyParametersDialog {
+export class PolicyParametersDialog implements OnDestroy {
     public blockInfo: any;
     public loading = false;
     public policyId: string;
@@ -50,6 +50,11 @@ export class PolicyParametersDialog {
         this.form = new FormGroup({
             items: new FormArray<AbstractControl<any>>([])
         });
+    }
+
+    ngOnDestroy(): void {
+        this._destroy$.next();
+        this._destroy$.complete();
     }
 
     ngOnInit() {

--- a/frontend/src/app/modules/schema-engine/vc-fullscreen-dialog/vc-fullscreen-dialog.component.spec.ts
+++ b/frontend/src/app/modules/schema-engine/vc-fullscreen-dialog/vc-fullscreen-dialog.component.spec.ts
@@ -1,0 +1,58 @@
+import { UntypedFormBuilder } from '@angular/forms';
+import { Subject, Subscription, takeUntil } from 'rxjs';
+import { VCFullscreenDialog } from './vc-fullscreen-dialog.component';
+
+describe('VCFullscreenDialog', () => {
+    function build(): any {
+        return new VCFullscreenDialog(
+            {} as any, { data: {} } as any, {} as any, {} as any, {} as any,
+            {} as any, {} as any, {} as any, {} as any, {} as any, {} as any,
+            {} as any, new UntypedFormBuilder(), {} as any, {} as any, {} as any,
+            {} as any,
+        );
+    }
+
+    // Seven takeUntil sites guarded on a subject nothing ever fired, so every
+    // open-and-close of the dialog leaked all of them.
+    it('stops its guarded subscriptions on destroy', () => {
+        const component = build();
+        const source = new Subject<number>();
+        const seen: number[] = [];
+        source.pipe(takeUntil(component._viewDestroyed$)).subscribe((value) => seen.push(value));
+
+        source.next(1);
+        component.ngOnDestroy();
+        source.next(2);
+
+        expect(seen).toEqual([1]);
+    });
+
+    // _destroy$ may be handed in by the caller as a "close the dialog" signal, so the
+    // dialog must not complete a subject its caller still owns and reuses.
+    it('leaves a caller-supplied destroy subject usable', () => {
+        const component = build();
+        const callerOwned = new Subject<void>();
+        component._destroy$ = callerOwned;
+        let completed = false;
+        callerOwned.subscribe({ complete: () => { completed = true; } });
+
+        const received: string[] = [];
+        callerOwned.subscribe(() => received.push('signal'));
+
+        component.ngOnDestroy();
+        callerOwned.next();
+
+        expect(completed).toBeFalse();
+        expect(received).toEqual(['signal']);
+    });
+
+    it('unsubscribes the close-signal subscription', () => {
+        const component = build();
+        const subscription = new Subscription();
+        component._subscription = subscription;
+
+        component.ngOnDestroy();
+
+        expect(subscription.closed).toBeTrue();
+    });
+});

--- a/frontend/src/app/modules/schema-engine/vc-fullscreen-dialog/vc-fullscreen-dialog.component.ts
+++ b/frontend/src/app/modules/schema-engine/vc-fullscreen-dialog/vc-fullscreen-dialog.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
+    OnDestroy,
     ViewChild,
 } from '@angular/core';
 import {
@@ -49,7 +50,7 @@ import { ViewerDialog } from '../../policy-engine/dialogs/viewer-dialog/viewer-d
     styleUrls: ['./vc-fullscreen-dialog.component.scss'],
     standalone: false
 })
-export class VCFullscreenDialog {
+export class VCFullscreenDialog implements OnDestroy {
     @ViewChild('discussionComponent', { static: false })
     discussionComponent: PolicyComments;
     @ViewChild('documentViewComponent', { static: false })
@@ -103,7 +104,14 @@ export class VCFullscreenDialog {
     public tags: any[] = [];
     public disconnected: boolean = false;
 
+    /**
+     * The caller may hand us its own subject (see the constructor), so this one
+     * cannot double as the teardown signal - completing it would tear down a
+     * subject the caller still owns. `_viewDestroyed$` is ours and is what every
+     * takeUntil below uses.
+     */
     private _destroy$ = new Subject<void>();
+    private readonly _viewDestroyed$ = new Subject<void>();
     private _subscription?: Subscription | null;
 
     constructor(
@@ -144,6 +152,14 @@ export class VCFullscreenDialog {
 
     get vcDocStatusEqRejectOrRevoke(): any {
         return this.allVcDocs.some(doc => doc?.option?.status === 'Rejected' || doc?.option?.status === 'Revoked') ?? false;
+    }
+
+    ngOnDestroy(): void {
+        this._viewDestroyed$.next();
+        this._viewDestroyed$.complete();
+        // _destroy$ may belong to the caller, so unsubscribe from it rather than complete it
+        this._subscription?.unsubscribe();
+        this._subscription = null;
     }
 
     ngOnInit() {
@@ -241,7 +257,7 @@ export class VCFullscreenDialog {
                     this.documentId
                 ),
             ])
-                .pipe(takeUntil(this._destroy$))
+                .pipe(takeUntil(this._viewDestroyed$))
                 .subscribe(
                     ([profile, count, vcDocs]) => {
                         this.user = new UserPermissions(profile);
@@ -268,7 +284,7 @@ export class VCFullscreenDialog {
                     this.documentId
                 ),
             ])
-                .pipe(takeUntil(this._destroy$))
+                .pipe(takeUntil(this._viewDestroyed$))
                 .subscribe(
                     ([profile, vcDocs]) => {
                         this.user = new UserPermissions(profile);
@@ -430,13 +446,13 @@ export class VCFullscreenDialog {
                         schemas.push(
                             this.schemaService
                                 .getSchemasByTypeAndUser(type)
-                                .pipe(takeUntil(this._destroy$))
+                                .pipe(takeUntil(this._viewDestroyed$))
                         );
                     } else {
                         schemas.push(
                             this.schemaService
                                 .getSchemasByType(type)
-                                .pipe(takeUntil(this._destroy$))
+                                .pipe(takeUntil(this._viewDestroyed$))
                         );
                     }
                 }
@@ -454,7 +470,7 @@ export class VCFullscreenDialog {
                     schemaId: this.schemaId,
                     documentId: this.documentId,
                 })
-                .pipe(takeUntil(this._destroy$));
+                .pipe(takeUntil(this._viewDestroyed$));
         }
 
         //Load Formulas
@@ -465,7 +481,7 @@ export class VCFullscreenDialog {
                     schemaId: this.schemaId,
                     documentId: this.documentId,
                 })
-                .pipe(takeUntil(this._destroy$));
+                .pipe(takeUntil(this._viewDestroyed$));
         }
 
         this.loading = true;
@@ -519,7 +535,7 @@ export class VCFullscreenDialog {
     public initForm($event: any) {
         this.dataForm = $event;
         this.dataForm.valueChanges
-            .pipe(takeUntil(this._destroy$))
+            .pipe(takeUntil(this._viewDestroyed$))
             .pipe(audit((ev) => interval(1000)))
             .subscribe();
     }


### PR DESCRIPTION
Fixes #6769

## The bug

`PolicyParametersDialog` and `VCFullscreenDialog` each declare a destroy `Subject` and guard their subscriptions with `takeUntil(this._destroy$)` - but neither implemented `OnDestroy`, and neither ever called `_destroy$.next()`. The guard reads as cleanup and performs none, so every open-and-close leaks its subscriptions. Eight between the two, on dialogs users open repeatedly.

| | before |
|---|---|
| `policy-parameters-dialog.component.ts` | `_destroy$` at `:36`, one guarded subscription, no `OnDestroy` |
| `vc-fullscreen-dialog.component.ts` | `_destroy$` at `:106`, seven guarded sites, `_subscription` at `:223` never unsubscribed, no `OnDestroy` |

## Why the obvious fix is wrong for the second one

`VCFullscreenDialog._destroy$` is not purely a teardown subject. The caller may supply its own through dialog data:

```ts
if (destroy) {
    this._destroy$ = destroy;
}
this._subscription = this._destroy$.subscribe(() => {
    this.onClose();
});
```

so it doubles as an inbound "close the dialog" signal owned by the parent. `ngOnDestroy() { this._destroy$.next(); this._destroy$.complete(); }` would complete a subject the caller still owns and reuses - trading a leak for a harder bug.

The two roles are separated instead:

- `_viewDestroyed$`, private to the dialog, fired and completed in `ngOnDestroy` - every `takeUntil` uses it
- `_destroy$` stays the external close-signal contract and is never completed here
- `_subscription` is unsubscribed in `ngOnDestroy`

`PolicyParametersDialog` has no such contract, so it just fires and completes its own subject.

## Tests

Neither file had a spec. Five added.

Four fail with the `ngOnDestroy` bodies emptied - the method is kept so the failure is behavioural rather than a compile error:

```
VCFullscreenDialog stops its guarded subscriptions on destroy FAILED
VCFullscreenDialog unsubscribes the close-signal subscription FAILED
PolicyParametersDialog completes the subject rather than leaving it open FAILED
PolicyParametersDialog stops its guarded subscriptions on destroy FAILED
TOTAL: 4 FAILED, 1 SUCCESS
```

The fifth - `leaves a caller-supplied destroy subject usable` - passes either way by construction. It is a guard against someone later "simplifying" this to complete `_destroy$`, which would look correct and break the caller silently.

All five pass with the fix.

## Scope

Found by a static scan of teardown patterns across the frontend. Worth noting the other 202 `takeUntil(destroy$)` sites in the app do fire correctly, so these two are outliers, not a convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)