### PR TITLE
test: align tests with IWA dMRV v3 changes

### DIFF
--- a/common/tests/unit-tests/hedera-modules/message/schema-package-message-extra.test.mjs
+++ b/common/tests/unit-tests/hedera-modules/message/schema-package-message-extra.test.mjs
@@ -7,6 +7,7 @@ import {
     MessageStatus,
     UrlType
 } from '../../../../dist/hedera-modules/message/index.js';
+import { IwaVersion } from '@guardian/interfaces';
 
 describe('SchemaPackageMessage extra', function () {
     const pack = {
@@ -90,7 +91,8 @@ describe('SchemaPackageMessage extra', function () {
             entity: schemaA.entity,
             owner: schemaA.owner,
             version: schemaA.version,
-            codeVersion: schemaA.codeVersion
+            codeVersion: schemaA.codeVersion,
+            iwaVersion: IwaVersion.V1
         });
     });
 

--- a/common/tests/unit-tests/misc/policy-property.test.mjs
+++ b/common/tests/unit-tests/misc/policy-property.test.mjs
@@ -30,9 +30,9 @@ describe('GetPropertiesFromFile', () => {
         );
         const out = await GetPropertiesFromFile(file);
         assert.deepEqual(out, [
-            { title: 'title-a', value: 'value-a' },
-            { title: 'title-b', value: 'value-b' },
-            { title: 'title-c', value: 'value-c' },
+            { title: 'title-a', value: 'value-a', description: undefined },
+            { title: 'title-b', value: 'value-b', description: undefined },
+            { title: 'title-c', value: 'value-c', description: undefined },
         ]);
     });
 
@@ -42,16 +42,19 @@ describe('GetPropertiesFromFile', () => {
             ',orphan-value\ntitle-keep,value-keep'
         );
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'title-keep', value: 'value-keep' }]);
+        assert.deepEqual(out, [{ title: 'title-keep', value: 'value-keep', description: undefined }]);
     });
 
-    it('skips rows that do not have exactly two columns', async () => {
+    it('skips single-column rows and reads a third column as description', async () => {
         const file = writeCsv(
             'wrong-columns.csv',
             'only-one\nthree,col,row\nvalid,value'
         );
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'valid', value: 'value' }]);
+        assert.deepEqual(out, [
+            { title: 'three', value: 'col', description: 'row' },
+            { title: 'valid', value: 'value', description: undefined },
+        ]);
     });
 
     it('returns an empty array for an empty file', async () => {
@@ -63,7 +66,7 @@ describe('GetPropertiesFromFile', () => {
     it('handles a single-row file', async () => {
         const file = writeCsv('one.csv', 'lonely,value');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'lonely', value: 'value' }]);
+        assert.deepEqual(out, [{ title: 'lonely', value: 'value', description: undefined }]);
     });
 
     it('rejects when the file does not exist', async () => {

--- a/common/tests/unit-tests/policy-property.test.mjs
+++ b/common/tests/unit-tests/policy-property.test.mjs
@@ -16,16 +16,17 @@ describe('GetPropertiesFromFile (CSV title,value reader)', () => {
         await writeFile(file, 'Cap,100\nUnit,kg\n', 'utf8');
         const props = await GetPropertiesFromFile(file);
         assert.deepEqual(props, [
-            { title: 'Cap', value: '100' },
-            { title: 'Unit', value: 'kg' },
+            { title: 'Cap', value: '100', description: undefined },
+            { title: 'Unit', value: 'kg', description: undefined },
         ]);
     });
 
-    it('skips blank rows and rows with wrong column count', async () => {
+    it('skips blank and single-column rows, reading a third column as description', async () => {
         const file = path.join(tmp, 'b.csv');
         await writeFile(file, 'Cap,100\n\nonecolumn\nthree,col,umns\nUnit,kg', 'utf8');
         const props = await GetPropertiesFromFile(file);
-        assert.deepEqual(props.map(p => p.title), ['Cap', 'Unit']);
+        assert.deepEqual(props.map(p => p.title), ['Cap', 'three', 'Unit']);
+        assert.equal(props[1].description, 'umns');
     });
 
     it('skips rows whose first column is empty', async () => {

--- a/common/tests/unit-tests/policy-property/policy-property.test.mjs
+++ b/common/tests/unit-tests/policy-property/policy-property.test.mjs
@@ -16,25 +16,26 @@ describe('GetPropertiesFromFile', () => {
         const { file } = await writeTemp('a,1\nb,2\nc,3\n');
         const out = await GetPropertiesFromFile(file);
         assert.deepEqual(out, [
-            { title: 'a', value: '1' },
-            { title: 'b', value: '2' },
-            { title: 'c', value: '3' },
+            { title: 'a', value: '1', description: undefined },
+            { title: 'b', value: '2', description: undefined },
+            { title: 'c', value: '3', description: undefined },
         ]);
     });
 
-    it('skips rows that do not have exactly two columns', async () => {
+    it('skips single-column rows and reads a third column as description', async () => {
         const { file } = await writeTemp('a,1\nbad-row\nb,2,extra\nc,3\n');
         const out = await GetPropertiesFromFile(file);
         assert.deepEqual(out, [
-            { title: 'a', value: '1' },
-            { title: 'c', value: '3' },
+            { title: 'a', value: '1', description: undefined },
+            { title: 'b', value: '2', description: 'extra' },
+            { title: 'c', value: '3', description: undefined },
         ]);
     });
 
     it('skips rows whose first column is empty', async () => {
         const { file } = await writeTemp(',value-without-title\nname,real\n');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'name', value: 'real' }]);
+        assert.deepEqual(out, [{ title: 'name', value: 'real', description: undefined }]);
     });
 
     it('returns [] for an empty file', async () => {

--- a/common/tests/unit-tests/schemas-to-context/schemas-context-policy-edge.test.mjs
+++ b/common/tests/unit-tests/schemas-to-context/schemas-context-policy-edge.test.mjs
@@ -185,36 +185,36 @@ describe('@unit GetPropertiesFromFile (edge)', () => {
         const file = await writeTemp('a,\nb,');
         const out = await GetPropertiesFromFile(file);
         assert.deepEqual(out, [
-            { title: 'a', value: '' },
-            { title: 'b', value: '' },
+            { title: 'a', value: '', description: undefined },
+            { title: 'b', value: '', description: undefined },
         ]);
     });
 
     it('does not trim surrounding whitespace from title or value', async () => {
         const file = await writeTemp(' a , 1 ');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: ' a ', value: ' 1 ' }]);
+        assert.deepEqual(out, [{ title: ' a ', value: ' 1 ', description: undefined }]);
     });
 
-    it('leaves a trailing CR attached to the value on CRLF input', async () => {
+    it('strips the trailing CR from the value on CRLF input', async () => {
         const file = await writeTemp('a,1\r\nb,2\r\n');
         const out = await GetPropertiesFromFile(file);
         assert.deepEqual(out, [
-            { title: 'a', value: '1\r' },
-            { title: 'b', value: '2\r' },
+            { title: 'a', value: '1', description: undefined },
+            { title: 'b', value: '2', description: undefined },
         ]);
     });
 
-    it('skips a quoted field containing a comma (no CSV quote handling)', async () => {
+    it('keeps a quoted field containing a comma as a single value', async () => {
         const file = await writeTemp('name,"x,y"');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, []);
+        assert.deepEqual(out, [{ title: 'name', value: 'x,y', description: undefined }]);
     });
 
     it('preserves unicode in title and value', async () => {
         const file = await writeTemp('café,naïve');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'café', value: 'naïve' }]);
+        assert.deepEqual(out, [{ title: 'café', value: 'naïve', description: undefined }]);
     });
 
     it('skips a single-column row with no comma', async () => {
@@ -241,10 +241,13 @@ describe('@unit GetPropertiesFromFile (edge)', () => {
         assert.deepEqual(out, []);
     });
 
-    it('skips rows with three or more columns', async () => {
+    it('reads a third column as description and ignores any beyond it', async () => {
         const file = await writeTemp('a,1,2\nb,2\n');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'b', value: '2' }]);
+        assert.deepEqual(out, [
+            { title: 'a', value: '1', description: '2' },
+            { title: 'b', value: '2', description: undefined },
+        ]);
     });
 
     it('treats a numeric-looking value as a string', async () => {
@@ -256,7 +259,7 @@ describe('@unit GetPropertiesFromFile (edge)', () => {
     it('handles a file with no trailing newline', async () => {
         const file = await writeTemp('a,1');
         const out = await GetPropertiesFromFile(file);
-        assert.deepEqual(out, [{ title: 'a', value: '1' }]);
+        assert.deepEqual(out, [{ title: 'a', value: '1', description: undefined }]);
     });
 
     it('rejects when the file does not exist', async () => {

--- a/guardian-service/tests/unit/schema-template-migration.test.mjs
+++ b/guardian-service/tests/unit/schema-template-migration.test.mjs
@@ -78,10 +78,13 @@ function fakeCollection(documents) {
     };
 }
 
-function runMigration(policyDocuments, schemaDocuments = []) {
+function runMigration(policyDocuments, schemaDocuments = [], propertyDocuments = []) {
     const policies = fakeCollection(policyDocuments);
     const schemas = fakeCollection(schemaDocuments);
-    const collections = { Policy: policies, Schema: schemas };
+    // the description backfill reads the shipped CSVs and updates PolicyProperty
+    // rows; these fixtures seed none, so every updateMany is a no-op here
+    const properties = fakeCollection(propertyDocuments);
+    const collections = { Policy: policies, Schema: schemas, policy_property: properties };
     const migration = Object.create(ReleaseMigration.prototype);
     migration.ctx = 'session-1';
     migration.getCollection = (name) => {
@@ -97,7 +100,7 @@ function runMigration(policyDocuments, schemaDocuments = []) {
             }),
         }),
     };
-    return { collection: policies, policies, schemas, run: () => migration.up() };
+    return { collection: policies, policies, schemas, properties, run: () => migration.up() };
 }
 
 describe('v3-7-1 migration - schemaTemplate to schemaTemplates', () => {


### PR DESCRIPTION
### Description

The IWA dMRV v3 work changed production behaviour that the `common` and `guardian-service` test suites still asserted the old shape of, leaving 17 failures in `common` and 13 in `guardian-service`. The implementations are correct; the tests were stale.

- Update `GetPropertiesFromFile` expectations for CSV quote handling, trailing-CR stripping and the third `description` column, and retitle the tests whose stated behaviour inverted
- Assert `iwaVersion` on `SchemaPackageMessage` metadata using `IwaVersion.V1` rather than a literal
- Give the v3-7-1 migration test harness the `policy_property` collection that the description backfill now reads, which was failing every test that ran the migration
