### PR TITLE
fix(guardian-service): stop recursive sub-tool import looping on a cycle

### DIFF
--- a/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
+++ b/guardian-service/src/helpers/import-helpers/tool/tool-import-helper.ts
@@ -5,11 +5,15 @@ import { SchemaImportExportHelper } from '../schema/schema-import-helper.js';
 import { ImportToolMap, ImportToolResult, ImportToolResults } from './tool-import.interface.js';
 import { resolveToolOverrides } from './tool-override-resolver.js';
 
+// backstop only - `visited` is what catches cycles
+const MAX_TOOL_IMPORT_DEPTH = 32;
+
 /**
  * Import tools by messages
  * @param owner
  * @param messages
  * @param notifier
+ * @param visited message ids on the current import path
  */
 export async function importSubTools(
     hederaAccount: IRootConfig,
@@ -19,7 +23,8 @@ export async function importSubTools(
     }[],
     user: IOwner,
     notifier: INotificationStep,
-    userId: string | null
+    userId: string | null,
+    visited: Set<string> = new Set<string>()
 ): Promise<ImportToolResults> {
     notifier.start();
 
@@ -40,7 +45,8 @@ export async function importSubTools(
                 message.messageId,
                 user,
                 step,
-                userId
+                userId,
+                visited
             );
             if (importResult.tool) {
                 tools.push(importResult.tool);
@@ -82,7 +88,8 @@ export async function importToolByMessage(
     messageId: string,
     user: IOwner,
     notifier: INotificationStep,
-    userId: string | null
+    userId: string | null,
+    visited: Set<string> = new Set<string>()
 ): Promise<ImportToolResult> {
     // <-- Steps
     const STEP_LOAD_FILE = 'Load tool file';
@@ -110,6 +117,27 @@ export async function importToolByMessage(
         throw new Error('Invalid Message Id');
     }
     messageId = messageId.trim();
+
+    /*
+     * The getTool dedup below cannot catch this: createTool writes that row only
+     * after the recursion returns, so a tool on the current path is invisible to
+     * its own check and a self-referencing archive recursed without end.
+     * `visited` is the path, not everything seen - the id is popped on the way
+     * out, so a diamond still resolves twice instead of reading as a cycle.
+     */
+    if (visited.has(messageId)) {
+        throw new Error(
+            `Circular tool reference: "${messageId}" is already being imported further up the chain.`
+        );
+    }
+    if (visited.size >= MAX_TOOL_IMPORT_DEPTH) {
+        throw new Error(
+            `Tool import nested deeper than ${MAX_TOOL_IMPORT_DEPTH} levels; refusing to continue.`
+        );
+    }
+    visited.add(messageId);
+
+    try {
     const message = await messageServer
         .getMessage<ToolMessage>({
             messageId,
@@ -161,16 +189,18 @@ export async function importToolByMessage(
     }
     notifier.completeStep(STEP_LOAD_FILE);
 
-    notifier.startStep(STEP_SAVE_FILE_IN_DB);
-    const buffer = Buffer.from(message.document);
-    const contentFileId = await DatabaseServer.saveFile(GenerateUUIDv4(), buffer);
-    notifier.completeStep(STEP_SAVE_FILE_IN_DB);
-
     notifier.startStep(STEP_PARSE_FILE);
     const components = await ToolImportExport.parseZipFile(message.document);
 
     // Import Tools
-    const toolsResults = await importSubTools(hederaAccount, components.tools, user, notifier, userId);
+    const toolsResults = await importSubTools(hederaAccount, components.tools, user, notifier, userId, visited);
+
+    // saved after the recursion: a blob written before it is orphaned by anything
+    // that throws in between, with no reference and no cleanup path
+    notifier.startStep(STEP_SAVE_FILE_IN_DB);
+    const buffer = Buffer.from(message.document);
+    const contentFileId = await DatabaseServer.saveFile(GenerateUUIDv4(), buffer);
+    notifier.completeStep(STEP_SAVE_FILE_IN_DB);
 
     delete components.tool._id;
     delete components.tool.id;
@@ -263,6 +293,9 @@ export async function importToolByMessage(
         tool: result,
         errors
     };
+    } finally {
+        visited.delete(messageId);
+    }
 }
 
 /**

--- a/guardian-service/tests/tool-import-cycle.test.mjs
+++ b/guardian-service/tests/tool-import-cycle.test.mjs
@@ -1,0 +1,188 @@
+import { assert } from 'chai';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import esmock from 'esmock';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, '../dist');
+const P = (p) => p.split(path.sep).join('/');
+
+const helperPath = P(path.join(distDir, 'helpers/import-helpers/tool/tool-import-helper.js'));
+const tagHelperPath = P(path.join(distDir, 'helpers/import-helpers/tag/tag-import-helper.js'));
+const schemaHelperPath = P(path.join(distDir, 'helpers/import-helpers/schema/schema-import-helper.js'));
+
+/*
+ * A self- or mutually-referencing archive used to recurse without end: the only
+ * dedup check is a getTool lookup for a row createTool writes after the
+ * recursion returns. `graph` is the sub-tool list parseZipFile hands back.
+ */
+let graph, calls;
+
+function reset() {
+    graph = {};
+    calls = { saveFile: [], createTool: [], getMessage: [] };
+}
+reset();
+
+const DatabaseServerMock = {
+    async getTool() { return null; },                       // nothing pre-existing
+    async getTools() { return []; },                        // updateToolConfig walks sub-tools
+    async getTopicById() { return { topicId: '0.0.1' }; },
+    async saveTopic() {},
+    async getSchemas() { return []; },
+    async saveSchemas() {},
+    createSchema(s) { return { ...s }; },
+    async saveFile(uuid) { calls.saveFile.push(uuid); return `file-${calls.saveFile.length}`; },
+    async createTool(tool) {
+        calls.createTool.push(tool.messageId);
+        return { ...tool, id: `db-${calls.createTool.length}` };
+    },
+};
+
+class MessageServerMock {
+    async getMessage({ messageId }) {
+        calls.getMessage.push(messageId);
+        return {
+            type: 'tool', action: 'publish-tool',
+            document: `zip:${messageId}`,
+            hash: `hash-${messageId}`, owner: 'did:owner',
+            uuid: `uuid-${messageId}`, id: messageId,
+            topicId: { toString: () => '0.0.2' },
+            name: messageId, description: messageId,
+            tagsTopicId: null,
+        };
+    }
+    async getMessages() { return []; }
+}
+
+const ToolImportExportMock = {
+    async parseZipFile(document) {
+        const id = String(document).replace(/^zip:/, '');
+        return {
+            tool: { name: id, config: { blockType: 'tool' } },
+            tools: (graph[id] || []).map((m) => ({ name: m, messageId: m })),
+            schemas: [],
+            tags: [],
+        };
+    },
+};
+
+function makeNotifier() {
+    const n = {
+        // importSubTools passes addStep's return value down as the child
+        // notifier, so it has to be one.
+        addStep() { return makeNotifier(); },
+        start() {}, startStep() {}, completeStep() {},
+        skipStep() {}, complete() {}, fail() {}, setEstimate() {},
+        getStep() { return makeNotifier(); },
+    };
+    return n;
+}
+
+let mod;
+before(async function () {
+    this.timeout(120000);
+    mod = await esmock(helperPath, {
+        '@guardian/common': {
+            DatabaseServer: DatabaseServerMock,
+            MessageServer: MessageServerMock,
+            ToolImportExport: ToolImportExportMock,
+            MessageType: { Tool: 'tool', Tag: 'tag' },
+            MessageAction: { PublishTool: 'publish-tool', PublishTag: 'publish-tag' },
+        },
+        [tagHelperPath]: { importTag: async () => {} },
+        [schemaHelperPath]: {
+            SchemaImportExportHelper: {
+                importSchemaByFiles: async () => ({ schemasMap: [], errors: [] }),
+            },
+        },
+    });
+});
+
+beforeEach(() => reset());
+
+const account = { hederaAccountId: '0.0.222', hederaAccountKey: 'k', signOptions: {} };
+const user = { id: 'u-1', creator: 'did:creator', owner: 'did:owner' };
+
+const importTool = (id) =>
+    mod.importToolByMessage(account, id, user, makeNotifier(), 'u-1');
+
+describe('@unit tool import cycle guard', function () {
+    this.timeout(20000);
+
+    it('a tool that lists itself terminates instead of looping', async () => {
+        graph = { A: ['A'] };
+        const result = await importTool('A');
+        // The outer import still succeeds; the self-reference is reported as a
+        // per-tool error, which is how importSubTools surfaces any bad entry.
+        assert.equal(result.tool.messageId, 'A');
+        assert.lengthOf(result.errors, 1);
+        assert.match(result.errors[0].error, /[Cc]ircular/);
+    });
+
+    it('a mutual reference A -> B -> A terminates', async () => {
+        graph = { A: ['B'], B: ['A'] };
+        const result = await importTool('A');
+        assert.equal(result.tool.messageId, 'A');
+        assert.deepEqual(calls.createTool.sort(), ['A', 'B']);
+        assert.isAtMost(calls.getMessage.length, 4, 'must not keep re-fetching around the loop');
+    });
+
+    it('a longer cycle A -> B -> C -> A terminates', async () => {
+        graph = { A: ['B'], B: ['C'], C: ['A'] };
+        const result = await importTool('A');
+        assert.equal(result.tool.messageId, 'A');
+        assert.deepEqual(calls.createTool.sort(), ['A', 'B', 'C']);
+    });
+
+    it('writes no GridFS blob for a tool it never creates', async () => {
+        // The orphan-per-turn symptom: saveFile ran before the recursion, so a
+        // blob was written for every level the loop reached and never referenced.
+        graph = { A: ['A'] };
+        await importTool('A');
+        assert.equal(calls.saveFile.length, calls.createTool.length,
+            'every saved blob must belong to a tool that was actually created');
+    });
+
+    it('does not mistake a diamond for a cycle', async () => {
+        // A imports B and C, both of which import D. D is on two different paths,
+        // not on its own path, so it must import rather than be refused.
+        graph = { A: ['B', 'C'], B: ['D'], C: ['D'], D: [] };
+        const result = await importTool('A');
+        assert.deepEqual(result.errors, [], 'a diamond is legitimate');
+        assert.include(calls.createTool, 'D');
+    });
+
+    it('a sibling repeated at the same level is not a cycle either', async () => {
+        graph = { A: ['B', 'B'], B: [] };
+        const result = await importTool('A');
+        assert.deepEqual(result.errors, []);
+    });
+
+    it('stops a pathological but acyclic chain at the depth ceiling', async () => {
+        graph = {};
+        for (let i = 0; i < 60; i++) { graph[`T${i}`] = [`T${i + 1}`]; }
+        graph.T60 = [];
+        const result = await importTool('T0');
+        // Deepest levels are refused; the import still returns rather than hanging.
+        assert.isAbove(result.errors.length, 0);
+        assert.match(result.errors[0].error, /nested deeper than/);
+        assert.isBelow(calls.getMessage.length, 60, 'the ceiling must actually bound the walk');
+    });
+
+    it('a plain tool with no sub-tools is unaffected', async () => {
+        graph = { A: [] };
+        const result = await importTool('A');
+        assert.equal(result.tool.messageId, 'A');
+        assert.deepEqual(result.errors, []);
+        assert.deepEqual(calls.createTool, ['A']);
+        assert.equal(calls.saveFile.length, 1);
+    });
+
+    it('a normal nested tool still imports its sub-tool', async () => {
+        graph = { A: ['B'], B: [] };
+        const result = await importTool('A');
+        assert.deepEqual(result.errors, []);
+        assert.deepEqual(calls.createTool.sort(), ['A', 'B']);
+    });
+});


### PR DESCRIPTION
## Problem

`importToolByMessage` recurses into the sub-tools listed inside the archive, and the only dedup check is the `DatabaseServer.getTool({ messageId })` lookup — for a row that `createTool` writes **after** the recursion has already returned. A tool on the current import path is therefore never visible to its own check.

So a self- or mutually-referencing archive recurses without end. Every call is awaited, so the stack never overflows and nothing is raised: the import simply never returns, writing **one orphan GridFS blob, one notifier step, one Hedera `getMessage` and one IPFS fetch per turn**.

Running the new suite against current `develop` exhausts a 2 GB heap:

```
[166386:0x28def1c0] 29817 ms: Scavenge (reduce) 2045.4 (2081.3) -> 2045.0 (2081.6) MB ... allocation failure
```

The sub-tool list is archive-controlled: `parseZipFile` returns every `tools/*.json` entry verbatim, `messageId` included, and nothing checks an entry against the tool being imported. **It does not take a malicious archive** — a mis-published tool that references itself is enough.

## Fix

**Cycle guard.** Thread a `visited` set through `importSubTools` / `importToolByMessage` holding the message ids on the current import *path*, and refuse an id already on it. The id is removed on the way out, so a legitimate diamond (A imports B and C, both importing D) still resolves D twice rather than being mistaken for a cycle. `MAX_TOOL_IMPORT_DEPTH` (32) is a backstop for a pathological but acyclic chain, and bounds the damage if a future edit breaks the cycle check.

**Orphan blobs.** Save the tool file to GridFS *after* the sub-tool import rather than before. `createTool` is only reached further down, so a blob saved ahead of the recursion is orphaned by anything that throws in between, with no reference and no cleanup path. That was one orphan per turn of the loop, and it is still one per failed import of any kind. Steps are looked up by name, so the reordering does not disturb the progress tree.

## Tests

`guardian-service/tests/tool-import-cycle.test.mjs` — 9 cases: self-reference, mutual (A→B→A) and longer (A→B→C→A) cycles, the depth ceiling, orphan-blob accounting, and the cases that must **not** be treated as cycles (diamond, repeated sibling), plus the plain and normally-nested tools as controls.

All 9 pass with the fix. Against current `develop` the cycle cases hang until the process runs out of memory, which is what the heap trace above is.