### PR TITLE
fix: 6779 compose source filters into $and

### DIFF
--- a/policy-service/src/policy-engine/blocks/document-validator-block.ts
+++ b/policy-service/src/policy-engine/blocks/document-validator-block.ts
@@ -137,7 +137,8 @@ export class DocumentValidatorBlock {
             (rawValue === coerced || rawValue === undefined || rawValue === null)
                 ? [coerced]
                 : [coerced, rawValue];
-        const rangeFilters: any[] = [];
+
+        const predicates: any[] = [];
 
         for (const f of (sourceValidation.filters || [])) {
             const raw = f.typeValue === 'variable'
@@ -147,14 +148,16 @@ export class DocumentValidatorBlock {
             const both = alternatives(raw, value);
 
             switch (f.type) {
-                case 'not_equal': filter[f.field] = { $nin: both }; break;
+                case 'not_equal':
+                    predicates.push({ [f.field]: { $nin: both } });
+                    break;
                 case 'in':
                 case 'not_in': {
                     const source: any[] = f.typeValue === 'variable'
                         ? (Array.isArray(raw) ? raw : [raw])
                         : String(f.value).split(',').map((v: string) => v.trim());
                     const arr = source.flatMap((e: any) => alternatives(e, this.coerceValue(e)));
-                    filter[f.field] = f.type === 'in' ? { $in: arr } : { $nin: arr };
+                    predicates.push({ [f.field]: f.type === 'in' ? { $in: arr } : { $nin: arr } });
                     break;
                 }
                 case 'gt':
@@ -163,20 +166,22 @@ export class DocumentValidatorBlock {
                 case 'lte': {
                     const op = `$${f.type}`;
                     if (both.length === 1) {
-                        filter[f.field] = { [op]: both[0] };
+                        predicates.push({ [f.field]: { [op]: both[0] } });
                     } else {
                         // type bracketing means one predicate cannot span both, so the
                         // document qualifies if it compares true as EITHER type
-                        rangeFilters.push({ $or: both.map((v) => ({ [f.field]: { [op]: v } })) });
+                        predicates.push({ $or: both.map((v) => ({ [f.field]: { [op]: v } })) });
                     }
                     break;
                 }
-                default:          filter[f.field] = { $in: both }; break;
+                default:
+                    predicates.push({ [f.field]: { $in: both } });
+                    break;
             }
         }
 
-        if (rangeFilters.length) {
-            filter.$and = rangeFilters;
+        if (predicates.length) {
+            filter.$and = predicates;
         }
 
         return filter;

--- a/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/document-validator-filter-coercion.test.mjs
@@ -4,6 +4,9 @@ import { DocumentValidatorBlock } from '../../../dist/policy-engine/blocks/docum
 const block = () => Object.create(DocumentValidatorBlock.prototype);
 const ref = { policyId: 'policy-1' };
 
+// every filter predicate is composed into $and, so repeated fields survive
+const clauseFor = (filter, field) => (filter.$and || []).find((c) => field in c)?.[field];
+
 describe('documentValidatorBlock source filter coercion', () => {
     describe('type coercion against string-stored values', () => {
         const filterFor = (type, value) => block().buildSourceFilter(
@@ -16,13 +19,13 @@ describe('documentValidatorBlock source filter coercion', () => {
 
             // '100' coerces to the number 100; VC JSON stores the string, and Mongo
             // comparisons are type-bracketed, so one representation alone misses
-            assert.deepEqual(filter['document.credentialSubject.0.date'], { $in: [100, '100'] });
+            assert.deepEqual(clauseFor(filter, 'document.credentialSubject.0.date'), { $in: [100, '100'] });
         });
 
         it('excludes both representations for not_equal', () => {
             const filter = filterFor('not_equal', '100');
 
-            assert.deepEqual(filter['document.credentialSubject.0.date'], { $nin: [100, '100'] });
+            assert.deepEqual(clauseFor(filter, 'document.credentialSubject.0.date'), { $nin: [100, '100'] });
         });
 
         it('compares a date range as either type', () => {
@@ -38,8 +41,9 @@ describe('documentValidatorBlock source filter coercion', () => {
         it('keeps a single predicate when coercion changes nothing', () => {
             const filter = filterFor('gte', 'abc');
 
-            assert.isUndefined(filter.$and);
-            assert.deepEqual(filter['document.credentialSubject.0.date'], { $gte: 'abc' });
+            assert.lengthOf(filter.$and, 1);
+
+            assert.deepEqual(clauseFor(filter, 'document.credentialSubject.0.date'), { $gte: 'abc' });
         });
 
         it('widens every element of an in list', () => {
@@ -48,7 +52,7 @@ describe('documentValidatorBlock source filter coercion', () => {
                 ref, {}, {}
             );
 
-            assert.deepEqual(filter.f, { $in: [1, '1', 2, '2'] });
+            assert.deepEqual(clauseFor(filter, 'f'), { $in: [1, '1', 2, '2'] });
         });
     });
 
@@ -74,7 +78,7 @@ describe('documentValidatorBlock source filter coercion', () => {
                 ref, document, {}
             );
 
-            assert.deepEqual(filter.f, { $in: [1, '1', 2, '2'] });
+            assert.deepEqual(clauseFor(filter, 'f'), { $in: [1, '1', 2, '2'] });
         });
     });
 });

--- a/policy-service/tests/unit-tests/blocks/document-validator-source-filter.test.mjs
+++ b/policy-service/tests/unit-tests/blocks/document-validator-source-filter.test.mjs
@@ -52,4 +52,53 @@ describe('documentValidatorBlock source filter', () => {
         });
     });
 
+    describe('two filters on the same field', () => {
+        const filtersFor = (filters) => block().buildSourceFilter({ filters }, ref, {}, {}).$and;
+
+        const range = { field: 'document.credentialSubject.0.projectId', type: 'gte', value: 'PRJ-100', typeValue: 'value' };
+        const exclude = { field: 'document.credentialSubject.0.projectId', type: 'not_equal', value: 'PRJ-150', typeValue: 'value' };
+
+        it('composes both predicates instead of overwriting one', () => {
+            // assigning into filter[field] kept only the last filter, so the range
+            // bound vanished and PRJ-050 satisfied the source validation
+            assert.deepEqual(filtersFor([range, exclude]), [
+                { 'document.credentialSubject.0.projectId': { $gte: 'PRJ-100' } },
+                { 'document.credentialSubject.0.projectId': { $nin: ['PRJ-150'] } }
+            ]);
+        });
+
+        it('does not depend on the order the author configured them in', () => {
+            const reversed = filtersFor([exclude, range]);
+
+            assert.sameDeepMembers(reversed, filtersFor([range, exclude]));
+        });
+
+        it('keeps a widened range alongside a same-field in list', () => {
+            const $and = filtersFor([
+                { field: 'amount', type: 'gte', value: '100', typeValue: 'value' },
+                { field: 'amount', type: 'in', value: '100, 200', typeValue: 'value' }
+            ]);
+
+            assert.lengthOf($and, 2);
+            assert.deepEqual($and[0].$or, [
+                { amount: { $gte: 100 } },
+                { amount: { $gte: '100' } }
+            ]);
+            assert.deepEqual($and[1], { amount: { $in: [100, '100', 200, '200'] } });
+        });
+
+        it('gives distinct fields one clause each', () => {
+            assert.deepEqual(filtersFor([
+                { field: 'a', type: 'equal', value: 'x', typeValue: 'value' },
+                { field: 'b', type: 'equal', value: 'y', typeValue: 'value' }
+            ]), [
+                { a: { $in: ['x'] } },
+                { b: { $in: ['y'] } }
+            ]);
+        });
+
+        it('adds no $and when there are no filters', () => {
+            assert.isUndefined(block().buildSourceFilter({}, ref, {}, {}).$and);
+        });
+    });
 });


### PR DESCRIPTION
### Description

`documentValidatorBlock` built its source query by assigning each configured filter onto `filter[field]`, so two filters on the same field overwrote each other. The surviving one decided whether the source validation admitted documents it was meant to exclude or rejected ones it was meant to admit, and nothing reported the dropped constraint.

- Accumulate every source filter predicate into `$and` instead of assigning onto `filter[field]`, so repeated fields compose
- Keep the structural clauses (`policyId`, `schema`, `owner`, `group`, `assignedTo`, `assignedToGroup`) as direct keys, since each is emitted at most once
- Leave `$and` unset when a source validation configures no filters
- Cover the composed predicates with unit tests, including the reported range-plus-exclusion case and its reverse order

A duplicated field is deliberately not reported as a config error: with predicates composing, a range bound plus an exclusion on one field is a valid configuration.

Closes #6779
