### PR TITLE
chore: bump Node, MongoDB and Nginx versions

### DIFF
--- a/.github/workflows/add-documentation-to-repo.yaml
+++ b/.github/workflows/add-documentation-to-repo.yaml
@@ -18,8 +18,8 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     strategy:
       matrix:
-        node-version: [ 24.18.1 ]
-        mongodb-version: [ 7.0.21 ]
+        node-version: [ 24.21.0 ]
+        mongodb-version: [ 7.0.41 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/api-after-commit.yml
+++ b/.github/workflows/api-after-commit.yml
@@ -16,8 +16,8 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
       MIN_PASSWORD_LENGTH: 4
       PASSWORD_COMPLEXITY: easy
-      NODE_VERSION: '24.18.1'
-      MONGODB_VERSION: '7.0.21'
+      NODE_VERSION: '24.21.0'
+      MONGODB_VERSION: '7.0.41'
       KUBO_VERSION: '0.43.0'
     services:
       cache:

--- a/.github/workflows/api-manual.yml
+++ b/.github/workflows/api-manual.yml
@@ -47,7 +47,7 @@ jobs:
       CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
       MIN_PASSWORD_LENGTH: 4
       PASSWORD_COMPLEXITY: easy
-      NODE_VERSION: "24.18.1"
+      NODE_VERSION: "24.21.0"
       # How many worker-service processes to run; the readiness gate expects exactly
       # this many WORKERS_SERVICE connections on NATS.
       WORKER_COUNT: 5
@@ -86,7 +86,7 @@ jobs:
 
       # DB_HOST=localhost in every service config.
       mongo:
-        image: mongo:7.0.21
+        image: mongo:7.0.41
         ports:
           - 127.0.0.1:27017:27017
         options: >-

--- a/.github/workflows/api-schedule-all.yml
+++ b/.github/workflows/api-schedule-all.yml
@@ -18,8 +18,8 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 24.18.1 ]
-        mongodb-version: [ 7.0.21 ]
+        node-version: [ 24.21.0 ]
+        mongodb-version: [ 7.0.41 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/api-schedule-vm0033.yml
+++ b/.github/workflows/api-schedule-vm0033.yml
@@ -18,8 +18,8 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 24.18.1 ]
-        mongodb-version: [ 7.0.21 ]
+        node-version: [ 24.21.0 ]
+        mongodb-version: [ 7.0.41 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,7 +46,7 @@ jobs:
       CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
       MIN_PASSWORD_LENGTH: 4
       PASSWORD_COMPLEXITY: easy
-      NODE_VERSION: "24.18.1"
+      NODE_VERSION: "24.21.0"
       # How many worker-service processes to run; the readiness gate expects exactly
       # this many WORKERS_SERVICE connections on NATS.
       WORKER_COUNT: 5
@@ -85,7 +85,7 @@ jobs:
 
       # DB_HOST=localhost in every service config.
       mongo:
-        image: mongo:7.0.21
+        image: mongo:7.0.41
         ports:
           - 127.0.0.1:27017:27017
         options: >-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'false'
     strategy:
       matrix:
-        node-version: [ 24.18.1 ]
+        node-version: [ 24.21.0 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/major-deps-update.yaml
+++ b/.github/workflows/major-deps-update.yaml
@@ -12,7 +12,7 @@ jobs:
   check-majors:
     runs-on: guardian-linux-medium
     env:
-      NODE_VERSION: "24.18.1"
+      NODE_VERSION: "24.21.0"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/.github/workflows/ui-manual.yml
+++ b/.github/workflows/ui-manual.yml
@@ -18,8 +18,8 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        node-version: [ 24.18.1 ]
-        mongodb-version: [ 7.0.21 ]
+        node-version: [ 24.21.0 ]
+        mongodb-version: [ 7.0.41 ]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/analytics-service/Dockerfile
+++ b/analytics-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/api-gateway/Dockerfile.demo
+++ b/api-gateway/Dockerfile.demo
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/application-events/Dockerfile
+++ b/application-events/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/auth-service/Dockerfile.demo
+++ b/auth-service/Dockerfile.demo
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/guardian-service/Dockerfile
+++ b/guardian-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/indexer-api-gateway/Dockerfile
+++ b/indexer-api-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/indexer-service/Dockerfile
+++ b/indexer-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/indexer-web-proxy/Dockerfile
+++ b/indexer-web-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
 ARG NODE_VERSION=20.20.2-alpine
-ARG NGINX_VERSION=1.30.3-alpine
+ARG NGINX_VERSION=1.30.4-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/indexer-worker-service/Dockerfile
+++ b/indexer-worker-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/logger-service/Dockerfile
+++ b/logger-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/mrv-sender/Dockerfile
+++ b/mrv-sender/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/policy-service/Dockerfile
+++ b/policy-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/queue-service/Dockerfile
+++ b/queue-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/topic-listener-service/Dockerfile
+++ b/topic-listener-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/topic-viewer/Dockerfile
+++ b/topic-viewer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/tree-viewer/Dockerfile
+++ b/tree-viewer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base

--- a/web-proxy/Dockerfile
+++ b/web-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=24.18.1-alpine
-ARG NGINX_VERSION=1.30.3-alpine
+ARG NODE_VERSION=24.21.0-alpine
+ARG NGINX_VERSION=1.30.4-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/web-proxy/Dockerfile.ci
+++ b/web-proxy/Dockerfile.ci
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=24.18.1-alpine
-ARG NGINX_VERSION=1.30.3-alpine
+ARG NODE_VERSION=24.21.0-alpine
+ARG NGINX_VERSION=1.30.4-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/web-proxy/Dockerfile.demo
+++ b/web-proxy/Dockerfile.demo
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Stage 0: # Define the versions of the base images used
-ARG NODE_VERSION=24.18.1-alpine
-ARG NGINX_VERSION=1.30.3-alpine
+ARG NODE_VERSION=24.21.0-alpine
+ARG NGINX_VERSION=1.30.4-alpine
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base
 WORKDIR /usr/local/app

--- a/worker-service/Dockerfile
+++ b/worker-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 0: Use node image for base image for all stages
-ARG NODE_VERSION=24.18.1-alpine
+ARG NODE_VERSION=24.21.0-alpine
 
 # JS compile: run on the builder's native arch (fast, output is arch-agnostic)
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS base


### PR DESCRIPTION
Upgrade Node from 24.18.1 to 24.21.0 across GitHub workflows and service Dockerfiles; bump MongoDB from 7.0.21 to 7.0.41 in workflows that run a local mongo service; update NGINX from 1.30.3-alpine to 1.30.4-alpine for web-proxy and indexer-web-proxy. Changes refresh base images for security and compatibility.
