### PR TITLE
fix: v2-12-0 fails on a fresh database

### DIFF
--- a/guardian-service/src/migrations/v2-12-0.ts
+++ b/guardian-service/src/migrations/v2-12-0.ts
@@ -54,6 +54,15 @@ export class ReleaseMigration extends Migration {
      */
     async updateVcIndexDocument() {
         const vcDocumentCollection = this.getCollection('VcDocument');
+        const db = this.driver.getConnection().getDb();
+        const exists = await db
+            .listCollections({ name: vcDocumentCollection.collectionName }, { nameOnly: true })
+            .hasNext();
+        if (!exists) {
+            // Fresh database: no collection, so no legacy index to replace and
+            // listIndexes() would throw NamespaceNotFound.
+            return;
+        }
         const listIndexes = vcDocumentCollection.listIndexes();
         while (await listIndexes.hasNext()) {
             const index = await listIndexes.next();


### PR DESCRIPTION
### Description

guardian-service failed to start against a fresh database: migration v2-12-0 called `listIndexes()` on the not-yet-created `vc_document` collection, which returns `NamespaceNotFound` instead of an empty list. Surfaced once `MikroORM.init()` stopped running `ensureIndexes()`, which previously created the collections before the migrations ran.

- Check that the `vc_document` collection exists before reading or dropping its indexes in v2-12-0
- Return early on a fresh database, where there is no legacy hash index to replace

Closes #6873 
