### PR TITLE
fix(frontend): four schema editor UI defects

### DIFF
--- a/frontend/src/app/modules/schema-engine/schema-delete-dialog/schema-delete-dialog.component.html
+++ b/frontend/src/app/modules/schema-engine/schema-delete-dialog/schema-delete-dialog.component.html
@@ -17,7 +17,7 @@
   @if (itemNames && itemNames.length && itemNames.length > 0) {
     @if (itemNames && itemNames.length && itemNames.length == 1) {
       <div class="delete-text">
-        Are you want to delete the "{{ itemNames[0] }}" schema?
+        Do you want to delete the "{{ itemNames[0] }}" schema?
       </div>
     }
     @if (itemNames && itemNames.length && itemNames.length > 1) {

--- a/frontend/src/app/services/handle-errors.service.ts
+++ b/frontend/src/app/services/handle-errors.service.ts
@@ -28,6 +28,18 @@ export class HandleErrorsService implements HttpInterceptor {
     excludeErrorCodes: string[] = ['401'];
     excludeErrorTexts: string[] = ['Block Unavailable'];
 
+    private titleFromCode(message: any): string | null {
+        const match = /^([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\s*:/.exec(String(message ?? '').trim());
+        if (!match) {
+            return null;
+        }
+        return match[1]
+            .toLowerCase()
+            .split('_')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+    }
+
     private messageToText(message: any) {
         if (typeof message === 'object') {
             return JSON.stringify(message, null, 2);
@@ -82,8 +94,11 @@ export class HandleErrorsService implements HttpInterceptor {
                 } else {
                     text = `${this.messageToText(translatedMessage.text)}`;
                 }
+                const codeTitle = this.titleFromCode(errorObject.message);
                 if (errorObject.type) {
                     header = `${errorObject.statusCode} ${(translatedMessage.wasTranslated) ? 'Hedera transaction failed' : errorObject.type}`;
+                } else if (!translatedMessage.wasTranslated && codeTitle) {
+                    header = codeTitle;
                 } else {
                     header = `${errorObject.statusCode} ${(translatedMessage.wasTranslated) ? 'Hedera transaction failed' : 'Other Error'}`;
                 }

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.scss
@@ -462,8 +462,14 @@
 
     i { font-size: 13px; }
 
-    &:hover {
+    &:hover:not(:disabled) {
         background: var(--guardian-grey-background, #F9FAFC);
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.45;
+        filter: none;
     }
 }
 
@@ -472,9 +478,15 @@
     color: #fff;
     border-color: var(--color-primary, #4169E2);
 
-    &:hover {
+    &:hover:not(:disabled) {
         filter: brightness(0.92);
         background: var(--color-primary, #4169E2);
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.45;
+        filter: none;
     }
 }
 

--- a/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
+++ b/frontend/src/app/views/schemas-configuration/schemas-configuration.component.ts
@@ -194,6 +194,7 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
 
     public get canPublishTemplate(): boolean {
         if (!this.isTemplateConfigMode || !this.schemaTemplate?.id) { return false; }
+        if (this.hasUnsavedChanges) { return false; }
         const status = this.schemaTemplate.status;
         return status === ModuleStatus.DRAFT || status === ModuleStatus.PUBLISH_ERROR;
     }
@@ -1331,7 +1332,8 @@ export class SchemasConfigurationComponent implements OnInit, OnDestroy {
         const createObs = toCreate.map(s =>
             this.schemaService.create(s.category ?? this.getCategory(), s, this.topic).pipe(
                 map((schemas: ISchema[]) => {
-                    const saved = schemas.find(r => r.uuid === s.uuid && r.topicId === this.topic);
+                    const matches = schemas.filter(r => r.uuid === s.uuid);
+                    const saved = matches.find(r => r.topicId === this.topic) ?? matches[0];
                     const savedId = saved?.id || (saved as any)?._id;
                     if (savedId) {
                         s.id = savedId;


### PR DESCRIPTION
Fixes #6826.

Four schema-editor defects found together while working through that area.

## 1. Disabled buttons render as enabled

`.sc-btn` and `.sc-btn-primary` had no `:disabled` rule, so Publish, Export, New Version and "Add link" showed full active styling while carrying the `disabled` attribute. Added, matching the dim-and-drop-the-cursor convention the other button classes in the same file already use.

The hover rules moved behind `:not(:disabled)` — without that, a disabled primary button keeps `filter: brightness(0.92)` on hover, which is a large part of why it reads as clickable.

## 2. Publish and Export stay disabled after a successful save

```ts
const saved = schemas.find(r => r.uuid === s.uuid && r.topicId === this.topic);
```

A schema created without a topic is stored with the placeholder `'draft'` (`schema-helper.ts`: `topic?.topicId || 'draft'`), so this never matches a fresh draft. `s.id` was never assigned, `selectedSchemaId` stayed null, and both buttons stayed disabled even though the schema was persisted and its id returned.

`uuid` already identifies the schema, so the match is on `uuid`, with the topic comparison kept as a *preference* for the case where several rows share one:

```ts
const matches = schemas.filter(r => r.uuid === s.uuid);
const saved = matches.find(r => r.topicId === this.topic) ?? matches[0];
```

## 3. Templates publish while dirty

`canPublishTemplate` now returns false while `hasUnsavedChanges` — the same flag that already drives the "Unsaved changes" indicator beside the button, so the control and the indicator now agree.

## 4. "&lt;status&gt; Other Error" toasts

A leading machine code is promoted to the title, so `MESSAGE_NOT_FOUND: …` reads **"Message Not Found"** instead of "500 Other Error".

**The generic label is deliberately unchanged** for messages with no code. `getMessage()` builds that same `Other Error` string in four branches; renaming it in only the one being edited would make the header differ by code path. That rename is defensible on its own but belongs in its own change. (I made exactly that mistake first and backed it out.)

## Also

Delete confirmation read "Are you want to delete" → "Do you want to delete".

## Verification

Reproduced and checked in a browser against a stubbed API. Defect 2 was verified against the backend rather than inferred from the symptom — `schema-helper.ts` is what makes the comparison unsatisfiable.

I could not get a clean `ng build` in my checkout to confirm compilation: it fails on `Could not resolve "marked"` (declared `^12.0.2`, absent from `node_modules`), and it fails identically with my changes stashed, so it is a pre-existing environment issue rather than anything in this diff. The same four edits compile and pass tests in a downstream fork carrying identical files.
