### PR TITLE
fix: update CODEOWNERS removing non existent group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/envision-blockchain-hedera
+*                                               @hashgraph/guardian-committers @hashgraph/guardian-maintainers
 
 ############################
 #####  Project Files  ######


### PR DESCRIPTION
@hashgraph/envision-blockchain-hedera is not a valid group anymore.
Updated CODEOWNERS to reflect new ownership for unspecified files.
