### PR TITLE
fix(policy-service): keep a saturated fleet scaling and stop losing policy slots

### DIFF
--- a/policy-service/src/helpers/policy-container.ts
+++ b/policy-service/src/helpers/policy-container.ts
@@ -78,6 +78,11 @@ export interface IPolicyServiceInfo {
      */
     requestId: string
 
+    /**
+     * Whether this service has recently asked for a new replica
+     */
+    startNewPolicyServiceTriggered?: boolean
+
 }
 
 /**
@@ -147,10 +152,81 @@ export class PolicyContainer extends NatsService {
     private generatePolicySubscription: Subscription;
 
     /**
+     * Identity of the live GENERATE_POLICY subscription. A pending unsubscribe
+     * timer only tears down the generation it was scheduled for.
+     * @private
+     */
+    private generateSubscriptionGeneration: number = 0;
+
+    /**
+     * Whether this service is currently listening for GENERATE_POLICY.
+     * @private
+     */
+    private intakeSubscribed: boolean = false;
+
+    /**
+     * A service has usable capacity only when it is below its limit AND actually
+     * listening. Reporting slots it will never fill keeps every other service's
+     * `hasFree` true, which suppresses scale-up across the whole fleet.
+     * @private
+     */
+    private get canAcceptPolicies(): boolean {
+        return this.intakeSubscribed && this.processCount < this.maxPolicyInstances;
+    }
+
+    /**
+     * Consecutive failed starts per policy, for the crash-loop backoff.
+     * @private
+     */
+    private readonly restartAttempts: Map<string, number> = new Map();
+    private readonly maxRestartAttempts: number = process.env.POLICY_MAX_RESTART_ATTEMPTS
+        ? parseInt(process.env.POLICY_MAX_RESTART_ATTEMPTS, 10)
+        : 10;
+    private readonly restartBaseDelayMs: number = process.env.POLICY_RESTART_BASE_DELAY_MS
+        ? parseInt(process.env.POLICY_RESTART_BASE_DELAY_MS, 10)
+        : 10000;
+    private readonly restartMaxDelayMs: number = process.env.POLICY_RESTART_MAX_DELAY_MS
+        ? parseInt(process.env.POLICY_RESTART_MAX_DELAY_MS, 10)
+        : 5 * 60 * 1000;
+
+    /**
+     * When this service last asked for a replica. Replaces the permanent boolean
+     * seal so a fleet that stays saturated can keep scaling.
+     * @private
+     */
+    private lastScaleTriggeredAt: number = 0;
+
+    /**
+     * Guards checkForRunNewInstance against overlapping runs.
+     * @private
+     */
+    private scaleCheckInFlight: boolean = false;
+
+    private readonly scaleCooldownMs: number = process.env.SCALE_COOLDOWN_MS
+        ? parseInt(process.env.SCALE_COOLDOWN_MS, 10)
+        : 60000;
+
+    /**
+     * Fleet headroom, in policy slots, below which a full service asks for another
+     * replica. Defaults to one service's worth of capacity.
+     * @private
+     */
+    private readonly scaleHeadroomSlots: number = process.env.SCALE_HEADROOM_SLOTS
+        ? parseInt(process.env.SCALE_HEADROOM_SLOTS, 10)
+        : 0;
+
+    /**
      * Start new policy-service triggered
      * @private
      */
-    private startNewPolicyServiceTriggered: boolean = false;
+    private get startNewPolicyServiceTriggered(): boolean {
+        return this.lastScaleTriggeredAt > 0
+            && (Date.now() - this.lastScaleTriggeredAt) < this.scaleCooldownMs;
+    }
+
+    private set startNewPolicyServiceTriggered(value: boolean) {
+        this.lastScaleTriggeredAt = value ? Date.now() : 0;
+    }
 
     constructor(private readonly logger: PinoLogger) {
         super();
@@ -173,19 +249,24 @@ export class PolicyContainer extends NatsService {
             if (replySubject) {
                 this.sendMessage(replySubject, {
                     service: process.env.SERVICE_CHANNEL,
-                    free: this.processCount < this.maxPolicyInstances,
-                    count: this.maxPolicyInstances - this.processCount,
+                    free: this.canAcceptPolicies,
+                    count: this.canAcceptPolicies ? this.maxPolicyInstances - this.processCount : 0,
                     instanceId: this.instanceId,
-                    requestId
+                    requestId,
+                    startNewPolicyServiceTriggered: this.startNewPolicyServiceTriggered
                 })
             }
         });
 
         this.getMessages([this.replySubject, PolicyEvents.POLICY_SERVICE_FREE_STATUS, this.instanceId].join('.'), (msg: IPolicyServiceInfo) => {
-            if (!this._policiInfoArrays.has(msg.requestId)) {
-                this._policiInfoArrays.set(msg.requestId, [])
+            // Drop replies for a request we are not collecting. Creating the bucket
+            // on demand let a late reply re-create an entry that nothing deletes -
+            // getFreePolicyServices only removes the id it is waiting on - so this
+            // leaked one Map entry per late reply for the lifetime of the process.
+            const arr = this._policiInfoArrays.get(msg?.requestId);
+            if (!arr) {
+                return;
             }
-            const arr = this._policiInfoArrays.get(msg.requestId);
             arr.push(msg);
         });
 
@@ -219,6 +300,9 @@ export class PolicyContainer extends NatsService {
      */
     public getFreePolicyServices(): Promise<IPolicyServiceInfo[]> {
         const requestId = GenerateUUIDv4();
+        // Register before publishing so a reply can never arrive for an id we are
+        // not tracking.
+        this._policiInfoArrays.set(requestId, []);
         this.publish(PolicyEvents.GET_FREE_POLICY_SERVICES, {
             replySubject: [this.replySubject, PolicyEvents.POLICY_SERVICE_FREE_STATUS, this.instanceId].join('.'),
             requestId
@@ -226,9 +310,9 @@ export class PolicyContainer extends NatsService {
 
         return new Promise(resolve => {
             setTimeout(() => {
-                const arr = this._policiInfoArrays.get(requestId);
-                resolve(arr);
+                const arr = this._policiInfoArrays.get(requestId) || [];
                 this._policiInfoArrays.delete(requestId);
+                resolve(arr);
             }, 500);
         })
     }
@@ -238,10 +322,15 @@ export class PolicyContainer extends NatsService {
      * @private
      */
     private subscribeForModelGeneration(): void {
+        // Drop any prior listener first, so repeated exit/respawn cycles cannot
+        // accumulate GENERATE_POLICY handlers.
+        this.generatePolicySubscription?.unsubscribe();
+        this.generateSubscriptionGeneration++;
         this.generatePolicySubscription = this.getMessages(PolicyEvents.GENERATE_POLICY, async (data: IPolicyStartOptions) => {
             const confirmed = this.addPolicy(data);
             return new MessageResponse({ confirmed, free: this.maxPolicyInstances - this.processCount })
         });
+        this.intakeSubscribed = true;
         this.startNewPolicyServiceTriggered = false;
     }
 
@@ -250,8 +339,21 @@ export class PolicyContainer extends NatsService {
      * @private
      */
     private unsubscribeFromModelGeneration(): void {
+        /*
+         * Cancel only the subscription this call was scheduled for. The timer used
+         * to dereference `generatePolicySubscription` when it fired, so a policy
+         * exiting inside the 500ms window - which re-subscribes - had its NEW
+         * subscription torn down instead. That left the service below capacity and
+         * deaf to GENERATE_POLICY while still advertising free slots, which also
+         * suppressed fleet-wide scale-up through checkForRunNewInstance.
+         */
+        const generation = this.generateSubscriptionGeneration;
         setTimeout(() => {
-            this.generatePolicySubscription.unsubscribe();
+            if (generation !== this.generateSubscriptionGeneration) {
+                return;
+            }
+            this.generatePolicySubscription?.unsubscribe();
+            this.intakeSubscribed = false;
         }, 500);
     }
 
@@ -269,26 +371,68 @@ export class PolicyContainer extends NatsService {
         if (!this.runServiceScript) {
             return;
         }
-        const freeCheck = await this.getFreePolicyServices();
-        if (!freeCheck) {
+        /*
+         * The 1s interval does not await this and the scatter below takes ~500ms, so
+         * without a synchronous guard two invocations can both pass the seal check
+         * before either records a trigger, and both ask for a replica.
+         */
+        if (this.scaleCheckInFlight) {
             return;
         }
-        let hasFree = false;
-        for (const info of freeCheck) {
-            hasFree = hasFree || info.free
-        }
-        if (hasFree) {
-            return;
-        }
-
-        execFile(this.runServiceScript, (error, _data) => {
-            if (error) {
-                this.logger.error(error, ['POLICY_SERVICE', this.runServiceScript], null);
+        this.scaleCheckInFlight = true;
+        try {
+            const freeCheck = await this.getFreePolicyServices();
+            /*
+             * An EMPTY reply set means nothing answered the scatter, not that the
+             * fleet is full - otherwise a broker hiccup reads as "no capacity" and
+             * scales up on its own.
+             */
+            if (!freeCheck || freeCheck.length === 0) {
                 return;
             }
-            this.logger.info(_data, ['POLICY_SERVICE', this.runServiceScript], null);
-        });
-        this.startNewPolicyServiceTriggered = true;
+
+            /*
+             * Scale on fleet headroom rather than "any service has a slot". This one
+             * is already full; if what is left across the fleet is under a single
+             * service's worth, another replica is warranted.
+             */
+            const headroom = Math.max(1, this.scaleHeadroomSlots || this.maxPolicyInstances);
+            const totalFree = freeCheck.reduce(
+                (sum, info) => sum + (info.free ? (Number.isFinite(info.count) ? info.count : 1) : 0),
+                0
+            );
+            if (totalFree >= headroom) {
+                return;
+            }
+
+            /*
+             * Only one service should scale per cooldown. With a permanent seal that
+             * was emergent - each service scaled at most once ever - but a re-arming
+             * seal makes a stampede reachable, so the winner is elected explicitly.
+             */
+            if (freeCheck.some(info => info.instanceId !== this.instanceId && info.startNewPolicyServiceTriggered)) {
+                return;
+            }
+            const candidates = freeCheck
+                .filter(info => !info.startNewPolicyServiceTriggered)
+                .sort((a, b) => a.instanceId.localeCompare(b.instanceId));
+            if (candidates.length && candidates[0].instanceId !== this.instanceId) {
+                // Another service is the elected scaler; hold off until the cooldown.
+                this.startNewPolicyServiceTriggered = true;
+                return;
+            }
+
+            execFile(this.runServiceScript, (error, _data) => {
+                if (error) {
+                    this.logger.error(error, ['POLICY_SERVICE', this.runServiceScript], null);
+                    return;
+                }
+                this.logger.info(_data, ['POLICY_SERVICE', this.runServiceScript], null);
+            });
+            this.startNewPolicyServiceTriggered = true;
+        } finally {
+            this.scaleCheckInFlight = false;
+        }
     }
 
     /**
@@ -326,12 +470,26 @@ export class PolicyContainer extends NatsService {
         });
         p.once('error', (error) => {
             this.logger.error(error.message, ['POLICY_SERVICE', policyId], policyOwnerId);
-            // Restart policy
+            /*
+             * Node emits 'error' when a process cannot be SPAWNED (EAGAIN, ENOMEM, a
+             * bad process path) and 'exit' may never follow, so nothing else runs.
+             * `instance.process` is already assigned and runPolicyProcess skips any
+             * instance that has one, so the policy stayed wedged forever - still
+             * counted in processCount, holding a slot it never used, and with no
+             * responder for requests addressed to it.
+             *
+             * Clearing the handle is enough: the 1s sweep re-forks on its next tick,
+             * and the crash-loop guard below bounds the retries if it keeps failing.
+             */
+            if (instance.process === p) {
+                instance.process = null;
+            }
         });
         p.once('exit', (code) => {
             this.logger.info(`Policy process exit with code ${code}`, ['POLICY_SERVICE', policyId], policyOwnerId);
             if (code === 0) {
                 this.container.delete(policyId);
+                this.restartAttempts.delete(policyId);
 
                 if (this.processCount < this.maxPolicyInstances) {
                     this.subscribeForModelGeneration();
@@ -349,11 +507,39 @@ export class PolicyContainer extends NatsService {
                     }
                 }
             } else {
-                // rerun every 10 secs
+                /*
+                 * Back off, and eventually stop. This used to re-fork every 10s with
+                 * no ceiling, so a policy that could not start hammered the service
+                 * forever - each attempt a full policy generation.
+                 *
+                 * Giving up RELEASES the slot rather than holding one that is never
+                 * used. guardian-service can still assign the policy again through
+                 * GENERATE_POLICY, so this is a local stop, not a permanent verdict.
+                 */
+                const attempts = (this.restartAttempts.get(policyId) || 0) + 1;
+                this.restartAttempts.set(policyId, attempts);
+
+                if (attempts >= this.maxRestartAttempts) {
+                    this.logger.error(
+                        `Policy ${policyId} failed to start ${attempts} times; releasing its slot instead of respawning`,
+                        ['POLICY_SERVICE', policyId], policyOwnerId
+                    );
+                    this.container.delete(policyId);
+                    this.restartAttempts.delete(policyId);
+                    if (this.processCount < this.maxPolicyInstances) {
+                        this.subscribeForModelGeneration();
+                    }
+                    return;
+                }
+
+                const delay = Math.min(
+                    this.restartBaseDelayMs * Math.pow(2, attempts - 1),
+                    this.restartMaxDelayMs
+                );
                 setTimeout(() => {
-                    this.logger.warn(`Process for policy with id: ${policyId} respawning`, ['POLICY_SERVICE', policyId], policyOwnerId);
+                    this.logger.warn(`Process for policy with id: ${policyId} respawning (attempt ${attempts + 1}) after ${delay}ms`, ['POLICY_SERVICE', policyId], policyOwnerId);
                     instance.process = null;
-                }, 10000)
+                }, delay)
             }
         });
         instance.process = p;

--- a/policy-service/src/helpers/policy-container.ts
+++ b/policy-service/src/helpers/policy-container.ts
@@ -211,9 +211,10 @@ export class PolicyContainer extends NatsService {
      * replica. Defaults to one service's worth of capacity.
      * @private
      */
-    private readonly scaleHeadroomSlots: number = process.env.SCALE_HEADROOM_SLOTS
-        ? parseInt(process.env.SCALE_HEADROOM_SLOTS, 10)
-        : 0;
+    private readonly scaleHeadroomSlots: number | null =
+        process.env.SCALE_HEADROOM_SLOTS === undefined
+            ? null
+            : parseInt(process.env.SCALE_HEADROOM_SLOTS, 10);
 
     /**
      * Start new policy-service triggered
@@ -396,7 +397,12 @@ export class PolicyContainer extends NatsService {
              * is already full; if what is left across the fleet is under a single
              * service's worth, another replica is warranted.
              */
-            const headroom = Math.max(1, this.scaleHeadroomSlots || this.maxPolicyInstances);
+            //null is unset, not zero: an explicit SCALE_HEADROOM_SLOTS=0 asks for no
+            //buffer at all, which the floor of 1 turns into "scale when nothing is free"
+            const configured = Number.isFinite(this.scaleHeadroomSlots)
+                ? this.scaleHeadroomSlots
+                : this.maxPolicyInstances;
+            const headroom = Math.max(1, configured);
             const totalFree = freeCheck.reduce(
                 (sum, info) => sum + (info.free ? (Number.isFinite(info.count) ? info.count : 1) : 0),
                 0
@@ -413,8 +419,11 @@ export class PolicyContainer extends NatsService {
             if (freeCheck.some(info => info.instanceId !== this.instanceId && info.startNewPolicyServiceTriggered)) {
                 return;
             }
+            //a peer with capacity returns at the first line of checkForRunNewInstance and
+            //never reaches the spawn, so electing one parks the whole fleet behind a
+            //leader that cannot act
             const candidates = freeCheck
-                .filter(info => !info.startNewPolicyServiceTriggered)
+                .filter(info => !info.free && !info.startNewPolicyServiceTriggered)
                 .sort((a, b) => a.instanceId.localeCompare(b.instanceId));
             if (candidates.length && candidates[0].instanceId !== this.instanceId) {
                 // Another service is the elected scaler; hold off until the cooldown.
@@ -474,15 +483,15 @@ export class PolicyContainer extends NatsService {
              * Node emits 'error' when a process cannot be SPAWNED (EAGAIN, ENOMEM, a
              * bad process path) and 'exit' may never follow, so nothing else runs.
              * `instance.process` is already assigned and runPolicyProcess skips any
-             * instance that has one, so the policy stayed wedged forever - still
-             * counted in processCount, holding a slot it never used, and with no
-             * responder for requests addressed to it.
+             * instance that has one, so the policy stayed wedged forever, holding a
+             * slot it never used.
              *
-             * Clearing the handle is enough: the 1s sweep re-forks on its next tick,
-             * and the crash-loop guard below bounds the retries if it keeps failing.
+             * Routed through the same backoff as a non-zero exit: a spawn that keeps
+             * failing is a crash loop too, and the 1s sweep would otherwise retry it
+             * every tick with no ceiling.
              */
             if (instance.process === p) {
-                instance.process = null;
+                this.scheduleRestart(policyId, instance, policyOwnerId);
             }
         });
         p.once('exit', (code) => {
@@ -507,41 +516,49 @@ export class PolicyContainer extends NatsService {
                     }
                 }
             } else {
-                /*
-                 * Back off, and eventually stop. This used to re-fork every 10s with
-                 * no ceiling, so a policy that could not start hammered the service
-                 * forever - each attempt a full policy generation.
-                 *
-                 * Giving up RELEASES the slot rather than holding one that is never
-                 * used. guardian-service can still assign the policy again through
-                 * GENERATE_POLICY, so this is a local stop, not a permanent verdict.
-                 */
-                const attempts = (this.restartAttempts.get(policyId) || 0) + 1;
-                this.restartAttempts.set(policyId, attempts);
-
-                if (attempts >= this.maxRestartAttempts) {
-                    this.logger.error(
-                        `Policy ${policyId} failed to start ${attempts} times; releasing its slot instead of respawning`,
-                        ['POLICY_SERVICE', policyId], policyOwnerId
-                    );
-                    this.container.delete(policyId);
-                    this.restartAttempts.delete(policyId);
-                    if (this.processCount < this.maxPolicyInstances) {
-                        this.subscribeForModelGeneration();
-                    }
-                    return;
-                }
-
-                const delay = Math.min(
-                    this.restartBaseDelayMs * Math.pow(2, attempts - 1),
-                    this.restartMaxDelayMs
-                );
-                setTimeout(() => {
-                    this.logger.warn(`Process for policy with id: ${policyId} respawning (attempt ${attempts + 1}) after ${delay}ms`, ['POLICY_SERVICE', policyId], policyOwnerId);
-                    instance.process = null;
-                }, delay)
+                this.scheduleRestart(policyId, instance, policyOwnerId);
             }
         });
         instance.process = p;
+    }
+
+    /*
+     * Back off, and eventually stop. This used to re-fork every 10s with no ceiling,
+     * so a policy that could not start hammered the service forever - each attempt a
+     * full policy generation.
+     *
+     * Giving up RELEASES the slot rather than holding one that is never used.
+     * guardian-service can still assign the policy again through GENERATE_POLICY, so
+     * this is a local stop, not a permanent verdict.
+     */
+    private scheduleRestart(
+        policyId: string,
+        instance: IPolicyInstance,
+        policyOwnerId: string | null
+    ): void {
+        const attempts = (this.restartAttempts.get(policyId) || 0) + 1;
+        this.restartAttempts.set(policyId, attempts);
+
+        if (attempts >= this.maxRestartAttempts) {
+            this.logger.error(
+                `Policy ${policyId} failed to start ${attempts} times; releasing its slot instead of respawning`,
+                ['POLICY_SERVICE', policyId], policyOwnerId
+            );
+            this.container.delete(policyId);
+            this.restartAttempts.delete(policyId);
+            if (this.processCount < this.maxPolicyInstances) {
+                this.subscribeForModelGeneration();
+            }
+            return;
+        }
+
+        const delay = Math.min(
+            this.restartBaseDelayMs * Math.pow(2, attempts - 1),
+            this.restartMaxDelayMs
+        );
+        setTimeout(() => {
+            this.logger.warn(`Process for policy with id: ${policyId} respawning (attempt ${attempts + 1}) after ${delay}ms`, ['POLICY_SERVICE', policyId], policyOwnerId);
+            instance.process = null;
+        }, delay)
     }
 }

--- a/policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs
@@ -225,12 +225,31 @@ describe('@unit PolicyContainer spawn failure + crash loop', () => {
 
             // Spawn failure: Node emits 'error' and 'exit' may never follow.
             lastForked._fire('error', new Error('spawn EAGAIN'));
+            // released on the backoff timer, not inline - a spawn that keeps failing
+            // is a crash loop and goes through the same ceiling
+            await new Promise((r) => setTimeout(r, 20));
         } finally { console.debug = origDebug; }
 
         assert.isNull(instance.process,
             'the handle must be released or the sweep skips this policy forever');
         assert.isTrue(c.container.has('p1'),
             'the policy itself stays queued for the next sweep');
+    });
+
+    it('A2: a spawn that keeps failing gives up instead of retrying forever', async () => {
+        const { c, instance } = await withPolicy();
+        const origDebug = console.debug; console.debug = () => {};
+        try {
+            // POLICY_MAX_RESTART_ATTEMPTS is 3 for this suite
+            for (let i = 0; i < 3; i++) {
+                c.runPolicyProcess(instance);
+                lastForked._fire('error', new Error('spawn EAGAIN'));
+                await new Promise((r) => setTimeout(r, 20));
+            }
+        } finally { console.debug = origDebug; }
+
+        assert.isFalse(c.container.has('p1'),
+            'the slot is released rather than held by a policy that cannot spawn');
     });
 
     it('B: backs off between crash respawns instead of a fixed 10s', async () => {
@@ -390,6 +409,38 @@ describe('@unit PolicyContainer scale-up', () => {
         await c.checkForRunNewInstance();
         assert.lengthOf(execFileCalls, 0, 'aaa sorts first and is the elected scaler');
         assert.isTrue(c.startNewPolicyServiceTriggered, 'the loser holds off for the cooldown');
+    });
+
+    it('a free peer cannot be elected, however its id sorts', async () => {
+        // 'aaa' has capacity, so its own checkForRunNewInstance returns at the first
+        // line and it never spawns. Electing it parks the fleet behind a leader that
+        // cannot act.
+        const c = await saturated([
+            peer('aaa', true, 1),
+            peer('uuid-fixed', false, 0),
+        ]);
+        await c.checkForRunNewInstance();
+        assert.deepEqual(execFileCalls, ['/run.sh'],
+            'the saturated service scales rather than deferring to one with headroom');
+        assert.isTrue(c.startNewPolicyServiceTriggered,
+            'the cooldown is armed by the service that actually scaled');
+    });
+
+    it('an explicit SCALE_HEADROOM_SLOTS=0 is honoured, not read as unset', async () => {
+        // 0 means "no buffer": scale only once nothing is free. Read as unset it would
+        // fall through to maxPolicyInstances (2 here) and scale with a slot to spare.
+        const c = await saturated([
+            peer('uuid-fixed', false, 0),
+            peer('zzz', true, 1),
+        ], { SCALE_HEADROOM_SLOTS: '0' });
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 0, 'one free slot is enough when no buffer was asked for');
+    });
+
+    it('with no buffer configured it still scales once nothing is free', async () => {
+        const c = await saturated([peer('uuid-fixed', false, 0)], { SCALE_HEADROOM_SLOTS: '0' });
+        await c.checkForRunNewInstance();
+        assert.deepEqual(execFileCalls, ['/run.sh']);
     });
 
     it('overlapping runs cannot both trigger a replica', async () => {

--- a/policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs
@@ -1,0 +1,450 @@
+import { assert } from 'chai';
+import esmock from 'esmock';
+
+/**
+ * Coverage for #1934: a pod could end up below capacity, unsealed, and deaf to
+ * GENERATE_POLICY while still advertising free slots.
+ *
+ * unsubscribeFromModelGeneration() dereferenced `generatePolicySubscription`
+ * inside its 500ms timer, so it cancelled whatever subscription was current when
+ * it fired rather than the one it was scheduled for. A policy exiting inside that
+ * window re-subscribes, and the stale timer then tore down that NEW subscription.
+ *
+ * Measured on dev: two pods sat at 18/25 and 24/25 `Sealed: false` for 99
+ * consecutive 10-minute samples (~16.5h) with ~67 policies unhosted. Because they
+ * kept reporting free capacity, checkForRunNewInstance's `hasFree` bail-out also
+ * stopped every other pod from scaling the fleet up.
+ */
+
+const FREE_STATUS = 'FREE_STATUS';
+const GENERATE_POLICY = 'GEN';
+const GET_FREE = 'GET_FREE';
+
+// Every subscription handed out by the fake broker, so a test can assert exactly
+// which one was torn down.
+let subscriptions;
+let lastForked;
+let execFileCalls;
+
+function makeHarness() {
+    class FakeNatsService {
+        constructor() {}
+        async init() {}
+        subscribe(event, cb) { this._subs.set(event, cb); }
+        getMessages(event, cb) {
+            this._msgs.set(event, cb);
+            const sub = { event, unsubscribed: false, unsubscribe() { this.unsubscribed = true; } };
+            subscriptions.push(sub);
+            return sub;
+        }
+        sendMessage(subject, payload) { this._sent.push({ subject, payload }); }
+        publish() { return Promise.resolve(); }
+        _subs = new Map();
+        _msgs = new Map();
+        _sent = [];
+    }
+
+    return esmock.strict(
+        '../../../dist/helpers/policy-container.js',
+        {
+            '@guardian/common': {
+                MessageResponse: class { constructor(body) { this.body = body; } },
+                NatsService: FakeNatsService,
+                PinoLogger: class { info() {} error() {} warn() {} },
+                Singleton: (target) => target,
+            },
+            '@guardian/interfaces': {
+                GenerateUUIDv4: () => 'uuid-fixed',
+                PolicyEvents: {
+                    GET_FREE_POLICY_SERVICES: GET_FREE,
+                    POLICY_SERVICE_FREE_STATUS: FREE_STATUS,
+                    GENERATE_POLICY,
+                },
+            },
+            'node:child_process': {
+                ChildProcess: class {},
+                fork: () => {
+                    // A process stub whose handlers can be fired, so the exit branch
+                    // is reachable from a unit test.
+                    const handlers = {};
+                    const proc = {
+                        pid: 1234,
+                        on(ev, cb) { handlers[ev] = cb; return proc; },
+                        once(ev, cb) { handlers[ev] = cb; return proc; },
+                        send() {}, kill() {},
+                        _fire(ev, ...args) { return handlers[ev] && handlers[ev](...args); },
+                    };
+                    lastForked = proc;
+                    return proc;
+                },
+                execFile: (...args) => { execFileCalls.push(args[0]); },
+            },
+            '../../../dist/api/policy-process-path.js': { POLICY_PROCESS_PATH: '/fake/path.js' },
+        },
+    );
+}
+
+const fakeLogger = { info() {}, error() {}, warn() {} };
+const cfg = (policyId) => ({
+    policyId, policyServiceName: 'svc',
+    skipRegistration: false, policyOwnerId: 'owner', enableMock: false,
+});
+
+// init() installs 1s/10m/30m intervals; stub them so nothing lingers past a test.
+async function initQuiet(container) {
+    const realSetInterval = global.setInterval;
+    global.setInterval = () => 0;
+    try {
+        await container.init();
+    } finally {
+        global.setInterval = realSetInterval;
+    }
+}
+
+describe('@unit PolicyContainer GENERATE_POLICY intake race', () => {
+    let PolicyContainer;
+
+    beforeEach(async () => {
+        subscriptions = []; execFileCalls = [];
+        process.env.MAX_POLICY_INSTANCES = '1';
+        ({ PolicyContainer } = await makeHarness());
+    });
+
+    afterEach(() => {
+        delete process.env.MAX_POLICY_INSTANCES;
+    });
+
+    it('a re-subscribe inside the 500ms window survives the pending unsubscribe', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+
+        // Fill the pod, then have a refused add schedule the unsubscribe.
+        assert.isTrue(c.addPolicy(cfg('p1')));
+        assert.isFalse(c.addPolicy(cfg('p2')), 'second add must be refused at capacity');
+
+        // A policy exits inside the window: the pod drops below capacity and
+        // re-subscribes. This is the subscription that used to be destroyed.
+        c.container.delete('p1');
+        c.subscribeForModelGeneration();
+        const live = subscriptions[subscriptions.length - 1];
+
+        await new Promise((resolve) => setTimeout(resolve, 700));
+
+        assert.isFalse(live.unsubscribed, 'the newer subscription must not be torn down');
+        assert.isTrue(c.intakeSubscribed, 'pod must still be listening for GENERATE_POLICY');
+        assert.isTrue(c.addPolicy(cfg('p3')), 'pod below capacity must accept work again');
+    });
+
+    it('still unsubscribes when nothing re-subscribed in the window', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        const original = subscriptions[subscriptions.length - 1];
+
+        assert.isTrue(c.addPolicy(cfg('p1')));
+        assert.isFalse(c.addPolicy(cfg('p2')));
+
+        await new Promise((resolve) => setTimeout(resolve, 700));
+
+        assert.isTrue(original.unsubscribed, 'a full pod should stop taking GENERATE_POLICY');
+        assert.isFalse(c.intakeSubscribed);
+    });
+
+    it('a pod that is not listening advertises no capacity even when below its limit', async () => {
+        // The shape a SIGKILL exit leaves behind: a slot is freed but intake was
+        // never re-enabled. Reporting that slot keeps `hasFree` true fleet-wide and
+        // blocks scale-up, so an unsubscribed pod must report free=false/count=0.
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        const handler = c._subs.get(GET_FREE);
+        assert.isFunction(handler, 'GET_FREE handler should be registered');
+
+        c.intakeSubscribed = false;
+        c._sent.length = 0;
+        handler({ replySubject: 'reply.subject', requestId: 'r1' });
+
+        const reply = c._sent.find((m) => m.subject === 'reply.subject');
+        assert.ok(reply, 'a reply should be sent');
+        assert.equal(reply.payload.free, false);
+        assert.equal(reply.payload.count, 0);
+    });
+
+    it('reports capacity again once intake is restored', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        const handler = c._subs.get(GET_FREE);
+
+        c.intakeSubscribed = false;
+        c.subscribeForModelGeneration();
+
+        c._sent.length = 0;
+        handler({ replySubject: 'reply.subject', requestId: 'r1' });
+
+        const reply = c._sent.find((m) => m.subject === 'reply.subject');
+        assert.equal(reply.payload.free, true);
+        assert.equal(reply.payload.count, 1);
+    });
+});
+
+
+
+/*
+ *   A. a spawn failure ('error' with no following 'exit') left instance.process
+ *      set, so the 1s sweep skipped the policy forever while it still counted
+ *      against processCount - a slot held by a policy that was not running
+ *   B. a crashing policy re-forked every 10s with no backoff and no ceiling
+ */
+describe('@unit PolicyContainer spawn failure + crash loop', () => {
+    let PolicyContainer;
+
+    beforeEach(async () => {
+        subscriptions = []; lastForked = undefined; execFileCalls = [];
+        process.env.MAX_POLICY_INSTANCES = '5';
+        process.env.POLICY_RESTART_BASE_DELAY_MS = '5';
+        process.env.POLICY_MAX_RESTART_ATTEMPTS = '3';
+        ({ PolicyContainer } = await makeHarness());
+    });
+    afterEach(() => {
+        delete process.env.MAX_POLICY_INSTANCES;
+        delete process.env.POLICY_RESTART_BASE_DELAY_MS;
+        delete process.env.POLICY_MAX_RESTART_ATTEMPTS;
+    });
+
+    async function withPolicy() {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        c.addPolicy(cfg('p1'));
+        return { c, instance: c.container.get('p1') };
+    }
+
+    it('A: releases the instance when the process cannot be spawned', async () => {
+        const { c, instance } = await withPolicy();
+        const origDebug = console.debug; console.debug = () => {};
+        try {
+            c.runPolicyProcess(instance);
+            assert.ok(instance.process, 'a process handle is assigned up front');
+
+            // Spawn failure: Node emits 'error' and 'exit' may never follow.
+            lastForked._fire('error', new Error('spawn EAGAIN'));
+        } finally { console.debug = origDebug; }
+
+        assert.isNull(instance.process,
+            'the handle must be released or the sweep skips this policy forever');
+        assert.isTrue(c.container.has('p1'),
+            'the policy itself stays queued for the next sweep');
+    });
+
+    it('B: backs off between crash respawns instead of a fixed 10s', async () => {
+        const { c, instance } = await withPolicy();
+        const key = 'p1';
+        const delays = [];
+        const realSetTimeout = global.setTimeout;
+        global.setTimeout = (fn, ms) => { delays.push(ms); return realSetTimeout(fn, 0); };
+        const origDebug = console.debug; console.debug = () => {};
+        try {
+            for (let i = 0; i < 2; i++) {
+                c.runPolicyProcess(instance);
+                lastForked._fire('exit', 1, null);      // crash, not a clean exit
+                await new Promise((r) => realSetTimeout(r, 5));
+            }
+        } finally { global.setTimeout = realSetTimeout; console.debug = origDebug; }
+
+        assert.equal(c.restartAttempts.get(key), 2, 'attempts are counted per policy');
+        assert.isAbove(delays[1], delays[0], 'the delay must grow, not stay fixed');
+    });
+
+    it('B: gives up and releases the slot after the attempt ceiling', async () => {
+        const { c, instance } = await withPolicy();
+        const key = 'p1';
+        const realSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => realSetTimeout(fn, 0);
+        const origDebug = console.debug; console.debug = () => {};
+        try {
+            for (let i = 0; i < 3; i++) {
+                c.runPolicyProcess(instance);
+                lastForked._fire('exit', 1, null);
+                await new Promise((r) => realSetTimeout(r, 5));
+            }
+        } finally { global.setTimeout = realSetTimeout; console.debug = origDebug; }
+
+        assert.isFalse(c.container.has(key),
+            'a policy that will not start must not hold a slot forever');
+        assert.isFalse(c.restartAttempts.has(key), 'its counter goes with it');
+    });
+
+    it('B: a clean exit resets the crash count', async () => {
+        const { c, instance } = await withPolicy();
+        const key = 'p1';
+        const realSetTimeout = global.setTimeout;
+        global.setTimeout = (fn) => realSetTimeout(fn, 0);
+        const origDebug = console.debug; console.debug = () => {};
+        try {
+            c.runPolicyProcess(instance);
+            lastForked._fire('exit', 1, null);                  // crash
+            await new Promise((r) => realSetTimeout(r, 5));
+            assert.equal(c.restartAttempts.get(key), 1);
+
+            c.container.set(key, instance);                     // re-added, then exits cleanly
+            c.runPolicyProcess(instance);
+            lastForked._fire('exit', 0, null);
+        } finally { global.setTimeout = realSetTimeout; console.debug = origDebug; }
+
+        assert.isFalse(c.restartAttempts.has(key), 'a healthy stop must not count against it');
+    });
+});
+
+/*
+ * Scale-up used to stop after one round per service. `startNewPolicyServiceTriggered`
+ * was a permanent boolean cleared only when a policy EXITED, so a service that
+ * filled up and stayed full asked for a replica exactly once in its lifetime. On top
+ * of that, `hasFree` bailed out if any peer reported a single free slot, so a nearly
+ * saturated fleet never grew.
+ */
+describe('@unit PolicyContainer scale-up', () => {
+    let PolicyContainer;
+
+    const peer = (instanceId, free, count, triggered = false) => ({
+        service: 'svc', instanceId, free, count,
+        requestId: 'r', startNewPolicyServiceTriggered: triggered,
+    });
+
+    // Saturate the service and drive one scaling round against a fixed peer set.
+    async function saturated(peers, env = {}) {
+        Object.assign(process.env, env);
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        c.runServiceScript = '/run.sh';
+        for (let i = 0; i < 2; i++) { c.addPolicy(cfg(`p${i}`)); }
+        c.getFreePolicyServices = async () => peers;
+        return c;
+    }
+
+    beforeEach(async () => {
+        subscriptions = []; execFileCalls = [];
+        process.env.MAX_POLICY_INSTANCES = '2';
+        ({ PolicyContainer } = await makeHarness());
+    });
+    afterEach(() => {
+        delete process.env.MAX_POLICY_INSTANCES;
+        delete process.env.SCALE_COOLDOWN_MS;
+        delete process.env.SCALE_HEADROOM_SLOTS;
+    });
+
+    it('scales when the fleet is saturated', async () => {
+        const c = await saturated([peer('uuid-fixed', false, 0)]);
+        await c.checkForRunNewInstance();
+        assert.deepEqual(execFileCalls, ['/run.sh']);
+    });
+
+    it('re-arms after the cooldown instead of sealing for the process lifetime', async () => {
+        const c = await saturated([peer('uuid-fixed', false, 0)], { SCALE_COOLDOWN_MS: '30' });
+        await c.checkForRunNewInstance();
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 1, 'the cooldown must suppress the immediate retry');
+
+        await new Promise(r => setTimeout(r, 45));
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 2, 'a still-saturated fleet must scale again after the cooldown');
+    });
+
+    it('a single free slot elsewhere no longer blocks scaling', async () => {
+        // 'zzz' sorts after this service, so this one is the elected scaler and the
+        // assertion isolates the headroom rule from the election.
+        const c = await saturated([
+            peer('uuid-fixed', false, 0),
+            peer('zzz', true, 1),
+        ]);
+        await c.checkForRunNewInstance();
+        assert.deepEqual(execFileCalls, ['/run.sh']);
+    });
+
+    it('does not scale while the fleet still has a service worth of headroom', async () => {
+        const c = await saturated([
+            peer('uuid-fixed', false, 0),
+            peer('zzz', true, 2),
+        ]);
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 0);
+    });
+
+    it('an empty reply set means nobody answered, not that the fleet is full', async () => {
+        const c = await saturated([]);
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 0, 'a broker hiccup must not be read as zero capacity');
+    });
+
+    it('stands down when a peer is already inside its cooldown', async () => {
+        const c = await saturated([
+            peer('uuid-fixed', false, 0),
+            peer('zzz', false, 0, true),
+        ]);
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 0, 'only one service may scale per cooldown');
+    });
+
+    it('only the elected service scales; the loser holds off', async () => {
+        // Election is by instanceId order, and this service is 'uuid-fixed'.
+        const c = await saturated([
+            peer('aaa', false, 0),
+            peer('uuid-fixed', false, 0),
+        ]);
+        await c.checkForRunNewInstance();
+        assert.lengthOf(execFileCalls, 0, 'aaa sorts first and is the elected scaler');
+        assert.isTrue(c.startNewPolicyServiceTriggered, 'the loser holds off for the cooldown');
+    });
+
+    it('overlapping runs cannot both trigger a replica', async () => {
+        let release;
+        const gate = new Promise(r => { release = r; });
+        const c = await saturated([peer('uuid-fixed', false, 0)]);
+        c.getFreePolicyServices = async () => { await gate; return [peer('uuid-fixed', false, 0)]; };
+
+        const first = c.checkForRunNewInstance();
+        const second = c.checkForRunNewInstance();   // must find the in-flight guard set
+        release();
+        await Promise.all([first, second]);
+        assert.lengthOf(execFileCalls, 1, 'the 1s interval does not await, so re-entry must be guarded');
+    });
+});
+
+/*
+ * getFreePolicyServices only deletes the request id it is waiting on, but the reply
+ * handler created a bucket for any id it saw. A reply arriving after the 500ms
+ * window therefore re-created an entry that nothing ever removed - one leaked Map
+ * entry per late reply, in a process that runs for weeks.
+ */
+describe('@unit PolicyContainer free-status reply bookkeeping', () => {
+    let PolicyContainer;
+
+    beforeEach(async () => {
+        subscriptions = []; execFileCalls = [];
+        ({ PolicyContainer } = await makeHarness());
+    });
+
+    const replyTo = (c, msg) =>
+        c._msgs.get([c.replySubject, FREE_STATUS, c.instanceId].join('.'))(msg);
+
+    it('drops a reply for a request it is no longer collecting', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        replyTo(c, { requestId: 'stale', instanceId: 'bbb', free: true, count: 1 });
+        assert.equal(c._policiInfoArrays.size, 0, 'a late reply must not resurrect a bucket');
+    });
+
+    it('collects replies for a request that is in flight, and cleans up after', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        const pending = c.getFreePolicyServices();
+        replyTo(c, { requestId: 'uuid-fixed', instanceId: 'bbb', free: true, count: 1 });
+        const got = await pending;
+        assert.lengthOf(got, 1);
+        assert.equal(c._policiInfoArrays.size, 0, 'the bucket is removed once resolved');
+    });
+
+    it('resolves an array even when nothing replies', async () => {
+        const c = new PolicyContainer(fakeLogger);
+        await initQuiet(c);
+        // Previously resolved undefined, which checkForRunNewInstance read as a
+        // falsy bail-out rather than "no answers".
+        assert.deepEqual(await c.getFreePolicyServices(), []);
+    });
+});


### PR DESCRIPTION
Fixes #6793.

## Problem

Four defects in `PolicyContainer`, each of which strands policy slots. Together they produce a fleet that stops growing while policies have nowhere to run — and a request to an unhosted policy then waits out the full Block Timeout, because there is genuinely no responder.

**The unsubscribe timer cancels whatever is current, not what it was scheduled for.** `unsubscribeFromModelGeneration()` re-reads `this.generatePolicySubscription` inside its 500 ms timer. A policy exiting inside that window calls `subscribeForModelGeneration()`, and the stale timer then tears down that *new* subscription. The service is left below capacity and deaf to `GENERATE_POLICY`.

**Capacity is reported from `processCount` alone**, so the service above still advertises `free: true`. `checkForRunNewInstance` bails when any peer reports free, so one such service suppresses scale-up for the entire fleet.

**`startNewPolicyServiceTriggered` is a permanent seal.** It is cleared only in `subscribeForModelGeneration()`, which on the scaling path runs only when a policy *exits*, so a service that fills up and stays full asks for a replica exactly once per lifetime. The `hasFree` bail-out compounds it: a single spare slot anywhere blocks scaling no matter how far short the fleet is.

**A failed spawn strands the slot.** Node emits `'error'` when a process cannot be spawned and `'exit'` may never follow; the handler only logged. `instance.process` is already assigned and `runPolicyProcess` skips instances that have one, so the policy stayed wedged forever while still counting against `processCount`. The non-zero-exit branch has the opposite problem — re-forking every 10 s with no backoff and no ceiling.

## Fix

**Generation counter for the unsubscribe.** `subscribeForModelGeneration()` bumps a counter; the pending timer no-ops if the generation changed, so a re-subscribe inside the window survives. It also drops any prior subscription before installing a new one, so repeated exit/respawn cycles cannot accumulate handlers.

**`canAcceptPolicies`** gates the advertised capacity on `intakeSubscribed && processCount < max`, and `count` reports 0 when the service cannot accept work. A service that is not listening no longer suppresses fleet-wide scaling.

**The seal becomes a timestamp** (`SCALE_COOLDOWN_MS`, default 60 s) so a fleet that stays saturated keeps scaling, and **`hasFree` becomes a headroom test** — scale when total free slots fall below one service's worth (`SCALE_HEADROOM_SLOTS`, defaulting to `MAX_POLICY_INSTANCES`).

Making the seal re-armable makes a stampede reachable where it previously was not — with a permanent seal, "one replica per window" was emergent, since each service could scale at most once ever. So the winner is now elected explicitly: services stand down if any peer is inside its cooldown, and otherwise the lowest `instanceId` scales. `startNewPolicyServiceTriggered` rides along in the existing scatter reply; no new transport. A synchronous in-flight guard covers re-entry, since the 1 s interval does not await `checkForRunNewInstance` and the scatter takes ~500 ms.

**Spawn failure clears `instance.process`** so the 1 s sweep re-forks on its next tick, and **crash respawns back off exponentially** (`POLICY_RESTART_BASE_DELAY_MS` → `POLICY_RESTART_MAX_DELAY_MS`) up to `POLICY_MAX_RESTART_ATTEMPTS`, after which the policy *releases* its slot rather than holding one it never uses. guardian-service can still assign it again through `GENERATE_POLICY`, so this is a local stop, not a permanent verdict. A clean exit resets the count.

**Reply bookkeeping.** The handler now drops replies for ids it is not collecting, and `getFreePolicyServices` registers the bucket before publishing and always resolves an array. That fixes both the per-late-reply Map leak and the `undefined` return that `checkForRunNewInstance` could not distinguish from "the fleet is full" — the new empty-set check treats no answers as no information rather than as zero capacity.

All five new env vars are optional and defaulted; behaviour with none of them set is the intended one.

## Tests

`policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs` — 19 specs across four groups: the intake race and honest capacity reporting, scale-up (cooldown re-arm, headroom, empty reply set, peer cooldown, election, re-entry), spawn failure and crash-loop backoff/ceiling/reset, and the free-status reply bookkeeping.

19 pass with the fix. Against unmodified `develop`, **15 of the 19 fail**.

```
$ yarn workspace policy-service run build
$ node_modules/.bin/mocha --no-config --exit \
    --spec policy-service/tests/unit-tests/helpers/policy-container-lifecycle.test.mjs
  19 passing
```

`yarn lint` in `policy-service` is clean.

## Note, deliberately not included

`develop` sets the stop script from the wrong variable:

```ts
this.stopServiceScript = process.env.RUN_SERVICE_SCRIPT;   // policy-container.ts:160
```

so the scale-down path at the empty-service branch runs the **start** script. It is unrelated to these four defects and wants its own explanation, so it is left untouched here — happy to send it separately.
