### PR TITLE
fix(guardian-service): check parent ownership before accepting an artifact upload

### DIFF
--- a/guardian-service/src/api/artifact.service.ts
+++ b/guardian-service/src/api/artifact.service.ts
@@ -55,6 +55,21 @@ export async function artifactAPI(logger: PinoLogger): Promise<void> {
                 return new MessageError('There is no appropriate policy', 422);
             }
 
+            /*
+             * The parent was resolved by id alone, so verify the caller owns it.
+             * Without this an artifact can be attached to another user's draft:
+             * the row is written with the uploader as `owner`, so it is hidden
+             * from the policy owner's listing (GET_ARTIFACTS filters on owner)
+             * while export, comparison and publish key on `policyId` alone and
+             * pull it in. DELETE_ARTIFACT already scopes its lookup by owner.
+             *
+             * Answers exactly as for a missing parent: telling the caller the id
+             * exists but belongs to someone else is itself a disclosure.
+             */
+            if (parent.item?.owner !== owner.owner) {
+                return new MessageError('There is no appropriate policy', 422);
+            }
+
             const category: string = parent.type;
             if (parent.type === 'policy') {
                 if (parent.item.status !== PolicyStatus.DRAFT) {

--- a/guardian-service/src/api/artifact.service.ts
+++ b/guardian-service/src/api/artifact.service.ts
@@ -55,17 +55,8 @@ export async function artifactAPI(logger: PinoLogger): Promise<void> {
                 return new MessageError('There is no appropriate policy', 422);
             }
 
-            /*
-             * The parent was resolved by id alone, so verify the caller owns it.
-             * Without this an artifact can be attached to another user's draft:
-             * the row is written with the uploader as `owner`, so it is hidden
-             * from the policy owner's listing (GET_ARTIFACTS filters on owner)
-             * while export, comparison and publish key on `policyId` alone and
-             * pull it in. DELETE_ARTIFACT already scopes its lookup by owner.
-             *
-             * Answers exactly as for a missing parent: telling the caller the id
-             * exists but belongs to someone else is itself a disclosure.
-             */
+            // answers exactly as for a missing parent: saying the id exists but belongs
+            // to someone else is itself a disclosure
             if (parent.item?.owner !== owner.owner) {
                 return new MessageError('There is no appropriate policy', 422);
             }

--- a/guardian-service/tests/artifact-upload-owner.test.mjs
+++ b/guardian-service/tests/artifact-upload-owner.test.mjs
@@ -1,0 +1,107 @@
+import { assert } from 'chai';
+import { loadAPI, Interfaces } from './_handler-harness.mjs';
+
+/*
+ * UPLOAD_ARTIFACT resolved its parent policy/tool by id alone and checked only
+ * that it was a draft, never that the caller owned it.
+ *
+ * The row is written with the UPLOADER as `owner`, and GET_ARTIFACTS filters the
+ * listing on `owner`, so the policy owner never sees the injected artifact - while
+ * export, comparison and publish key on `policyId` alone and pull it in.
+ *
+ * DELETE_ARTIFACT in the same service already scopes its lookup by owner, which is
+ * what makes this an omission rather than a deliberate design.
+ */
+
+const M = Interfaces.MessageAPI;
+
+const OWNER = { creator: 'did:owner', owner: 'did:owner', id: 'u-owner' };
+const ATTACKER = { creator: 'did:mallory', owner: 'did:mallory', id: 'u-mallory' };
+
+const artifact = { filename: 'payload.json', buffer: Buffer.from('{}') };
+
+let H, store;
+
+function makeStore() {
+    return { policy: null, tool: null, saved: [] };
+}
+
+async function setup() {
+    store = makeStore();
+    const loaded = await loadAPI('../dist/api/artifact.service.js', 'artifactAPI', {
+        '@guardian/common': {
+            DatabaseServer: class {
+                static async getPolicyById() { return store.policy; }
+                static async getToolById() { return store.tool; }
+                static async saveArtifact(row) { store.saved.push(row); return { ...row, uuid: 'uuid-1' }; }
+                static async saveArtifactFile() {}
+            },
+            getArtifactExtention: () => 'json',
+            getArtifactType: () => 'json',
+        },
+    });
+    H = loaded.handlers;
+}
+
+const upload = (owner) => H[M.UPLOAD_ARTIFACT]({ artifact, parentId: 'p-1', owner });
+
+describe('@unit UPLOAD_ARTIFACT parent ownership', () => {
+    before(async function () {
+        this.timeout(180000);
+        await setup();
+    });
+    beforeEach(() => { store = Object.assign(store, makeStore()); });
+
+    it('accepts an upload from the policy owner', async () => {
+        store.policy = { id: 'p-1', status: 'DRAFT', owner: OWNER.owner };
+        const r = await upload(OWNER);
+        assert.isUndefined(r.error, `owner must be allowed: ${r.error}`);
+        assert.lengthOf(store.saved, 1);
+    });
+
+    it('refuses an upload against another user\'s draft policy', async () => {
+        store.policy = { id: 'p-1', status: 'DRAFT', owner: OWNER.owner };
+        const r = await upload(ATTACKER);
+        assert.isOk(r.error, 'a non-owner must not be able to attach an artifact');
+        assert.lengthOf(store.saved, 0, 'nothing may be written when the caller is not the owner');
+    });
+
+    it('does not disclose that the policy exists', async () => {
+        // Same answer as a missing parent: revealing "exists, but not yours"
+        // is itself a disclosure of another tenant's policy ids.
+        store.policy = { id: 'p-1', status: 'DRAFT', owner: OWNER.owner };
+        const denied = await upload(ATTACKER);
+
+        store.policy = null;
+        store.tool = null;
+        const missing = await upload(ATTACKER);
+
+        assert.equal(denied.error, missing.error, 'refusal must be indistinguishable from not-found');
+        assert.equal(denied.code, missing.code);
+    });
+
+    it('refuses an upload against another user\'s tool', async () => {
+        store.policy = null;
+        store.tool = { id: 'p-1', status: 'DRAFT', owner: OWNER.owner };
+        const r = await upload(ATTACKER);
+        assert.isOk(r.error, 'the tool branch must be scoped too');
+        assert.lengthOf(store.saved, 0);
+    });
+
+    it('accepts a tool upload from its owner', async () => {
+        store.policy = null;
+        store.tool = { id: 'p-1', status: 'DRAFT', owner: OWNER.owner };
+        const r = await upload(OWNER);
+        assert.isUndefined(r.error, `tool owner must be allowed: ${r.error}`);
+        assert.lengthOf(store.saved, 1);
+    });
+
+    it('still rejects a non-draft policy for its own owner', async () => {
+        // The status gate must survive the new ownership gate.
+        store.policy = { id: 'p-1', status: 'PUBLISH', owner: OWNER.owner };
+        const r = await upload(OWNER);
+        assert.isOk(r.error);
+        assert.match(String(r.error), /DRAFT/i);
+        assert.lengthOf(store.saved, 0);
+    });
+});

--- a/guardian-service/tests/artifact-upload-owner.test.mjs
+++ b/guardian-service/tests/artifact-upload-owner.test.mjs
@@ -2,15 +2,9 @@ import { assert } from 'chai';
 import { loadAPI, Interfaces } from './_handler-harness.mjs';
 
 /*
- * UPLOAD_ARTIFACT resolved its parent policy/tool by id alone and checked only
- * that it was a draft, never that the caller owned it.
- *
- * The row is written with the UPLOADER as `owner`, and GET_ARTIFACTS filters the
- * listing on `owner`, so the policy owner never sees the injected artifact - while
- * export, comparison and publish key on `policyId` alone and pull it in.
- *
- * DELETE_ARTIFACT in the same service already scopes its lookup by owner, which is
- * what makes this an omission rather than a deliberate design.
+ * UPLOAD_ARTIFACT resolved its parent by id alone and checked only that it was a
+ * draft, never that the caller owned it. The refusal reuses the not-found message
+ * so the caller cannot tell an id that exists from one that does not.
  */
 
 const M = Interfaces.MessageAPI;


### PR DESCRIPTION
Fixes #6810.

## Problem

`UPLOAD_ARTIFACT` resolves its parent policy or tool **by id alone** and checks only that it is a draft — never that the caller owns it. So an artifact can be attached to someone else's draft policy.

It is invisible to the victim: the row is written with the **uploader** as `owner`, and `GET_ARTIFACTS` filters the listing on `owner`, so the policy owner never sees it. The consumers that assemble the policy package key on `policyId` alone, so it is still pulled into that policy's export, comparison and publish.

`DELETE_ARTIFACT` in the same service already scopes its lookup by owner, which is what makes this an omission rather than a deliberate design.

## Fix

One ownership check on the resolved parent, covering both the policy and the tool branch.

It reuses the existing `'There is no appropriate policy'` 422 rather than a distinct message. Answering differently for *"exists, but not yours"* would confirm that an id exists in another user's account, which is a disclosure in its own right — so a refusal is indistinguishable from a miss.

The status gate is untouched and still applies to the owner's own non-draft policies.

## Tests

`guardian-service/tests/artifact-upload-owner.test.mjs` — 6 cases on the existing `_handler-harness.mjs`:

- accepts an upload from the policy owner *(control)*
- refuses an upload against another user's draft policy
- does not disclose that the policy exists — refusal is byte-identical to not-found
- refuses an upload against another user's tool
- accepts a tool upload from its owner *(control)*
- still rejects a non-draft policy for its own owner *(control — the status gate survives)*

**Three fail against current `develop`**; the other three are controls that pass either way.

## Note on running the suite

The three new cases pass in isolation and fail as expected without the fix. The full `guardian-service` suite could not be run in my environment — `tests/**` fails to load on `SyntaxError: The requested module '@hiero-ledger/sdk' does not provide an export named 'MirrorNodeAccountBalanceQuery'`. I confirmed that error reproduces on a clean checkout with my changes stashed, so it is pre-existing and unrelated to this branch, but it does mean I have not exercised the whole suite locally.
