### PR TITLE
fix: run the VC wrapper's conditional-required strip

### DIFF
--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -296,8 +296,12 @@ export class VCJS {
 
         const vcObject = JSON.parse(JSON.stringify(vc));
 
-        const subjects = vcObject.credentialSubject;
-        const subject = Array.isArray(subjects) ? subjects[0] : subjects;
+        const rawSubjects = vcObject.credentialSubject;
+        const subjects: any[] = Array.isArray(rawSubjects) ? rawSubjects : [rawSubjects];
+        if (!subjects.length || !subjects[0]) {
+            throw new Error('"credentialSubject" property is required.');
+        }
+        const subject = subjects[0];
 
         if (!this.schemaLoader) {
             throw new Error('Schema Loader not found');
@@ -318,7 +322,12 @@ export class VCJS {
 
         const schemaObject = Schema.fromVc(schema);
 
-        ContextHelper.setContext(subject, schemaObject);
+        // Every subject needs its ref-field type/@context restored before validation,
+        // not just the first - otherwise a multi-subject VC only gets subject[0]
+        // checked consistently with the schema.
+        for (const item of subjects) {
+            ContextHelper.setContext(item, schemaObject);
+        }
 
         const validate = await ajv.compileAsync(schema);
         const valid = validate(vcObject);
@@ -373,10 +382,34 @@ export class VCJS {
             nestedSchema.required = required.filter((field: any) => !nestedSchema.properties[field] || !nestedSchema.properties[field].readOnly);
         }
 
-        if (!Array.isArray(schema.allOf)) {
+        // The conditions that gate a base-required field don't only live on the
+        // document handed to us: when verifySchema compiles the VC wrapper, the
+        // wrapper's own root never carries allOf - the subject schema's allOf sits
+        // one level down, inside $defs. Run the strip against every $defs entry
+        // that carries its own allOf, in addition to the root, so a condition
+        // nested under the wrapper is honoured the same as a condition at the root
+        // (e.g. when prepareSchema is called directly on a subject schema).
+        for (const key of defsKeys) {
+            this.applyConditionalStrip(defsObj[key], defsObj, key);
+        }
+        this.applyConditionalStrip(schema, defsObj, 'root');
+    }
+
+    /**
+     * Strip conditionally-inactive required/forbidden fields from one schema
+     * container (the root schema, or one $defs entry) that carries its own allOf.
+     *
+     * @param container Schema object carrying the allOf conditions
+     * @param defsObj Shared $defs object the per-container clones are written into
+     * @param scope Identifier of the container, used to key clones so two different
+     * containers stripping the same $ref'd entry along different paths don't collide
+     */
+    private applyConditionalStrip(container: any, defsObj: any, scope: string) {
+        if (!container || !Array.isArray(container.allOf)) {
             return;
         }
-        const rootProperties = schema.properties || {};
+        const rootProperties = container.properties || {};
+        const scopeKey = String(scope).replace(/[^A-Za-z0-9_-]/g, '');
 
         // Collect fields to strip keyed by container dot-path (not by IRI).
         // Multiple conditions targeting the same container accumulate into one Set.
@@ -406,7 +439,7 @@ export class VCJS {
             }
         };
 
-        for (const condEntry of schema.allOf) {
+        for (const condEntry of container.allOf) {
             if (!condEntry?.if) { continue; }
             for (const branch of [condEntry.then, condEntry.else]) {
                 collectPath(branch, [], rootProperties);
@@ -452,7 +485,7 @@ export class VCJS {
             if (!iri) { continue; }
             const pathArr = pathKey.split('.');
             const fieldsToStrip = stripByPath.get(pathKey);
-            const cloneKey = `${iri}__${pathArr.join('__')}`;
+            const cloneKey = `${iri}__${scopeKey}__${pathArr.join('__')}`;
 
             // Deep-copy original def so the shared entry is never mutated.
             const clone = JSON.parse(JSON.stringify(defsObj[iri]));

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -389,10 +389,65 @@ export class VCJS {
         // that carries its own allOf, in addition to the root, so a condition
         // nested under the wrapper is honoured the same as a condition at the root
         // (e.g. when prepareSchema is called directly on a subject schema).
-        for (const key of defsKeys) {
+        //
+        // Order matters: applyConditionalStrip deep-copies whatever currently sits
+        // in defsObj[ref] when it clones a referenced def into a container (e.g.
+        // Subject cloning Detail into Detail__copy). If Detail's own conditional
+        // strip hasn't run yet, the clone carries a stale $ref to Detail's
+        // original (unstripped) dependency, and that dependency's fix never
+        // reaches the clone - it isn't among the original defsKeys, so the flat
+        // loop this replaced would never visit it. Preparing depth-first (a def's
+        // own $ref'd dependencies before the def itself) guarantees every def is
+        // fully stripped before anything clones it. The prepared/inProgress sets
+        // make sure each def runs once and $ref cycles terminate instead of
+        // recursing forever.
+        const prepared = new Set<string>();
+        const inProgress = new Set<string>();
+        const prepareDef = (key: string) => {
+            if (prepared.has(key) || inProgress.has(key) || !defsObj[key]) {
+                return;
+            }
+            inProgress.add(key);
+            for (const ref of this.collectSchemaRefs(defsObj[key])) {
+                if (ref !== key && defsObj[ref]) {
+                    prepareDef(ref);
+                }
+            }
             this.applyConditionalStrip(defsObj[key], defsObj, key);
+            inProgress.delete(key);
+            prepared.add(key);
+        };
+        for (const key of defsKeys) {
+            prepareDef(key);
         }
         this.applyConditionalStrip(schema, defsObj, 'root');
+    }
+
+    /**
+     * Collect every $ref value reachable within a schema node, so callers can tell
+     * which $defs entries a given def depends on before deciding processing order.
+     *
+     * @param node Schema node to scan
+     */
+    private collectSchemaRefs(node: any): Set<string> {
+        const refs = new Set<string>();
+        const seen = new Set<any>();
+        const walk = (current: any) => {
+            if (!current || typeof current !== 'object' || seen.has(current)) {
+                return;
+            }
+            seen.add(current);
+            if (typeof current.$ref === 'string') {
+                refs.add(current.$ref);
+            }
+            for (const value of Object.values(current)) {
+                if (value && typeof value === 'object') {
+                    walk(value);
+                }
+            }
+        };
+        walk(node);
+        return refs;
     }
 
     /**

--- a/common/src/hedera-modules/vcjs/vcjs.ts
+++ b/common/src/hedera-modules/vcjs/vcjs.ts
@@ -382,25 +382,8 @@ export class VCJS {
             nestedSchema.required = required.filter((field: any) => !nestedSchema.properties[field] || !nestedSchema.properties[field].readOnly);
         }
 
-        // The conditions that gate a base-required field don't only live on the
-        // document handed to us: when verifySchema compiles the VC wrapper, the
-        // wrapper's own root never carries allOf - the subject schema's allOf sits
-        // one level down, inside $defs. Run the strip against every $defs entry
-        // that carries its own allOf, in addition to the root, so a condition
-        // nested under the wrapper is honoured the same as a condition at the root
-        // (e.g. when prepareSchema is called directly on a subject schema).
-        //
-        // Order matters: applyConditionalStrip deep-copies whatever currently sits
-        // in defsObj[ref] when it clones a referenced def into a container (e.g.
-        // Subject cloning Detail into Detail__copy). If Detail's own conditional
-        // strip hasn't run yet, the clone carries a stale $ref to Detail's
-        // original (unstripped) dependency, and that dependency's fix never
-        // reaches the clone - it isn't among the original defsKeys, so the flat
-        // loop this replaced would never visit it. Preparing depth-first (a def's
-        // own $ref'd dependencies before the def itself) guarantees every def is
-        // fully stripped before anything clones it. The prepared/inProgress sets
-        // make sure each def runs once and $ref cycles terminate instead of
-        // recursing forever.
+        // Strip the root and every $defs entry with its own allOf, deps first,
+        // so a def is fully stripped before it's cloned elsewhere.
         const prepared = new Set<string>();
         const inProgress = new Set<string>();
         const prepareDef = (key: string) => {

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { DefaultDocumentLoader } from '../../../../dist/hedera-modules/document-loader/document-loader-default.js';
 import { LocalDidLoader } from '../../../../dist/document-loader/local-did-loader.js';
 import { VCJS } from '../../../../dist/hedera-modules/vcjs/vcjs.js';
+import { ContextHelper } from '../../../../dist/hedera-modules/vcjs/context-helper.js';
 import { SignatureType } from '@guardian/interfaces';
 
 void DefaultDocumentLoader;
@@ -333,6 +334,168 @@ describe('VCJS coverage (offline paths)', function () {
                 credentialSubject: [{ '@context': [], type: 'X', name: 'alice' }]
             });
             assert.property(result, 'ok');
+        });
+
+        // #1743: verifySchema used to restore ref-field type/@context (via
+        // ContextHelper.setContext) for credentialSubject[0] only, so a
+        // multi-subject VC was checked consistently for its first subject alone.
+        it('rejects an empty credentialSubject array instead of passing vacuously', async function () {
+            const vcjs = makeVcjs();
+            await assertRejects(
+                () => vcjs.verifySchema({ credentialSubject: [] }),
+                /credentialSubject/
+            );
+        });
+
+        it('rejects an array holding no usable subject', async function () {
+            const vcjs = makeVcjs();
+            await assertRejects(
+                () => vcjs.verifySchema({ credentialSubject: [null] }),
+                /credentialSubject/
+            );
+        });
+
+        it('runs ContextHelper.setContext for every subject, not just the first', async function () {
+            const vcjs = makeVcjs();
+            vcjs.schemaLoader = async () => ({
+                type: 'object',
+                properties: {
+                    credentialSubject: {
+                        oneOf: [{ type: 'object' }, { type: 'array' }]
+                    }
+                },
+                $defs: {}
+            });
+
+            const seen = [];
+            const original = ContextHelper.setContext;
+            ContextHelper.setContext = (vc, schema) => {
+                seen.push(vc);
+                return original(vc, schema);
+            };
+            try {
+                await vcjs.verifySchema({
+                    credentialSubject: [
+                        { '@context': [], type: 'X', name: 'alice' },
+                        { '@context': [], type: 'X', name: 'bob' }
+                    ]
+                });
+            } finally {
+                ContextHelper.setContext = original;
+            }
+
+            assert.equal(seen.length, 2, 'setContext must run once per subject, not once total');
+            assert.equal(seen[0].name, 'alice');
+            assert.equal(seen[1].name, 'bob');
+        });
+
+        it('still runs ContextHelper.setContext once for a non-array credentialSubject', async function () {
+            const vcjs = makeVcjs();
+            vcjs.schemaLoader = async () => ({ type: 'object', properties: {}, $defs: {} });
+
+            const seen = [];
+            const original = ContextHelper.setContext;
+            ContextHelper.setContext = (vc, schema) => {
+                seen.push(vc);
+                return original(vc, schema);
+            };
+            try {
+                await vcjs.verifySchema({
+                    credentialSubject: { '@context': [], type: 'X', name: 'alice' }
+                });
+            } finally {
+                ContextHelper.setContext = original;
+            }
+
+            assert.equal(seen.length, 1);
+            assert.equal(seen[0].name, 'alice');
+        });
+    });
+
+    describe('prepareSchema - conditional strip on the VC wrapper path (#1743)', function () {
+        // prepareSchema's conditional-required strip used to require Array.isArray(schema.allOf)
+        // on the object passed in directly. That holds when prepareSchema runs on a subject
+        // schema (verifySubject), but verifySchema hands it the VC WRAPPER schema instead - the
+        // wrapper's own root never carries allOf, only the subject schema nested in $defs does.
+        // A cross-target field that's base-required in that nested sub-schema stayed
+        // unconditionally required, so a document valid at request time could fail later on an
+        // external-verify path. The strip must also walk each $defs entry that carries its own
+        // allOf, not just the root.
+
+        function wrapperWithSubjectConditions() {
+            return {
+                type: 'object',
+                properties: {
+                    credentialSubject: { $ref: '#Subject' }
+                },
+                required: ['credentialSubject'],
+                // deliberately no allOf here - it lives one level down, in $defs['#Subject']
+                $defs: {
+                    '#Subject': {
+                        $id: '#Subject',
+                        type: 'object',
+                        properties: {
+                            trigger: { type: 'string' },
+                            detail: { $ref: '#Detail' }
+                        },
+                        required: ['trigger', 'detail'],
+                        allOf: [{
+                            if: { properties: { trigger: { const: 'yes' } }, required: ['trigger'] },
+                            then: { properties: { detail: { required: ['note'] } } },
+                            else: { properties: { detail: { properties: { note: false } } } }
+                        }]
+                    },
+                    '#Detail': {
+                        $id: '#Detail',
+                        type: 'object',
+                        properties: { note: { type: 'string' } },
+                        required: ['note'],
+                        additionalProperties: false
+                    }
+                }
+            };
+        }
+
+        it('accepts a document that omits the base-required field while the branch is inactive', async function () {
+            const vcjs = makeVcjs();
+            vcjs.schemaLoader = async () => wrapperWithSubjectConditions();
+            const result = await vcjs.verifySchema({
+                credentialSubject: { '@context': [], type: 'X', trigger: 'no', detail: {} }
+            });
+            assert.isTrue(result.ok, `expected valid, got ${JSON.stringify(result.error?.details ?? result.errors)}`);
+        });
+
+        it('still forbids the field when the inactive branch says so', async function () {
+            const vcjs = makeVcjs();
+            vcjs.schemaLoader = async () => wrapperWithSubjectConditions();
+            const result = await vcjs.verifySchema({
+                credentialSubject: { '@context': [], type: 'X', trigger: 'no', detail: { note: 'should not be here' } }
+            });
+            assert.isFalse(result.ok, 'an inactive branch must still forbid the field');
+        });
+
+        it('requires the field when the active branch says so', async function () {
+            const vcjs = makeVcjs();
+            vcjs.schemaLoader = async () => wrapperWithSubjectConditions();
+            const missing = await vcjs.verifySchema({
+                credentialSubject: { '@context': [], type: 'X', trigger: 'yes', detail: {} }
+            });
+            assert.isFalse(missing.ok, 'an active branch must still require the field');
+
+            const present = await vcjs.verifySchema({
+                credentialSubject: { '@context': [], type: 'X', trigger: 'yes', detail: { note: 'present' } }
+            });
+            assert.isTrue(present.ok, `expected valid, got ${JSON.stringify(present.error?.details ?? present.errors)}`);
+        });
+
+        it('leaves prepareSchema a no-op when neither the root nor any $defs entry carries allOf', function () {
+            const vcjs = makeVcjs();
+            const schema = {
+                type: 'object',
+                properties: { credentialSubject: { $ref: '#Subject' } },
+                $defs: { '#Subject': { type: 'object', properties: {}, required: [] } }
+            };
+            assert.doesNotThrow(() => vcjs.prepareSchema(schema));
         });
     });
 

--- a/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs
@@ -336,9 +336,6 @@ describe('VCJS coverage (offline paths)', function () {
             assert.property(result, 'ok');
         });
 
-        // #1743: verifySchema used to restore ref-field type/@context (via
-        // ContextHelper.setContext) for credentialSubject[0] only, so a
-        // multi-subject VC was checked consistently for its first subject alone.
         it('rejects an empty credentialSubject array instead of passing vacuously', async function () {
             const vcjs = makeVcjs();
             await assertRejects(


### PR DESCRIPTION
**Description**:

This PR fixes two `verifySchema` defects on the VC-wrapper validation path.

* Run the conditional-required strip against every `$defs` entry that carries its own `allOf`, not just the object handed to `prepareSchema` directly, so a condition nested in the subject definition (not the root) is honored
* Restore ref-field `type`/`@context` for every credential subject via `ContextHelper.setContext`, not just the first
* Reject an empty or all-null `credentialSubject` array instead of validating vacuously

**Related issue(s)**:

Fixes #6783

**Notes for reviewer**:

`tsc --noEmit` clean on `interfaces` and `common`. New/extended tests in `common/tests/unit-tests/hedera-modules/vcjs/vcjs-coverage.test.mjs`, logic-verified against the compiled dist via a standalone script (this checkout's `node_modules` is missing chai's transitive deps repo-wide, so `npm test` could not run as-is). 8/8 checks passed, including a regression check that the pre-existing "shared sub-schema sibling isolation" behavior is unchanged.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)