### PR TITLE
fix(guardian-service): refuse a duplicate policy key instead of destroying the first

### DIFF
--- a/api-gateway/src/api/service/profile.ts
+++ b/api-gateway/src/api/service/profile.ts
@@ -1,12 +1,13 @@
 import { Permissions, TaskAction } from '@guardian/interfaces';
 import { IAuthUser, PinoLogger, RunFunctionAsync } from '@guardian/common';
 import { Body, Controller, Get, HttpCode, HttpException, HttpStatus, Param, Post, Put, Req, Response, Query, Delete } from '@nestjs/common';
-import { ApiAcceptedResponse, ApiBody, ApiExtraModels, ApiInternalServerErrorResponse, ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags, ApiUnauthorizedResponse, ApiUnprocessableEntityResponse } from '@nestjs/swagger';
+import { ApiAcceptedResponse, ApiBody, ApiConflictResponse, ApiExtraModels, ApiInternalServerErrorResponse, ApiNoContentResponse, ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags, ApiUnauthorizedResponse, ApiUnprocessableEntityResponse } from '@nestjs/swagger';
 import {
     CredentialsDTO,
     DidDocumentDTO,
     DidDocumentStatusDTO,
     DidDocumentWithKeyDTO,
+    ConflictErrorDTO,
     DidKeyStatusDTO,
     DidVerificationMethodEntryDTO,
     Examples,
@@ -664,7 +665,8 @@ export class ProfileApi {
         description:
             'Registers a **policy message key** for the authenticated user\'s DID. ' +
             '**Generate:** send only `messageId`—the server creates a private key for that policy. The owner can copy the `messageId` and returned `key` from the response and pass them **out of band** to another person. ' +
-            '**Import:** the recipient calls this endpoint with the same `messageId` plus the DER-encoded private `key` they received, so their account can use the policy like the original owner.'
+            '**Import:** the recipient calls this endpoint with the same `messageId` plus the DER-encoded private `key` they received, so their account can use the policy like the original owner. ' +
+            'Either way the call is refused with **409** when this DID already holds a key for that `messageId`: one vault slot is addressed per `did#messageId`, so a second key would overwrite the first with no way to recover it. Delete the existing key before creating another.'
     })
     @ApiBody({
         description:
@@ -691,6 +693,14 @@ export class ProfileApi {
         description: 'Successful operation.',
         type: PolicyKeyDTO,
         example: ObjectExamples.PROFILE_POST_KEYS_RESPONSE
+    })
+    @ApiConflictResponse({
+        description: 'Conflict.',
+        type: ConflictErrorDTO,
+        example: {
+            statusCode: 409,
+            message: 'A key for this policy already exists. Delete it before creating another.'
+        }
     })
     @ApiUnprocessableEntityResponse({
         description: 'Unprocessable entity.',

--- a/guardian-service/src/api/profile.service.ts
+++ b/guardian-service/src/api/profile.service.ts
@@ -631,23 +631,15 @@ export function profileAPI(logger: PinoLogger) {
                 const { messageId, user } = msg;
                 let { key } = msg;
 
-                /*
-                 * One row per creation, but a single vault slot per
-                 * `${did}#${messageId}`: the address below carries no row id. A
-                 * second create for the same policy would add a second row while
-                 * setUserKey overwrote the first row's secret, leaving a keys list
-                 * where the older entry is dead and nothing says so.
-                 *
-                 * Refused rather than silently replaced, because the previous
-                 * secret cannot be recovered. Rotation is delete-then-create.
-                 */
+                // one vault slot per `did#messageId`, so a second create would overwrite
+                // the first row's secret with no way to recover it
                 const existing = await DatabaseServer.getKeys({
                     messageId,
                     owner: user.did
                 });
                 if (existing?.length) {
                     return new MessageError(
-                        `A key for this policy already exists. Delete it before creating another.`,
+                        'A key for this policy already exists. Delete it before creating another.',
                         409
                     );
                 }

--- a/guardian-service/src/api/profile.service.ts
+++ b/guardian-service/src/api/profile.service.ts
@@ -630,6 +630,28 @@ export function profileAPI(logger: PinoLogger) {
                 }
                 const { messageId, user } = msg;
                 let { key } = msg;
+
+                /*
+                 * One row per creation, but a single vault slot per
+                 * `${did}#${messageId}`: the address below carries no row id. A
+                 * second create for the same policy would add a second row while
+                 * setUserKey overwrote the first row's secret, leaving a keys list
+                 * where the older entry is dead and nothing says so.
+                 *
+                 * Refused rather than silently replaced, because the previous
+                 * secret cannot be recovered. Rotation is delete-then-create.
+                 */
+                const existing = await DatabaseServer.getKeys({
+                    messageId,
+                    owner: user.did
+                });
+                if (existing?.length) {
+                    return new MessageError(
+                        `A key for this policy already exists. Delete it before creating another.`,
+                        409
+                    );
+                }
+
                 const item = await DatabaseServer.saveKey({
                     messageId,
                     owner: user.did

--- a/guardian-service/tests/profile-policy-keys.test.mjs
+++ b/guardian-service/tests/profile-policy-keys.test.mjs
@@ -1,0 +1,82 @@
+import { assert } from 'chai';
+import { loadAPI, Interfaces } from './_handler-harness.mjs';
+
+/*
+ * GENERATE_USER_KEYS writes one row per creation, but the vault slot it fills is
+ * addressed by `${user.did}#${item.messageId}` and carries no row id. A second
+ * create for the same policy therefore added a second row while setUserKey
+ * overwrote the first row's secret: the keys list showed two entries for one
+ * policy, only the newer one resolved, and nothing said the older was dead.
+ *
+ * messageId is free text in the create dialog, so entering the same policy id
+ * twice is enough to reach it.
+ */
+
+const M = Interfaces.MessageAPI;
+
+let H, state;
+
+function makeState() {
+    return { existingKeys: [], saved: [], filters: [] };
+}
+
+async function setup() {
+    state = makeState();
+    const loaded = await loadAPI('../dist/api/profile.service.js', 'profileAPI', {
+        '@guardian/common': {
+            DatabaseServer: class {
+                static async getKeys(filter) {
+                    state.filters.push(filter);
+                    return state.existingKeys;
+                }
+                static async saveKey(row) {
+                    state.saved.push(row);
+                    return { ...row, id: `k-${state.saved.length}` };
+                }
+            },
+            Wallet: class {
+                async setUserKey() { }
+            },
+        },
+    });
+    H = loaded.handlers;
+}
+
+const create = (messageId, did = 'did:x') =>
+    H[M.GENERATE_USER_KEYS]({ user: { id: 'u1', did }, messageId });
+
+describe('@unit GENERATE_USER_KEYS duplicate policy keys', () => {
+    before(async function () {
+        this.timeout(180000);
+        await setup();
+    });
+    beforeEach(() => { state = Object.assign(state, makeState()); });
+
+    it('creates a key when the owner has none for that policy', async () => {
+        const r = await create('m1');
+        assert.isUndefined(r.error, `unexpected refusal: ${r.error}`);
+        assert.lengthOf(state.saved, 1);
+    });
+
+    it('refuses a second key for a policy the owner already has', async () => {
+        state.existingKeys = [{ id: 'k1', messageId: 'm1', owner: 'did:x' }];
+        const r = await create('m1');
+        assert.isOk(r.error, 'a duplicate must be refused');
+        assert.match(String(r.error), /already exists/i);
+        assert.lengthOf(state.saved, 0, 'no second row may be written');
+    });
+
+    it('scopes the check to the owner and the policy', async () => {
+        // scoping matters both ways: one user's key must not block another's,
+        // and a key for a different policy must not block this one
+        await create('m1');
+        assert.deepEqual(state.filters[0], { messageId: 'm1', owner: 'did:x' });
+    });
+
+    it('still allows a different policy for the same owner', async () => {
+        state.existingKeys = [];
+        const r = await create('m2');
+        assert.isUndefined(r.error);
+        assert.equal(state.saved[0].messageId, 'm2');
+    });
+});

--- a/guardian-service/tests/profile-policy-keys.test.mjs
+++ b/guardian-service/tests/profile-policy-keys.test.mjs
@@ -2,16 +2,10 @@ import { assert } from 'chai';
 import { loadAPI, Interfaces } from './_handler-harness.mjs';
 
 /*
- * GENERATE_USER_KEYS writes one row per creation, but the vault slot it fills is
- * addressed by `${user.did}#${item.messageId}` and carries no row id. A second
- * create for the same policy therefore added a second row while setUserKey
- * overwrote the first row's secret: the keys list showed two entries for one
- * policy, only the newer one resolved, and nothing said the older was dead.
- *
- * messageId is free text in the create dialog, so entering the same policy id
- * twice is enough to reach it.
+ * GENERATE_USER_KEYS writes one row per creation, but the vault slot is addressed by
+ * `did#messageId` alone - so a second create overwrote the first row's secret and left
+ * a dead entry in the list. messageId is free text in the create dialog.
  */
-
 const M = Interfaces.MessageAPI;
 
 let H, state;


### PR DESCRIPTION
Fixes #6862.

## Problem

`GENERATE_USER_KEYS` inserts a row per creation, but the vault slot it fills is addressed by `${user.did}#${item.messageId}` and carries **no row id**:

```ts
const item = await DatabaseServer.saveKey({ messageId, owner: user.did });
...
await wallet.setUserKey(user.did, KeyType.MESSAGE_KEY, `${user.did}#${item.messageId}`, key, ...);
```

A second create for the same policy therefore added a second row while `setUserKey` **overwrote the first row's secret**. The keys list showed two entries for one policy, only the newer one resolved, and nothing said the older was dead.

`messageId` is free text in the create dialog, so entering the same policy id twice is enough. (The documented import flow is unaffected — a recipient importing a shared key is a different DID, so their vault address differs.)

## Fix

Refuse the create when the owner already holds a key for that `messageId`, rather than replacing it silently, because the previous secret cannot be recovered. Rotation is delete-then-create, which frees the row and lets the next create take the slot.

## Tests

Four cases in `guardian-service/tests/profile-policy-keys.test.mjs`, using the existing `_handler-harness`.

They assert the **lookup filter**, not only the refusal — scoping to `messageId` *and* `owner` is what keeps one user's key from blocking another's, and a key for a different policy from blocking this one. A test that only checked "the second create failed" would pass against a filter scoped too broadly.

Verified against this branch: 4 pass. Against the unpatched source **2 fail** — the other two are the deliberate guards that ordinary creates still work.

## A separate problem I deliberately did not fix

`DELETE_USER_KEYS` removes the Mongo row and nothing else, so a key the user believes they revoked is still resolvable by anything addressing the vault directly.

There is no delete path to call: `Wallet` exposes only `getKey`/`setKey`, because `SecretManagerBase` declares only `getSecrets`/`setSecrets`, and none of the backends under `common/src/secret-manager/` mentions delete, destroy or purge.

Adding one means extending that interface across all of them, where "delete" means materially different things:

| backend | semantics |
|---|---|
| Vault KV v2 | `delete` soft-deletes a version; `destroy` is permanent |
| AWS Secrets Manager | schedules deletion with a minimum recovery window |
| Azure Key Vault | soft-deletes, then needs a separate purge |
| GCP Secret Manager | destroys a version |

Getting it wrong leaves the secret recoverable — not a fix — or destroys it irrecoverably. That reads as a maintainer decision about secret lifecycle rather than something to settle inside this change, so it is described in the issue and left out here. Happy to implement whichever semantics you prefer.
