### PR TITLE
fix: 6606 skip the comment count request for dry-run documents

### DIFF
--- a/frontend/src/app/modules/policy-engine/policy-viewer/blocks/documents-source-block/documents-source-block.component.ts
+++ b/frontend/src/app/modules/policy-engine/policy-viewer/blocks/documents-source-block/documents-source-block.component.ts
@@ -308,14 +308,17 @@ export class DocumentsSourceBlockComponent implements OnInit {
                 }
             })!;
             dialogRef.onClose.subscribe(async (result) => {
+                if (row.dryRunId) {
+                    // dry-run documents are never persisted as real VC records,
+                    // so the backend cannot resolve a count for this row.
+                    return;
+                }
                 this.commentsService
                     .getPolicyCommentsCount(this.policyId, row.id)
                     .subscribe(
                         (count) => {
                             row.comments = count?.count ?? row.comments;
                         },
-                        // not resolvable in dry-run. The row keeps its previous count
-                        // either way; this only stops the failure being swallowed.
                         (error) => console.error('[documents-source] comment count failed', error)
                     );
             });


### PR DESCRIPTION
**Description**:

Comment counts for a document row were being requested from the backend even for dry-run rows, whose IDs don't exist as real VC records — the request always failed and the error was silently swallowed. Now the request is skipped entirely for rows with dryRunId set, so dry-run rows keep their existing count without firing a doomed network call.

Fixes #6606

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
