### PR TITLE
docs: 6594 add table columns user guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -239,6 +239,8 @@
           * [Existing file \_id to overwrite (optional)](guardian/workspace/schemas/available-schema-types/table-data-input-field/apis-related/existing-file-_id-to-overwrite-optional.md)
           * [Add file to ipfs directly](guardian/workspace/schemas/available-schema-types/table-data-input-field/apis-related/add-file-to-ipfs-directly.md)
           * [Deletes file from GridFS by id](guardian/workspace/schemas/available-schema-types/table-data-input-field/apis-related/deletes-file-from-gridfs-by-id.md)
+      * [Table Columns](guardian/workspace/schemas/available-schema-types/table-columns/README.md)
+        * [Configure Table Columns](guardian/workspace/schemas/available-schema-types/table-columns/configure-table-columns.md)
     * [Property Glossary](guardian/workspace/schemas/property-glossary.md)
     * [Schema Design Best Practices](guardian/workspace/schemas/best-practices-to-implement-schema/README.md)
       * [Excel-First Design](guardian/workspace/schemas/best-practices-to-implement-schema/excel-first-design.md)

--- a/docs/guardian/workspace/schemas/available-schema-types/table-columns/README.md
+++ b/docs/guardian/workspace/schemas/available-schema-types/table-columns/README.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - concept
+  - tag: new
+    primary: true
+---
+
+# Table Columns
+
+Table Columns let a schema author declare the columns of a Table field - a display name and a stable key for each - while building the schema, instead of the keys being inferred later from whatever text sits in the header row of an uploaded file.
+
+Declaring columns is optional. A Table field with no declared columns keeps working exactly as before: its column keys come from the first row of each uploaded CSV file.
+
+### The problem it solves
+
+A Table field's keys used to come only from the uploaded file's header row. Two files for the same field with differently worded headers - `CO2` versus `CO2 (tonnes)` - produce documents with different keys, so a `table.col(field, "CO2")` expression, a Custom Logic script, or an API consumer written against one file silently stops matching the other. Nothing in the schema records what the columns are supposed to be, so a mismatch is only caught by re-reading data by hand.
+
+Declared columns give the schema a single, stable name for each column, independent of what any particular uploaded file happens to say in its first row.
+
+### How it works
+
+**A Define columns switch turns declaration on for a Table field.** Off is the default and the legacy behavior: no `tableColumns` on the field, keys come from the uploaded file. On adds one column row and requires at least one column at all times.
+
+**Each column has a display name and a key.** Typing a display name, for example `CO2 (tonnes)`, derives the key automatically - `co2_tonnes`. The key stays read-only while it is derived. Clicking the pencil inside the key input unlocks it for manual editing; clicking the pencil again rebuilds it from the name. Keys must be non-empty, free of whitespace, and unique within the field.
+
+**Column order is set by dragging rows**, and that order is the column order everywhere the table is shown - the form, the document view, and calculations that read columns by position.
+
+**The declared columns live in the schema field's `$comment`**, the same place other field metadata such as `unit` or `enumName` is stored, so an unknown property never reaches AJV schema validation.
+
+**An uploaded file is matched to declared columns by position, not by header text.** Guardian expects exactly as many columns as are declared. If the file's first row matches the declared display names or keys, that row is recognized as a header and excluded from the data; otherwise the first row is treated as data. Either way, the values produced in the document are keyed by the declared keys, not by whatever the file's header said.
+
+**Consumers read the same stable keys.** The `table` helper available to AutoCalculate expressions, Math Block Advanced JavaScript, and Custom Logic scripts resolves a declared column by its key, for example `table.col(tableData, 'co2_tonnes')`, and stays correct no matter what an uploaded file's header row says. A legacy Table with no declared columns still works with the same helper, using the header text itself as the key, for example `table.col(tableLegacy, 'CO2 (tonnes)')`.
+
+**The policy documents API can expand a Table's file into rows without the caller parsing CSV.** `GET /policies/{policyId}/documents` accepts `expandTables=true`, plus `tableOffset`, `tableLimit`, and a `tableColumns` filter of comma-separated keys, and returns each Table's rows as objects keyed by the declared keys - or by the file's header text for a legacy Table. The stored document, its signature, and its IPFS copy are unchanged; expansion happens only in the response, bounded by a server-side row ceiling.
+
+**XLSX schema export and import carry the declared columns as well.** A Table field's row in the exported spreadsheet keeps its column names, keys, and order as a JSON array in the `Parameter` cell, so a schema round-tripped through Excel keeps its column configuration.
+
+### Key distinctions
+
+* **Optional, not required.** Declaring columns is a stricter contract an author opts into. An author who does not yet know a file's structure can leave a Table field undeclared.
+* **Keys are stable identifiers, display names are labels - but only once the key is unlocked.** The key is what a formula, script, or API consumer matches on. The display name is what a person sees in the form and the document view. While the key is still derived from the name, renaming the display name rewrites the key to match, by design. Unlocking the key with the pencil breaks that link: after that, renaming the display name no longer changes the key.
+* **Files are matched by position, not by column name.** The number and order of a declared Table's columns must match the uploaded file. A header row is recognized by content, but it is never used to remap columns.
+* **A Table field saved before this feature has no declared columns and is unaffected.** It keeps deriving keys from each uploaded file's header row.
+
+### Related
+
+* Task: [Configure Table Columns](configure-table-columns.md)
+* Concept: [Table Data Input Field](../table-data-input-field/README.md) - the Table field itself: importing, editing and viewing table data.

--- a/docs/guardian/workspace/schemas/available-schema-types/table-columns/configure-table-columns.md
+++ b/docs/guardian/workspace/schemas/available-schema-types/table-columns/configure-table-columns.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - tasks
+---
+
+# Configure Table Columns
+
+Declare the columns of a Table field so forms, calculations, APIs and the Indexer use stable keys that do not depend on the text in an uploaded file. See [Table Columns](README.md) for how declared columns behave.
+
+### Prerequisites
+
+* You have a schema open in the schema editor in **DRAFT** status.
+* You know the number and order of columns that uploaded files will contain.
+
+### Steps
+
+#### Add or select a Table field
+
+1. Add a schema field and choose **Table** as its type, or select an existing Table field.
+2. The **Table columns** section appears at the bottom of the field settings.
+
+#### Define the columns
+
+1. Turn on **Define columns**. A new Table field starts with the toggle on and one empty column row.
+2. Enter a display name for the first column. Guardian creates a key from the name and keeps the key read-only while the name changes - for example, `CO2 (tonnes)` becomes `co2_tonnes`.
+3. To choose a different key, click the pencil in the key input and edit it. Click the pencil again to return to the generated key.
+4. Click **Add column** for each additional column. Drag rows by their handles until their order matches the files that users will upload. Use the trash button to remove a row.
+
+Each column needs a display name and a key. Keys cannot contain spaces and must be unique within the Table field. A declared Table must keep at least one column.
+
+Leave the toggle off only when the field must keep the legacy behavior, where column keys come from the first row of every uploaded CSV file.
+
+#### Save the schema
+
+1. Click **Save all**.
+2. Close and reopen the schema if you want to verify that the toggle, names, keys and order were stored.
+
+#### Export or import the schema as XLSX
+
+1. Export the schema. If **Define columns** is on, the Table field's row appears with type `Table`, and its `Parameter` cell contains the ordered column configuration as JSON:
+
+   ```json
+   [{"name":"Year","key":"year"},{"name":"CO2 (tonnes)","key":"co2_tonnes"}]
+   ```
+2. To import a Table field with declared columns, use the same JSON format in the `Parameter` cell, with entries in the same order as the file columns. A blank `Parameter` cell means **Define columns** is off.
+3. Import the file. Guardian rejects the import when a non-empty Table `Parameter` is not valid JSON, is an empty array, contains an empty name or key, contains whitespace in a key, or repeats a key.
+
+#### Upload a matching CSV file
+
+1. When the schema is used in a form, upload a CSV file with exactly the declared number of columns. Guardian maps file columns to schema columns by position.
+2. If the first row matches the declared display names or keys, Guardian recognizes it as a header and does not include it in the data rows. Otherwise, the first row is treated as data. Header text does not change the declared keys.
+
+#### Use declared keys in a calculation
+
+1. Open an AutoCalculate expression, a Math Block's **Formulas → Advanced (Optional)**, or a Custom Logic script.
+2. Reference the Table field's declared column with the `table` helper, using the key rather than the display name: `table.col(tableData, 'co2_tonnes')`.
+3. A legacy Table with no declared columns still works with the same helper, using the exact text of its file's header row as the key instead: `table.col(tableLegacy, 'CO2 (tonnes)')`.
+
+#### Read declared keys through the policy documents API
+
+1. Call `GET /policies/{policyId}/documents` with `includeDocument=true` and `expandTables=true`.
+2. Optionally add `tableOffset`, `tableLimit`, and a `tableColumns` filter of comma-separated keys to bound which rows come back.
+3. Each Table value in the response gains a `rows` array keyed by the declared keys - or by the file's header text for a legacy Table - alongside `columnNames`, `columnKeys`, and paging fields (`rowsTotal`, `rowsOffset`, `rowsRequested`, `rowsTruncated`). The stored document itself is not changed by this call.
+
+### Result
+
+Guardian stores the Table value with both `columnNames` and `columnKeys`. Guardian and the Indexer show the display names, while calculations, scripts and expanded API row objects use the stable keys.
+
+XLSX schema export and import preserve the Table field's column names, keys and order. A blank Table `Parameter` preserves the toggle-off state.
+
+Table fields created before this feature have no declared columns and continue to work. Their column keys come from the first row of each uploaded CSV file.
+
+### Troubleshooting
+
+**The schema does not save.** Check that every column has a display name and key, that no key contains spaces, and that keys are unique within the field.
+
+**The file is rejected after upload.** Its number of columns does not match the schema. Correct the file or the draft schema, then upload it again.
+
+**Values appear under the wrong names.** Guardian matches columns by position, not by header text. Reorder the file columns or the declared rows so both orders match.
+
+**The XLSX schema cannot be imported.** Check the Table row's `Parameter` cell. When it is not blank, it must contain a non-empty JSON array of unique `name` and `key` pairs. Keys cannot contain whitespace.
+
+### Related
+
+* Concept: [Table Columns](README.md)

--- a/docs/guardian/workspace/schemas/available-schema-types/table-data-input-field/README.md
+++ b/docs/guardian/workspace/schemas/available-schema-types/table-data-input-field/README.md
@@ -79,3 +79,7 @@ What it does:
 ## Demo Video
 
 [Youtube](https://youtu.be/m3waGJ7qgs4?si=0bEJusqaQ2hPEU4t\&t=121)
+
+## Related
+
+* [Table Columns](../table-columns/README.md) — declare a Table field's column names and keys in the schema instead of relying on an uploaded file's header row.


### PR DESCRIPTION
**Description**:

A Table field could be added to a schema but could not be described there. Its columns appeared only after somebody uploaded a spreadsheet, and the file's first row silently became the column keys. A schema author therefore could not write a stable formula, script, or API integration against those columns before a document existed.

The field panel now provides a Define columns switch. Each declared column has a display name and a stable key generated from that name, and columns can be added, removed down to one, and reordered. The configuration survives schema save and reload, controls the document form, and is carried with the stored table reference. AutoCalculate, Custom Logic, and Math Advanced JavaScript use the same table helpers and declared keys, including the Math editor's Testing flow. The Indexer displays the same column names as Guardian.

The documents endpoint can expand table values on request and apply row paging and column filtering without changing stored documents. Tables without declared columns keep their legacy behavior and use the uploaded file's first row as the header. Column data types, per-column validation and defaults, and the General formula builder remain unchanged.

**Related issue(s)**:

Docs #6594

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
