### PR TITLE
fix: documentValidatorBlock rejects conditions on a schema-forbidden branch

### DIFF
--- a/policy-service/src/policy-engine/helpers/utils.ts
+++ b/policy-service/src/policy-engine/helpers/utils.ts
@@ -485,6 +485,10 @@ export class PolicyUtils {
         // an explicit `equal` null check must fail closed here - otherwise not_equal/
         // not_in trivially pass for a side that lacks the field, validating nothing.
         if (left === null || left === undefined) {
+            // Both sides unresolved - nothing to compare, so the condition is not applicable.
+            if (right === null || right === undefined) {
+                return true;
+            }
             return type === 'equal' && PolicyUtils.coerceComparable(right) === null;
         }
         switch (type) {

--- a/policy-service/tests/unit-tests/helpers/check-document-field.test.mjs
+++ b/policy-service/tests/unit-tests/helpers/check-document-field.test.mjs
@@ -39,6 +39,60 @@ describe('PolicyUtils.checkDocumentField', () => {
         });
     });
 
+    describe('unresolved operands', () => {
+        // [operator, satisfying pair, violating pair]
+        const CASES = [
+            ['equal',     ['A', 'A'],   ['A', 'B']],
+            ['not_equal', ['A', 'B'],   ['A', 'A']],
+            ['gt',        [10, 5],      [5, 10]],
+            ['gte',       [5, 5],       [4, 5]],
+            ['lt',        [5, 10],      [10, 5]],
+            ['lte',       [5, 5],       [6, 5]],
+            ['in',        ['B', 'A,B,C'], ['D', 'A,B,C']],
+            ['not_in',    ['D', 'A,B,C'], ['B', 'A,B,C']],
+        ];
+
+        it('both sides absent: not applicable, for every operator', () => {
+            for (const [type] of CASES) {
+                assert.equal(PolicyUtils.evaluateFieldCondition(null, type, null), true, type);
+                assert.equal(PolicyUtils.evaluateFieldCondition(undefined, type, undefined), true, type);
+            }
+        });
+
+        it('absent left against a present right still fails closed, for every operator', () => {
+            for (const [type, [, right]] of CASES) {
+                assert.equal(PolicyUtils.evaluateFieldCondition(null, type, right), false, type);
+            }
+            assert.equal(PolicyUtils.evaluateFieldCondition(null, 'equal', 'null'), true);
+        });
+
+        it('both sides present: unchanged, for every operator', () => {
+            for (const [type, ok, bad] of CASES) {
+                assert.equal(PolicyUtils.evaluateFieldCondition(ok[0], type, ok[1]), true, `${type} pass`);
+                assert.equal(PolicyUtils.evaluateFieldCondition(bad[0], type, bad[1]), false, `${type} fail`);
+            }
+        });
+
+        it('a rule against a configured value cannot be bypassed by omitting the field', () => {
+            for (const [type, , bad] of CASES) {
+                const f = { field: 'document.credentialSubject.0.missing', type, valueSource: 'value', value: bad[1] };
+                assert.equal(PolicyUtils.checkDocumentField(doc({}), f), false, type);
+            }
+        });
+
+        it('a condition on a schema branch the document omits does not block it', () => {
+            // if/then/else discriminator: cert_type "A" forbids branch_b entirely
+            const d = doc({ cert_type: 'A', branch_a: { from: '2024-01-01', to: '2024-06-01' } });
+            const cond = (field, value) => ({ field, type: 'gte', valueSource: 'document', value });
+            assert.equal(PolicyUtils.checkDocumentField(d, cond(
+                'document.credentialSubject.0.branch_a.to',
+                'document.credentialSubject.0.branch_a.from')), true);
+            assert.equal(PolicyUtils.checkDocumentField(d, cond(
+                'document.credentialSubject.0.branch_b.to',
+                'document.credentialSubject.0.branch_b.from')), true);
+        });
+    });
+
     describe('in / not_in (comma-separated list)', () => {
         it('in: field value is in the list', () => {
             assert.equal(PolicyUtils.checkDocumentField(doc({ type: 'B' }), filter('document.credentialSubject.0.type', 'in', 'A,B,C')), true);


### PR DESCRIPTION
**Description**:

Closes #6884.

`documentValidatorBlock` rejects a document on conditions targeting a schema branch the schema itself forbids, with an error no user input can clear.

A JSON-Schema `if`/`then`/`else` discriminator marks the non-selected branch `false`, which matches nothing - a document carrying that key is schema-invalid, and the frontend removes the control entirely (`field-form.ts`). The block, however, holds a flat condition list with no notion of the discriminator, so a policy validating both branches evaluates both sets against every document. On the forbidden branch **both** operands resolve to `null`, and since #6786 that fails for every operator but `equal`:

```
Field "mostRecentDate": Value null is not greater than or equal to null
```

The field is not on the user's form and cannot be added without failing schema validation - **unsatisfiable by construction**. Both enum values are affected symmetrically: whichever branch is forbidden, that branch's non-`equal` conditions fail.

#6786's guard is correct for the case it was written for - a field the document does not carry made `not_equal`/`not_in` against a **configured value** trivially true, so a rule meant to reject a value validated nothing. It is only too broad when both operands are unresolved paths, where there is no configured value to check against and nothing to compare.

**Change**:

```ts
if (left === null || left === undefined) {
    // Both sides unresolved - nothing to compare, so the condition is not applicable.
    if (right === null || right === undefined) {
        return true;
    }
    return type === 'equal' && PolicyUtils.coerceComparable(right) === null;
}
```

A configured value is never `null`, so #6786's fail-closed behaviour is untouched. Only the both-absent case changes.

**Verification**:

Scenario matrix, run against the built code:

```
scenario                                            before     after      changed?
rule vs LITERAL, field present & bad                REJECT     REJECT
rule vs LITERAL, field OMITTED  (bypass attempt)    REJECT     REJECT
not_equal vs LITERAL, field OMITTED (#6786 case)    REJECT     REJECT
not_in vs LITERAL, field OMITTED   (#6786 case)     REJECT     REJECT
cross-field, both present & bad                     REJECT     REJECT
cross-field, both present & good                    pass       pass
cross-field, LEFT omitted only                      REJECT     REJECT
cross-field, RIGHT omitted only                     pass       pass
cross-field, BOTH omitted                           REJECT     pass       YES
```

Exactly one row moves.

**Tests**:

New `unresolved operands` suite in `check-document-field.test.mjs`, table-driven across all eight condition types (`equal`, `not_equal`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`):

- both sides absent - not applicable, for every operator (`null` and `undefined`)
- absent left against a present right - still fails closed, for every operator
- both sides present - unchanged pass/fail behaviour, for every operator
- a rule against a configured value cannot be bypassed by omitting the field, for every operator
- an `if`/`then`/`else` discriminator scenario end to end

Confirmed the new tests fail on `develop` unpatched and pass with the change, so they pin the behaviour rather than merely describing it.

**Related issue(s)**:

Fixes #6884. Regression from #6786. Same `documentValidatorBlock` family as #6546, #6713, #6740, #6744, #6779.

**Checklist**
- [x] Documentation added
- [x] Tests added
