### PR TITLE
fix: schema nav buttons submit the enclosing form

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-form-navigation/schema-form-navigation.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-form-navigation/schema-form-navigation.component.html
@@ -21,6 +21,7 @@
         class="nav-label"
         (click)="onSelect(node)"
         [pTooltip]="node.title"
+        type="button"
         >
         <span class="nav-title">{{ node.title }}</span>
         @if (node.count) {

--- a/frontend/src/app/modules/schema-engine/schema-form-view-navigation/schema-form-view-navigation.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-form-view-navigation/schema-form-view-navigation.component.html
@@ -20,6 +20,7 @@
           class="nav-label"
           (click)="onSelect(node)"
           [pTooltip]="node.title"
+          type="button"
           >
           <span class="nav-title">{{ node.title }}</span>
           @if (node.count) {


### PR DESCRIPTION
**Description**:

Buttons in the schema form navigation tree (section toggle / section title) don't declare a `type` attribute, so the browser defaults them to `type="submit"`. When this navigation is rendered inside a form (e.g. the document creation / registration flow), clicking a section in the tree submits the enclosing form instead of just scrolling to or expanding that section - on an invalid form it jumps straight to validation errors, on a valid form it submits/creates the document unintentionally.

- Add `type="button"` to the section-toggle and section-title buttons in `schema-form-navigation.component.html`
- Add `type="button"` to the section-title button in `schema-form-view-navigation.component.html`

**Related issue(s)**:

Fixes #6813

**Notes for reviewer**:

Template-only change, no TS/logic touched. Root cause confirmed by inspecting the usages: these components are rendered inside `<form (ngSubmit)="onStep()">` in `request-document-block.component.html` and `request-document-block-dialog.component.html`, so an untyped `<button>` there defaults to `submit` and fires the form's submit handler on click instead of only running its own `(click)` handler.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)