### PR TITLE
fix(policy-service): apply the org TOKEN_MINTING guard on every mint account path

### DIFF
--- a/policy-service/src/policy-engine/blocks/mint-block.ts
+++ b/policy-service/src/policy-engine/blocks/mint-block.ts
@@ -550,10 +550,7 @@ export class MintBlock {
         // entry events (RunEvent and AdditionalMintEvent) — a guard in runAction() alone
         // would be bypassed by AdditionalMintEvent.
         const mintUser = event.user;
-        const mintOptions = await ref.getOptions(mintUser);
-        if (mintOptions.accountType === 'custom-value') {
-            await checkOrgTokenPermission(ref, mintUser, targetAccount, OrgRolePermission.TOKEN_MINTING, userId);
-        }
+        await checkOrgTokenPermission(ref, mintUser, targetAccount, OrgRolePermission.TOKEN_MINTING, userId);
         if (relayerAccount !== mintUser?.hederaAccountId) {
             await checkOrgTokenPermission(ref, mintUser, relayerAccount, OrgRolePermission.TOKEN_TRANSFER, userId);
         }

--- a/policy-service/tests/unit-tests/blocks/mint-block-org-token-guard.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/mint-block-org-token-guard.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { OrgRolePermission } from '@guardian/interfaces';
+import { Users } from '@guardian/common';
+import { makeBlock, makeUser, restoreHarness } from './_block-exec-harness.mjs';
+import { MintBlock } from '../../../dist/policy-engine/blocks/mint-block.js';
+import { PolicyUtils } from '../../../dist/policy-engine/helpers/utils.js';
+import { PolicyComponentsUtils } from '../../../dist/policy-engine/policy-components-utils.js';
+
+const _origStore = [];
+function ovr(obj, name, fn) {
+    _origStore.push({ obj, name, orig: obj[name] });
+    obj[name] = fn;
+}
+function restoreOverrides() {
+    while (_origStore.length) {
+        const { obj, name, orig } = _origStore.pop();
+        obj[name] = orig;
+    }
+}
+function captureEvents(block) {
+    const cap = [];
+    block.triggerEvents = (...a) => { cap.push(a); return Promise.resolve([]); };
+    block.saveState = async () => { };
+    block.backup = () => { };
+    return cap;
+}
+
+after(() => { restoreOverrides(); restoreHarness(); });
+
+describe('@unit mint-block org TOKEN_MINTING guard', () => {
+    afterEach(() => restoreOverrides());
+
+    const ORG_ACCOUNT = '0.0.1001';
+    const OWN_ACCOUNT = '0.0.2002';
+    const OTHER_ACCOUNT = '0.0.3003';
+    const MINTING_ERROR = /Insufficient organization permissions for token minting/;
+    const TRANSFER_ERROR = /Insufficient organization permissions for token transfer/;
+
+    /**
+     * Drive run() with everything around the guard stubbed, but leave the real
+     * getAccount() to resolve targetAccount so each of its three account paths is
+     * genuinely exercised. mintProcessing records its args: the guard has to reject
+     * before it is reached.
+     */
+    function setupRun(options, { accounts = [], relayerAccount = OWN_ACCOUNT, orgAccount = ORG_ACCOUNT } = {}) {
+        const { block } = makeBlock(MintBlock, { options });
+        const events = captureEvents(block);
+        ovr(PolicyComponentsUtils, 'ExternalEventFn', () => { });
+        ovr(PolicyUtils, 'getDocumentRelayerAccount', async () => relayerAccount);
+        // the single NATS hop checkOrgTokenPermission makes, via getOrgHederaAccountId
+        ovr(Users.prototype, 'getOrgHederaInfo', async () => ({ hederaAccountId: orgAccount }));
+        block.getToken = async () => ({ tokenId: '0.0.5' });
+        block.getObjects = async () => ({ vcs: [], messages: [], topics: ['0.0.1'], accounts });
+        const minted = [];
+        block.mintProcessing = async (...a) => { minted.push(a); return [{}, 1]; };
+        return { block, minted, events };
+    }
+
+    // a fresh user per test also gives a fresh WeakMap memo in getOrgHederaAccountId
+    const member = (permissions) => makeUser({
+        did: 'did:member',
+        hederaAccountId: OWN_ACCOUNT,
+        organization: 'org-1',
+        organizationRolePermissions: permissions,
+    });
+
+    const run = (block, user) => block.run(
+        block,
+        { user, data: {}, actionStatus: null },
+        makeUser({ did: 'did:owner' }),
+        [{ id: 'd1' }],
+        null,
+        'uid-1',
+    );
+
+    // mintProcessing(token, topicId, user, relayerAccount, targetAccount, ...)
+    const RELAYER_ARG = 3;
+    const TARGET_ARG = 4;
+
+    it('rejects when the document names the org account (default accountType + accountId)', async () => {
+        const { block, minted } = setupRun({ accountId: 'beneficiary' }, { accounts: [ORG_ACCOUNT] });
+        await assert.rejects(run(block, member([])), MINTING_ERROR);
+        assert.equal(minted.length, 0);
+    });
+
+    it('rejects when the relayer account is the org account, and TOKEN_TRANSFER does not confer minting', async () => {
+        const { block, minted } = setupRun({}, { relayerAccount: ORG_ACCOUNT });
+        await assert.rejects(run(block, member([OrgRolePermission.TOKEN_TRANSFER])), MINTING_ERROR);
+        assert.equal(minted.length, 0);
+    });
+
+    it('rejects when accountIdValue is the org account (custom-value)', async () => {
+        const { block, minted } = setupRun({ accountType: 'custom-value', accountIdValue: ORG_ACCOUNT });
+        await assert.rejects(run(block, member([])), MINTING_ERROR);
+        assert.equal(minted.length, 0);
+    });
+
+    it('allows a member holding TOKEN_MINTING and mints into the org account', async () => {
+        const { block, minted } = setupRun({ accountId: 'beneficiary' }, { accounts: [ORG_ACCOUNT] });
+        await run(block, member([OrgRolePermission.TOKEN_MINTING]));
+        assert.equal(minted.length, 1);
+        assert.equal(minted[0][TARGET_ARG], ORG_ACCOUNT);
+    });
+
+    it('leaves non-org target accounts alone — the guard self-limits to the org account', async () => {
+        const { block, minted } = setupRun({ accountId: 'beneficiary' }, { accounts: [OTHER_ACCOUNT] });
+        await run(block, member([]));
+        assert.equal(minted.length, 1);
+        assert.equal(minted[0][TARGET_ARG], OTHER_ACCOUNT);
+    });
+
+    it('leaves a user with no organization alone', async () => {
+        const { block, minted } = setupRun({ accountId: 'beneficiary' }, { accounts: [ORG_ACCOUNT] });
+        await run(block, makeUser({ hederaAccountId: OWN_ACCOUNT }));
+        assert.equal(minted.length, 1);
+    });
+
+    // this entry point does not pass through runAction()
+    it('rejects through the additionalMintEvent entry point', async () => {
+        const { block, minted } = setupRun({ accountId: 'beneficiary' }, { accounts: [ORG_ACCOUNT] });
+        ovr(PolicyUtils, 'getArray', (d) => Array.isArray(d) ? d : [d]);
+        ovr(PolicyUtils, 'getDocumentOwner', async () => makeUser({ did: 'did:owner' }));
+        await assert.rejects(
+            block.additionalMintEvent({
+                user: member([]),
+                data: { data: [{ id: 'd1' }], result: [{ messageId: 'add1' }] },
+                actionStatus: null,
+            }),
+            MINTING_ERROR
+        );
+        assert.equal(minted.length, 0);
+    });
+
+    it('rejects the relayer transfer when the relayer is the org account and the target is not', async () => {
+        const { block, minted } = setupRun(
+            { accountId: 'beneficiary' },
+            { accounts: [OTHER_ACCOUNT], relayerAccount: ORG_ACCOUNT }
+        );
+        await assert.rejects(run(block, member([OrgRolePermission.TOKEN_MINTING])), TRANSFER_ERROR);
+        assert.equal(minted.length, 0);
+    });
+
+    it('allows the relayer transfer when the member holds TOKEN_TRANSFER', async () => {
+        const { block, minted } = setupRun(
+            { accountId: 'beneficiary' },
+            { accounts: [OTHER_ACCOUNT], relayerAccount: ORG_ACCOUNT }
+        );
+        await run(block, member([OrgRolePermission.TOKEN_TRANSFER]));
+        assert.equal(minted.length, 1);
+        assert.equal(minted[0][RELAYER_ARG], ORG_ACCOUNT);
+        assert.equal(minted[0][TARGET_ARG], OTHER_ACCOUNT);
+    });
+});


### PR DESCRIPTION
Fixes #6853.

## Problem

The organization `TOKEN_MINTING` guard was gated on the block's account **type**, so it ran for only one of the three accounts `getAccount()` can return:

```ts
const mintOptions = await ref.getOptions(mintUser);
if (mintOptions.accountType === 'custom-value') {
    await checkOrgTokenPermission(ref, mintUser, targetAccount, OrgRolePermission.TOKEN_MINTING, userId);
}
```

| path `getAccount()` returns | condition | guarded |
|---|---|---|
| the account named on the document (`accountId`) | default | **no** |
| the relayer account | default | **no** |
| `accountIdValue` | `accountType === 'custom-value'` | yes |

The two unguarded ones are the **defaults** — `accountType` is unset unless a policy explicitly chooses `custom-value` — and both can resolve to the organization's account. So an org member without `TOKEN_MINTING` could mint into the org account through either.

The `TOKEN_TRANSFER` check directly below was never gated this way, which is part of why the asymmetry reads as unintended.

## Fix

Check the resolved `targetAccount` unconditionally. The permission concerns which account receives the tokens, not how the block was configured to name it.

This does not tighten ordinary mints: `checkOrgTokenPermission` already self-limits — it is a no-op when the target is not the caller's organization account, and when the caller has no organization. Two of the tests pin exactly that, so the broader call cannot silently start rejecting non-org mints.

## Tests

Nine cases in a new `mint-block-org-token-guard.test.mjs`, using the existing `_block-exec-harness`. They cover all three account paths, the `additionalMintEvent` entry point (which does **not** pass through `runAction()`, so a guard placed there would miss it), and both relayer-transfer outcomes.

They deliberately leave the real `getAccount()` in place rather than stubbing `targetAccount`, since *which paths the guard covers* is the entire subject of this change — stubbing the account would test nothing.

**Verified non-vacuous.** Against the unpatched source, 3 of the 9 fail:

- `rejects when the document names the org account (default accountType + accountId)`
- `rejects when the relayer account is the org account, and TOKEN_TRANSFER does not confer minting`
- `rejects through the additionalMintEvent entry point`

— exactly the two default paths plus the second entry point. The `custom-value` case passes either way, which is the control: it was already guarded.

`tsc --noEmit` passes for `policy-service`, and the 9 tests pass against the patched build.

## Provenance

This has been running downstream for some months and is covered there by the same tests; contributing it back now.
