### PR TITLE
chore: version bump 3.7.1-rc

### DIFF
--- a/ai-service/package.json
+++ b/ai-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-service",
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "main": "dist/app.js",
     "license": "Apache-2.0",
     "dependencies": {

--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -62,5 +62,5 @@
         "test": "mocha tests/**/*.test.mjs --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/analytics-service.xml --timeout 10000 --exit"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -69,5 +69,5 @@
         "test:local": "mocha --exit"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/application-events/package.json
+++ b/application-events/package.json
@@ -51,5 +51,5 @@
         "test": "mocha --require ts-node/register tests/**/*.ts --timeout 10000"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -66,5 +66,5 @@
         "test": "mocha tests/**/*.test.mjs --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/auth-service.xml --exit"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/common/package.json
+++ b/common/package.json
@@ -90,5 +90,5 @@
         "test:local": "mocha tests/**/*.test.mjs --exit"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "guardian-e2e-test",
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "guardian-e2e-test",
-            "version": "3.7.0",
+            "version": "3.7.1-rc",
             "license": "ISC",
             "dependencies": {
                 "@bahmutov/cy-api": "2.3.0",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "guardian-e2e-test",
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "description": "This a place for quardian e2e automation test suite",
     "main": "index.js",
     "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guardian",
-  "version": "3.7.0",
+  "version": "3.7.1-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guardian",
-      "version": "3.7.0",
+      "version": "3.7.1-rc",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/cdk": "^21.2.14",
@@ -85,7 +85,7 @@
     },
     "../interfaces": {
       "name": "@guardian/interfaces",
-      "version": "3.7.0",
+      "version": "3.7.1-rc",
       "license": "Apache-2.0",
       "dependencies": {
         "countries-list": "3.4.1",
@@ -5132,7 +5132,7 @@
       "license": "MIT"
     },
     "node_modules/connect": {
-      "version": "3.7.0",
+      "version": "3.7.1-rc",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
       "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
       "dev": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,5 +90,5 @@
     "test": "ng test",
     "watch": "ng build --watch --configuration development --output-path ../www-data"
   },
-  "version": "3.7.0"
+  "version": "3.7.1-rc"
 }

--- a/guardian-service/package.json
+++ b/guardian-service/package.json
@@ -72,5 +72,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/indexer-api-gateway/package.json
+++ b/indexer-api-gateway/package.json
@@ -74,5 +74,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/indexer-common/package.json
+++ b/indexer-common/package.json
@@ -48,5 +48,5 @@
         "prepack": "npm run build:prod"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/indexer-frontend/package-lock.json
+++ b/indexer-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "indexer-frontend",
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "indexer-frontend",
-            "version": "3.7.0",
+            "version": "3.7.1-rc",
             "dependencies": {
                 "@angular/animations": "^17.3.0",
                 "@angular/cdk": "^17.3.2",
@@ -56,7 +56,7 @@
         },
         "../indexer-common": {
             "name": "@indexer/common",
-            "version": "3.7.0",
+            "version": "3.7.1-rc",
             "license": "Apache-2.0",
             "dependencies": {
                 "@indexer/interfaces": "3.6.0",
@@ -85,7 +85,7 @@
         },
         "../indexer-interfaces": {
             "name": "@indexer/interfaces",
-            "version": "3.7.0",
+            "version": "3.7.1-rc",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/glob": "^8.1.0",

--- a/indexer-frontend/package.json
+++ b/indexer-frontend/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Hashgraph <guardian@hashgraph.com>",
     "name": "indexer-frontend",
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "scripts": {
         "ng": "ng",
         "start": "ng serve --proxy-config ./proxy.conf.json",

--- a/indexer-interfaces/package.json
+++ b/indexer-interfaces/package.json
@@ -21,5 +21,5 @@
         "prepack": "npm run build"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/indexer-service/package.json
+++ b/indexer-service/package.json
@@ -55,5 +55,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/indexer-worker-service/package.json
+++ b/indexer-worker-service/package.json
@@ -51,5 +51,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -32,5 +32,5 @@
         "test": "mocha tests/**/*.test.mjs --reporter mocha-junit-reporter --reporter-options mochaFile=../test_results/interfaces.xml --exit"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/logger-service/package.json
+++ b/logger-service/package.json
@@ -40,5 +40,5 @@
         "watch": "nodemon src/index.ts"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/mrv-sender/package.json
+++ b/mrv-sender/package.json
@@ -33,5 +33,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/notification-service/package.json
+++ b/notification-service/package.json
@@ -41,5 +41,5 @@
         "watch": "nodemon src/index.ts"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "publish-policies": "guardian-cli publish-policies \"Methodology Library\" -c \"configs/automatic-publish-policies.config.json\" -o \"published-policies.txt\"",
         "clean": "find . -type d \\( -name dist -o -name node_modules \\) -prune -exec rm -rf {} +"
     },
-    "version": "3.7.0",
+    "version": "3.7.1-rc",
     "workspaces": [
         "interfaces",
         "common",

--- a/policy-service/package.json
+++ b/policy-service/package.json
@@ -69,5 +69,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/queue-service/package.json
+++ b/queue-service/package.json
@@ -42,5 +42,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/swagger-analytics.yaml
+++ b/swagger-analytics.yaml
@@ -215,7 +215,7 @@ info:
     leverages a customizable Policy Workflow Engine and Web3 technology to
     ensure transparent and fraud-proof operations, making it a key tool for
     transforming sustainability practices and carbon markets.
-  version: 3.7.0
+  version: 3.7.1-rc
   contact:
     name: API developer
     url: https://hashgraph.com

--- a/swagger-indexer.yaml
+++ b/swagger-indexer.yaml
@@ -3264,7 +3264,7 @@ info:
     leverages a customizable Policy Workflow Engine and Web3 technology to
     ensure transparent and fraud-proof operations, making it a key tool for
     transforming sustainability practices and carbon markets.
-  version: 3.7.0
+  version: 3.7.1-rc
   contact:
     name: API developer
     url: https://hashgraph.com

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -53458,7 +53458,7 @@ info:
     leverages a customizable Policy Workflow Engine and Web3 technology to
     ensure transparent and fraud-proof operations, making it a key tool for
     transforming sustainability practices and carbon markets.
-  version: 3.7.0
+  version: 3.7.1-rc
   contact:
     name: API developer
     url: https://hashgraph.com

--- a/topic-listener-service/package.json
+++ b/topic-listener-service/package.json
@@ -52,5 +52,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/topic-viewer/package.json
+++ b/topic-viewer/package.json
@@ -26,5 +26,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/tree-viewer/package.json
+++ b/tree-viewer/package.json
@@ -25,5 +25,5 @@
         "start": "node dist/index.js"
     },
     "type": "module",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }

--- a/worker-service/package.json
+++ b/worker-service/package.json
@@ -55,5 +55,5 @@
     },
     "type": "module",
     "types": "dist/index.d.ts",
-    "version": "3.7.0"
+    "version": "3.7.1-rc"
 }


### PR DESCRIPTION
Update the workspace package versions and lock files from 3.7.0 to 3.7.1-rc across all services and frontend apps in preparation for the next release candidate.