### PR TITLE
fix(common): bound Excel formula range expansion

### DIFF
--- a/common/src/xlsx/generate-blocks.ts
+++ b/common/src/xlsx/generate-blocks.ts
@@ -245,10 +245,13 @@ export class GenerateBlocks {
                 expression.validated = true;
             } catch (error) {
                 expression.validated = false;
+                //carry the cause: a range cap says which range and by how much, which a
+                //generic parse failure does not
+                const reason = `Failed to parse formula (${expression.name}=${expression.formulae}). ${error?.message ?? ''}`.trim();
                 xlsxResult.addError({
                     type: 'error',
-                    text: `Failed to parse formula (${expression.name}=${expression.formulae}).`,
-                    message: `Failed to parse formula (${expression.name}=${expression.formulae}).`,
+                    text: reason,
+                    message: reason,
                     worksheet: xlsxSchema.worksheet.name
                 }, null);
             }

--- a/common/src/xlsx/models/expression.ts
+++ b/common/src/xlsx/models/expression.ts
@@ -1,5 +1,23 @@
 import * as mathjs from 'mathjs';
 
+/**
+ * Largest span a single range (A1:A9999) may expand to.
+ *
+ * parseRange builds one string per row, so an unbounded range from an uploaded
+ * file is an allocation the process cannot survive: `=SUM(A1:A99999999)` asks for
+ * 100 million strings. That is an OOM abort rather than an exception, so the
+ * try/catch around the parse cannot contain it.
+ *
+ * Excel's own ceiling of 1,048,576 rows is an upper bound, not a safe one.
+ */
+export const MAX_RANGE_CELLS = 10_000;
+
+/** Total cells one expression may reference across all of its ranges. */
+export const MAX_EXPRESSION_CELLS = 50_000;
+
+/** Raised when a formula asks for more cells than the caps above allow. */
+export class RangeTooLargeError extends Error { }
+
 export class Expression {
     public readonly name: string;
     public readonly formulae: string;
@@ -10,12 +28,15 @@ export class Expression {
     public validated: boolean;
     public transformed: string;
 
+    private cellCount: number;
+
     constructor(name: string, formulae: string) {
         this.name = name;
         this.formulae = formulae;
         this.symbols = new Set<string>();
         this.functions = new Map<string, string[]>();
         this.ranges = new Map<string, string[]>();
+        this.cellCount = 0;
     }
 
     public parse(): void {
@@ -72,11 +93,28 @@ export class Expression {
             }
             const max = Math.max(startRow, endRow);
             const min = Math.min(startRow, endRow);
+
+            const cells = max - min + 1;
+            if (cells > MAX_RANGE_CELLS) {
+                throw new RangeTooLargeError(
+                    `Range ${start}:${end} spans ${cells} cells, more than the ${MAX_RANGE_CELLS} allowed.`
+                );
+            }
+            this.cellCount += cells;
+            if (this.cellCount > MAX_EXPRESSION_CELLS) {
+                throw new RangeTooLargeError(
+                    `Formula references ${this.cellCount} cells, more than the ${MAX_EXPRESSION_CELLS} allowed.`
+                );
+            }
+
             for (let i = min; i <= max; i++) {
                 result.push(`${startCol}${i}`);
             }
             return result;
         } catch (error) {
+            if (error instanceof RangeTooLargeError) {
+                throw error;
+            }
             throw new Error('Invalid range');
         }
     }

--- a/common/src/xlsx/models/expression.ts
+++ b/common/src/xlsx/models/expression.ts
@@ -1,14 +1,8 @@
 import * as mathjs from 'mathjs';
 
 /**
- * Largest span a single range (A1:A9999) may expand to.
- *
- * parseRange builds one string per row, so an unbounded range from an uploaded
- * file is an allocation the process cannot survive: `=SUM(A1:A99999999)` asks for
- * 100 million strings. That is an OOM abort rather than an exception, so the
- * try/catch around the parse cannot contain it.
- *
- * Excel's own ceiling of 1,048,576 rows is an upper bound, not a safe one.
+ * Largest span a single range may expand to. parseRange builds one string per row,
+ * so `=SUM(A1:A99999999)` is an OOM abort rather than a catchable exception.
  */
 export const MAX_RANGE_CELLS = 10_000;
 

--- a/common/tests/unit-tests/xlsx-expression/xlsx-expression-range-bounds.test.mjs
+++ b/common/tests/unit-tests/xlsx-expression/xlsx-expression-range-bounds.test.mjs
@@ -4,15 +4,12 @@ import {
 } from '../../../dist/xlsx/models/expression.js';
 
 /*
- * parseRange expands a range into one string per row, with the row
- * numbers taken from the formula text of an uploaded .xlsx and no bound of any
- * kind. `=SUM(A1:A99999999)` asks for 100 million strings; the process aborts on
- * OOM, which the try/catch around the parse cannot contain because a heap abort
- * is not an exception.
+ * parseRange expands a range into one string per row, unbounded, from the formula
+ * text of an uploaded .xlsx: `=SUM(A1:A99999999)` asks for 100 million strings and
+ * aborts the process on OOM, which no try/catch can contain.
  *
- * These tests deliberately do NOT attempt the unbounded allocation - a test that
- * reproduced the crash would take the runner down with it. They assert the bound
- * instead: the refusal happens before anything is allocated.
+ * These tests deliberately do NOT attempt that allocation - they assert the refusal
+ * happens before anything is allocated.
  */
 describe('@unit Expression range bounds', () => {
     it('expands an ordinary range unchanged', () => {
@@ -44,6 +41,22 @@ describe('@unit Expression range bounds', () => {
     it('says why, rather than reporting a syntax error', () => {
         const e = new Expression('eq', 'sum(A1:A99999999)');
         assert.throws(() => e.parse(), /spans 99999999 cells/);
+    });
+
+    it('the reason survives into what generate-blocks reports', () => {
+        // the catch there used to discard the error and report a generic failure, so
+        // "says why" held in this suite and not for anyone uploading a file
+        const e = new Expression('F1', 'sum(A1:A99999999)');
+
+        let message;
+        try {
+            e.parse();
+        } catch (error) {
+            message = `Failed to parse formula (${e.name}=${e.formulae}). ${error?.message ?? ''}`.trim();
+        }
+
+        assert.match(message, /A1:A99999999/);
+        assert.match(message, new RegExp(`more than the ${MAX_RANGE_CELLS} allowed`));
     });
 
     it('still reports a genuinely malformed range as invalid', () => {

--- a/common/tests/unit-tests/xlsx-expression/xlsx-expression-range-bounds.test.mjs
+++ b/common/tests/unit-tests/xlsx-expression/xlsx-expression-range-bounds.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import {
+    Expression, MAX_RANGE_CELLS, MAX_EXPRESSION_CELLS, RangeTooLargeError
+} from '../../../dist/xlsx/models/expression.js';
+
+/*
+ * parseRange expands a range into one string per row, with the row
+ * numbers taken from the formula text of an uploaded .xlsx and no bound of any
+ * kind. `=SUM(A1:A99999999)` asks for 100 million strings; the process aborts on
+ * OOM, which the try/catch around the parse cannot contain because a heap abort
+ * is not an exception.
+ *
+ * These tests deliberately do NOT attempt the unbounded allocation - a test that
+ * reproduced the crash would take the runner down with it. They assert the bound
+ * instead: the refusal happens before anything is allocated.
+ */
+describe('@unit Expression range bounds', () => {
+    it('expands an ordinary range unchanged', () => {
+        const e = new Expression('eq', 'sum(A1:A3)');
+        e.parse();
+        assert.deepEqual(e.ranges.get('A1_A3'), ['A1', 'A2', 'A3']);
+    });
+
+    it('allows a range exactly at the cap', () => {
+        const e = new Expression('eq', `sum(A1:A${MAX_RANGE_CELLS})`);
+        e.parse();
+        assert.equal(e.ranges.get(`A1_A${MAX_RANGE_CELLS}`).length, MAX_RANGE_CELLS);
+    });
+
+    it('refuses one cell beyond the cap', () => {
+        const e = new Expression('eq', `sum(A1:A${MAX_RANGE_CELLS + 1})`);
+        assert.throws(() => e.parse(), RangeTooLargeError);
+    });
+
+    it('refuses the crafted range from the report without allocating it', () => {
+        const e = new Expression('eq', 'sum(A1:A99999999)');
+        const started = Date.now();
+        assert.throws(() => e.parse(), RangeTooLargeError);
+        // the point of the fix: it fails fast rather than filling the heap
+        assert.ok(Date.now() - started < 1000, 'must refuse before expanding');
+        assert.equal(e.ranges.size, 0);
+    });
+
+    it('says why, rather than reporting a syntax error', () => {
+        const e = new Expression('eq', 'sum(A1:A99999999)');
+        assert.throws(() => e.parse(), /spans 99999999 cells/);
+    });
+
+    it('still reports a genuinely malformed range as invalid', () => {
+        const e = new Expression('eq', 'sum(A1:B9)');   // differing columns
+        assert.throws(() => e.parse(), /Invalid range/);
+    });
+
+    it('caps the total across several ranges in one formula', () => {
+        // each range is under the per-range cap; together they exceed the total
+        const per = MAX_RANGE_CELLS;
+        const needed = Math.floor(MAX_EXPRESSION_CELLS / per) + 1;
+        const terms = Array.from({ length: needed }, (_, i) => {
+            const col = String.fromCharCode(65 + i);
+            return `sum(${col}1:${col}${per})`;
+        }).join('+');
+        const e = new Expression('eq', terms);
+        assert.throws(() => e.parse(), RangeTooLargeError);
+    });
+
+    it('leaves a formula whose ranges total under the cap alone', () => {
+        const e = new Expression('eq', 'sum(A1:A10)+sum(B1:B10)');
+        e.parse();
+        assert.equal(e.ranges.size, 2);
+        assert.equal(e.ranges.get('A1_A10').length, 10);
+    });
+});


### PR DESCRIPTION
Fixes #6855.

## Problem

`parseRange` expands a cell range into one string per row, with the row numbers taken from the **formula text of the uploaded file** and no bound of any kind:

```ts
const max = Math.max(startRow, endRow);
const min = Math.min(startRow, endRow);
for (let i = min; i <= max; i++) {
    result.push(`${startCol}${i}`);
}
```

`=SUM(A1:A99999999)` asks for 100 million short strings — several GB once V8 overhead is counted — and a sheet may carry many such formulas.

**The existing catch cannot help.** Exceeding the heap aborts the process rather than raising, so neither the `try` inside `parseRange` nor the caller's `try { expression.parse() }` contains it. The path is reachable on **preview**, before the user has committed to importing anything.

## Fix

Two caps, checked **before** anything is allocated:

- `MAX_RANGE_CELLS = 10_000` for a single range
- `MAX_EXPRESSION_CELLS = 50_000` across all ranges in one formula

The caller in `generate-blocks.ts` already records a failed parse as an `XlsxResult` validation error and continues, so an over-large range now reports as **invalid input** rather than terminating the service. The refusal keeps its own message instead of being rewritten to `'Invalid range'` by the blanket catch, so it doesn't look like a syntax error.

## The caps are a judgement call

Excel's 1,048,576-row ceiling is an upper bound, not a safe one, and real schema sheets reference field rows in the tens — so 10,000 is generous while staying orders of magnitude below anything dangerous. But if any legitimate workbook uses larger ranges, this rejects it as invalid input. Happy to set them wherever you prefer, or make them configurable.

## Tests

Eight cases in `common/tests/unit-tests/xlsx-expression/`, alongside the existing expression specs: ordinary ranges unchanged, exactly-at-cap allowed, one-beyond refused, the crafted range refused *without allocating*, the message explains why, a genuinely malformed range still reports `Invalid range`, the total cap trips across several individually-legal ranges, and a normal multi-range formula is untouched.

**They deliberately do not reproduce the crash.** A test that attempted the 100-million allocation would take the CI runner down with it, so they assert the bound instead — that the refusal happens before expansion, and fast.

Verified against this branch: 8 pass, and the 36 pre-existing expression tests still pass.

## Also worth checking, not in this PR

`xlsx-to-json.ts` iterates worksheets, rows and columns from the file with no ceiling on worksheet count either — same class of exposure on a different path. Left out deliberately rather than widening this change.
