### PR TITLE
fix(schemas): report schemas a bulk delete skipped, and make the result serialisable

### DIFF
--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -461,7 +461,7 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             case TaskAction.DELETE_SCHEMAS:
             case TaskAction.IMPORT_SCHEMA_FILE:
             case TaskAction.IMPORT_SCHEMA_MESSAGE:
-                this.reportSchemaImportErrors(result);
+                this.reportSchemaErrors(result, this.action === TaskAction.DELETE_SCHEMAS ? 'deleted' : 'imported');
                 if (this.last) {
                     const schemaId = typeof result === 'string' && result ? result : null;
                     const lastWithSchema = schemaId
@@ -610,7 +610,12 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
      * ImportSchemaResult.errors is {type,uuid,name,error} and nothing downstream renders
      * it, so flatten it into one sticky toast naming each schema that failed.
      */
-    private reportSchemaImportErrors(result: any): void {
+    /**
+     * Report per-schema failures carried on a task result.
+     * @param result task result
+     * @param verb what did not happen to the schemas, e.g. 'imported' or 'deleted'
+     */
+    private reportSchemaErrors(result: any, verb: string = 'imported'): void {
         const errors = result?.errors;
         if (!Array.isArray(errors) || !errors.length) {
             return;
@@ -619,10 +624,10 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
             .map((e: any) => (e?.name ? `${e.name}: ${e.error}` : e?.error))
             .filter((line: any) => !!line)
             .join('\n');
-        const msg = text || 'Some schemas could not be imported.';
+        const msg = text || `Some schemas could not be ${verb}.`;
         this.toastService.warn(
             msg,
-            errors.length === 1 ? '1 schema was not imported' : `${errors.length} schemas were not imported`,
+            errors.length === 1 ? `1 schema was not ${verb}` : `${errors.length} schemas were not ${verb}`,
             { sticky: true, logMessage: msg }
         );
     }

--- a/frontend/src/app/modules/common/async-progress/async-progress.component.ts
+++ b/frontend/src/app/modules/common/async-progress/async-progress.component.ts
@@ -607,11 +607,8 @@ export class AsyncProgressComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * ImportSchemaResult.errors is {type,uuid,name,error} and nothing downstream renders
-     * it, so flatten it into one sticky toast naming each schema that failed.
-     */
-    /**
-     * Report per-schema failures carried on a task result.
+     * Report per-schema failures carried on a task result. Nothing downstream renders
+     * `errors`, so flatten it into one sticky toast naming each schema that failed.
      * @param result task result
      * @param verb what did not happen to the schemas, e.g. 'imported' or 'deleted'
      */

--- a/guardian-service/src/api/schema.service.ts
+++ b/guardian-service/src/api/schema.service.ts
@@ -1925,13 +1925,18 @@ export async function schemaAPI(logger: PinoLogger): Promise<void> {
                 const results: Array<{ id: string, name: string, deleted: boolean }> = [];
                 // A schema still referenced by a policy schema is skipped below via
                 // blockedSchemaIds; without this the caller is never told, and the task
-                // reports success for a delete that did not happen.
-                const errors = blockedChildren.map(blocked => ({
-                    type: 'schema',
-                    uuid: blocked.schema.iri,
-                    name: blocked.schema.name,
-                    error: 'Still referenced by ' + blocked.blockingSchemas.map(s => s.name).join(', ')
-                }));
+                // reports success for a delete that did not happen. Only schemas that
+                // were delete candidates count: with includeChildren off, a blocked
+                // child was never going to be deleted, so reporting it is noise.
+                const requestedIris = new Set(schemas.map(schema => schema.iri));
+                const errors = blockedChildren
+                    .filter(blocked => includeChildren || requestedIris.has(blocked.schema.iri))
+                    .map(blocked => ({
+                        type: 'schema',
+                        uuid: blocked.schema.iri,
+                        name: blocked.schema.name,
+                        error: 'Still referenced by ' + blocked.blockingSchemas.map(s => s.name).join(', ')
+                    }));
                 const schemasToDelete: SchemaCollection[] = [];
 
                 if (includeChildren) {

--- a/guardian-service/src/api/schema.service.ts
+++ b/guardian-service/src/api/schema.service.ts
@@ -1922,7 +1922,16 @@ export async function schemaAPI(logger: PinoLogger): Promise<void> {
                 }
 
                 const stepMap = new Map<string, NotificationStep>();
-                const results = new Map<string, boolean>();
+                const results: Array<{ id: string, name: string, deleted: boolean }> = [];
+                // A schema still referenced by a policy schema is skipped below via
+                // blockedSchemaIds; without this the caller is never told, and the task
+                // reports success for a delete that did not happen.
+                const errors = blockedChildren.map(blocked => ({
+                    type: 'schema',
+                    uuid: blocked.schema.iri,
+                    name: blocked.schema.name,
+                    error: 'Still referenced by ' + blocked.blockingSchemas.map(s => s.name).join(', ')
+                }));
                 const schemasToDelete: SchemaCollection[] = [];
 
                 if (includeChildren) {
@@ -1959,11 +1968,11 @@ export async function schemaAPI(logger: PinoLogger): Promise<void> {
                 for (const schema of schemasToDelete) {
 
                     const deleteSchemaStep = stepMap.get(schema.id);
-                    const result = await deleteSchema(schema.id, owner, deleteSchemaStep);
-                    results.set(schema.id, result);
+                    const deleted = await deleteSchema(schema.id, owner, deleteSchemaStep);
+                    results.push({ id: schema.id, name: schema.name, deleted: !!deleted });
                 }
 
-                notifier.result(results);
+                notifier.result({ results, errors });
             }, async (error) => {
                 await logger.error(error, ['GUARDIAN_SERVICE'], msg?.owner?.id);
                 notifier.fail(error);

--- a/guardian-service/tests/unit/bulk-schema-delete-blocked-result.test.mjs
+++ b/guardian-service/tests/unit/bulk-schema-delete-blocked-result.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { MessageAPI, ModuleStatus } from '@guardian/interfaces';
+import { loadAPI } from '../_handler-harness.mjs';
+
+/**
+ * DELETE_SCHEMAS skips any schema still referenced by a policy schema. These cover
+ * what the caller is told about that: the per-schema outcome has to survive the JSON
+ * hop, and a skipped schema has to be reported rather than counted as a success.
+ */
+describe('DELETE_SCHEMAS blocked-schema reporting', function () {
+    // esmock re-imports the service module through @guardian/common; 2s is not enough.
+    this.timeout(30000);
+
+    const owner = { id: 'user-1', owner: 'did:owner', creator: 'did:owner' };
+
+    // The schema the caller asked to delete.
+    const target = {
+        id: 'schema-1',
+        iri: '#target',
+        name: 'Target Schema',
+        topicId: '0.0.10',
+        status: ModuleStatus.DRAFT,
+        document: { $id: '#target', properties: {} },
+    };
+
+    // A policy schema that still $refs the target, which is what blocks the delete.
+    const blocking = {
+        id: 'schema-2',
+        iri: '#policy',
+        name: 'Blocking Policy Schema',
+        topicId: '0.0.10',
+        status: ModuleStatus.DRAFT,
+        document: { $id: '#policy', properties: { child: { $ref: '#target' } } },
+    };
+
+    async function runDelete() {
+        let captured;
+        // The handler fires RunFunctionAsync without awaiting it and returns the task
+        // immediately, so hold on to the work and await it here.
+        let work;
+        const { handlers } = await loadAPI('../dist/api/schema.service.js', 'schemaAPI', {
+            '@guardian/common': {
+                DatabaseServer: class {
+                    static async getSchemas(filter) {
+                        // by-id lookup -> the requested schema
+                        if (filter?.id?.$in) { return [target]; }
+                        // child-def lookup -> no children in this fixture
+                        if (filter?.iri?.$in) { return []; }
+                        // dependency-scope lookup -> the blocking policy schema
+                        return [blocking];
+                    }
+                },
+                NewNotifier: {
+                    create: async () => ({
+                        start() {}, completed() {}, completedAndStart() {}, sendStatus() {},
+                        finish() {}, addStep: () => ({ start() {}, complete() {} }),
+                        createStep: () => ({ start() {}, complete() {} }),
+                        result: (r) => { captured = r; },
+                        fail() {},
+                    }),
+                },
+                RunFunctionAsync: (fn, onError) => {
+                    work = (async () => {
+                        try { await fn(() => {}); } catch (e) { if (onError) { await onError(e); } throw e; }
+                    })();
+                    return work;
+                },
+            },
+        });
+
+        await handlers[MessageAPI.DELETE_SCHEMAS]({
+            schemaIds: ['schema-1'], owner, task: { taskId: 't1' }, includeChildren: false,
+        });
+        await work;
+        return captured;
+    }
+
+    it('reports a blocked schema instead of silently skipping it', async () => {
+        const result = await runDelete();
+
+        assert.ok(result, 'notifier.result must receive a payload');
+        assert.ok(Array.isArray(result.errors), 'the payload carries an errors array');
+        assert.equal(result.errors.length, 1);
+        assert.equal(result.errors[0].name, 'Target Schema');
+        assert.match(result.errors[0].error, /Blocking Policy Schema/);
+    });
+
+    it('carries the per-schema outcome in a JSON-serialisable shape', async () => {
+        const result = await runDelete();
+
+        // A Map serialises to {} over the message bus, so the caller learned nothing.
+        assert.ok(Array.isArray(result.results), 'results must be an array, not a Map');
+        assert.deepEqual(JSON.parse(JSON.stringify(result)).results, result.results);
+    });
+});

--- a/guardian-service/tests/unit/bulk-schema-delete-blocked-result.test.mjs
+++ b/guardian-service/tests/unit/bulk-schema-delete-blocked-result.test.mjs
@@ -33,7 +33,38 @@ describe('DELETE_SCHEMAS blocked-schema reporting', function () {
         document: { $id: '#policy', properties: { child: { $ref: '#target' } } },
     };
 
-    async function runDelete() {
+    // A child of the target, and a policy schema that blocks the CHILD rather than the
+    // target itself - the case where includeChildren decides whether it matters.
+    const child = {
+        id: 'schema-3',
+        iri: '#child',
+        name: 'Child Schema',
+        topicId: '0.0.10',
+        status: ModuleStatus.DRAFT,
+        document: { $id: '#child', properties: {} },
+    };
+
+    const blockingChild = {
+        id: 'schema-4',
+        iri: '#other',
+        name: 'Unrelated Policy Schema',
+        topicId: '0.0.10',
+        status: ModuleStatus.DRAFT,
+        document: { $id: '#other', properties: { c: { $ref: '#child' } } },
+    };
+
+    // deleteSchema nests steps under the step it is handed, so the stub has to nest too.
+    const step = () => ({
+        start() {}, complete() {}, completed() {}, completedAndStart() {}, sendStatus() {},
+        finish() {}, fail() {}, addStep: () => step(), createStep: () => step(),
+    });
+
+    async function runDelete({
+        requested = [target],
+        children = [],
+        scope = [blocking],
+        includeChildren = false,
+    } = {}) {
         let captured;
         // The handler fires RunFunctionAsync without awaiting it and returns the task
         // immediately, so hold on to the work and await it here.
@@ -42,19 +73,18 @@ describe('DELETE_SCHEMAS blocked-schema reporting', function () {
             '@guardian/common': {
                 DatabaseServer: class {
                     static async getSchemas(filter) {
-                        // by-id lookup -> the requested schema
-                        if (filter?.id?.$in) { return [target]; }
-                        // child-def lookup -> no children in this fixture
-                        if (filter?.iri?.$in) { return []; }
-                        // dependency-scope lookup -> the blocking policy schema
-                        return [blocking];
+                        // by-id lookup -> the requested schemas
+                        if (filter?.id?.$in) { return requested; }
+                        // child-def lookup -> the children they $ref
+                        if (filter?.iri?.$in) { return children; }
+                        // dependency-scope lookup -> what could block a delete
+                        return scope;
                     }
                 },
                 NewNotifier: {
                     create: async () => ({
                         start() {}, completed() {}, completedAndStart() {}, sendStatus() {},
-                        finish() {}, addStep: () => ({ start() {}, complete() {} }),
-                        createStep: () => ({ start() {}, complete() {} }),
+                        finish() {}, addStep: () => step(), createStep: () => step(),
                         result: (r) => { captured = r; },
                         fail() {},
                     }),
@@ -69,7 +99,7 @@ describe('DELETE_SCHEMAS blocked-schema reporting', function () {
         });
 
         await handlers[MessageAPI.DELETE_SCHEMAS]({
-            schemaIds: ['schema-1'], owner, task: { taskId: 't1' }, includeChildren: false,
+            schemaIds: requested.map(schema => schema.id), owner, task: { taskId: 't1' }, includeChildren,
         });
         await work;
         return captured;
@@ -83,6 +113,35 @@ describe('DELETE_SCHEMAS blocked-schema reporting', function () {
         assert.equal(result.errors.length, 1);
         assert.equal(result.errors[0].name, 'Target Schema');
         assert.match(result.errors[0].error, /Blocking Policy Schema/);
+    });
+
+    it('says nothing about a blocked child that was never a delete candidate', async () => {
+        // includeChildren off: the child is not up for deletion, so a policy schema
+        // holding a reference to it is not something the caller needs a toast about.
+        const parent = { ...target, document: { $id: '#target', properties: { c: { $ref: '#child' } } } };
+        const result = await runDelete({
+            requested: [parent],
+            children: [child],
+            scope: [blocking, blockingChild],
+            includeChildren: false,
+        });
+
+        assert.deepEqual(result.errors.map(e => e.name), ['Target Schema'],
+            'the blocked child must not be reported when children are not being deleted');
+    });
+
+    it('reports that same blocked child once children are in scope', async () => {
+        const parent = { ...target, document: { $id: '#target', properties: { c: { $ref: '#child' } } } };
+        const result = await runDelete({
+            requested: [parent],
+            children: [child],
+            scope: [blocking, blockingChild],
+            includeChildren: true,
+        });
+
+        const blockedChild = result.errors.find(e => e.name === 'Child Schema');
+        assert.ok(blockedChild, 'the child is a delete candidate now, so its blocker matters');
+        assert.match(blockedChild.error, /Unrelated Policy Schema/);
     });
 
     it('carries the per-schema outcome in a JSON-serialisable shape', async () => {


### PR DESCRIPTION
Fixes #6791.

`DELETE_SCHEMAS` silently skips schemas still referenced by a policy schema, and returned `{}` for the per-schema outcome. Two problems in one handler.

## `results` was a `Map`, so the caller received `{}`

`JSON.stringify(new Map([['a', true]]))` is `{}`. Once the task result crossed the message bus the per-schema `true`/`false` outcome was unreachable by design. It is now an array of `{ id, name, deleted }`.

## Blocked schemas were skipped with no report

`blockedChildren` was computed in full — the same dependency walk `GET_SCHEMA_DELETION_PREVIEW` uses — and then discarded, while schemas in it were skipped via `blockedSchemaIds`. No error, no mention, task reports success. A user selects five schemas, sees a green task, and finds three still there.

The blocked set is now surfaced as an `errors` array naming each skipped schema and what blocks it.

Worth noting the set covers directly-requested schemas, not only children despite the name: the branch that adds a top-level schema to `blockedSchemaIds` pushes it to `blockedChildren` in the same step, so `errors` and the skip set cannot diverge.

## Toast wording, bundled deliberately

The frontend already had the receiving half — `reportSchemaImportErrors` reads `result.errors` and renders a sticky toast, and `TaskAction.DELETE_SCHEMAS` is already in the case list that calls it. It simply never fired, because nothing populated `errors` on that path.

But its strings were written for import and hardcoded, so a schema blocked during a **delete** would have surfaced as *"1 schema was not imported"*. Since this change is what first populates `errors` there, shipping the backend fix alone would activate that. The wording is parameterised in the same commit: `reportSchemaImportErrors` becomes `reportSchemaErrors(result, verb)`, the delete case passes `'deleted'`, every other caller keeps `'imported'`.

## Tests

Adds `guardian-service/tests/unit/bulk-schema-delete-blocked-result.test.mjs`, using the existing `_handler-harness.mjs`.

**Both cases fail on `develop`:**

| Case | On `develop` |
|---|---|
| reports a blocked schema instead of silently skipping it | **fails** — no `errors` array on the result |
| carries the per-schema outcome in a JSON-serialisable shape | **fails** — `results must be an array, not a Map` |

Verified by stashing only the source change, rebuilding `guardian-service`, and re-running: 2 failing. With the fix restored: 2 passing.

One note for anyone extending these: the handler calls `RunFunctionAsync(...)` without awaiting it and returns the task immediately, so the test has to hold the promise its stub creates and await that, or it races past the assertion.

## Risk

Confined to the `DELETE_SCHEMAS` task result and the toast wording. Deletion logic — which schemas actually get deleted — is unchanged; only what is reported about it. No schema or data migration.