### PR TITLE
fix(indexer): treat a computed message-page limit of 0 as a full page

### DIFF
--- a/indexer-service/src/api/search.service.ts
+++ b/indexer-service/src/api/search.service.ts
@@ -27,7 +27,7 @@ export class SearchService {
         msg: {
             pageIndex: number,
             pageSize: number,
-            search: string
+            search?: string
         }
     ) {
         try {
@@ -35,7 +35,7 @@ export class SearchService {
                 throw new Error('Invalid page parameters')
             }
             const options = parsePageParams(msg);
-            const { search } = msg;
+            const search = msg.search ?? '';
 
             const em = DataBaseHelper.getEntityManager();
 
@@ -46,39 +46,53 @@ export class SearchService {
                 } as any,
                 options
             )) as any as [SearchItem[], number];
-            const [messages, messagesCount] = (await em.findAndCount(
-                Message,
-                {
-                    $or: [
-                        {
-                            'analytics.textSearch': createRegex(search)
-                        },
-                        {
-                            'topicId': search
-                        },
-                        {
-                            'tokenId': search
-                        },
-                        {
-                            'consensusTimestamp': search
-                        },
-                        {
-                            'owner': search
-                        },
-                        {
-                            'type': search
-                        },
-                        {
-                            'action': search
-                        },
-                    ]
-                } as any,
-                {
-                    ...options,
-                    offset: Math.max(options.offset - tokensCount, 0),
-                    limit: Math.max(options.limit - tokens.length, 0),
-                }
-            )) as any as [SearchItem[], number];
+
+            const messagesFilter = {
+                $or: [
+                    {
+                        'analytics.textSearch': createRegex(search)
+                    },
+                    {
+                        'topicId': search
+                    },
+                    {
+                        'tokenId': search
+                    },
+                    {
+                        'consensusTimestamp': search
+                    },
+                    {
+                        'owner': search
+                    },
+                    {
+                        'type': search
+                    },
+                    {
+                        'action': search
+                    },
+                ]
+            } as any;
+            // When the token match already fills the requested page this subtraction
+            // yields 0, which MongoDB reads as "no limit" rather than "nothing left to
+            // fetch" - a single request would then load the whole Message collection.
+            // Skip the document query and count instead, so total stays correct.
+            const messagesLimit = Math.max(options.limit - tokens.length, 0);
+
+            let messages: SearchItem[] = [];
+            let messagesCount: number;
+            if (messagesLimit > 0) {
+                [messages, messagesCount] = (await em.findAndCount(
+                    Message,
+                    messagesFilter,
+                    {
+                        ...options,
+                        offset: Math.max(options.offset - tokensCount, 0),
+                        limit: messagesLimit,
+                    }
+                )) as any as [SearchItem[], number];
+            } else {
+                messagesCount = await em.count(Message, messagesFilter);
+            }
 
             const result = {
                 items: [...tokens, ...messages],

--- a/indexer-service/tests/search-service.test.mjs
+++ b/indexer-service/tests/search-service.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { DataBaseHelper } from '@indexer/common';
+import { SearchService } from '../dist/api/search.service.js';
+
+/**
+ * The /search handler pages two collections by subtraction: it fills the page from
+ * TokenCache first, then asks Message for whatever is left. Both of these cover the
+ * edges of that arithmetic.
+ */
+describe('SearchService.search', () => {
+    let calls;
+    let origGetEntityManager;
+
+    /**
+     * @param tokens rows the TokenCache query returns
+     * @param tokensCount total TokenCache matches
+     */
+    function stubEntityManager(tokens, tokensCount, messages = [], messagesCount = 0) {
+        calls = [];
+        origGetEntityManager = DataBaseHelper.getEntityManager;
+        DataBaseHelper.getEntityManager = () => ({
+            async findAndCount(entity, filter, options) {
+                calls.push({ method: 'findAndCount', entity: entity?.name, filter, options });
+                // first call is TokenCache, second is Message
+                return calls.filter((c) => c.method === 'findAndCount').length === 1
+                    ? [tokens, tokensCount]
+                    : [messages, messagesCount];
+            },
+            async count(entity, filter) {
+                calls.push({ method: 'count', entity: entity?.name, filter });
+                return messagesCount;
+            },
+        });
+    }
+
+    afterEach(() => {
+        if (origGetEntityManager) {
+            DataBaseHelper.getEntityManager = origGetEntityManager;
+            origGetEntityManager = null;
+        }
+    });
+
+    it('does not issue an unbounded Message query when tokens already fill the page', async () => {
+        // pageSize 1 with one token match makes the remaining message limit 1 - 1 = 0,
+        // and MongoDB treats limit(0) as no limit at all.
+        stubEntityManager([{ id: 't1' }], 1, [], 42);
+
+        const res = await new SearchService().search({ pageIndex: 1, pageSize: 1, search: '0.0.1234' });
+
+        const messageFinds = calls.filter((c) => c.method === 'findAndCount' && c.entity === 'Message');
+        assert.equal(messageFinds.length, 0, 'Message must not be queried for documents when the page is full');
+        assert.ok(calls.some((c) => c.method === 'count' && c.entity === 'Message'), 'total still needs a count');
+
+        // the page is still reported correctly
+        assert.equal(res.body.total, 1 + 42);
+        assert.equal(res.body.items.length, 1);
+    });
+
+    it('never passes limit 0 to the Message document query', async () => {
+        stubEntityManager([{ id: 't1' }], 1, [], 7);
+
+        await new SearchService().search({ pageIndex: 1, pageSize: 1, search: 'x' });
+
+        for (const c of calls) {
+            if (c.method === 'findAndCount' && c.entity === 'Message') {
+                assert.notEqual(c.options?.limit, 0, 'limit 0 reaches the driver as "unlimited"');
+            }
+        }
+    });
+
+    it('still queries messages when the page has room left', async () => {
+        stubEntityManager([{ id: 't1' }], 1, [{ id: 'm1' }], 5);
+
+        const res = await new SearchService().search({ pageIndex: 1, pageSize: 10, search: 'x' });
+
+        const messageFind = calls.find((c) => c.method === 'findAndCount' && c.entity === 'Message');
+        assert.ok(messageFind, 'messages are still fetched when the page is not full');
+        assert.equal(messageFind.options.limit, 9);
+        assert.equal(res.body.items.length, 2);
+    });
+
+    it('does not throw when the optional search parameter is omitted', async () => {
+        // the gateway declares `search` optional; escapeStringRegexp(undefined) throws.
+        stubEntityManager([], 0, [], 0);
+
+        const res = await new SearchService().search({ pageIndex: 1, pageSize: 10 });
+
+        assert.ok(res.body, 'a missing search must not produce an error response');
+        assert.equal(res.body.items.length, 0);
+    });
+});


### PR DESCRIPTION
Fixes #6789.

`/search` pages two collections by subtraction: it fills the page from `TokenCache` first, then asks `Message` for whatever room is left. When a token match already fills the page that subtraction yields `0`, and MongoDB reads `limit(0)` as *no limit* rather than *nothing left to fetch*.

`tokenId` is an exact-match key, so `tokens.length` is 0 or 1. With `pageSize=1` a token hit makes the messages limit `Math.max(1 - 1, 0)` — `0`. MikroORM forwards it (`0 !== undefined`), `cursor.limit(0)` reaches the driver, and a single GET materialises every matching `Message` into memory. The `$or` is not narrow either: it combines a `.*<search>.*` regex on `analytics.textSearch` with six equality branches, one of them `tokenId`, so every message referencing that token matches.

`DataBaseUtils.pageParams` caps the requested page size, and this is the only place that mutates `options.limit` afterwards, so the cap is defeated here specifically.

## Changes

- Skip the document query when the computed limit is `0` and `em.count()` instead, so `total` still reflects the real match count without loading the documents. `findAndCount`'s count ignores `limit`/`offset`, so the reported total is unchanged.
- Guard the optional `search` parameter. The gateway declares it optional (`@Query('search') search?: string`) but the handler used it unguarded, and `escapeStringRegexp(undefined)` throws — omitting a documented-optional parameter returned a 500. The payload type is now `search?: string` to match the gateway's actual contract.

Response shape (`items` / `pageIndex` / `pageSize` / `total` / `order`) is unchanged.

## Tests

Adds `indexer-service/tests/search-service.test.mjs`. This is the first test file in this service — `mocha` and the `test` script were already configured, so no tooling changes were needed.

**3 of the 4 cases fail on `develop`:**

| Case | On `develop` |
|---|---|
| does not issue an unbounded Message query when tokens already fill the page | **fails** — `Message must not be queried for documents when the page is full` (1 !== 0) |
| never passes limit 0 to the Message document query | **fails** — `limit 0 reaches the driver as "unlimited"` |
| does not throw when the optional search parameter is omitted | **fails** — `a missing search must not produce an error response` |
| still queries messages when the page has room left | passes either way — regression guard so the fix cannot over-correct into skipping that query too |

Verified by stashing only the source change, rebuilding, and re-running: 3 failing. With the fix restored: 4 passing.

## Risk

Confined to the `/search` handler. No schema or data migration — pure query construction. The change only removes an unbounded-read failure mode and a crash-on-missing-parameter failure mode.