### PR TITLE
fix: 6774 stop standard registry relationship fallthrough

### DIFF
--- a/indexer-service/src/utils/relationships.ts
+++ b/indexer-service/src/utils/relationships.ts
@@ -290,6 +290,7 @@ export class Relationships {
                         type: 'relationships',
                     });
                 }
+                break;
             }
             case MessageType.CONTRACT: {
                 tagsCount = await this.em.count(Message, {

--- a/indexer-service/tests/relationships.test.mjs
+++ b/indexer-service/tests/relationships.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { DataBaseHelper } from '@indexer/common';
+import { MessageType, TagType } from '@indexer/interfaces';
+import { Relationships } from '../dist/utils/relationships.js';
+
+describe('Relationships.load', () => {
+    let originalGetEntityManager;
+
+    afterEach(() => {
+        DataBaseHelper.getEntityManager = originalGetEntityManager;
+    });
+
+    it('does not count Contract tags for a Standard Registry', async () => {
+        const registry = {
+            consensusTimestamp: 'registry-1',
+            uuid: 'registry-uuid',
+            type: MessageType.STANDARD_REGISTRY,
+            topicId: 'registry-topic',
+            options: { did: 'did:hedera:registry' },
+        };
+        const policy = {
+            consensusTimestamp: 'policy-1',
+            uuid: 'policy-uuid',
+            type: MessageType.INSTANCE_POLICY,
+            topicId: 'policy-topic',
+            options: {},
+        };
+        const countFilters = [];
+        originalGetEntityManager = DataBaseHelper.getEntityManager;
+        DataBaseHelper.getEntityManager = () => ({
+            findOne: async () => registry,
+            find: async (_entity, filter) =>
+                filter['options.owner'] ? [policy] : [],
+            count: async (_entity, filter) => {
+                countFilters.push(filter);
+                return 3;
+            },
+        });
+
+        const graph = await new Relationships(registry).load();
+
+        assert.deepEqual(countFilters.map((filter) => filter['options.entity']), [TagType.Policy]);
+        assert.equal(graph.relationships.find((item) => item.id === 'registry-1').tagsCount, 0);
+        assert.equal(graph.relationships.find((item) => item.id === 'policy-1').tagsCount, 3);
+    });
+});


### PR DESCRIPTION
**Description**:

The Indexer relationship graph could treat a Standard Registry as a Contract after it had finished adding the registry's policy children. The registry switch arm had no `break`, so JavaScript continued into the following Contract arm. That arm counted Contract tags for the registry topic and overwrote the registry's default tag count. A registry could therefore show a Contract tag badge and make an extra database count query.

This change ends Standard Registry handling before the Contract arm. Registry relationship nodes now keep `tagsCount: 0`, while their policy children keep their existing Policy tag counts. A focused Indexer unit test stubs the entity manager and checks both the returned graph and the query path, proving that Contract tags are not counted for registries.

Fixes #6774

**Checklist**:

- [x] Tests added or updated
- [x] Documentation considered; no user-facing page is required