### PR TITLE
fix: apply .dockerignore to service build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Dependencies
+**/node_modules
+.yarn/install-state.gz
+
+# Build outputs
+**/dist
+**/.output
+**/.angular
+**/.nuxt
+**/coverage
+
+# VCS and tooling
+.git
+.gitignore
+.github
+.claude
+**/.DS_Store
+**/*.log
+
+# Local env files
+**/.env
+**/.env.local
+!**/.env.docker

--- a/ai-service/.dockerignore
+++ b/ai-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/analytics-service/.dockerignore
+++ b/analytics-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/api-gateway/.dockerignore
+++ b/api-gateway/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/application-events/.dockerignore
+++ b/application-events/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/auth-service/.dockerignore
+++ b/auth-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/common/.dockerignore
+++ b/common/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/guardian-service/.dockerignore
+++ b/guardian-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/indexer-api-gateway/.dockerignore
+++ b/indexer-api-gateway/.dockerignore
@@ -1,4 +1,0 @@
-node_modules
-npm-debug.log
-dist
-.env

--- a/indexer-web-proxy/.dockerignore
+++ b/indexer-web-proxy/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/interfaces/.dockerignore
+++ b/interfaces/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/logger-service/.dockerignore
+++ b/logger-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/mrv-sender/.dockerignore
+++ b/mrv-sender/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/notification-service/.dockerignore
+++ b/notification-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/policy-service/.dockerignore
+++ b/policy-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/queue-service/.dockerignore
+++ b/queue-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/topic-listener-service/.dockerignore
+++ b/topic-listener-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/topic-viewer/.dockerignore
+++ b/topic-viewer/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/tree-viewer/.dockerignore
+++ b/tree-viewer/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/web-proxy/.dockerignore
+++ b/web-proxy/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log

--- a/worker-service/.dockerignore
+++ b/worker-service/.dockerignore
@@ -1,9 +1,0 @@
-.dockerignore
-.env
-.git
-.gitignore
-.npmrc
-dist
-Dockerfile
-node_modules
-npm-debug.log


### PR DESCRIPTION
### Description

Guardian service images build with `context: .`, so BuildKit never read the per-service `.dockerignore` files and every build shipped files it did not need. Adds the ignore file at the context root, where it actually applies.

- Add a root `.dockerignore` covering `**/node_modules`, VCS and tooling directories, build outputs and local env files, with `**/.env.docker` negated so `application-events` keeps its copied env file
- Exclude `.yarn/install-state.gz`, which every local `yarn install` rewrites and which invalidated the shared `COPY .yarn .yarn` layer across the 24 Dockerfiles that copy it
- Remove the 20 per-service `.dockerignore` files that had no effect, and keep the three whose build context is their own directory (`e2e-tests`, `sustainability-atlas/frontend`, `policy-service/docker/python-sandbox`)
- Use `**/`-prefixed patterns throughout, since a bare `node_modules` matches only the root-level path and not `frontend/node_modules`

Closes #6865
