### PR TITLE
fix: 6835 prevent a policy from being started twice and hosted by two processes

### DIFF
--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -238,6 +238,12 @@ export class PolicyEngine extends NatsService {
     private readonly policyReadyCallbacks: Map<string, (data: any, error?: any) => void> = new Map();
 
     /**
+     * Starts currently in flight, keyed by policy id
+     * @private
+     */
+    private readonly inFlightStarts: Map<string, Promise<any>> = new Map();
+
+    /**
      * Policy initialization errors container
      * @private
      */
@@ -2453,6 +2459,28 @@ export class PolicyEngine extends NatsService {
      * @param policyId
      */
     public async generateModel(policyId: string, enableMock: boolean): Promise<any> {
+        const inFlight = this.inFlightStarts.get(policyId);
+        if (inFlight) {
+            return inFlight;
+        }
+
+        const start = this.startModel(policyId, enableMock)
+            // Released before the caller settles, so a `.then` that starts the policy
+            // again cannot observe a stale entry. `finally` runs too late for that.
+            .then(
+                (result) => { this.inFlightStarts.delete(policyId); return result; },
+                (error) => { this.inFlightStarts.delete(policyId); throw error; }
+            );
+        this.inFlightStarts.set(policyId, start);
+        return start;
+    }
+
+    /**
+     * Start the policy process. Callers go through generateModel, which serialises
+     * concurrent starts of the same policy.
+     * @param policyId
+     */
+    private async startModel(policyId: string, enableMock: boolean): Promise<any> {
         const policy = await DatabaseServer.getPolicyById(policyId);
         if (!policy || (typeof policy !== 'object')) {
             throw new Error('Policy was not exist');
@@ -2493,7 +2521,7 @@ export class PolicyEngine extends NatsService {
             } else {
                 await new Promise(resolve => setTimeout(resolve, 10000));
 
-                return this.generateModel(policyId, enableMock);
+                return this.startModel(policyId, enableMock);
             }
         } else {
             return Promise.resolve();

--- a/guardian-service/src/policy-engine/policy-engine.ts
+++ b/guardian-service/src/policy-engine/policy-engine.ts
@@ -244,6 +244,12 @@ export class PolicyEngine extends NatsService {
     private readonly inFlightStarts: Map<string, Promise<any>> = new Map();
 
     /**
+     * Ceiling on one start attempt, after which the entry is released so a later
+     * caller can retry rather than await a promise that will never settle.
+     */
+    private static readonly START_TIMEOUT_MS = 15 * 60 * 1000;
+
+    /**
      * Policy initialization errors container
      * @private
      */
@@ -2450,8 +2456,19 @@ export class PolicyEngine extends NatsService {
      * @param policyOwnerId
      */
     public async destroyModel(policyId: string, policyOwnerId: string | null): Promise<void> {
+        //a start in flight can no longer complete: the child exits with code 0 and no
+        //ready event follows, so the entry has to go with it
+        this.clearInFlightStart(policyId);
         PolicyServiceChannelsContainer.deletePolicyServiceChannel(policyId);
         new GuardiansService().sendPolicyMessage(PolicyEvents.DELETE_POLICY, policyId, { policyOwnerId });
+    }
+
+    /**
+     * Drop a recorded start attempt, so the next caller starts afresh.
+     * @param policyId
+     */
+    private clearInFlightStart(policyId: string): void {
+        this.inFlightStarts.delete(policyId);
     }
 
     /**
@@ -2464,12 +2481,25 @@ export class PolicyEngine extends NatsService {
             return inFlight;
         }
 
-        const start = this.startModel(policyId, enableMock)
+        // Bounded: startModel's confirmed branch waits on POLICY_READY with no timeout,
+        // and that event never arrives if policy-service gives up after
+        // maxRestartAttempts or the policy is destroyed mid-start. An unbounded entry
+        // would make every later caller await a promise that cannot settle, leaving the
+        // policy unstartable for the lifetime of the process.
+        let expiry: any;
+        const bound = new Promise((_resolve, reject) => {
+            expiry = setTimeout(
+                () => reject(new Error(`Policy ${policyId} did not start within ${PolicyEngine.START_TIMEOUT_MS}ms`)),
+                PolicyEngine.START_TIMEOUT_MS
+            );
+        });
+
+        const start = Promise.race([this.startModel(policyId, enableMock), bound])
             // Released before the caller settles, so a `.then` that starts the policy
             // again cannot observe a stale entry. `finally` runs too late for that.
             .then(
-                (result) => { this.inFlightStarts.delete(policyId); return result; },
-                (error) => { this.inFlightStarts.delete(policyId); throw error; }
+                (result) => { clearTimeout(expiry); this.clearInFlightStart(policyId); return result; },
+                (error) => { clearTimeout(expiry); this.clearInFlightStart(policyId); throw error; }
             );
         this.inFlightStarts.set(policyId, start);
         return start;
@@ -2554,6 +2584,7 @@ export class PolicyEngine extends NatsService {
      * @param policyOwnerId
      */
     public async destroyModelForMigration(policyId: string, policyOwnerId: string | null): Promise<void> {
+        this.clearInFlightStart(policyId);
         PolicyServiceChannelsContainer.deletePolicyServiceChannel(policyId);
 
         const guardians = new GuardiansService();

--- a/guardian-service/tests/unit/policy-engine-generate-dedupe.test.mjs
+++ b/guardian-service/tests/unit/policy-engine-generate-dedupe.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import esmock from 'esmock';
+
+/*
+ * A policy could be started twice and end up hosted by two policy-service pods.
+ *
+ * checkIfPolicyAlive is a short ping, and a policy needs tens of seconds from fork to
+ * answering it. A second caller entering that window saw "not alive" and sent its own
+ * GENERATE_POLICY, which a different pod accepted - addPolicy does not check whether
+ * the policy is already hosted elsewhere. Both processes then joined the same NATS
+ * queue group for the policy, so block requests were split between two instances with
+ * divergent in-memory block state and roughly half returned "Block Unavailable".
+ *
+ * Every start path funnels through generateModel, so the guard belongs there:
+ * concurrent callers join the attempt already running instead of racing it.
+ */
+
+let PolicyEngine;
+
+async function loadEngine() {
+    return esmock(
+        '../../dist/policy-engine/policy-engine.js',
+        {
+            '@guardian/common': {
+                DatabaseServer: { async getPolicyById() { return { id: 'p1', ownerId: 'owner' }; } },
+            },
+            '../../dist/helpers/guardians.js': {
+                GuardiansService: class {
+                    constructor() {}
+                    async checkIfPolicyAlive() { return false; }
+                },
+            },
+        },
+    );
+}
+
+function makeEngine(sent) {
+    const engine = Object.create(PolicyEngine.prototype);
+    engine.policyReadyCallbacks = new Map();
+    engine.policyInitializationErrors = new Map();
+    engine.inFlightStarts = new Map();
+    engine.sendMessageWithTimeout = async (_event, _timeout, payload) => {
+        sent.push(payload.policyId);
+        return { confirmed: true, free: 1 };
+    };
+    return engine;
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe('@unit PolicyEngine.generateModel start dedupe', () => {
+    before(async function () {
+        this.timeout(120000);
+        ({ PolicyEngine } = await loadEngine());
+    });
+
+    it('collapses concurrent starts of the same policy into ONE GENERATE_POLICY', async () => {
+        const sent = [];
+        const engine = makeEngine(sent);
+
+        const first = engine.generateModel('p1', false);
+        const second = engine.generateModel('p1', false);
+        await settle();
+
+        assert.deepEqual(sent, ['p1'], 'a second caller must not issue its own GENERATE_POLICY');
+
+        const cb = engine.policyReadyCallbacks.get('p1');
+        assert.ok(cb, 'the single start should be parked on POLICY_READY');
+        cb({ ok: true }, null);
+
+        assert.deepEqual(await first, { ok: true });
+        assert.deepEqual(await second, { ok: true }, 'both callers share the one start');
+    });
+
+    it('does not dedupe different policies against each other', async () => {
+        const sent = [];
+        const engine = makeEngine(sent);
+
+        const a = engine.generateModel('p1', false);
+        const b = engine.generateModel('p2', false);
+        await settle();
+
+        assert.deepEqual(sent.sort(), ['p1', 'p2']);
+        engine.policyReadyCallbacks.get('p1')({ p: 1 }, null);
+        engine.policyReadyCallbacks.get('p2')({ p: 2 }, null);
+        assert.deepEqual(await a, { p: 1 });
+        assert.deepEqual(await b, { p: 2 });
+    });
+
+    it('releases the guard once the start settles, so a later start is allowed', async () => {
+        const sent = [];
+        const engine = makeEngine(sent);
+
+        const first = engine.generateModel('p1', false);
+        await settle();
+        engine.policyReadyCallbacks.get('p1')({ ok: 1 }, null);
+        await first;
+
+        const second = engine.generateModel('p1', false);
+        await settle();
+        assert.deepEqual(sent, ['p1', 'p1'], 'the guard must not be a permanent cache');
+        engine.policyReadyCallbacks.get('p1')({ ok: 2 }, null);
+        assert.deepEqual(await second, { ok: 2 });
+    });
+
+    it('releases the guard when the start FAILS, so the next attempt retries', async () => {
+        const sent = [];
+        const engine = makeEngine(sent);
+
+        const first = engine.generateModel('p1', false);
+        await settle();
+        engine.policyReadyCallbacks.get('p1')(null, 'schema error');
+        await assert.rejects(first, /schema error/);
+
+        const second = engine.generateModel('p1', false);
+        await settle();
+        assert.deepEqual(sent, ['p1', 'p1'], 'a failed start must not wedge the guard shut');
+        engine.policyReadyCallbacks.get('p1')({ ok: true }, null);
+        await second;
+    });
+
+    it('a caller joining an in-flight start receives its failure too', async () => {
+        const sent = [];
+        const engine = makeEngine(sent);
+
+        const first = engine.generateModel('p1', false);
+        const second = engine.generateModel('p1', false);
+        await settle();
+        engine.policyReadyCallbacks.get('p1')(null, 'boom');
+
+        await assert.rejects(first, /boom/);
+        await assert.rejects(second, /boom/, 'the joined caller must not resolve as success');
+    });
+});

--- a/guardian-service/tests/unit/policy-engine-generate-dedupe.test.mjs
+++ b/guardian-service/tests/unit/policy-engine-generate-dedupe.test.mjs
@@ -2,17 +2,10 @@ import assert from 'node:assert/strict';
 import esmock from 'esmock';
 
 /*
- * A policy could be started twice and end up hosted by two policy-service pods.
- *
- * checkIfPolicyAlive is a short ping, and a policy needs tens of seconds from fork to
- * answering it. A second caller entering that window saw "not alive" and sent its own
- * GENERATE_POLICY, which a different pod accepted - addPolicy does not check whether
- * the policy is already hosted elsewhere. Both processes then joined the same NATS
- * queue group for the policy, so block requests were split between two instances with
- * divergent in-memory block state and roughly half returned "Block Unavailable".
- *
- * Every start path funnels through generateModel, so the guard belongs there:
- * concurrent callers join the attempt already running instead of racing it.
+ * A policy could be started twice and end up hosted by two pods: checkIfPolicyAlive is
+ * a short ping, and a policy needs tens of seconds from fork to answering it, so a
+ * second caller in that window sent its own GENERATE_POLICY and a different pod took
+ * it. Every start path funnels through generateModel, so the guard belongs there.
  */
 
 let PolicyEngine;
@@ -28,6 +21,7 @@ async function loadEngine() {
                 GuardiansService: class {
                     constructor() {}
                     async checkIfPolicyAlive() { return false; }
+                    sendPolicyMessage() {}
                 },
             },
         },
@@ -117,6 +111,39 @@ describe('@unit PolicyEngine.generateModel start dedupe', () => {
         assert.deepEqual(sent, ['p1', 'p1'], 'a failed start must not wedge the guard shut');
         engine.policyReadyCallbacks.get('p1')({ ok: true }, null);
         await second;
+    });
+
+    it('a start that never settles is released, so a later caller can retry', async () => {
+        // startModel's confirmed branch waits on POLICY_READY with no timeout, and that
+        // event never arrives when policy-service gives up after maxRestartAttempts or
+        // the policy is destroyed mid-start. An unbounded entry would leave the policy
+        // unstartable for the lifetime of the process.
+        const sent = [];
+        const engine = makeEngine(sent);
+        const realTimeout = PolicyEngine.START_TIMEOUT_MS;
+        PolicyEngine.START_TIMEOUT_MS = 30;
+        engine.startModel = () => new Promise(() => { });   // never settles
+
+        try {
+            await assert.rejects(engine.generateModel('p1', false), /did not start within/);
+        } finally {
+            PolicyEngine.START_TIMEOUT_MS = realTimeout;
+        }
+
+        assert.equal(engine.inFlightStarts.has('p1'), false,
+            'the dead attempt must not be handed to the next caller');
+    });
+
+    it('destroying a policy drops a start still in flight', async () => {
+        const engine = makeEngine([]);
+        engine.startModel = () => new Promise(() => { });
+        engine.generateModel('p1', false).catch(() => { });
+
+        assert.equal(engine.inFlightStarts.has('p1'), true, 'precondition');
+        await engine.destroyModel('p1', 'owner');
+
+        assert.equal(engine.inFlightStarts.has('p1'), false,
+            'the child exits with code 0 and no ready event follows');
     });
 
     it('a caller joining an in-flight start receives its failure too', async () => {

--- a/policy-service/src/helpers/policy-container.ts
+++ b/policy-service/src/helpers/policy-container.ts
@@ -283,6 +283,14 @@ export class PolicyContainer extends NatsService {
      * @param config
      */
     public addPolicy(config: IPolicyStartOptions): boolean {
+        // Already hosted here: keep the existing entry. Replacing it would hand
+        // runPolicyProcess a `process: null` instance and defeat its guard, forking a
+        // second child while the first keeps running and stays subscribed. Checked
+        // before the capacity test because re-adding a hosted policy costs no slot.
+        if (this.container.has(config.policyId)) {
+            return true;
+        }
+
         if (this.processCount >= this.maxPolicyInstances) {
             this.unsubscribeFromModelGeneration();
             return false

--- a/policy-service/src/helpers/policy-container.ts
+++ b/policy-service/src/helpers/policy-container.ts
@@ -279,15 +279,34 @@ export class PolicyContainer extends NatsService {
         this.subscribeForModelGeneration();
     }
     /**
+     * Whether a start request asks for the same process the policy already has.
+     */
+    private static sameStartOptions(a: IPolicyStartOptions, b: IPolicyStartOptions): boolean {
+        return !!a.enableMock === !!b.enableMock
+            && !!a.skipRegistration === !!b.skipRegistration;
+    }
+
+    /**
      * Add policy to run queue
      * @param config
      */
     public addPolicy(config: IPolicyStartOptions): boolean {
-        // Already hosted here: keep the existing entry. Replacing it would hand
-        // runPolicyProcess a `process: null` instance and defeat its guard, forking a
-        // second child while the first keeps running and stays subscribed. Checked
-        // before the capacity test because re-adding a hosted policy costs no slot.
-        if (this.container.has(config.policyId)) {
+        // Already hosted here: keep the existing entry rather than replacing it, which
+        // would hand runPolicyProcess a `process: null` instance and fork a second child.
+        const hosted = this.container.get(config.policyId);
+        if (hosted) {
+            // ...but only claim it when the request matches what the child was forked
+            // with. Accepting a different enableMock/skipRegistration would serve it
+            // from the old process while the caller waits for a POLICY_READY that
+            // describes a policy it did not ask for; declining routes it to a pod that
+            // can honour it.
+            if (!PolicyContainer.sameStartOptions(hosted.options, config)) {
+                this.logger.warn(
+                    `Policy ${config.policyId} is already hosted with different start options; declining`,
+                    ['POLICY_SERVICE', config.policyId], config.policyOwnerId
+                );
+                return false;
+            }
             return true;
         }
 

--- a/policy-service/tests/unit-tests/helpers/policy-container-add-policy.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/policy-container-add-policy.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { PolicyContainer } from '../../../dist/helpers/policy-container.js';
+
+/*
+ * addPolicy used to overwrite an existing container entry with a fresh
+ * `{ options, process: null }`. runPolicyProcess only skips an instance that
+ * already has a `process`, so replacing the entry defeated that guard: a repeated
+ * GENERATE_POLICY for a policy this pod already hosts forked a SECOND child and
+ * dropped the handle to the first, which kept running and stayed subscribed to the
+ * policy's NATS subjects. Two live processes then served the same policy from
+ * divergent in-memory state, and the orphan could never be stopped or counted.
+ */
+
+/** A container with just the state addPolicy touches - no NATS, no child processes. */
+function makeContainer(maxPolicyInstances = 5) {
+    const container = Object.create(PolicyContainer.prototype);
+    container.container = new Map();
+    container.maxPolicyInstances = maxPolicyInstances;
+    container.unsubscribeFromModelGeneration = () => { container.unsubscribed = true; };
+    return container;
+}
+
+const config = (policyId) => ({ policyId, skipRegistration: false, policyOwnerId: 'o', enableMock: false });
+
+describe('PolicyContainer.addPolicy', () => {
+    it('accepts a policy this pod is not hosting yet', () => {
+        const c = makeContainer();
+        assert.equal(c.addPolicy(config('p1')), true);
+        assert.equal(c.container.size, 1);
+    });
+
+    it('does not replace the entry of a policy this pod already hosts', () => {
+        const c = makeContainer();
+        c.addPolicy(config('p1'));
+
+        // The policy has been forked by now, so the entry owns a live child handle.
+        const running = { pid: 111 };
+        c.container.get('p1').process = running;
+
+        assert.equal(c.addPolicy(config('p1')), true, 'the policy is hosted, so report success');
+        assert.equal(
+            c.container.get('p1').process,
+            running,
+            'the live child handle must survive a repeated GENERATE_POLICY'
+        );
+        assert.equal(c.container.size, 1, 'no second entry for the same policy');
+    });
+
+    it('does not grow the process count when the same policy is added twice', () => {
+        const c = makeContainer(1);
+        assert.equal(c.addPolicy(config('p1')), true);
+        // At maxPolicyInstances now. Re-adding the SAME policy costs no slot, so it
+        // must not be refused as if the pod were full.
+        assert.equal(c.addPolicy(config('p1')), true);
+        assert.equal(c.container.size, 1);
+    });
+
+    it('still refuses a NEW policy once the pod is full', () => {
+        const c = makeContainer(1);
+        c.addPolicy(config('p1'));
+        assert.equal(c.addPolicy(config('p2')), false);
+        assert.equal(c.container.size, 1);
+        assert.equal(c.unsubscribed, true, 'a full pod stops advertising for more work');
+    });
+});

--- a/policy-service/tests/unit-tests/helpers/policy-container-add-policy.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/policy-container-add-policy.test.mjs
@@ -2,13 +2,9 @@ import assert from 'node:assert/strict';
 import { PolicyContainer } from '../../../dist/helpers/policy-container.js';
 
 /*
- * addPolicy used to overwrite an existing container entry with a fresh
- * `{ options, process: null }`. runPolicyProcess only skips an instance that
- * already has a `process`, so replacing the entry defeated that guard: a repeated
- * GENERATE_POLICY for a policy this pod already hosts forked a SECOND child and
- * dropped the handle to the first, which kept running and stayed subscribed to the
- * policy's NATS subjects. Two live processes then served the same policy from
- * divergent in-memory state, and the orphan could never be stopped or counted.
+ * addPolicy used to overwrite an existing entry with `{ options, process: null }`, and
+ * runPolicyProcess only skips an instance that already has a `process` - so a repeated
+ * GENERATE_POLICY forked a SECOND child and dropped the handle to the first.
  */
 
 /** A container with just the state addPolicy touches - no NATS, no child processes. */
@@ -17,10 +13,13 @@ function makeContainer(maxPolicyInstances = 5) {
     container.container = new Map();
     container.maxPolicyInstances = maxPolicyInstances;
     container.unsubscribeFromModelGeneration = () => { container.unsubscribed = true; };
+    container.logger = { warn() {}, info() {}, error() {} };
     return container;
 }
 
-const config = (policyId) => ({ policyId, skipRegistration: false, policyOwnerId: 'o', enableMock: false });
+const config = (policyId, overrides = {}) => ({
+    policyId, skipRegistration: false, policyOwnerId: 'o', enableMock: false, ...overrides,
+});
 
 describe('PolicyContainer.addPolicy', () => {
     it('accepts a policy this pod is not hosting yet', () => {
@@ -53,6 +52,26 @@ describe('PolicyContainer.addPolicy', () => {
         // must not be refused as if the pod were full.
         assert.equal(c.addPolicy(config('p1')), true);
         assert.equal(c.container.size, 1);
+    });
+
+    it('declines a request whose start options differ from the running child', () => {
+        // the child was forked with the old options, so claiming this request would
+        // serve it from a process that does not match what the caller asked for
+        const c = makeContainer();
+        c.addPolicy(config('p1'));
+        c.container.get('p1').process = { pid: 1 };
+
+        assert.equal(c.addPolicy(config('p1', { enableMock: true })), false,
+            'declining routes the request to a pod that can honour it');
+        assert.equal(c.container.get('p1').options.enableMock, false,
+            'and the hosted entry is left as it is');
+    });
+
+    it('still claims a repeat request that matches', () => {
+        const c = makeContainer();
+        c.addPolicy(config('p1'));
+
+        assert.equal(c.addPolicy(config('p1')), true);
     });
 
     it('still refuses a NEW policy once the pod is full', () => {


### PR DESCRIPTION
Fixes #6835

A policy could end up running on two policy-service processes at once. Both join the same NATS queue group for that policy, so block requests are split between two instances holding divergent in-memory state and roughly half fail with `Block Unavailable`. This closes both routes into that state.

### 1. `guardian-service`: serialise starts of the same policy

`generateModel` decides whether to start a policy from `checkIfPolicyAlive`, a short ping, while a policy takes tens of seconds from fork to answering it. A second caller inside that window saw "not alive" and sent its own `GENERATE_POLICY`, which a different pod accepted.

Every start path funnels through `generateModel` — startup, dry-run, publish, `regenerateModel`, `restore-data-from-hedera` — so the guard belongs there. It now keeps an `inFlightStarts` map and hands a concurrent caller the attempt already running. The entry is released when that attempt settles, on success and on failure alike, so it is not a cache and a failed start does not wedge it shut.

The body moved to a private `startModel`. The capacity retry re-enters `startModel` rather than `generateModel` — going through the guarded entry point would make it join itself and never settle.

### 2. `policy-service`: do not re-add a policy the pod already hosts

`addPolicy` overwrote an existing container entry with a fresh `{ options, process: null }`. `runPolicyProcess` only skips an instance that already has a `process`, so replacing the entry defeated that guard: a repeated `GENERATE_POLICY` forked a second child and dropped the handle to the first, which kept running and stayed subscribed — it could no longer be stopped, and it was not counted.

It now returns early when the policy is already in the container. That check runs *before* the capacity test, because re-adding a hosted policy consumes no slot and must not be refused as if the pod were full.

### Tests

Nine new unit tests, all failing before the change and passing after.

`guardian-service/tests/unit/policy-engine-generate-dedupe.test.mjs`
* concurrent starts of one policy produce a single `GENERATE_POLICY`, and both callers get the same result
* different policies are not deduped against each other
* the guard is released once a start settles, so a later start is still allowed
* the guard is released when a start fails, so the next attempt retries
* a caller that joins an in-flight start receives its failure too

`policy-service/tests/unit-tests/helpers/policy-container-add-policy.test.mjs`
* a policy the pod is not hosting is accepted
* a live child handle survives a repeated `GENERATE_POLICY`
* re-adding a hosted policy does not consume a slot, so it is not refused when the pod is full
* a genuinely new policy is still refused once the pod is full

### Verification

Run against `develop` (`4063d4725`):

| suite | baseline | with this PR |
|---|---|---|
| `guardian-service` `tests/unit` | 1822 passing, 11 failing | 1827 passing, 11 failing |
| `policy-service` `tests/unit-tests` | 3263 passing, 0 failing | 3267 passing, 0 failing |

The 11 `guardian-service` failures are present on unmodified `develop` and are all schema-template / package-publish tests, unrelated to policy startup. `policy-service` has an intermittent 2s-timeout flake in `custom-logic-worker-error.test.mjs` that fires on some runs on `develop` too.

`tslint` is clean on both changed files.
